### PR TITLE
CLI option --window-type

### DIFF
--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -208,7 +208,7 @@ std::vector<struct Configuration::Config> Configuration::ParseConfig(
     getCliOverrides(cfg, config);
 
     if (cfg.view.window_type.empty())
-      cfg.view.window_type = "BG";
+      cfg.view.window_type = "NORMAL";
 
     if (cfg.view.bundle_path.empty()) {
       FML_LOG(ERROR) << "A bundle path must be specified";

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -151,6 +151,16 @@ int main(int argc, char** argv) {
       FML_DLOG(INFO) << "Cursor Theme: " << config.cursor_theme;
       RemoveArgument(config.view.vm_args, "--t=" + config.cursor_theme);
     }
+    if (cl.HasOption("window-type")) {
+      cl.GetOptionValue("window-type", &config.view.window_type);
+      if (config.view.window_type.empty()) {
+        FML_LOG(ERROR)
+            << "--window-type option requires an argument (e.g. --window-type=BG)";
+        return EXIT_FAILURE;
+      }
+      FML_DLOG(INFO) << "Window Type: " << config.view.window_type;
+      RemoveArgument(config.view.vm_args, "--window-type=" + config.view.window_type);
+    }
   }
 
   auto vm_arg_count = config.view.vm_args.size();


### PR DESCRIPTION
-Adds --window-type= as CLI option
 Enables running on AGL without using `--j=` CLI option

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>