### PR TITLE
screen size CLI options

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -30,12 +30,14 @@ App::App(const std::string& app_id,
          const std::string& application_override_path,
          bool fullscreen,
          bool enable_cursor,
-         bool debug_egl)
+         bool debug_egl,
+         uint32_t width,
+         uint32_t height)
     : m_gl_resolver(std::make_shared<GlResolver>()),
       m_display(std::make_shared<Display>(this, enable_cursor)),
       m_egl_window {
   std::make_shared<EglWindow>(0, m_display, EglWindow::WINDOW_BG, app_id,
-                              fullscreen, debug_egl)
+                              fullscreen, debug_egl, width, height)
 }
 #ifdef ENABLE_TEXTURE_TEST
 , m_texture_test(std::make_unique<TextureTest>(this))

--- a/shell/app.h
+++ b/shell/app.h
@@ -47,7 +47,9 @@ class App {
                const std::string& application_override_path,
                bool fullscreen,
                bool enable_cursor,
-               bool debug_egl);
+               bool debug_egl,
+               uint32_t width,
+               uint32_t height);
   App(const App&) = delete;
   const App& operator=(const App&) = delete;
 

--- a/shell/egl_window.cc
+++ b/shell/egl_window.cc
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "egl_window.h"
 
 #include <fcntl.h>
 #include <flutter/fml/logging.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <cassert>
 #include <cstring>
 #include <utility>
-#include <sys/stat.h>
 
 #include "constants.h"
 #include "display.h"
@@ -60,7 +59,7 @@ EglWindow::EglWindow(size_t index,
 
   wl_shell_surface_add_listener(m_shell_surface, &shell_surface_listener, this);
 
-  m_egl_window[index] = wl_egl_window_create(m_surface, width, height);
+  m_egl_window[index] = wl_egl_window_create(m_surface, m_width, m_height);
 
   m_egl_surface[index] = create_egl_surface(this, m_egl_window[index], nullptr);
 
@@ -70,8 +69,9 @@ EglWindow::EglWindow(size_t index,
   struct wl_callback* callback;
 
   if (m_fullscreen) {
-    wl_shell_surface_set_fullscreen(
-        m_shell_surface, WL_SHELL_SURFACE_FULLSCREEN_METHOD_SCALE, 0, nullptr);
+    wl_shell_surface_set_fullscreen(m_shell_surface,
+                                    WL_SHELL_SURFACE_FULLSCREEN_METHOD_SCALE,
+                                    60000, nullptr);
   } else {
     wl_shell_surface_set_toplevel(m_shell_surface);
 
@@ -205,7 +205,7 @@ static int os_create_anonymous_file(off_t size) {
      * There is also no need to check for the return value, we
      * couldn't do anything with it anyway.
      */
-    if(fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK)<0){
+    if (fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK) < 0) {
       return -1;
     }
   } else
@@ -346,7 +346,8 @@ void EglWindow::paint_pixels_top(void* image,
                                  int width,
                                  int height,
                                  [[maybe_unused]] uint32_t time) {
-  memset(image, 0xa0, static_cast<size_t>(width) * static_cast<size_t>(height) * 4);
+  memset(image, 0xa0,
+         static_cast<size_t>(width) * static_cast<size_t>(height) * 4);
 }
 
 void EglWindow::paint_pixels_bottom(void* image,
@@ -354,7 +355,8 @@ void EglWindow::paint_pixels_bottom(void* image,
                                     int width,
                                     int height,
                                     [[maybe_unused]] uint32_t time) {
-  memset(image, 0xa0, static_cast<size_t>(width) * static_cast<size_t>(height) * 4);
+  memset(image, 0xa0,
+         static_cast<size_t>(width) * static_cast<size_t>(height) * 4);
 }
 
 void EglWindow::paint_pixels(void* image,
@@ -431,7 +433,9 @@ void EglWindow::redraw(void* data,
       buffer = nullptr;
     else
       /* paint the padding */
-      memset(buffer->shm_data, 0xff, static_cast<size_t>(window->m_width) * static_cast<size_t>(window->m_height) * 4);
+      memset(buffer->shm_data, 0xff,
+             static_cast<size_t>(window->m_width) *
+                 static_cast<size_t>(window->m_height) * 4);
   }
 
   if (!buffer) {
@@ -481,8 +485,9 @@ void EglWindow::toggle_fullscreen() {
   struct wl_callback* callback;
 
   if (m_fullscreen) {
-    wl_shell_surface_set_fullscreen(
-        m_shell_surface, WL_SHELL_SURFACE_FULLSCREEN_METHOD_SCALE, 0, nullptr);
+    wl_shell_surface_set_fullscreen(m_shell_surface,
+                                    WL_SHELL_SURFACE_FULLSCREEN_METHOD_SCALE,
+                                    60000, nullptr);
   } else {
     wl_shell_surface_set_toplevel(m_shell_surface);
     handle_shell_configure(this, m_shell_surface, 0, m_width, m_height);

--- a/shell/egl_window.h
+++ b/shell/egl_window.h
@@ -38,8 +38,8 @@ class EglWindow : public Egl {
             std::string app_id,
             bool fullscreen,
             bool debug_egl,
-            int32_t width = kScreenWidth,
-            int32_t height = kScreenHeight);
+            int32_t width,
+            int32_t height);
   ~EglWindow();
   EglWindow(const EglWindow&) = delete;
   const EglWindow& operator=(const EglWindow&) = delete;

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -161,7 +161,7 @@ Engine::Engine(App* app,
   }
   FML_DLOG(INFO) << "(" << m_index << ") icu_data_path: " << m_icu_data_path;
 
-    // Configure AOT
+  // Configure AOT
   m_aot_path.assign(paths::JoinPaths({m_assets_path, "libapp.so"}));
   if (FlutterEngineRunsAOTCompiledDartCode()) {
     m_args.aot_data = nullptr;
@@ -170,7 +170,7 @@ Engine::Engine(App* app,
       m_args.aot_data = m_aot_data.get();
     }
   } else {
-    FML_LOG(INFO) << "Engine instance not able to run AOT compiled Dart code";
+    FML_LOG(INFO) << "Runtime=debug";
   }
 
   // Configure task runner interop

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -40,14 +40,15 @@ int main(int argc, char** argv) {
   bool disable_cursor = false;
   bool debug_egl = false;
   bool fullscreen = false;
+  uint32_t width = 0;
+  uint32_t height = 0;
 
   auto cl = fml::CommandLineFromArgcArgv(argc, argv);
 
   if (!cl.options().empty()) {
     if (cl.HasOption("a")) {
       cl.GetOptionValue("a", &application_override_path);
-      FML_DLOG(INFO) << "Override Assets Path: "
-                     << application_override_path;
+      FML_DLOG(INFO) << "Override Assets Path: " << application_override_path;
       auto find = "--a=" + application_override_path;
       auto result = std::find(args.begin(), args.end(), find);
       if (result != args.end()) {
@@ -75,15 +76,43 @@ int main(int argc, char** argv) {
     if (cl.HasOption("f")) {
       FML_DLOG(INFO) << "Fullscreen";
       fullscreen = true;
-      auto idx = std::find(args.begin(), args.end(), "--f");
-      if (idx != args.end()) {
-        args.erase(idx);
+      auto result = std::find(args.begin(), args.end(), "--f");
+      if (result != args.end()) {
+        args.erase(result);
+      }
+    }
+    if (cl.HasOption("w")) {
+      std::string width_str;
+      cl.GetOptionValue("w", &width_str);
+      width = static_cast<uint32_t>(std::stoul(width_str));
+      auto find = "--w=" + application_override_path;
+      auto result = std::find(args.begin(), args.end(), find);
+      if (result != args.end()) {
+        args.erase(result);
+      }
+    }
+    if (cl.HasOption("h")) {
+      std::string height_str;
+      cl.GetOptionValue("h", &height_str);
+      height = static_cast<uint32_t>(std::stoul(height_str));
+      auto find = "--h=" + application_override_path;
+      auto result = std::find(args.begin(), args.end(), find);
+      if (result != args.end()) {
+        args.erase(result);
       }
     }
   }
+  if (!width) {
+    width = kScreenWidth;
+  }
+  if (!height) {
+    height = kScreenHeight;
+  }
+  FML_DLOG(INFO) << "Screen Width: " << width;
+  FML_DLOG(INFO) << "Screen Height: " << height;
 
   App app("homescreen", args, application_override_path, fullscreen,
-          !disable_cursor, debug_egl);
+          !disable_cursor, debug_egl, width, height);
 
   std::signal(SIGINT, SignalHandler);
 


### PR DESCRIPTION
Adds CLI options '--w' and '--h' to enable manual selection of egl_window_surface.  If either --w or --h is not specified it uses default sizes found in constants.h.

Signed-off-by: Joel Winarske <joel.winarske@toyotaconnected.com>