### PR TITLE
Couple of fixes related to transform orientation and width/height 

### DIFF
--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -258,9 +258,12 @@ void Display::display_handle_mode(void* data,
   (void)wl_output;
   (void)flags;
   auto* oi = static_cast<output_info_t*>(data);
-  oi->width = static_cast<unsigned int>(width);
-  oi->height = static_cast<unsigned int>(height);
-  oi->refresh_rate = refresh;
+
+  if (flags == WL_OUTPUT_MODE_CURRENT) {
+    oi->height = static_cast<unsigned int>(height);
+    oi->width = static_cast<unsigned int>(width);
+    oi->refresh_rate = refresh;
+  }
 
   FML_DLOG(INFO) << "Video mode: " << width << " x " << height << " @ "
                  << (refresh > 1000 ? refresh / 1000.0 : (double)refresh)

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -243,6 +243,7 @@ void Display::display_handle_geometry(void* data,
   auto* oi = static_cast<output_info_t*>(data);
   oi->physical_width = static_cast<unsigned int>(physical_width);
   oi->physical_height = static_cast<unsigned int>(physical_height);
+  oi->transform = transform;
 
   FML_DLOG(INFO) << "Physical width: " << physical_width << " mm x "
                  << physical_height << " mm";

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -244,6 +244,7 @@ class Display {
     MAYBE_UNUSED int refresh_rate;
     int32_t scale;
     MAYBE_UNUSED bool done;
+    int transform;
   } output_info_t;
 
   struct pointer_event {


### PR DESCRIPTION
These fix some trivial issues with wl_output events. The orientation one is of particular useful to have. For the width and height without having output_info_t as a list we will be overriding the width and height for each display_handle_mode event we get. 

Both these seem unused at this point but we'll make use of them in AGL in order to have an activation area being set-up irrespective of the output dimensions or its orientation.  