### PR TITLE
OpenGL Texture create response

### DIFF
--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -414,7 +414,7 @@ FlutterEngineResult Engine::MarkExternalTextureFrameAvailable(
             engine->m_flutter_engine, texture_id);
 }
 
-int64_t Engine::TextureCreate(int64_t texture_id,
+flutter::EncodableValue Engine::TextureCreate(int64_t texture_id,
                               int32_t width,
                               int32_t height) {
     FML_DLOG(INFO) << "Engine::TextureCreate: <" << texture_id << ">";
@@ -422,10 +422,13 @@ int64_t Engine::TextureCreate(int64_t texture_id,
     auto texture = this->m_texture_registry[texture_id];
 
     if (texture != nullptr) {
-        int64_t id = texture->Create(width, height);
-        return id;
+        return texture->Create(width, height);
     }
-    return -1;
+
+    return flutter::EncodableValue (flutter::EncodableMap{
+        {flutter::EncodableValue("result"), flutter::EncodableValue(-1)},
+        {flutter::EncodableValue("error"), flutter::EncodableValue("Not found in registry")}
+    });
 }
 
 std::string Engine::GetPersistentCachePath() {

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -85,7 +85,7 @@ public:
             const std::shared_ptr<Engine> &engine,
             int64_t texture_id);
 
-    int64_t TextureCreate(int64_t texture_id, int32_t width, int32_t height);
+    flutter::EncodableValue TextureCreate(int64_t texture_id, int32_t width, int32_t height);
 
     FlutterEngineResult TextureDispose(int64_t texture_id);
 

--- a/shell/static_plugins/opengl_texture/opengl_texture.cc
+++ b/shell/static_plugins/opengl_texture/opengl_texture.cc
@@ -50,12 +50,18 @@ void OpenGlTexture::OnPlatformMessage(const FlutterPlatformMessage *message,
                 height = std::get<double>(it->second);
             }
 
-            // cast size to that what Wayland uses
-            textureId = engine->TextureCreate(textureId, static_cast<int32_t>(width),
-                                              static_cast<int32_t>(height));
+            if (0 == textureId || 0 == width || 0 == height) {
+              result = codec.EncodeErrorEnvelope(
+                  "argument_error",
+                  "textureId, width and height must be non-zero");
+            } else {
+              // cast size to that what Wayland uses
+              auto value =
+                  engine->TextureCreate(textureId, static_cast<int32_t>(width),
+                                        static_cast<int32_t>(height));
 
-            flutter::EncodableValue value(textureId);
-            result = codec.EncodeSuccessEnvelope(&value);
+              result = codec.EncodeSuccessEnvelope(&value);
+            }
         } else {
             result = codec.EncodeErrorEnvelope("argument_error", "Invalid Arguments");
         }

--- a/shell/textures/test_egl/texture_test_egl.cc
+++ b/shell/textures/test_egl/texture_test_egl.cc
@@ -30,7 +30,7 @@ TextureTestEgl::TextureTestEgl(App *app)
 
 TextureTestEgl::~TextureTestEgl() = default;
 
-void TextureTestEgl::Create(void *userdata) {
+flutter::EncodableValue TextureTestEgl::Create(void *userdata) {
     auto *obj = reinterpret_cast<TextureTestEgl *>(userdata);
 
     obj->m_egl_backend->MakeTextureCurrent();
@@ -53,6 +53,22 @@ void TextureTestEgl::Create(void *userdata) {
 
     obj->m_initialized = true;
     obj->Enable(textureId);
+
+    return flutter::EncodableValue(flutter::EncodableMap{
+        {flutter::EncodableValue("result"),
+         flutter::EncodableValue(0)},
+        {flutter::EncodableValue("textureId"),
+         flutter::EncodableValue(obj->m_name)},
+        {flutter::EncodableValue("width"),
+         flutter::EncodableValue(obj->m_width)},
+        {flutter::EncodableValue("height"),
+         flutter::EncodableValue(obj->m_height)},
+        {flutter::EncodableValue("GL_target"),
+         flutter::EncodableValue(obj->m_target)},
+        {flutter::EncodableValue("GL_format"),
+         flutter::EncodableValue(obj->m_format)},
+        {flutter::EncodableValue("GL_textureId"),
+         flutter::EncodableValue(textureId)}});
 }
 
 void TextureTestEgl::Dispose(void *userdata) {

--- a/shell/textures/test_egl/texture_test_egl.h
+++ b/shell/textures/test_egl/texture_test_egl.h
@@ -50,7 +50,7 @@ private:
 
     WaylandEglBackend *m_egl_backend;
 
-    static void Create(void *userdata);
+    static flutter::EncodableValue Create(void *userdata);
 
     static void Dispose(void *userdata);
 };

--- a/shell/textures/texture.cc
+++ b/shell/textures/texture.cc
@@ -23,7 +23,7 @@
 Texture::Texture(uint32_t id,
                  uint32_t target,
                  uint32_t format,
-                 VoidCallback create_callback,
+                 EncodableValueCallback create_callback,
                  VoidCallback dispose_callback,
                  int width,
                  int height)
@@ -55,13 +55,17 @@ void Texture::GetFlutterOpenGLTexture(FlutterOpenGLTexture *texture_out,
     m_draw_next = true;
 }
 
-int64_t Texture::Create(int32_t width, int32_t height) {
+flutter::EncodableValue Texture::Create(int32_t width, int32_t height) {
     m_width = width;
     m_height = height;
     if (m_create_callback) {
-        m_create_callback(this);
+        return m_create_callback(this);
     }
-    return m_name;
+
+    return flutter::EncodableValue (flutter::EncodableMap{
+        {flutter::EncodableValue("result"), flutter::EncodableValue(-1)},
+        {flutter::EncodableValue("error"),
+         flutter::EncodableValue("Create callback not set")}});
 }
 
 void Texture::Dispose() {

--- a/shell/textures/texture.h
+++ b/shell/textures/texture.h
@@ -24,15 +24,18 @@
 
 #include <flutter_embedder.h>
 #include "constants.h"
+#include <flutter/encodable_value.h>
 
 class Engine;
+
+typedef flutter::EncodableValue (*EncodableValueCallback)(void* /* user data */);
 
 class Texture {
 public:
     Texture(uint32_t id,
             uint32_t target,
             uint32_t format,
-            VoidCallback create_callback,
+            EncodableValueCallback create_callback,
             VoidCallback dispose_callback,
             int width = 0,
             int height = 0);
@@ -49,7 +52,7 @@ public:
                                  int width,
                                  int height);
 
-    int64_t Create(int width, int height);
+    flutter::EncodableValue Create(int width, int height);
 
     void Dispose();
 
@@ -76,6 +79,6 @@ protected:
     bool m_draw_next;
 
 private:
-    const VoidCallback m_create_callback;
+    const EncodableValueCallback m_create_callback;
     const VoidCallback m_dispose_callback;
 };


### PR DESCRIPTION
-Adds key map response to opengl_texture methods
-success envelope is used to pass errors
-error if create/dispose provides invalid args
-error if texture create callback doesn't exist
-error if texture not found in registry

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>