### PR TITLE
Build time configure EGL parameters

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -35,5 +35,22 @@ endif ()
 # variables
 set(THIRD_PARTY_DIR ${CMAKE_SOURCE_DIR}/third_party)
 
-option(BUILD_IVI "Build IVI variant" ON)
-option(BUILD_IC "Build IC variant" ON)
+# EGL Surface Options
+if (NOT BUILD_EGL_CONTEXT_VERSION_MAJOR)
+    set(BUILD_EGL_CONTEXT_VERSION_MAJOR "3" CACHE STRING "Valid options are: 1, 2, 3." FORCE)
+    message(STATUS "EGL_CONTEXT_VERSION_MAJOR not set, defaulting to 3.")
+endif()
+add_compile_definitions(BUILD_EGL_CONTEXT_VERSION_MAJOR=${BUILD_EGL_CONTEXT_VERSION_MAJOR})
+
+option(BUILD_EGL_OPENGL_ES3 "Build with EGL_OPENGL_ES3_BIT set" ON)
+option(BUILD_EGL_OPENGL_ES2 "Build with EGL_OPENGL_ES2_BIT set" OFF)
+if(BUILD_EGL_OPENGL_ES3)
+    add_compile_definitions(BUILD_EGL_OPENGL_ES3)
+elseif(BUILD_EGL_OPENGL_ES2)
+    add_compile_definitions(BUILD_EGL_OPENGL_ES2)
+endif()
+
+option(BUILD_EGL_TRANSPARENCY "Build with EGL Transparency Enabled" ON)
+if(BUILD_EGL_TRANSPARENCY)
+    add_compile_definitions(BUILD_EGL_ENABLE_TRANSPARENCY)
+endif()

--- a/shell/constants.h
+++ b/shell/constants.h
@@ -51,21 +51,29 @@ static constexpr std::array<char[kSoMaxLength], kSoCount> kGlSoNames[]{
 // Engine constants
 constexpr int kEngineInstanceCount = 1;
 
-static constexpr std::array<EGLint, 3> kEglContextAttribs = {
-    {
-        EGL_CONTEXT_MAJOR_VERSION, 3,
-        EGL_NONE
-    }
-};
+static constexpr std::array<EGLint, 3> kEglContextAttribs = {{
+    // clang-format off
+    EGL_CONTEXT_MAJOR_VERSION, BUILD_EGL_CONTEXT_VERSION_MAJOR,
+    EGL_NONE
+    // clang-format on
+}};
 
 static constexpr std::array<EGLint, 13> kEglConfigAttribs = {{
     // clang-format off
     EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+#if defined(BUILD_EGL_OPENGL_ES3)
     EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+#elif defined(BUILD_EGL_OPENGL_ES2)
+    EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+#endif
     EGL_RED_SIZE, 8,
     EGL_GREEN_SIZE, 8,
     EGL_BLUE_SIZE, 8,
+#if defined(BUILD_EGL_ENABLE_TRANSPARENCY)
     EGL_ALPHA_SIZE, 8,
+#else
+    EGL_ALPHA_SIZE, 0,
+#endif
     EGL_NONE // termination sentinel
     // clang-format on
 }};

--- a/shell/display.cc
+++ b/shell/display.cc
@@ -565,7 +565,7 @@ void Display::touch_handle_cancel(void* data,
 
 void Display::touch_handle_frame([[maybe_unused]] void* data,
                                  [[maybe_unused]] struct wl_touch* wl_touch) {
-  FML_DLOG(INFO) << "touch_handle_frame";
+  //  FML_DLOG(INFO) << "touch_handle_frame";
 }
 
 const struct wl_touch_listener Display::touch_listener = {
@@ -583,8 +583,8 @@ void Display::gesture_pinch_begin(
     [[maybe_unused]] uint32_t serial,
     [[maybe_unused]] uint32_t time,
     [[maybe_unused]] struct wl_surface* surface,
-    uint32_t fingers) {
-  FML_DLOG(INFO) << "gesture_pinch_begin: fingers: " << fingers;
+    [[maybe_unused]] uint32_t fingers) {
+  //  FML_DLOG(INFO) << "gesture_pinch_begin: fingers: " << fingers;
 }
 
 void Display::gesture_pinch_update(
@@ -592,14 +592,16 @@ void Display::gesture_pinch_update(
     [[maybe_unused]] struct zwp_pointer_gesture_pinch_v1*
         zwp_pointer_gesture_pinch_v1,
     [[maybe_unused]] uint32_t time,
-    wl_fixed_t dx,
-    wl_fixed_t dy,
-    wl_fixed_t scale,
-    wl_fixed_t rotation) {
+    [[maybe_unused]] wl_fixed_t dx,
+    [[maybe_unused]] wl_fixed_t dy,
+    [[maybe_unused]] wl_fixed_t scale,
+    [[maybe_unused]] wl_fixed_t rotation) {
+#if 0
   FML_DLOG(INFO) << "gesture_pinch_update: " << wl_fixed_to_double(dx) << ", "
                  << wl_fixed_to_double(dy)
                  << " scale: " << wl_fixed_to_double(scale)
                  << ", rotation: " << wl_fixed_to_double(rotation);
+#endif
 }
 
 void Display::gesture_pinch_end(
@@ -608,9 +610,9 @@ void Display::gesture_pinch_end(
         zwp_pointer_gesture_pinch_v1,
     [[maybe_unused]] uint32_t serial,
     [[maybe_unused]] uint32_t time,
-    int32_t cancelled) {
-  FML_DLOG(INFO) << "gesture_pinch_end";
-  FML_DLOG(INFO) << "gesture_pinch_begin: cancelled: " << cancelled;
+    [[maybe_unused]] int32_t cancelled) {
+  //  FML_DLOG(INFO) << "gesture_pinch_end";
+  //  FML_DLOG(INFO) << "gesture_pinch_begin: cancelled: " << cancelled;
 }
 
 const struct zwp_pointer_gesture_pinch_v1_listener


### PR DESCRIPTION
- Enables build time configuration for EGL parameters
- Minimize debug spew for touch

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>