### PR TITLE
FPS output processing

### DIFF
--- a/shell/app.h
+++ b/shell/app.h
@@ -40,6 +40,10 @@ class App {
   std::shared_ptr<Display> m_display;
   std::shared_ptr<EglWindow> m_egl_window[kEngineInstanceCount];
   std::shared_ptr<Engine> m_engine[kEngineInstanceCount];
+  uint8_t m_fps_output;
+  uint32_t m_fps_period;
+  uint32_t m_fps_counter;
+  int32_t m_fps_pretime;
 #ifdef ENABLE_TEXTURE_TEST
   std::unique_ptr<TextureTest> m_texture_test;
 #endif

--- a/shell/display.cc
+++ b/shell/display.cc
@@ -34,6 +34,7 @@ Display::Display([[maybe_unused]] App* app,
       m_display(nullptr),
       m_output(nullptr),
       m_compositor(nullptr),
+      m_subcompositor(nullptr),
       m_cursor_surface(nullptr),
       m_keyboard(nullptr),
       m_xkb_context(xkb_context_new(XKB_CONTEXT_NO_FLAGS)),
@@ -57,6 +58,10 @@ Display::Display([[maybe_unused]] App* app,
   wl_display_dispatch(m_display);
 
   if (!m_compositor) {
+    assert(false);
+  }
+
+  if (!m_subcompositor) {
     assert(false);
   }
 
@@ -93,6 +98,9 @@ Display::~Display() {
   if (m_agl_shell)
     agl_shell_destroy(m_agl_shell);
 
+  if (m_subcompositor)
+    wl_subcompositor_destroy(m_subcompositor);
+
   if (m_compositor)
     wl_compositor_destroy(m_compositor);
 
@@ -110,9 +118,9 @@ Display::~Display() {
 }
 
 void Display::registry_handle_global(void* data,
-                                     struct wl_registry* registry,
-                                     uint32_t name,
-                                     const char* interface,
+                                     [[maybe_unused]] struct wl_registry* registry,
+                                     [[maybe_unused]] uint32_t name,
+                                     [[maybe_unused]] const char* interface,
                                      [[maybe_unused]] uint32_t version) {
   auto* d = static_cast<Display*>(data);
 
@@ -121,6 +129,11 @@ void Display::registry_handle_global(void* data,
   if (strcmp(interface, wl_compositor_interface.name) == 0) {
     d->m_compositor = static_cast<struct wl_compositor*>(
         wl_registry_bind(registry, name, &wl_compositor_interface, 1));
+  }
+
+  if (strcmp(interface, wl_subcompositor_interface.name) == 0) {
+    d->m_subcompositor = static_cast<struct wl_subcompositor*>(
+        wl_registry_bind(registry, name, &wl_subcompositor_interface, 1));
   }
 
   if (strcmp(interface, wl_shell_interface.name) == 0) {
@@ -211,8 +224,8 @@ void Display::display_handle_geometry(void* data,
 }
 
 void Display::display_handle_mode(void* data,
-                                  struct wl_output* wl_output,
-                                  uint32_t flags,
+                                  [[maybe_unused]] struct wl_output* wl_output,
+                                  [[maybe_unused]] uint32_t flags,
                                   int width,
                                   int height,
                                   [[maybe_unused]] int refresh) {
@@ -256,7 +269,7 @@ const struct wl_output_listener Display::output_listener = {
 
 void Display::shm_format(void* data,
                          [[maybe_unused]] struct wl_shm* wl_shm,
-                         uint32_t format) {
+                         [[maybe_unused]] uint32_t format) {
   auto* display = reinterpret_cast<Display*>(data);
 
   if (format == WL_SHM_FORMAT_XRGB8888)
@@ -267,7 +280,7 @@ const struct wl_shm_listener Display::shm_listener = {shm_format};
 
 void Display::seat_handle_capabilities(void* data,
                                        struct wl_seat* seat,
-                                       uint32_t caps) {
+                                       [[maybe_unused]] uint32_t caps) {
   auto* d = static_cast<Display*>(data);
 
   if ((caps & WL_SEAT_CAPABILITY_POINTER) && !d->m_pointer.pointer) {
@@ -304,7 +317,7 @@ const struct wl_seat_listener Display::seat_listener = {
 };
 
 FlutterPointerPhase Display::getPointerPhase(struct pointer* p) {
-  FlutterPointerPhase res = p->phase;
+  [[maybe_unused]] FlutterPointerPhase res = p->phase;
 
   if (p->buttons) {
     switch (p->event.state) {
@@ -315,14 +328,11 @@ FlutterPointerPhase Display::getPointerPhase(struct pointer* p) {
           res = FlutterPointerPhase::kDown;
         else
           res = FlutterPointerPhase::kMove;
-        break;
       case WL_POINTER_BUTTON_STATE_RELEASED:
         // FML_DLOG(INFO) << "WL_POINTER_BUTTON_STATE_RELEASED";
         if ((p->phase == FlutterPointerPhase::kDown) ||
             (p->phase == FlutterPointerPhase::kMove))
           res = FlutterPointerPhase::kUp;
-        p->buttons = 0;
-        break;
     }
   } else {
     res = p->event.state == WL_POINTER_BUTTON_STATE_RELEASED
@@ -338,8 +348,8 @@ void Display::pointer_handle_enter(void* data,
                                    [[maybe_unused]] struct wl_pointer* pointer,
                                    uint32_t serial,
                                    [[maybe_unused]] struct wl_surface* surface,
-                                   wl_fixed_t sx,
-                                   wl_fixed_t sy) {
+                                   [[maybe_unused]] wl_fixed_t sx,
+                                   [[maybe_unused]] wl_fixed_t sy) {
   auto* d = static_cast<Display*>(data);
 
   d->m_pointer.event.surface_x = wl_fixed_to_double(sx);
@@ -373,8 +383,8 @@ void Display::pointer_handle_leave(
 void Display::pointer_handle_motion(void* data,
                                     [[maybe_unused]] struct wl_pointer* pointer,
                                     [[maybe_unused]] uint32_t time,
-                                    wl_fixed_t sx,
-                                    wl_fixed_t sy) {
+                                    [[maybe_unused]] wl_fixed_t sx,
+                                    [[maybe_unused]] wl_fixed_t sy) {
   auto* d = static_cast<Display*>(data);
 
   d->m_pointer.event.surface_x = wl_fixed_to_double(sx);
@@ -413,8 +423,8 @@ void Display::pointer_handle_axis(
     void* data,
     [[maybe_unused]] struct wl_pointer* wl_pointer,
     uint32_t time,
-    uint32_t axis,
-    wl_fixed_t value) {
+    [[maybe_unused]] uint32_t axis,
+    [[maybe_unused]] wl_fixed_t value) {
   auto* d = static_cast<Display*>(data);
   d->m_pointer.event.time = time;
   d->m_pointer.event.axes[axis].value = wl_fixed_to_double(value);
@@ -468,14 +478,14 @@ void Display::keyboard_handle_keymap(
   d->m_xkb_state = xkb_state_new(d->m_keymap);
 }
 
-void Display::keyboard_handle_key(void* data,
-                                  struct wl_keyboard* keyboard,
-                                  uint32_t serial,
-                                  uint32_t time,
-                                  uint32_t key,
-                                  uint32_t state) {
-  auto* d = static_cast<Display*>(data);
+void Display::keyboard_handle_key([[maybe_unused]] void* data,
+                                  [[maybe_unused]] struct wl_keyboard* keyboard,
+                                  [[maybe_unused]] uint32_t serial,
+                                  [[maybe_unused]] uint32_t time,
+                                  [[maybe_unused]] uint32_t key,
+                                  [[maybe_unused]] uint32_t state) {
 #if ENABLE_PLUGIN_TEXT_INPUT
+  auto* d = static_cast<Display*>(data);
   if (d->m_text_input) {
     if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
       xkb_keysym_t keysym = xkb_state_key_get_one_sym(d->m_xkb_state, key + 8);
@@ -486,12 +496,12 @@ void Display::keyboard_handle_key(void* data,
 #else
 #if !defined(NDEBUG)
   if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-    xkb_keysym_t keysym = xkb_state_key_get_one_sym(d->m_xkb_state, key + 8);
+    [[maybe_unused]] xkb_keysym_t keysym = xkb_state_key_get_one_sym(d->m_xkb_state, key + 8);
     uint32_t utf32 = xkb_keysym_to_utf32(keysym);
     if (utf32) {
       FML_DLOG(INFO) << "[Press] U" << utf32;
     } else {
-      char name[64];
+      [[maybe_unused]] char name[64];
       xkb_keysym_get_name(keysym, name, 64);
       FML_DLOG(INFO) << "[Press] " << name;
     }
@@ -523,8 +533,8 @@ const struct wl_keyboard_listener Display::keyboard_listener = {
 
 [[maybe_unused]] struct Display::touch_point* Display::get_touch_point(
     Display* d,
-    int32_t id) {
-  struct touch_event* touch = &d->m_touch.event;
+    [[maybe_unused]] int32_t id) {
+  [[maybe_unused]] auto touch = &d->m_touch.event;
 
   for (auto& point : touch->points) {
     if (point.id == id && point.valid) {
@@ -545,11 +555,11 @@ void Display::touch_handle_down(void* data,
                                 [[maybe_unused]] uint32_t time,
                                 [[maybe_unused]] struct wl_surface* surface,
                                 int32_t id,
-                                wl_fixed_t x_w,
-                                wl_fixed_t y_w) {
+                                [[maybe_unused]] wl_fixed_t x_w,
+                                [[maybe_unused]] wl_fixed_t y_w) {
   auto* d = static_cast<Display*>(data);
 
-  bool first_down = (d->m_touch.down_count[id] == 0);
+  [[maybe_unused]] bool first_down = (d->m_touch.down_count[id] == 0);
   d->m_touch.down_count[id] += 1;
 
   d->m_touch.surface_x = x_w;
@@ -570,9 +580,9 @@ void Display::touch_handle_up(void* data,
   auto* d = static_cast<Display*>(data);
 
   d->m_touch.down_count[id] -= 1;
-  bool last_up = (d->m_touch.down_count[id] == 0);
 
   if (d->m_flutter_engine) {
+    [[maybe_unused]] bool last_up = (d->m_touch.down_count[id] == 0);
     d->m_flutter_engine->SendTouchEvent(
         (last_up ? FlutterPointerPhase::kUp : FlutterPointerPhase::kMove),
         wl_fixed_to_double(d->m_touch.surface_x),
@@ -583,9 +593,9 @@ void Display::touch_handle_up(void* data,
 void Display::touch_handle_motion(void* data,
                                   [[maybe_unused]] struct wl_touch* wl_touch,
                                   [[maybe_unused]] uint32_t time,
-                                  int32_t id,
-                                  wl_fixed_t x_w,
-                                  wl_fixed_t y_w) {
+                                  [[maybe_unused]] int32_t id,
+                                  [[maybe_unused]] wl_fixed_t x_w,
+                                  [[maybe_unused]] wl_fixed_t y_w) {
   auto* d = static_cast<Display*>(data);
 
   d->m_touch.surface_x = x_w;
@@ -674,8 +684,8 @@ void Display::gesture_pinch_end(
   }
 }
 
-[[maybe_unused]] void Display::AglShellDoPanel(struct wl_surface* surface,
-                                               enum agl_shell_edge mode) {
+[[maybe_unused]] void Display::AglShellDoPanel([[maybe_unused]] struct wl_surface* surface,
+                                               [[maybe_unused]] enum agl_shell_edge mode) {
   if (m_agl_shell) {
     agl_shell_set_panel(m_agl_shell, surface, m_output, mode);
   }
@@ -713,12 +723,12 @@ bool Display::ActivateSystemCursor([[maybe_unused]] int32_t device,
       return false;
     }
 
-    auto cursor = wl_cursor_theme_get_cursor(m_cursor_theme, cursor_name);
+    [[maybe_unused]] auto cursor = wl_cursor_theme_get_cursor(m_cursor_theme, cursor_name);
     if (cursor == nullptr) {
       FML_DLOG(INFO) << "Cursor [" << cursor_name << "] not found";
       return false;
     }
-    auto cursor_buffer = wl_cursor_image_get_buffer(cursor->images[0]);
+    [[maybe_unused]] auto cursor_buffer = wl_cursor_image_get_buffer(cursor->images[0]);
     if (cursor_buffer && m_cursor_surface) {
       wl_pointer_set_cursor(m_pointer.pointer, m_pointer.serial,
                             m_cursor_surface,

--- a/shell/display.h
+++ b/shell/display.h
@@ -45,6 +45,11 @@ class Display {
     return m_compositor;
   };
 
+  struct wl_subcompositor* GetSubCompositor() {
+    assert(m_subcompositor);
+    return m_subcompositor;
+  };
+
   struct wl_display* GetDisplay() {
     assert(m_display);
     return m_display;
@@ -87,6 +92,7 @@ class Display {
   struct wl_registry* m_registry;
   struct wl_output* m_output;
   struct wl_compositor* m_compositor;
+  struct wl_subcompositor* m_subcompositor;
   struct wl_shell* m_shell{};
   struct wl_shm* m_shm{};
 

--- a/shell/egl_window.cc
+++ b/shell/egl_window.cc
@@ -53,6 +53,12 @@ EglWindow::EglWindow(size_t index,
   assert(m_surface);
   FML_DLOG(INFO) << "EglWindow::m_surface = " << static_cast<void*>(m_surface);
 
+  m_fps_surface = wl_compositor_create_surface(m_display->GetCompositor());
+  m_subsurface = wl_subcompositor_get_subsurface(m_display->GetSubCompositor(),
+                                                 m_fps_surface, m_surface);
+  wl_subsurface_set_position(m_subsurface, 50, 50);
+  wl_subsurface_set_sync(m_subsurface);
+
   m_shell_surface =
       wl_shell_get_shell_surface(m_display->GetShell(), m_surface);
   assert(m_shell_surface);
@@ -97,6 +103,14 @@ EglWindow::EglWindow(size_t index,
   eglSwapInterval(m_dpy, m_frame_sync);
   ClearCurrent();
 
+  memset(m_fps, 0, sizeof(m_fps));
+  m_fps_idx = 0;
+  m_fps_counter = 0;
+
+  this->m_callback = wl_surface_frame(this->m_surface);
+  wl_callback_add_listener(this->m_callback, &frame_listener, this);
+  wl_surface_commit(this->m_surface);
+
   FML_DLOG(INFO) << "- EglWindow()";
 }
 
@@ -115,6 +129,7 @@ EglWindow::~EglWindow() {
   if (m_shell_surface)
     wl_shell_surface_destroy(m_shell_surface);
 
+  wl_surface_destroy(m_fps_surface);
   wl_surface_destroy(m_surface);
 
   FML_DLOG(INFO) << "- ~EglWindow()";
@@ -421,70 +436,24 @@ void EglWindow::paint_pixels(void* image,
 
 void EglWindow::redraw(void* data,
                        struct wl_callback* callback,
-                       uint32_t time) {
+                       [[maybe_unused]] uint32_t time) {
   auto* window = reinterpret_cast<EglWindow*>(data);
-  struct shm_buffer* buffer;
-  int ret;
-
-  if (!window->m_buffers[0].busy)
-    buffer = &window->m_buffers[0];
-  else if (!window->m_buffers[1].busy)
-    buffer = &window->m_buffers[1];
-  else
-    buffer = nullptr;
-
-  if (buffer && !buffer->buffer) {
-    FML_DLOG(INFO)
-        << "next_buffer() bubffer->buffer is not set, setting with width "
-        << window->m_width << ", height " << window->m_height;
-    ret = create_shm_buffer(window->m_display.get(), buffer, window->m_width,
-                            window->m_height, WL_SHM_FORMAT_XRGB8888);
-
-    if (ret < 0)
-      buffer = nullptr;
-    else
-      /* paint the padding */
-      memset(buffer->shm_data, 0xff,
-             static_cast<size_t>(window->m_width) *
-                 static_cast<size_t>(window->m_height) * 4);
-  }
-
-  if (!buffer) {
-    FML_LOG(ERROR) << (!callback
-                           ? "Failed to create the first buffer."
-                           : "Both buffers busy at redraw(). Server bug?");
-    exit(EXIT_FAILURE);
-  }
-
-  switch (window->m_type) {
-    case WINDOW_NORMAL:
-    case WINDOW_BOTTOM:
-      paint_pixels_bottom(buffer->shm_data, 0, window->m_width,
-                          window->m_height, time);
-      break;
-    case WINDOW_TOP:
-      paint_pixels_top(buffer->shm_data, 0, window->m_width, window->m_height,
-                       time);
-      break;
-    case WINDOW_BG:
-      paint_pixels(buffer->shm_data, 20, window->m_width, window->m_height,
-                   time);
-      break;
-    default:
-      FML_LOG(ERROR) << "Missing Window Type";
-  }
-
-  wl_surface_attach(window->m_surface, buffer->buffer, 0, 0);
-  wl_surface_damage(window->m_surface, 0, 0, window->m_width, window->m_height);
 
   if (callback)
     wl_callback_destroy(callback);
 
   window->m_callback = wl_surface_frame(window->m_surface);
   wl_callback_add_listener(window->m_callback, &frame_listener, window);
-  wl_surface_commit(window->m_surface);
 
-  buffer->busy = 1;
+  window->m_fps_counter++;
+  window->m_fps_counter++;
+}
+
+uint32_t EglWindow::GetFpsCounter() {
+  uint32_t fps_counter = m_fps_counter;
+  m_fps_counter = 0;
+
+  return fps_counter;
 }
 
 const struct wl_callback_listener EglWindow::frame_listener = {redraw};
@@ -493,8 +462,6 @@ const struct wl_callback_listener EglWindow::frame_listener = {redraw};
   return nullptr;
 }
 void EglWindow::toggle_fullscreen() {
-  struct wl_callback* callback;
-
   if (m_fullscreen) {
     wl_shell_surface_set_fullscreen(m_shell_surface,
                                     WL_SHELL_SURFACE_FULLSCREEN_METHOD_SCALE,
@@ -504,10 +471,57 @@ void EglWindow::toggle_fullscreen() {
     handle_shell_configure(this, m_shell_surface, 0, m_width, m_height);
   }
 
-  callback = wl_display_sync(m_display->GetDisplay());
-  wl_callback_add_listener(callback, &shell_configure_callback_listener, this);
+  wl_callback_add_listener(wl_display_sync(m_display->GetDisplay()),
+                           &shell_configure_callback_listener, this);
 }
 
 bool EglWindow::ActivateSystemCursor(int32_t device, const std::string& kind) {
   return m_display->ActivateSystemCursor(device, kind);
+}
+
+void EglWindow::DrawFps(uint8_t fps) {
+  const int bars = 20;
+  const int bar_w = 10;
+  const int bar_space = 2;
+  const int surface_w = bars * (bar_w + bar_space) - bar_space;
+  const int surface_h = 150;
+  int x, y;
+
+  // update fps array
+  m_fps[m_fps_idx] = fps;
+  m_fps_idx = (m_fps_idx + 1) % bars;
+
+  // create buffer
+  if (!m_fps_buffer.buffer) {
+    create_shm_buffer(m_display.get(), &m_fps_buffer, surface_w, surface_h,
+                      WL_SHM_FORMAT_XRGB8888);
+  }
+  memset(m_fps_buffer.shm_data, 0x00,
+         static_cast<size_t>(surface_w) * static_cast<size_t>(surface_h) * 4);
+
+  // draw bar
+  [[maybe_unused]] auto pixels =
+      reinterpret_cast<uint32_t*>(m_fps_buffer.shm_data);
+
+  for (int i = 0; i < bars; i++) {
+    [[maybe_unused]] auto p =
+        std::clamp(m_fps[(m_fps_idx + i) % bars] / 60.0, 0.0, 1.0);
+    int draw_y = surface_h * (1.0 - p);
+    int draw_x = i * (bar_w + bar_space);
+
+    if (draw_y < 0)
+      draw_y = 0;
+
+    for (y = draw_y; y < surface_h; y++) {
+      for (x = draw_x; x < draw_x + bar_w; x++) {
+        pixels[y * surface_w + x] = 0xFF << 24 | (int)(0xFF * (1.0 - p)) << 16 |
+                                    (int)(0xFF * p) << 8 | 0x00 << 0;
+      }
+    }
+  }
+
+  // commit buffer
+  wl_surface_attach(m_fps_surface, m_fps_buffer.buffer, 0, 0);
+  wl_surface_damage(m_fps_surface, 0, 0, surface_w, surface_h);
+  wl_surface_commit(m_fps_surface);
 }

--- a/shell/egl_window.h
+++ b/shell/egl_window.h
@@ -54,7 +54,12 @@ class EglWindow : public Egl {
   [[nodiscard]] int32_t GetWidth() const { return m_width; }
   [[nodiscard]] int32_t GetHeight() const { return m_height; }
 
+  uint32_t GetFpsCounter();
+  void DrawFps(uint8_t fps);
+
   bool ActivateSystemCursor(int32_t device, const std::string& kind);
+
+  uint32_t m_fps_counter;
 
  private:
   struct shm_buffer {
@@ -77,6 +82,12 @@ class EglWindow : public Egl {
   bool m_sprawl;
   enum window_type m_type;
   std::string m_app_id;
+
+  struct wl_surface* m_fps_surface;
+  struct wl_subsurface* m_subsurface;
+  struct shm_buffer m_fps_buffer;
+  uint8_t m_fps_idx;
+  uint8_t m_fps[20];
 
   struct shm_buffer m_buffers[2]{};
   struct wl_callback* m_callback;


### PR DESCRIPTION
* Environment variables are used to control
  the ON/OFF and frequency of the fps's output.
* FPS_OUTPUT_CONSOLE - value >0 enables console
* FPS_OUTPUT_OVERLAY - value >0 enables overlay
* FPS_OUTPUT_FREQUENCY - override fps period

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>