### PR TITLE
Minor parsing fixes for JSON configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Loads Single View
 
 {
    "disable_cursor":true,
-   "backend_debug":true,
+   "debug_backend":true,
    "accessibility_features":31,
    "view":{
       "bundle_path":"/home/joel/development/gallery/.homescreen/x86/release",

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -152,10 +152,12 @@ void Configuration::getCliOverrides(Config& instance, Config& cli) {
   if (!cli.cursor_theme.empty()) {
     instance.cursor_theme = cli.cursor_theme;
   }
-  if (cli.disable_cursor != instance.disable_cursor) {
+  if (cli.disable_cursor == true &&
+      cli.disable_cursor != instance.disable_cursor) {
     instance.disable_cursor = cli.disable_cursor;
   }
-  if (cli.debug_backend != instance.debug_backend) {
+  if (cli.debug_backend == true &&
+      cli.debug_backend != instance.debug_backend) {
     instance.debug_backend = cli.debug_backend;
   }
   if (!cli.view.vm_args.empty()) {

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -220,6 +220,8 @@ std::vector<struct Configuration::Config> Configuration::ParseConfig(
     if (cfg.view.height == 0) {
       cfg.view.height = kDefaultViewHeight;
     }
+    if (cfg.app_id.empty())
+      cfg.app_id = kApplicationName;
 
     res.emplace_back(cfg);
   }

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -44,7 +44,7 @@ void RemoveArgument(std::vector<std::string>& args, const std::string& arg) {
 
 int main(int argc, char** argv) {
   struct Configuration::Config config {
-    .app_id = kApplicationName, .json_configuration_path{}, .cursor_theme{},
+    .app_id = {}, .json_configuration_path{}, .cursor_theme{},
     .disable_cursor{}, .debug_backend{}, .view {}
   };
 


### PR DESCRIPTION
This patch series fixes some minor parsing isssues I've found while using the JSON config file.

Specifically, app_id specified over the configuration is being ignored and found similar issue with debug_backend and disable_cursor.


