### PR TITLE
Simplify wayland mouse input translation

### DIFF
--- a/shell/display.h
+++ b/shell/display.h
@@ -126,7 +126,6 @@ class Display {
 
     uint32_t buttons;
     uint32_t state;
-    FlutterPointerPhase phase;
   } m_pointer{};
 
   struct touch_point {
@@ -239,7 +238,7 @@ class Display {
                                struct wl_seat* seat,
                                const char *name);
 
-  static FlutterPointerPhase getPointerPhase(struct pointer* p);
+  static bool pointerButtonStatePressed(struct pointer* p);
 
   static void pointer_handle_enter(void* data,
                                    struct wl_pointer* pointer,


### PR DESCRIPTION
Addressing issue described in #56  and simplifying the previous wayland mouse input events to flutter pointer events translation in ivi-homescreen:

Sanity checked implementation here against the official flutter linux shell's mouse input handling for motion, scrolling and button events. The relevant analogous code sections are linked below:

Motion:
https://github.com/flutter/engine/blob/main/shell/platform/linux/fl_view.cc#L371-L372
motion events are either kMove or KHover, matching linux desktop:
https://github.com/flutter/engine/blob/main/shell/platform/linux/fl_view.cc#L383

Scrolling (Axis in wayland):
https://github.com/flutter/engine/blob/main/shell/platform/linux/fl_scrolling_manager.cc#L67
Notice that for scrolling events the pointer phase is disregarded and kMove is chosen arbitrarily based on this comment
https://github.com/flutter/engine/blob/main/shell/platform/linux/fl_scrolling_manager.cc#L122-L123

Button:
https://github.com/flutter/engine/blob/main/shell/platform/linux/fl_view.cc#L114-L115
Currently this PR does not drop redundant events but perhaps it should try to mimic such behavior.  Another difference is that this PR does not keep track of previous button state and so only sends kUp or kDown events for button events, never kMove or KHover, it's unclear to me if this should behavior should be copied or not.
https://github.com/flutter/engine/blob/main/shell/platform/linux/fl_view.cc#L130-L148

Tested this PR manually on the default flutter increment button app which no longer crashes with debug assertions described in Issue #56.