### PR TITLE
Enable changing Mouse Cursor via Dart

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -32,9 +32,10 @@ App::App(const std::string& app_id,
          bool enable_cursor,
          bool debug_egl,
          uint32_t width,
-         uint32_t height)
+         uint32_t height,
+         const std::string& cursor_theme_name)
     : m_gl_resolver(std::make_shared<GlResolver>()),
-      m_display(std::make_shared<Display>(this, enable_cursor)),
+      m_display(std::make_shared<Display>(this, enable_cursor, cursor_theme_name)),
       m_egl_window {
   std::make_shared<EglWindow>(0, m_display, EglWindow::WINDOW_BG, app_id,
                               fullscreen, debug_egl, width, height)

--- a/shell/app.h
+++ b/shell/app.h
@@ -49,7 +49,8 @@ class App {
                bool enable_cursor,
                bool debug_egl,
                uint32_t width,
-               uint32_t height);
+               uint32_t height,
+               const std::string& cursor_theme_name);
   App(const App&) = delete;
   const App& operator=(const App&) = delete;
 

--- a/shell/constants.h
+++ b/shell/constants.h
@@ -25,6 +25,12 @@ constexpr int32_t kScreenWidth = 1920;
 constexpr int32_t kScreenHeight = 720;
 constexpr int kEglBufferSize = 24;
 
+// Cursor
+constexpr int kCursorSize = 24;
+constexpr char kCursorPointerBasic[] = "left_ptr";
+constexpr char kCursorPointerClick[] = "hand";
+constexpr char kCursorPointerText[] = "left_ptr";
+
 // Touch
 constexpr int kMaxTouchPoints = 10;
 

--- a/shell/display.h
+++ b/shell/display.h
@@ -34,7 +34,7 @@ class Engine;
 
 class Display {
  public:
-  explicit Display(App* app, bool enable_cursor);
+  explicit Display(App* app, bool enable_cursor, std::string  cursor_theme_name);
   ~Display();
   Display(const Display&) = delete;
   const Display& operator=(const Display&) = delete;
@@ -74,6 +74,8 @@ class Display {
 
   void SetEngine(std::shared_ptr<Engine> engine);
 
+  bool ActivateSystemCursor([[maybe_unused]] int32_t device, const std::string& kind);
+
  private:
   std::shared_ptr<Engine> m_flutter_engine;
 
@@ -92,6 +94,8 @@ class Display {
   bool m_has_xrgb;
 
   bool m_enable_cursor;
+  struct wl_surface* m_cursor_surface;
+  std::string m_cursor_theme_name;
 
   struct pointer_event {
     [[maybe_unused]] uint32_t event_mask;
@@ -119,6 +123,7 @@ class Display {
   struct pointer {
     struct wl_pointer* pointer;
     struct pointer_event event;
+    uint32_t serial;
 
     uint32_t buttons;
     uint32_t state;
@@ -152,12 +157,9 @@ class Display {
   } m_touch{};
 
   // for cursor
-  // struct wl_shm *shm;
   struct wl_cursor_theme* m_cursor_theme{};
-  [[maybe_unused]] struct wl_cursor* m_default_cursor{};
-  // struct wl_surface* m_cursor_surface;
 
-  struct zwp_pointer_gestures_v1* m_gestures{};
+  [[maybe_unused]] struct zwp_pointer_gestures_v1* m_gestures{};
   [[maybe_unused]] struct zwp_pointer_gesture_swipe_v1* m_pointer_swipe{};
 
   struct info {
@@ -353,6 +355,6 @@ class Display {
       uint32_t time,
       int32_t cancelled);
 
-  static const struct zwp_pointer_gesture_pinch_v1_listener
+  [[maybe_unused]] static const struct zwp_pointer_gesture_pinch_v1_listener
       gesture_pinch_listener;
 };

--- a/shell/egl_window.cc
+++ b/shell/egl_window.cc
@@ -496,3 +496,7 @@ void EglWindow::toggle_fullscreen() {
   callback = wl_display_sync(m_display->GetDisplay());
   wl_callback_add_listener(callback, &shell_configure_callback_listener, this);
 }
+
+bool EglWindow::ActivateSystemCursor(int32_t device, const std::string& kind) {
+  return m_display->ActivateSystemCursor(device, kind);
+}

--- a/shell/egl_window.h
+++ b/shell/egl_window.h
@@ -53,6 +53,8 @@ class EglWindow : public Egl {
   [[nodiscard]] int32_t GetWidth() const { return m_width; }
   [[nodiscard]] int32_t GetHeight() const { return m_height; }
 
+  bool ActivateSystemCursor(int32_t device, const std::string& kind);
+
  private:
   struct shm_buffer {
     struct wl_buffer* buffer;

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -147,7 +147,7 @@ Engine::Engine(App* app,
 
   char* error = dlerror();
   if (error != nullptr) {
-    FML_DLOG(ERROR) << dlerror();
+    FML_DLOG(ERROR) << error;
     exit(-1);
   }
 
@@ -557,4 +557,8 @@ FlutterEngineAOTData Engine::LoadAotData(
     return nullptr;
   }
   return data;
+}
+
+bool Engine::ActivateSystemCursor(int32_t device, const std::string& kind) {
+  return m_egl_window->ActivateSystemCursor(device, kind);
 }

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -111,6 +111,8 @@ class Engine {
     return m_gl_resolver;
   }
 
+  bool ActivateSystemCursor(int32_t device, const std::string& kind);
+
  private:
   size_t m_index;
   bool m_running;
@@ -154,5 +156,6 @@ class Engine {
       m_taskrunner;
 
   FlutterEngineAOTData m_aot_data;
-  [[nodiscard]] FlutterEngineAOTData LoadAotData(const std::string& aot_data_path) const;
+  [[nodiscard]] FlutterEngineAOTData LoadAotData(
+      const std::string& aot_data_path) const;
 };

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -35,6 +35,7 @@ int main(int argc, char** argv) {
   }
 
   std::string application_override_path;
+  std::string cursor_theme;
   bool disable_cursor = false;
   bool debug_egl = false;
   bool fullscreen = false;
@@ -97,6 +98,14 @@ int main(int argc, char** argv) {
         args.erase(result);
       }
     }
+    if (cl.HasOption("t")) {
+      cl.GetOptionValue("t", &cursor_theme);
+      FML_DLOG(INFO) << "Cursor Theme: " << cursor_theme;
+      auto result = std::find(args.begin(), args.end(), "--t");
+      if (result != args.end()) {
+        args.erase(result);
+      }
+    }
   }
   if (!width) {
     width = kScreenWidth;
@@ -108,7 +117,7 @@ int main(int argc, char** argv) {
   FML_DLOG(INFO) << "Screen Height: " << height;
 
   App app("homescreen", args, application_override_path, fullscreen,
-          !disable_cursor, debug_egl, width, height);
+          !disable_cursor, debug_egl, width, height, cursor_theme);
 
   std::signal(SIGINT, SignalHandler);
 

--- a/shell/static_plugins/mouse_cursor/mouse_cursor.cc
+++ b/shell/static_plugins/mouse_cursor/mouse_cursor.cc
@@ -25,7 +25,7 @@ void MouseCursor::OnPlatformMessage(const FlutterPlatformMessage* message,
   auto codec = &flutter::StandardMethodCodec::GetInstance();
   auto obj = codec->DecodeMethodCall(message->message, message->message_size);
 
-  if (obj->method_name() == "activateSystemCursor") {
+  if (obj->method_name() == kMethodActivateSystemCursor) {
     if (obj->arguments() && obj->arguments()->IsMap()) {
       const flutter::EncodableMap& args = obj->arguments()->MapValue();
 
@@ -40,11 +40,9 @@ void MouseCursor::OnPlatformMessage(const FlutterPlatformMessage* message,
       if (it != args.end()) {
         kind = it->second.StringValue();
       }
-#if 0 //TODO - call into display and set active cursor
-      FML_DLOG(INFO) << "activateSystemCursor: device=" << device
-                     << ", kind=" << kind;
-#endif
-      auto val = flutter::EncodableValue(true);
+
+      auto val =
+          flutter::EncodableValue(engine->ActivateSystemCursor(device, kind));
       auto result = codec->EncodeSuccessEnvelope(&val);
       engine->SendPlatformMessageResponse(message->response_handle,
                                           result->data(), result->size());

--- a/shell/static_plugins/mouse_cursor/mouse_cursor.h
+++ b/shell/static_plugins/mouse_cursor/mouse_cursor.h
@@ -25,4 +25,6 @@ class MouseCursor {
  public:
   static void OnPlatformMessage(const FlutterPlatformMessage* message,
                                 void* userdata);
+ private:
+  static constexpr char kMethodActivateSystemCursor[] = "activateSystemCursor";
 };


### PR DESCRIPTION
- Adds CLI cursor theme setting. I.E. --t=DMZ-White
- If --t is not used, it will  use the system "default" cursor theme
- Adds support for mouse cursor kind: basic, click, text

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>