### PR TITLE
Allow the embedder to run as a regular/normal application

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -25,7 +25,8 @@
 
 App::App(const std::vector<Configuration::Config>& configs)
     : m_wayland_display(std::make_shared<Display>(!configs[0].disable_cursor,
-                                                  configs[0].cursor_theme)) {
+                                                  configs[0].cursor_theme,
+                                                  configs)) {
   FML_DLOG(INFO) << "+App::App";
   bool found_view_with_bg = false;
 

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -27,6 +27,7 @@ App::App(const std::vector<Configuration::Config>& configs)
     : m_wayland_display(std::make_shared<Display>(!configs[0].disable_cursor,
                                                   configs[0].cursor_theme)) {
   FML_DLOG(INFO) << "+App::App";
+  bool found_view_with_bg = false;
 
   size_t index = 0;
   m_views.reserve(configs.size());
@@ -35,9 +36,16 @@ App::App(const std::vector<Configuration::Config>& configs)
     view->Initialize();
     m_views.emplace_back(std::move(view));
     index++;
+
+    if (WaylandWindow::get_window_type(cfg.view.window_type) ==
+        WaylandWindow::WINDOW_BG)
+      found_view_with_bg = true;
   }
 
-  m_wayland_display->AglShellDoReady();
+  // check that if we had a BG type and issue a ready() request for it,
+  // otherwise we're going to assume that this is a NORMAL/REGULAR application.
+  if (found_view_with_bg)
+    m_wayland_display->AglShellDoReady();
 
   FML_DLOG(INFO) << "-App::App";
 }

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -32,11 +32,15 @@
 #include "static_plugins/text_input/text_input.h"
 #include "xdg-shell-client-protocol.h"
 
+#include "configuration/configuration.h"
+
 class Engine;
 
 class Display {
  public:
-  explicit Display(bool enable_cursor, std::string cursor_theme_name);
+  explicit Display(bool enable_cursor,
+                   std::string cursor_theme_name,
+                   const std::vector<Configuration::Config>& configs);
 
   ~Display();
 
@@ -95,6 +99,8 @@ class Display {
   struct wl_subcompositor* m_subcompositor{};
   struct wl_shm* m_shm{};
   struct wl_surface* m_base_surface{};
+
+  bool m_bind_to_agl_shell = false;
 
   std::map<wl_surface*, Engine*> m_surface_engine_map;
   wl_surface* m_active_surface{};

--- a/shell/wayland/window.h
+++ b/shell/wayland/window.h
@@ -79,6 +79,7 @@ class WaylandWindow {
   wl_surface* GetBaseSurface() { return m_base_surface; }
 
   uint32_t m_fps_counter;
+  static window_type get_window_type(const std::string& type);
 
  private:
   struct shm_buffer {
@@ -157,5 +158,4 @@ class WaylandWindow {
 
   static const struct wl_callback_listener frame_listener;
 
-  static window_type get_window_type(const std::string& type);
 };


### PR DESCRIPTION
These changes allows the embedder, on the AGL platforms/systems, to run 
as a regular/normal application. 

Specifically, the changes here do the following:

- avoid a bind to agl-shell if the compositor advertises it. Without a protocol change this won't be easily fixed, but the
client can infer easily from the configuration/cmd line if it needs to actually bind to the interface. Plan on addressing that in the compositor but that would take some time. When I have done that we can revisit this change. 
- do not issue always the ready request if we didn't found a bg type of window. While technically there's nothing that stop
on doing it, it won't really work. Not setting a background surface (even with setting a panel) won't really work as we can not determine clients geometry nor can we deduce the panel dimensions (depending on the orientation). Further more, default
activation does require having at least background surface. 

I kinda in-lined these changes so probably they need a bit more massaging. 