### PR TITLE
libflutter_engine.so 3.x segfault issue

### DIFF
--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -138,7 +138,7 @@ Engine::Engine(App* app,
            }}) {
   FML_DLOG(INFO) << "(" << m_index << ") +Engine::Engine";
 
-  m_engine_so_handle = dlopen("libflutter_engine.so", RTLD_LAZY);
+  m_engine_so_handle = dlopen("libflutter_engine.so", RTLD_LAZY|RTLD_DEEPBIND);
   if (!m_engine_so_handle) {
     FML_DLOG(ERROR) << dlerror();
     exit(-1);


### PR DESCRIPTION
-dlopen was loading libflutter_engine.so with only RTLD_LAZY.
 GStreamer loaded prior to libflutter_engine.so
 Setting libflutter_engine.so to use RTLD_DEEPBIND resolves the issue.

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>