### PR TITLE
Enable pixel_ratio arg from CLI

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -33,6 +33,7 @@ App::App(const std::string& app_id,
          bool debug_egl,
          uint32_t width,
          uint32_t height,
+         double pixel_ratio,
          const std::string& cursor_theme_name)
     : m_gl_resolver(std::make_shared<GlResolver>()),
       m_display(
@@ -67,6 +68,7 @@ App::App(const std::string& app_id,
 
   for (size_t i = 0; i < kEngineInstanceCount; i++) {
     m_flutter_engine[i] = std::make_shared<Engine>(this, i,
+                                                   pixel_ratio,
                                                    m_command_line_args_c,
                                            application_override_path);
     m_flutter_engine[i]->Run(pthread_self());

--- a/shell/app.h
+++ b/shell/app.h
@@ -60,6 +60,7 @@ class App {
                bool debug_egl,
                uint32_t width,
                uint32_t height,
+               double pixel_ratio,
                const std::string& cursor_theme_name);
   App(const App&) = delete;
   const App& operator=(const App&) = delete;

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -49,9 +49,11 @@ static bool IsFile(const std::string& path) {
 
 Engine::Engine(App* app,
                size_t index,
+               double pixel_ratio,
                const std::vector<const char*>& command_line_args_c,
                const std::string& application_override_path)
     : m_index(index),
+      m_pixel_ratio(pixel_ratio),
       m_running(false),
       m_egl_window(app->GetEglWindow(index)),
       m_gl_resolver(app->GetGlResolver()),
@@ -333,7 +335,7 @@ FlutterEngineResult Engine::SetWindowSize(size_t height, size_t width) {
   FlutterWindowMetricsEvent fwme = {.struct_size = sizeof(fwme),
                                     .width = width,
                                     .height = height,
-                                    .pixel_ratio = 1.0};
+                                    .pixel_ratio = m_pixel_ratio};
 
   auto result = m_proc_table.SendWindowMetricsEvent(m_flutter_engine, &fwme);
   if (result != kSuccess) {

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -45,6 +45,7 @@ class Engine {
  public:
   Engine(App* app,
          size_t index,
+         double pixel_ratio,
          const std::vector<const char*>& command_line_args_c,
          const std::string& application_override_path);
 
@@ -129,6 +130,7 @@ class Engine {
 
  private:
   size_t m_index;
+  double m_pixel_ratio;
   bool m_running;
 
   std::shared_ptr<EglWindow> m_egl_window;

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -41,6 +41,7 @@ int main(int argc, char** argv) {
   bool fullscreen = false;
   uint32_t width = 0;
   uint32_t height = 0;
+  double pixel_ratio = 1.0;
 
   auto cl = fml::CommandLineFromArgcArgv(argc, argv);
 
@@ -111,6 +112,20 @@ int main(int argc, char** argv) {
         args.erase(result);
       }
     }
+    if (cl.HasOption("r")) {
+      std::string pixel_ratio_str;
+      cl.GetOptionValue("r", &pixel_ratio_str);
+      if (pixel_ratio_str.empty()) {
+        FML_LOG(ERROR) << "--r option requires an argument (e.g. --r=2.0)";
+        return 1;
+      }
+      pixel_ratio = static_cast<double>(std::stod(pixel_ratio_str));
+      auto find = "--r=" + pixel_ratio_str;
+      auto result = std::find(args.begin(), args.end(), find);
+      if (result != args.end()) {
+        args.erase(result);
+      }
+    }
     if (cl.HasOption("t")) {
       cl.GetOptionValue("t", &cursor_theme);
       if (cursor_theme.empty()) {
@@ -135,7 +150,8 @@ int main(int argc, char** argv) {
   FML_DLOG(INFO) << "Screen Height: " << height;
 
   App app("homescreen", args, application_override_path, fullscreen,
-          !disable_cursor, debug_egl, width, height, cursor_theme);
+          !disable_cursor, debug_egl, width, height, pixel_ratio,
+          cursor_theme);
 
   std::signal(SIGINT, SignalHandler);
 


### PR DESCRIPTION
Allows making `pixel_ratio` something other than `1.0` using optional command line arg.

Examples --

```shell
./homescreen --w=640 --h=480 --r=2.0
```

<img width="639" alt="Screen Shot 2022-06-22 at 8 44 03 PM" src="https://user-images.githubusercontent.com/8938879/175189714-a6823052-ac4c-4d07-a249-402888266200.png">

```shell
./homescreen --w=640 --h=480 --r=0.5
```

<img width="641" alt="Screen Shot 2022-06-22 at 8 44 21 PM" src="https://user-images.githubusercontent.com/8938879/175189747-84104686-bb80-4730-9072-cc58c0d2ad73.png">
