### PR TITLE
xdg_shell, multi-output, remove sprawl, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ Copy libflutter_engine.so to `/usr/local/lib` or use LD_LIBRARY_PATH to point do
     export LD_LIBRARY_PATH=`pwd`:$LD_LIBRARY_PATH
     homescreen
 
+## FPS
+Three environmental variables impact FPS reporting.
+
+### 1. FPS_OUTPUT_CONSOLE
+
+Setting `FPS_OUTPUT_CONSOLE` to "1" will output FPS count to console.
+
+### 2. FPS_OUTPUT_OVERLAY
+
+If `FPS_OUTPUT_CONSOLE=1` and `FPS_OUTPUT_OVERLAY=1` the screen overlay is enabled.
+
+### 3. FPS_OUTPUT_FREQUENCY
+
+Changing `FPS_OUTPUT_FREQUENCY` controls the update interval.  This parameter is optional.
+
 ## Debug
 
 cd to flutter app folder

--- a/README.md
+++ b/README.md
@@ -125,11 +125,7 @@ Changing `FPS_OUTPUT_FREQUENCY` controls the update interval.  This parameter is
 
 ## Debug
 
-cd to flutter app folder
-
-    flutter config --enable-linux-desktop
-    flutter create .
-    flutter attach --debug-port 41795 --host-vmservice-port 41795
+Setup custom devices to control ivi-homescreen via debugger. 
 
 # CMAKE dependency paths
 

--- a/cmake/wayland.cmake
+++ b/cmake/wayland.cmake
@@ -37,3 +37,6 @@ set(WAYLAND_PROTOCOL_SOURCES)
 wayland_generate(
         ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/agl/protocol/agl-shell.xml
         ${CMAKE_CURRENT_BINARY_DIR}/agl-shell-client-protocol)
+wayland_generate(
+        ${WAYLAND_PROTOCOLS_BASE}/stable/xdg-shell/xdg-shell.xml
+        ${CMAKE_CURRENT_BINARY_DIR}/xdg-shell-client-protocol)

--- a/cmake/wayland.cmake
+++ b/cmake/wayland.cmake
@@ -37,6 +37,3 @@ set(WAYLAND_PROTOCOL_SOURCES)
 wayland_generate(
         ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/agl/protocol/agl-shell.xml
         ${CMAKE_CURRENT_BINARY_DIR}/agl-shell-client-protocol)
-wayland_generate(
-        ${WAYLAND_PROTOCOLS_BASE}/unstable/pointer-gestures/pointer-gestures-unstable-v1.xml
-        ${CMAKE_CURRENT_BINARY_DIR}/pointer-gestures-unstable-v1-protocol)

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -107,8 +107,9 @@ App::App(const std::string& app_id,
   m_fps_counter = 0;
 
   const char* envstr_console;
+  char* pEnd;
   if ((envstr_console = getenv("FPS_OUTPUT_CONSOLE")) != nullptr) {
-    int val = atoi(envstr_console);
+    long val = strtol(envstr_console, &pEnd, 10);
 
     if (0 < val) {
       m_fps_output |= 0x01;
@@ -117,7 +118,7 @@ App::App(const std::string& app_id,
 
   const char* envstr_overlay;
   if ((envstr_overlay = getenv("FPS_OUTPUT_OVERLAY")) != nullptr) {
-    int val = atoi(envstr_overlay);
+    long val = strtol(envstr_overlay, &pEnd, 10);
 
     if (0 < val) {
       m_fps_output |= 0x02;
@@ -126,7 +127,7 @@ App::App(const std::string& app_id,
 
   const char* envstr_freq;
   if ((envstr_freq = getenv("FPS_OUTPUT_FREQUENCY")) != nullptr) {
-    int val = atoi(envstr_freq);
+    long val = strtol(envstr_freq, &pEnd, 10);
 
     if (0 < val) {
       m_fps_period = val;

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -67,17 +67,17 @@ App::App(const std::string& app_id,
   }
 
   for (size_t i = 0; i < kEngineInstanceCount; i++) {
-    m_engine[i] = std::make_shared<Engine>(this, i, m_command_line_args_c,
+    m_flutter_engine[i] = std::make_shared<Engine>(this, i, m_command_line_args_c,
                                            application_override_path);
-    m_engine[i]->Run(pthread_self());
+    m_flutter_engine[i]->Run(pthread_self());
 
-    if (!m_engine[i]->IsRunning()) {
+    if (!m_flutter_engine[i]->IsRunning()) {
       FML_LOG(ERROR) << "Failed to Run Engine";
       exit(-1);
     }
 
     // Set Flutter Window Size
-    auto result = m_engine[i]->SetWindowSize(m_egl_window[i]->GetHeight(),
+    auto result = m_flutter_engine[i]->SetWindowSize(m_egl_window[i]->GetHeight(),
                                              m_egl_window[i]->GetWidth());
     if (result != kSuccess) {
       FML_LOG(ERROR) << "Failed to set Flutter Engine Window Size";
@@ -87,13 +87,13 @@ App::App(const std::string& app_id,
   }
 
   // Enable pointer events
-  m_display->SetEngine(m_engine[0]);
+  m_display->SetEngine(m_flutter_engine[0]);
 
 #ifdef ENABLE_TEXTURE_TEST
-  m_texture_test->SetEngine(m_engine[0]);
+  m_texture_test->SetEngine(m_flutter_engine[0]);
 #endif
 #ifdef ENABLE_PLUGIN_TEXT_INPUT
-  m_text_input->SetEngine(m_engine[0]);
+  m_text_input->SetEngine(m_flutter_engine[0]);
   m_display->SetTextInput(m_text_input);
 #endif
 
@@ -151,7 +151,7 @@ int App::Loop() {
                         std::chrono::steady_clock::now().time_since_epoch())
                         .count();
 
-  for (auto& i : m_engine) {
+  for (auto& i : m_flutter_engine) {
     i->RunTask();
   }
 

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -89,6 +89,9 @@ App::App(const std::string& app_id,
   // Enable pointer events
   m_display->SetEngine(m_flutter_engine[0]);
 
+  // Buffer Scaling
+  m_display->SetSurface(m_egl_window[0]->GetNativeSurface());
+
 #ifdef ENABLE_TEXTURE_TEST
   m_texture_test->SetEngine(m_flutter_engine[0]);
 #endif

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -31,7 +31,6 @@ App::App(const std::string& app_id,
          bool fullscreen,
          bool enable_cursor,
          bool debug_egl,
-         bool sprawl,
          uint32_t width,
          uint32_t height,
          const std::string& cursor_theme_name)
@@ -44,7 +43,6 @@ App::App(const std::string& app_id,
                                                app_id,
                                                fullscreen,
                                                debug_egl,
-                                               sprawl,
                                                width,
                                                height)}
 #ifdef ENABLE_TEXTURE_TEST

--- a/shell/app.h
+++ b/shell/app.h
@@ -58,7 +58,6 @@ class App {
                bool fullscreen,
                bool enable_cursor,
                bool debug_egl,
-               bool sprawl,
                uint32_t width,
                uint32_t height,
                const std::string& cursor_theme_name);

--- a/shell/app.h
+++ b/shell/app.h
@@ -43,7 +43,7 @@ class App {
   uint8_t m_fps_output;
   uint32_t m_fps_period;
   uint32_t m_fps_counter;
-  int32_t m_fps_pretime;
+  long long m_fps_pretime;
 #ifdef ENABLE_TEXTURE_TEST
   std::unique_ptr<TextureTest> m_texture_test;
 #endif

--- a/shell/app.h
+++ b/shell/app.h
@@ -39,7 +39,7 @@ class App {
   std::shared_ptr<GlResolver> m_gl_resolver;
   std::shared_ptr<Display> m_display;
   std::shared_ptr<EglWindow> m_egl_window[kEngineInstanceCount];
-  std::shared_ptr<Engine> m_engine[kEngineInstanceCount];
+  std::shared_ptr<Engine> m_flutter_engine[kEngineInstanceCount];
   uint8_t m_fps_output;
   uint32_t m_fps_period;
   uint32_t m_fps_counter;

--- a/shell/display.cc
+++ b/shell/display.cc
@@ -167,11 +167,6 @@ void Display::registry_handle_global(void* data,
     wl_seat_add_listener(d->m_seat, &seat_listener, d);
   }
 
-  else if (strcmp(interface, zwp_pointer_gestures_v1_interface.name) == 0) {
-    d->m_gestures = static_cast<zwp_pointer_gestures_v1*>(wl_registry_bind(
-        registry, name, &zwp_pointer_gestures_v1_interface, 1));
-  }
-
   else if (strcmp(interface, agl_shell_interface.name) == 0) {
     d->m_agl_shell = static_cast<struct agl_shell*>(
         wl_registry_bind(registry, name, &agl_shell_interface, 1));
@@ -648,52 +643,6 @@ const struct wl_touch_listener Display::touch_listener = {
     .motion = touch_handle_motion,
     .frame = touch_handle_frame,
     .cancel = touch_handle_cancel,
-};
-
-void Display::gesture_pinch_begin(
-    [[maybe_unused]] void* data,
-    [[maybe_unused]] struct zwp_pointer_gesture_pinch_v1*
-        zwp_pointer_gesture_pinch_v1,
-    [[maybe_unused]] uint32_t serial,
-    [[maybe_unused]] uint32_t time,
-    [[maybe_unused]] struct wl_surface* surface,
-    [[maybe_unused]] uint32_t fingers) {
-  //  FML_DLOG(INFO) << "gesture_pinch_begin: fingers: " << fingers;
-}
-
-void Display::gesture_pinch_update(
-    [[maybe_unused]] void* data,
-    [[maybe_unused]] struct zwp_pointer_gesture_pinch_v1*
-        zwp_pointer_gesture_pinch_v1,
-    [[maybe_unused]] uint32_t time,
-    [[maybe_unused]] wl_fixed_t dx,
-    [[maybe_unused]] wl_fixed_t dy,
-    [[maybe_unused]] wl_fixed_t scale,
-    [[maybe_unused]] wl_fixed_t rotation) {
-#if 0
-  FML_DLOG(INFO) << "gesture_pinch_update: " << wl_fixed_to_double(dx) << ", "
-                 << wl_fixed_to_double(dy)
-                 << " scale: " << wl_fixed_to_double(scale)
-                 << ", rotation: " << wl_fixed_to_double(rotation);
-#endif
-}
-
-void Display::gesture_pinch_end(
-    [[maybe_unused]] void* data,
-    [[maybe_unused]] struct zwp_pointer_gesture_pinch_v1*
-        zwp_pointer_gesture_pinch_v1,
-    [[maybe_unused]] uint32_t serial,
-    [[maybe_unused]] uint32_t time,
-    [[maybe_unused]] int32_t cancelled) {
-  //  FML_DLOG(INFO) << "gesture_pinch_end";
-  //  FML_DLOG(INFO) << "gesture_pinch_begin: cancelled: " << cancelled;
-}
-
-[[maybe_unused]] const struct zwp_pointer_gesture_pinch_v1_listener
-    Display::gesture_pinch_listener = {
-        .begin = gesture_pinch_begin,
-        .update = gesture_pinch_update,
-        .end = gesture_pinch_end,
 };
 
 [[maybe_unused]] void Display::AglShellDoBackground(

--- a/shell/display.h
+++ b/shell/display.h
@@ -74,6 +74,8 @@ class Display {
 
   void SetEngine(std::shared_ptr<Engine> engine);
 
+  void SetSurface(wl_surface* surface);
+
   bool ActivateSystemCursor([[maybe_unused]] int32_t device,
                             const std::string& kind);
 
@@ -91,11 +93,11 @@ class Display {
 
   struct wl_display* m_display;
   struct wl_registry* m_registry;
-  struct wl_output* m_output;
   struct wl_compositor* m_compositor;
   struct wl_subcompositor* m_subcompositor;
   struct wl_shell* m_shell{};
   struct wl_shm* m_shm{};
+  struct wl_surface* m_surface{};
 
   struct wl_seat* m_seat{};
   struct wl_keyboard* m_keyboard;
@@ -166,30 +168,24 @@ class Display {
 
   std::shared_ptr<TextInput> m_text_input{};
 
-  struct info {
-    struct {
-      int32_t x;
-      int32_t y;
-      int32_t physical_width;
-      int32_t physical_height;
-      int32_t size;
-      int32_t subpixel;
-      std::string make;
-      std::string model;
-      int32_t transform;
-    } geometry;
+  typedef struct output_info {
+    struct wl_output* output;
+    uint32_t global_id;
+    unsigned width;
+    unsigned height;
+    unsigned physical_width;
+    unsigned physical_height;
+    int refresh_rate;
+    int32_t scale;
+    bool done;
+  } output_info_t;
 
-    struct {
-      int32_t width;
-      int32_t height;
-      double dots_per_in;
-    } mode{};
+  std::vector<std::shared_ptr<output_info_t>> m_all_outputs;
+  output_info_t* m_current_output{};
+  int32_t m_last_buffer_scale;
+  int32_t m_buffer_scale;
 
-    struct {
-      int32_t scale;
-    } scale{};
-
-  } m_info;
+  static void dump_output(output_info_t* output);
 
   static const struct wl_registry_listener registry_listener;
 
@@ -232,6 +228,12 @@ class Display {
   static void wl_output_configure_callback(void* data,
                                            wl_callback* wl_callback,
                                            uint32_t time);
+
+  static const struct wl_surface_listener primary_surface_listener;
+
+  static void handle_primary_surface_enter(void* data,
+                                           struct wl_surface* wl_surface,
+                                           struct wl_output* output);
 
   static const struct wl_shm_listener shm_listener;
 

--- a/shell/display.h
+++ b/shell/display.h
@@ -67,13 +67,6 @@ class Display {
     return m_shm;
   }
 
-  [[maybe_unused]] [[nodiscard]] int32_t GetModeWidth() const {
-    return m_info.mode.width;
-  }
-  [[maybe_unused]] [[nodiscard]] int32_t GetModeHeight() const {
-    return m_info.mode.height;
-  }
-
   [[maybe_unused]] void AglShellDoBackground(struct wl_surface*);
   [[maybe_unused]] void AglShellDoPanel(struct wl_surface*,
                                         enum agl_shell_edge mode);
@@ -109,7 +102,6 @@ class Display {
 
   struct agl_shell* m_agl_shell;
 
-  bool m_has_xrgb;
 
   bool m_enable_cursor;
   struct wl_surface* m_cursor_surface;
@@ -233,7 +225,7 @@ class Display {
                                    int scale);
   static void display_handle_done(void* data, struct wl_output* wl_output);
 
-  bool m_is_configured;
+  bool m_is_configured{};
 
   static const struct wl_callback_listener configure_callback_listener;
 

--- a/shell/display.h
+++ b/shell/display.h
@@ -29,7 +29,6 @@
 
 #include "agl-shell-client-protocol.h"
 #include "constants.h"
-#include "pointer-gestures-unstable-v1-protocol.h"
 #include "static_plugins/text_input/text_input.h"
 
 class App;
@@ -168,9 +167,6 @@ class Display {
 
   // for cursor
   struct wl_cursor_theme* m_cursor_theme{};
-
-  [[maybe_unused]] struct zwp_pointer_gestures_v1* m_gestures{};
-  [[maybe_unused]] struct zwp_pointer_gesture_swipe_v1* m_pointer_swipe{};
 
   struct xkb_context* m_xkb_context;
   struct xkb_keymap* m_keymap;
@@ -354,31 +350,4 @@ class Display {
   static void touch_handle_frame(void* data, struct wl_touch* wl_touch);
 
   static const struct wl_touch_listener touch_listener;
-
-  static void gesture_pinch_begin(
-      void* data,
-      struct zwp_pointer_gesture_pinch_v1* zwp_pointer_gesture_pinch_v1,
-      uint32_t serial,
-      uint32_t time,
-      struct wl_surface* surface,
-      uint32_t fingers);
-
-  static void gesture_pinch_update(
-      void* data,
-      struct zwp_pointer_gesture_pinch_v1* zwp_pointer_gesture_pinch_v1,
-      uint32_t time,
-      wl_fixed_t dx,
-      wl_fixed_t dy,
-      wl_fixed_t scale,
-      wl_fixed_t rotation);
-
-  static void gesture_pinch_end(
-      void* data,
-      struct zwp_pointer_gesture_pinch_v1* zwp_pointer_gesture_pinch_v1,
-      uint32_t serial,
-      uint32_t time,
-      int32_t cancelled);
-
-  [[maybe_unused]] static const struct zwp_pointer_gesture_pinch_v1_listener
-      gesture_pinch_listener;
 };

--- a/shell/egl_window.cc
+++ b/shell/egl_window.cc
@@ -32,7 +32,6 @@ EglWindow::EglWindow(size_t index,
                      std::string app_id,
                      bool fullscreen,
                      bool debug_egl,
-                     bool sprawl,
                      int32_t width,
                      int32_t height)
     : Egl(display->GetDisplay(), debug_egl),
@@ -45,7 +44,6 @@ EglWindow::EglWindow(size_t index,
       m_callback(nullptr),
       m_configured(false),
       m_fullscreen(fullscreen),
-      m_sprawl(sprawl),
       m_frame_sync(0) {  // disable vsync
   FML_DLOG(INFO) << "+ EglWindow()";
 
@@ -67,12 +65,6 @@ EglWindow::EglWindow(size_t index,
 
   m_display->WaitForConfig();
 
-  m_width = (m_sprawl && m_display->GetModeWidth() > 0)
-                ? m_display->GetModeWidth()
-                : width;
-  m_height = (m_sprawl && m_display->GetModeHeight() > 0)
-                 ? m_display->GetModeHeight()
-                 : height;
 
   m_egl_window[index] = wl_egl_window_create(m_surface, m_width, m_height);
 

--- a/shell/egl_window.h
+++ b/shell/egl_window.h
@@ -25,8 +25,16 @@
 #include "constants.h"
 
 #include "egl.h"
+#include "xdg-shell-client-protocol.h"
+
+// workaround for Wayland macro not compiling in C++
+#define WL_ARRAY_FOR_EACH(pos, array, type)                             \
+  for (pos = (type)(array)->data;                                       \
+       (const char*)pos < ((const char*)(array)->data + (array)->size); \
+       (pos)++)
 
 class Display;
+class Engine;
 
 class EglWindow : public Egl {
  public:
@@ -34,6 +42,7 @@ class EglWindow : public Egl {
 
   EglWindow(size_t index,
             const std::shared_ptr<Display>& display,
+            struct wl_surface* base_surface,
             enum window_type type,
             std::string app_id,
             bool fullscreen,
@@ -44,14 +53,9 @@ class EglWindow : public Egl {
   EglWindow(const EglWindow&) = delete;
   const EglWindow& operator=(const EglWindow&) = delete;
 
-  [[nodiscard]] wl_surface* GetNativeSurface() const { return m_surface; }
+  void SetEngine(const std::shared_ptr<Engine>& engine);
 
-  [[maybe_unused]] [[nodiscard]] bool SurfaceConfigured() const {
-    return m_configured;
-  };
-
-  [[nodiscard]] int32_t GetWidth() const { return m_width; }
-  [[nodiscard]] int32_t GetHeight() const { return m_height; }
+  wl_surface* GetNativeSurface() { return m_base_surface; }
 
   uint32_t GetFpsCounter();
   void DrawFps(uint8_t fps);
@@ -69,18 +73,29 @@ class EglWindow : public Egl {
 
   size_t m_index;
   std::shared_ptr<Display> m_display;
-
-  struct wl_surface* m_surface;
-  struct wl_shell_surface* m_shell_surface;
+  std::shared_ptr<Engine> m_flutter_engine;
+  struct wl_surface* m_base_surface;
   wl_egl_window* m_egl_window[kEngineInstanceCount]{};
 
-  int32_t m_width;
-  int32_t m_height;
+  bool m_fullscreen{};
+  bool m_maximized{};
+  bool m_resize{};
+  bool m_activated{};
+  bool m_running{};
+  struct {
+    int32_t width;
+    int32_t height;
+  } m_geometry;
+  struct {
+    int32_t width;
+    int32_t height;
+  } m_window_size{};
 
-  bool m_fullscreen;
   enum window_type m_type;
   std::string m_app_id;
 
+  struct xdg_surface* m_xdg_surface;
+  struct xdg_toplevel* m_xdg_toplevel;
   struct wl_surface* m_fps_surface;
   struct wl_subsurface* m_subsurface;
   struct shm_buffer m_fps_buffer {};
@@ -89,11 +104,8 @@ class EglWindow : public Egl {
 
   struct shm_buffer m_buffers[2]{};
   struct wl_callback* m_callback;
-  bool m_configured;
 
   int m_frame_sync;
-
-  void toggle_fullscreen();
 
   static void buffer_release(void* data,
                              [[maybe_unused]] struct wl_buffer* buffer);
@@ -106,26 +118,22 @@ class EglWindow : public Egl {
                                int height,
                                uint32_t format);
 
-  static void handle_shell_ping(void* data,
-                                struct wl_shell_surface* shell_surface,
-                                uint32_t serial);
+  static const struct xdg_surface_listener xdg_surface_listener;
 
-  static void handle_shell_configure(void* data,
-                                     struct wl_shell_surface* shell_surface,
-                                     uint32_t edges,
-                                     int32_t width,
-                                     int32_t height);
+  static void handle_xdg_surface_configure(void* data,
+                                           struct xdg_surface* xdg_surface,
+                                           uint32_t serial);
 
-  static void handle_shell_popup_done(void* data,
-                                      struct wl_shell_surface* shell_surface);
+  static const struct xdg_toplevel_listener xdg_toplevel_listener;
 
-  static const struct wl_shell_surface_listener shell_surface_listener;
+  static void handle_toplevel_configure(void* data,
+                                        struct xdg_toplevel* toplevel,
+                                        int32_t width,
+                                        int32_t height,
+                                        struct wl_array* states);
 
-  static void handle_shell_configure_callback(void* data,
-                                              struct wl_callback* callback,
-                                              uint32_t time);
-
-  static const struct wl_callback_listener shell_configure_callback_listener;
+  static void handle_toplevel_close(void* data,
+                                    struct xdg_toplevel* xdg_toplevel);
 
   [[maybe_unused]] static struct shm_buffer* next_buffer(EglWindow* window);
 

--- a/shell/egl_window.h
+++ b/shell/egl_window.h
@@ -38,7 +38,6 @@ class EglWindow : public Egl {
             std::string app_id,
             bool fullscreen,
             bool debug_egl,
-            bool sprawl,
             int32_t width,
             int32_t height);
   ~EglWindow();
@@ -79,7 +78,6 @@ class EglWindow : public Egl {
   int32_t m_height;
 
   bool m_fullscreen;
-  bool m_sprawl;
   enum window_type m_type;
   std::string m_app_id;
 

--- a/shell/egl_window.h
+++ b/shell/egl_window.h
@@ -83,9 +83,9 @@ class EglWindow : public Egl {
 
   struct wl_surface* m_fps_surface;
   struct wl_subsurface* m_subsurface;
-  struct shm_buffer m_fps_buffer;
+  struct shm_buffer m_fps_buffer {};
   uint8_t m_fps_idx;
-  uint8_t m_fps[20];
+  uint8_t m_fps[20]{};
 
   struct shm_buffer m_buffers[2]{};
   struct wl_callback* m_callback;
@@ -128,24 +128,6 @@ class EglWindow : public Egl {
   static const struct wl_callback_listener shell_configure_callback_listener;
 
   [[maybe_unused]] static struct shm_buffer* next_buffer(EglWindow* window);
-
-  static void paint_pixels_top(void* image,
-                               int padding,
-                               int width,
-                               int height,
-                               uint32_t time);
-
-  static void paint_pixels_bottom(void* image,
-                                  int padding,
-                                  int width,
-                                  int height,
-                                  uint32_t time);
-
-  static void paint_pixels(void* image,
-                           int padding,
-                           int width,
-                           int height,
-                           uint32_t time);
 
   static void redraw(void* data, struct wl_callback* callback, uint32_t time);
 

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -574,7 +574,7 @@ bool Engine::ActivateSystemCursor(int32_t device, const std::string& kind) {
 [[maybe_unused]] void Engine::SetTextInput(TextInput* text_input) {
   m_text_input = text_input;
 }
-[[maybe_unused]] TextInput* Engine::GetTextInput() {
+[[maybe_unused]] TextInput* Engine::GetTextInput() const {
   return m_text_input;
-};
+}
 #endif

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -122,9 +122,9 @@ class Engine {
   std::string GetAssetDirectory() { return m_assets_path; }
 
 #if ENABLE_PLUGIN_TEXT_INPUT
-  TextInput* m_text_input;
+  TextInput* m_text_input{};
   [[maybe_unused]] void SetTextInput(TextInput *text_input);
-  [[maybe_unused]] TextInput *GetTextInput();
+  [[maybe_unused]] TextInput *GetTextInput() const;
 #endif
 
  private:

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -39,7 +39,6 @@ int main(int argc, char** argv) {
   bool disable_cursor = false;
   bool debug_egl = false;
   bool fullscreen = false;
-  bool sprawl = false;
   uint32_t width = 0;
   uint32_t height = 0;
 
@@ -125,14 +124,6 @@ int main(int argc, char** argv) {
         args.erase(result);
       }
     }
-    if (cl.HasOption("S")) {
-      FML_DLOG(INFO) << "Sprawl";
-      sprawl = true;
-      auto result = std::find(args.begin(), args.end(), "--S");
-      if (result != args.end()) {
-        args.erase(result);
-      }
-    }
   }
   if (!width) {
     width = kScreenWidth;
@@ -144,7 +135,7 @@ int main(int argc, char** argv) {
   FML_DLOG(INFO) << "Screen Height: " << height;
 
   App app("homescreen", args, application_override_path, fullscreen,
-          !disable_cursor, debug_egl, sprawl, width, height, cursor_theme);
+          !disable_cursor, debug_egl, width, height, cursor_theme);
 
   std::signal(SIGINT, SignalHandler);
 


### PR DESCRIPTION
xdg_shell
-replaces wl_shell for xdg_shell

Multiple outputs
-Adds support for saving state on multiple outputs
-Enables deriving the buffer scaling factor

Cleanup
-Remove unused methods/variables
-Remove unused headers
-Initialize uninitialize variables
-rename m_engine to m_flutter_engine in App class

Remove sprawl option
-Not required with xdg_shell

Update README.md
-Enabling flutter desktop causes App build issue.
 This has been the case for some time.
 Only use custom devices for debugging eLinux Flutter.

FPS feature cleanup
-Fix narrowing warnings
-Update README for usage

Remove pinch gesture references
-Dart layer gesture detection being used.
 Not all targets have this protocol
