### PR TITLE
Change pointer event timestamp from nano to microseconds

### DIFF
--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -512,10 +512,10 @@ void Engine::SendMouseEvent(FlutterPointerSignalKind signal,
     .struct_size = sizeof(FlutterPointerEvent),
     .phase = phase,
 #if defined(ENV64BIT)
-    .timestamp = m_proc_table.GetCurrentTime(),
+    .timestamp = m_proc_table.GetCurrentTime() / 1000,
 #elif defined(ENV32BIT)
     .timestamp =
-        static_cast<size_t>(m_proc_table.GetCurrentTime() & 0xFFFFFFFFULL),
+        static_cast<size_t>(m_proc_table.GetCurrentTime() / 1000 & 0xFFFFFFFFULL),
 #endif
     .x = x,
     .y = y,
@@ -543,10 +543,10 @@ void Engine::SendTouchEvent(FlutterPointerPhase phase,
     .struct_size = sizeof(FlutterPointerEvent),
     .phase = phase,
 #if defined(ENV64BIT)
-    .timestamp = m_proc_table.GetCurrentTime(),
+    .timestamp = m_proc_table.GetCurrentTime() / 1000,
 #elif defined(ENV32BIT)
     .timestamp =
-        static_cast<size_t>(m_proc_table.GetCurrentTime() & 0xFFFFFFFFULL),
+        static_cast<size_t>(m_proc_table.GetCurrentTime() / 1000 & 0xFFFFFFFFULL),
 #endif
     .x = x,
     .y = y,


### PR DESCRIPTION
# Problem

We noticed visual scroll/touch physics bugs when running on hardware, such as lack of scroll velocity. We were able to reproduce locally for the videos below. The scroll velocity issue is the most obvious problem, but this issue is likely also making other more subtle touch mechanics work unexpectedly as well (button press timing, etc).

### First video without the change in this PR, showing reproduction of scroll velocity error:
<video src="https://user-images.githubusercontent.com/8938879/220007452-7ba3c8f9-faa5-4f33-a9c7-db9910d15dd7.mp4">
</video>

### Next video is with the change in this PR applied, showing scroll velocity working as expected:
<video src="https://user-images.githubusercontent.com/8938879/220007494-1ae32ac7-93df-4b91-9422-69bb61c4b329.mp4">
</video>

# Solution

The changes in this PR were arrived at by following the `embedder.h` doc comments, and finding that timestamps for pointer events should be in microseconds.

```c
  /// The timestamp at which the pointer event was generated. The timestamp
  /// should be specified in microseconds and the clock should be the same as
  /// that used by `FlutterEngineGetCurrentTime`.
  size_t timestamp;
```

However, we're currently using the return value from `FlutterEngineGetCurrentTime` directly, which returns nanoseconds:

```c
//------------------------------------------------------------------------------
/// @brief      Get the current time in nanoseconds from the clock used by the
///             flutter engine. This is the system monotonic clock.
///
/// @return     The current time in nanoseconds.
///
FLUTTER_EXPORT
uint64_t FlutterEngineGetCurrentTime();
```

 When the docs were followed in this case, the touch bugs disappeared immediately as per the video.

---

<sub>Note that In order to reproduce this in a Flutter app locally with pointer events acting as `drag devices` as seen in the video, it's necessary to force Flutter to treat all kinds of touch devices as "drag devices" by wrapping one of the app root widgets as follows

```dart
ScrollConfiguration(
  behavior: const ScrollBehavior().copyWith(
    dragDevices: {...PointerDeviceKind.values},
  ),
  child: /* your root widgets here */,
)
```
</sub>
