### PR TITLE
agl-shell protocol updates

### DIFF
--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -86,6 +86,17 @@ void Configuration::getViewParameters(
     instance.view.fps_output_frequency =
         static_cast<uint32_t>(obj[kFpsOutputFrequency].GetInt());
   }
+
+  if (obj.HasMember(kWindowActivationAreaKey)) {
+    const rapidjson::GenericValue val =
+        obj[kWindowActivationAreaKey].GetObject();
+
+    instance.view.activation_area_x = val["x"].GetInt();
+    instance.view.activation_area_y = val["y"].GetInt();
+
+    FML_LOG(INFO) << "activation area x " << instance.view.activation_area_x;
+    FML_LOG(INFO) << "activation area y " << instance.view.activation_area_y;
+  }
 }
 
 void Configuration::getGlobalParameters(

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -39,6 +39,8 @@ class Configuration {
       int32_t accessibility_features;
       uint32_t width;
       uint32_t height;
+      uint32_t activation_area_x;
+      uint32_t activation_area_y;
       bool fullscreen;
       bool fullscreen_set;
       double pixel_ratio;
@@ -75,6 +77,7 @@ class Configuration {
   static constexpr char kBundlePathKey[] = "bundle_path";
   static constexpr char kWindowTypeKey[] = "window_type";
   static constexpr char kOutputIndex[] = "output_index";
+  static constexpr char kWindowActivationAreaKey[] = "window_activation_area";
   static constexpr char kWidthKey[] = "width";
   static constexpr char kHeightKey[] = "height";
   static constexpr char kPixelRatioKey[] = "pixel_ratio";

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -65,6 +65,7 @@ FlutterView::FlutterView(Configuration::Config config,
       m_wayland_display->GetWlOutput(m_config.view.wl_output_index),
       m_config.view.wl_output_index, m_config.app_id, m_config.view.fullscreen,
       m_config.view.width, m_config.view.height, m_config.view.pixel_ratio,
+      m_config.view.activation_area_x, m_config.view.activation_area_y,
       m_backend.get());
 }
 

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -195,7 +195,7 @@ void Display::registry_handle_global(void* data,
     if (version >= 2) {
       d->m_agl.shell = static_cast<struct agl_shell*>(
           wl_registry_bind(registry, name, &agl_shell_interface,
-                           std::min(static_cast<uint32_t>(3), version)));
+                           std::min(static_cast<uint32_t>(4), version)));
       agl_shell_add_listener(d->m_agl.shell, &agl_shell_listener, data);
     } else {
       d->m_agl.shell = static_cast<struct agl_shell*>(
@@ -846,6 +846,27 @@ void Display::AglShellDoReady() const {
   if (m_agl.shell) {
     agl_shell_ready(m_agl.shell);
   }
+}
+
+void Display::AglShellDoSetupActivationArea(uint32_t x,
+                                            uint32_t y,
+                                            uint32_t index) {
+  uint32_t width = m_all_outputs[index]->width;
+  uint32_t height = m_all_outputs[index]->height - (2 * y);
+
+  if (!m_agl.shell)
+    return;
+
+  if (m_all_outputs[index]->transform == WL_OUTPUT_TRANSFORM_90) {
+    width = m_all_outputs[index]->height;
+    height = m_all_outputs[index]->width - (2 * y);
+  }
+
+  FML_LOG(INFO) << "Using custom rectangle [" << width << "x" << height << "+"
+                << x << "x" << y << "] for activation";
+
+  agl_shell_set_activate_region(m_agl.shell, m_all_outputs[index]->output, x, y,
+                                width, height);
 }
 
 void Display::SetEngine(wl_surface* surface, Engine* engine) {

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -258,9 +258,12 @@ void Display::display_handle_mode(void* data,
   (void)wl_output;
   (void)flags;
   auto* oi = static_cast<output_info_t*>(data);
-  oi->width = static_cast<unsigned int>(width);
-  oi->height = static_cast<unsigned int>(height);
-  oi->refresh_rate = refresh;
+
+  if (flags == WL_OUTPUT_MODE_CURRENT) {
+    oi->height = static_cast<unsigned int>(height);
+    oi->width = static_cast<unsigned int>(width);
+    oi->refresh_rate = refresh;
+  }
 
   FML_DLOG(INFO) << "Video mode: " << width << " x " << height << " @ "
                  << (refresh > 1000 ? refresh / 1000.0 : (double)refresh)

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -54,6 +54,7 @@ Display::Display(bool enable_cursor,
 
   m_registry = wl_display_get_registry(m_display);
   wl_registry_add_listener(m_registry, &registry_listener, this);
+  wl_display_dispatch(m_display);
 
   if (m_agl.shell && m_agl.bind_to_agl_shell && m_agl.version >= 2) {
     int ret = 0;
@@ -67,8 +68,6 @@ Display::Display(bool enable_cursor,
           << "agl_shell extension already in use by other shell client.";
       exit(EXIT_FAILURE);
     }
-  } else {
-    wl_display_dispatch(m_display);
   }
 
   if (!m_agl.shell && m_agl.bind_to_agl_shell) {

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -243,6 +243,7 @@ void Display::display_handle_geometry(void* data,
   auto* oi = static_cast<output_info_t*>(data);
   oi->physical_width = static_cast<unsigned int>(physical_width);
   oi->physical_height = static_cast<unsigned int>(physical_height);
+  oi->transform = transform;
 
   FML_DLOG(INFO) << "Physical width: " << physical_width << " mm x "
                  << physical_height << " mm";

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -947,6 +947,16 @@ void Display::agl_shell_app_state(void* data,
   switch (state) {
     case AGL_SHELL_APP_STATE_STARTED:
       FML_DLOG(INFO) << "Got AGL_SHELL_APP_STATE_STARTED for app_id " << app_id;
+
+      if (d->m_agl.shell) {
+	      // we always assume the first output advertised by the wl_output
+	      // interface
+	      unsigned int default_output_index = 0;
+
+	      agl_shell_activate_app(d->m_agl.shell, app_id,
+			             d->m_all_outputs[default_output_index]->output);
+      }
+
       break;
     case AGL_SHELL_APP_STATE_TERMINATED:
       FML_DLOG(INFO) << "Got AGL_SHELL_APP_STATE_TERMINATED for app_id "

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -195,7 +195,7 @@ void Display::registry_handle_global(void* data,
     if (version >= 2) {
       d->m_agl.shell = static_cast<struct agl_shell*>(
           wl_registry_bind(registry, name, &agl_shell_interface,
-                           std::min(static_cast<uint32_t>(2), version)));
+                           std::min(static_cast<uint32_t>(3), version)));
       agl_shell_add_listener(d->m_agl.shell, &agl_shell_listener, data);
     } else {
       d->m_agl.shell = static_cast<struct agl_shell*>(
@@ -938,7 +938,31 @@ void Display::agl_shell_bound_fail(void* data, struct agl_shell* shell) {
   d->m_agl.bound_ok = false;
 }
 
+void Display::agl_shell_app_state(void* data,
+                                  struct agl_shell* agl_shell,
+                                  const char* app_id,
+                                  uint32_t state) {
+  auto* d = static_cast<Display*>(data);
+
+  switch (state) {
+    case AGL_SHELL_APP_STATE_STARTED:
+      FML_DLOG(INFO) << "Got AGL_SHELL_APP_STATE_STARTED for app_id " << app_id;
+      break;
+    case AGL_SHELL_APP_STATE_TERMINATED:
+      FML_DLOG(INFO) << "Got AGL_SHELL_APP_STATE_TERMINATED for app_id "
+                     << app_id;
+      break;
+    case AGL_SHELL_APP_STATE_ACTIVATED:
+      FML_DLOG(INFO) << "Got AGL_SHELL_APP_STATE_ACTIVATED for app_id "
+                     << app_id;
+      break;
+    default:
+      break;
+  }
+}
+
 const struct agl_shell_listener Display::agl_shell_listener = {
     .bound_ok = agl_shell_bound_ok,
     .bound_fail = agl_shell_bound_fail,
+    .app_state = agl_shell_app_state,
 };

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -151,6 +151,35 @@ class Display {
   void AglShellDoReady() const;
 
   /**
+   * @brief AglShell: Set up an activation area where to display the client's
+   * window
+   * @return void
+   * @param[in] x the x position for the activation rectangle
+   * @param[in] y the y position for the activation rectangle
+   * @param[index] the output, as a number
+   * @relation
+   *
+   * see agl-shell::set_activate_region request for more information. The x and
+   * y values are the position of an activation rectangle, with the width and
+   * height grabbed from the output itself. This would specify the area where
+   * the client's window will be displayed.
+   *
+   * --------------------
+   * |                  |
+   * |  (x, y)          |
+   * |  +--------       |
+   * |  |       |       |
+   * |  |       | height|
+   * |  |       |       |
+   * |  ---------       |
+   * |    width		|
+   * .			|
+   * |			|
+   * --------------------
+   */
+  void AglShellDoSetupActivationArea(uint32_t x, uint32_t y, uint32_t index);
+
+  /**
    * @brief Set Engine
    * @param[in] surface Image
    * @param[in] engine Engine

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -225,7 +225,7 @@ class Display {
     bool bind_to_agl_shell = false;
     struct agl_shell* shell{};
 
-    bool wait_for_bound{};
+    bool wait_for_bound = true;
     bool bound_ok{};
     uint32_t version = 0;
   } m_agl;

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -837,5 +837,21 @@ class Display {
    */
   static void agl_shell_bound_fail(void* data, struct agl_shell* shell);
 
+  /**
+   * @brief AGL app_state event
+   * @param[in,out] data Data of type Display
+   * @param[in] shell No use
+   * @param[in] app_id the application id for which this event was sent
+   * @param[in] state the state: CREATED/TERMINATED/ACTIVATED/DEACTIVATED
+   * @return void
+   * @relation
+   * wayland, agl-shell
+   * @note Do nothing
+   */
+  static void agl_shell_app_state(void* data,
+                                  struct agl_shell* agl_shell,
+                                  const char* app_id,
+                                  uint32_t state);
+
   static const struct agl_shell_listener agl_shell_listener;
 };

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -244,6 +244,7 @@ class Display {
     MAYBE_UNUSED int refresh_rate;
     int32_t scale;
     MAYBE_UNUSED bool done;
+    int transform;
   } output_info_t;
 
   struct pointer_event {

--- a/shell/wayland/window.cc
+++ b/shell/wayland/window.cc
@@ -31,6 +31,8 @@ WaylandWindow::WaylandWindow(size_t index,
                              int32_t width,
                              int32_t height,
                              double pixel_ratio,
+                             uint32_t activation_area_x,
+                             uint32_t activation_area_y,
                              Backend* backend)
     : m_index(index),
       m_display(std::move(display)),
@@ -41,6 +43,7 @@ WaylandWindow::WaylandWindow(size_t index,
       m_geometry({width, height}),
       m_window_size({width, height}),
       m_pixel_ratio(pixel_ratio),
+      m_activation_area({activation_area_x, activation_area_y}),
       m_type(get_window_type(type)),
       m_app_id(std::move(app_id)),
       m_fullscreen(fullscreen) {  // disable vsync
@@ -76,7 +79,11 @@ WaylandWindow::WaylandWindow(size_t index,
       break;
     case WINDOW_BG:
       m_display->AglShellDoBackground(m_base_surface, 0);
-      m_display->AglShellDoSetupActivationArea(0, 160, 0);
+      if (m_activation_area.x > 0 && m_activation_area.y > 0)
+        m_display->AglShellDoSetupActivationArea(m_activation_area.x,
+                                                 m_activation_area.y, 0);
+      else
+        m_display->AglShellDoSetupActivationArea(0, 160, 0);
       break;
     case WINDOW_PANEL_TOP:
       m_display->AglShellDoPanel(m_base_surface, AGL_SHELL_EDGE_TOP, 0);

--- a/shell/wayland/window.cc
+++ b/shell/wayland/window.cc
@@ -76,6 +76,7 @@ WaylandWindow::WaylandWindow(size_t index,
       break;
     case WINDOW_BG:
       m_display->AglShellDoBackground(m_base_surface, 0);
+      m_display->AglShellDoSetupActivationArea(0, 160, 0);
       break;
     case WINDOW_PANEL_TOP:
       m_display->AglShellDoPanel(m_base_surface, AGL_SHELL_EDGE_TOP, 0);

--- a/shell/wayland/window.h
+++ b/shell/wayland/window.h
@@ -63,6 +63,8 @@ class WaylandWindow {
                 int32_t width,
                 int32_t height,
                 double pixel_ratio,
+                uint32_t activation_area_x,
+                uint32_t activation_area_y,
                 Backend* backend);
 
   ~WaylandWindow();
@@ -147,6 +149,10 @@ class WaylandWindow {
     int32_t width;
     int32_t height;
   } m_geometry;
+  struct {
+    uint32_t x;
+    uint32_t y;
+  } m_activation_area;
   struct {
     int32_t width;
     int32_t height;

--- a/third_party/agl/protocol/agl-shell.xml
+++ b/third_party/agl/protocol/agl-shell.xml
@@ -22,7 +22,7 @@
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
   </copyright>
-  <interface name="agl_shell" version="2">
+  <interface name="agl_shell" version="3">
     <description summary="user interface for Automotive Grade Linux platform">
       Starting with version 2 of the protocol, the client is required to wait
       for the 'bound_ok' or 'bound_fail' events in order to proceed further.
@@ -58,6 +58,13 @@
       <entry name="bottom" value="1"/>
       <entry name="left" value="2"/>
       <entry name="right" value="3"/>
+    </enum>
+
+    <enum name="app_state" since="3">
+      <entry name="started" value="0"/>
+      <entry name="terminated" value="1"/>
+      <entry name="activated" value="2"/>
+      <entry name="deactivated" value="3"/>
     </enum>
 
     <request name="ready">
@@ -155,6 +162,18 @@
       <description summary="destroys the factory object">
       </description>
     </request>
+
+    <event name="app_state" since="3">
+      <description summary="event sent when an application suffered state modification">
+        Informs the client that an application has changed its state to another,
+        specified by the app_state enum. Client can use this event to track
+        current application state. For instance to know when the application has
+        started, or when terminated/stopped.
+      </description>
+      <arg name="app_id" type="string"/>
+      <arg name="state" type="uint" enum="app_state"/>
+    </event>
+
 
   </interface>
 </protocol>

--- a/third_party/agl/protocol/agl-shell.xml
+++ b/third_party/agl/protocol/agl-shell.xml
@@ -22,7 +22,7 @@
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
   </copyright>
-  <interface name="agl_shell" version="3">
+  <interface name="agl_shell" version="4">
     <description summary="user interface for Automotive Grade Linux platform">
       Starting with version 2 of the protocol, the client is required to wait
       for the 'bound_ok' or 'bound_fail' events in order to proceed further.
@@ -174,6 +174,31 @@
       <arg name="state" type="uint" enum="app_state"/>
     </event>
 
+    <request name="set_activate_region" since="4">
+      <description summary="sets a specific region to activate">
+      A hint for the compositor to use a custom area, rather than
+      inferring the activation area. If any panels are used
+      the compositor computes the activation area by subtracting the
+      panels geometry area. If no panels are used then the entire output
+      is being used. This request changes that as to hint the compositor
+      to use the supplied rectangle and ignore any potential panels
+      that might been set-up previously.
 
+      In order for this request to take effect it will need to happen
+      before the 'ready' request in order for the compositor to make use of it.
+      Note that any 'set_panel' request be will not be honored, if this request
+      has been called.
+
+      The x and y coordinates use the top-left corner as the origin. The
+      rectangle area shouldn't exceed the output area, while an area smaller
+      than the output, would basically result in showing up the background
+      surface.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="x" type="int" summary="x position of rectangle"/>
+      <arg name="y" type="int" summary="y position of rectangle"/>
+      <arg name="width" type="int" summary="width of rectangle"/>
+      <arg name="height" type="int" summary="height of rectangle"/>
+    </request>
   </interface>
 </protocol>

--- a/third_party/agl/protocol/agl-shell.xml
+++ b/third_party/agl/protocol/agl-shell.xml
@@ -1,161 +1,160 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="agl_shell">
-    <copyright>
-        Copyright © 2019, 2022 Collabora, Ltd.
+  <copyright>
+    Copyright © 2019, 2022 Collabora, Ltd.
 
-        Permission is hereby granted, free of charge, to any person obtaining a
-        copy of this software and associated documentation files (the "Software"),
-        to deal in the Software without restriction, including without limitation
-        the rights to use, copy, modify, merge, publish, distribute, sublicense,
-        and/or sell copies of the Software, and to permit persons to whom the
-        Software is furnished to do so, subject to the following conditions:
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
 
-        The above copyright notice and this permission notice (including the next
-        paragraph) shall be included in all copies or substantial portions of the
-        Software.
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
 
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-        FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-        DEALINGS IN THE SOFTWARE.
-    </copyright>
-    <interface name="agl_shell" version="2">
-        <description summary="user interface for Automotive Grade Linux platform">
-            Starting with version 2 of the protocol, the client is required to wait
-            for the 'bound_ok' or 'bound_fail' events in order to proceed further.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+  <interface name="agl_shell" version="2">
+    <description summary="user interface for Automotive Grade Linux platform">
+      Starting with version 2 of the protocol, the client is required to wait
+      for the 'bound_ok' or 'bound_fail' events in order to proceed further.
 
-            In case the client gets a 'bound_fail' event then it should consider that
-            there's another client already bound to the agl_shell protocol.
-            A client that receives a 'bound_ok' event should consider that there's
-            no other client already bound to the interface and can proceed further.
+      In case the client gets a 'bound_fail' event then it should consider that
+      there's another client already bound to the agl_shell protocol.
+      A client that receives a 'bound_ok' event should consider that there's
+      no other client already bound to the interface and can proceed further.
 
-            If the client uses an older version of the protocol it will receive
-            automatically an error and the compositor will terminate the connection,
-            if there's another client already bound the interface.
+      If the client uses an older version of the protocol it will receive
+      automatically an error and the compositor will terminate the connection,
+      if there's another client already bound the interface.
 
-            If the client receives the 'bound_fail' event and attempts to use the
-            interface further it will receive an error and the compositor will
-            terminate the connection. After the 'bound_fail' event was received the
-            client should call the destructor, which has been added with version 2
-            of the protocol. The client is free to try at a later point in time to
-            see if it will receive the 'bound_ok' event, but there's no explicit way
-            of finding out when that event will be delivered.
-            It is assumed that it can infer that information through other
-            means/other channels.
-        </description>
+      If the client receives the 'bound_fail' event and attempts to use the
+      interface further it will receive an error and the compositor will
+      terminate the connection. After the 'bound_fail' event was received the
+      client should call the destructor, which has been added with version 2
+      of the protocol. The client is free to try at a later point in time to
+      see if it will receive the 'bound_ok' event, but there's no explicit way
+      of finding out when that event will be delivered.
+      It is assumed that it can infer that information through other
+      means/other channels.
+    </description>
 
-        <enum name="error">
-            <entry name="invalid_argument" value="0"/>
-            <entry name="background_exists" value="1"/>
-            <entry name="panel_exists" value="2"/>
-        </enum>
+    <enum name="error">
+      <entry name="invalid_argument" value="0"/>
+      <entry name="background_exists" value="1"/>
+      <entry name="panel_exists" value="2"/>
+    </enum>
 
-        <enum name="edge">
-            <entry name="top" value="0"/>
-            <entry name="bottom" value="1"/>
-            <entry name="left" value="2"/>
-            <entry name="right" value="3"/>
-        </enum>
+    <enum name="edge">
+      <entry name="top" value="0"/>
+      <entry name="bottom" value="1"/>
+      <entry name="left" value="2"/>
+      <entry name="right" value="3"/>
+    </enum>
 
-        <request name="ready">
-            <description summary="client is ready to be shown">
-                Tell the server that this client is ready to be shown. The server
-                will delay presentation during start-up until all shell clients are
-                ready to be shown, and will display a black screen instead.
-                This gives the client an opportunity to set up and configure several
-                surfaces into a coherent interface.
+    <request name="ready">
+      <description summary="client is ready to be shown">
+        Tell the server that this client is ready to be shown. The server
+        will delay presentation during start-up until all shell clients are
+        ready to be shown, and will display a black screen instead.
+        This gives the client an opportunity to set up and configure several
+        surfaces into a coherent interface.
 
-                The client that binds to this interface must send this request, otherwise
-                they may stall the compositor unnecessarily.
+        The client that binds to this interface must send this request, otherwise
+        they may stall the compositor unnecessarily.
 
-                If this request is called after the compositor has already finished
-                start-up, no operation is performed.
-            </description>
-        </request>
+        If this request is called after the compositor has already finished
+        start-up, no operation is performed.
+      </description>
+    </request>
 
-        <request name="set_background">
-            <description summary="set surface as output's background">
-                Set the surface to act as the background of an output. After this
-                request, the server will immediately send a configure event with
-                the dimensions the client should use to cover the entire output.
+    <request name="set_background">
+      <description summary="set surface as output's background">
+        Set the surface to act as the background of an output. After this
+        request, the server will immediately send a configure event with
+        the dimensions the client should use to cover the entire output.
 
-                The surface must have a "desktop" surface role, as supported by
-                libweston-desktop.
+        The surface must have a "desktop" surface role, as supported by
+        libweston-desktop.
 
-                Only a single surface may be the background for any output. If a
-                background surface already exists, a protocol error is raised.
-            </description>
-            <arg name="surface" type="object" interface="wl_surface"/>
-            <arg name="output" type="object" interface="wl_output"/>
-        </request>
+        Only a single surface may be the background for any output. If a
+        background surface already exists, a protocol error is raised.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
 
-        <request name="set_panel">
-            <description summary="set surface as panel">
-                Set the surface to act as a panel of an output. The 'edge' argument
-                says what edge of the output the surface will be anchored to.
-                After this request, the server will send a configure event with the
-                corresponding width/height that the client should use, and 0 for the
-                other dimension. E.g. if the edge is 'top', the width will be the
-                output's width, and the height will be 0.
+    <request name="set_panel">
+      <description summary="set surface as panel">
+        Set the surface to act as a panel of an output. The 'edge' argument
+        says what edge of the output the surface will be anchored to.
+        After this request, the server will send a configure event with the
+        corresponding width/height that the client should use, and 0 for the
+        other dimension. E.g. if the edge is 'top', the width will be the
+        output's width, and the height will be 0.
 
-                The surface must have a "desktop" surface role, as supported by
-                libweston-desktop.
+        The surface must have a "desktop" surface role, as supported by
+        libweston-desktop.
 
-                The compositor will take the panel's window geometry into account when
-                positioning other windows, so the panels are not covered.
+        The compositor will take the panel's window geometry into account when
+        positioning other windows, so the panels are not covered.
 
-                XXX: What happens if e.g. both top and left are used at the same time?
-                Who gets to have the corner?
+        XXX: What happens if e.g. both top and left are used at the same time?
+        Who gets to have the corner?
 
-                Only a single surface may be the panel for an output's edge. If a
-                surface already exists on an edge, a protocol error is raised.
-            </description>
-            <arg name="surface" type="object" interface="wl_surface"/>
-            <arg name="output" type="object" interface="wl_output"/>
-            <arg name="edge" type="uint" enum="edge"/>
-        </request>
+        Only a single surface may be the panel for an output's edge. If a
+        surface already exists on an edge, a protocol error is raised.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="edge" type="uint" enum="edge"/>
+    </request>
 
-        <request name="activate_app">
-            <description summary="make client current window">
-                Ask the compositor to make a toplevel to become the current/focused
-                window for window management purposes.
+    <request name="activate_app">
+      <description summary="make client current window">
+        Ask the compositor to make a toplevel to become the current/focused
+        window for window management purposes.
 
-                See xdg_toplevel.set_app_id from the xdg-shell protocol for a
-                description of app_id.
+        See xdg_toplevel.set_app_id from the xdg-shell protocol for a
+        description of app_id.
 
-                If multiple toplevels have the same app_id, the result is unspecified.
+        If multiple toplevels have the same app_id, the result is unspecified.
 
-                XXX: Do we need feedback to say it didn't work? (e.g. client does
-                not exist)
-            </description>
-            <arg name="app_id" type="string"/>
-            <arg name="output" type="object" interface="wl_output"/>
-        </request>
+        XXX: Do we need feedback to say it didn't work? (e.g. client does
+        not exist)
+      </description>
+      <arg name="app_id" type="string"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
 
-        <event name="bound_ok" since="2">
-            <description summary="event sent if binding was ok">
-                Informs the client that it was able to bind the agl_shell
-                interface succesfully. Clients are required to wait for this
-                event before continuing further.
-            </description>
-        </event>
+    <event name="bound_ok" since="2">
+     <description summary="event sent if binding was ok">
+        Informs the client that it was able to bind the agl_shell
+        interface succesfully. Clients are required to wait for this
+        event before continuing further.
+     </description>
+    </event>
 
-        <event name="bound_fail" since="2">
-            <description summary="event sent if binding was nok">
-                Informs the client that binding to the agl_shell interface was
-                unsuccesfull. Clients are required to wait for this event for
-                continuing further.
-            </description>
-        </event>
+    <event name="bound_fail" since="2">
+      <description summary="event sent if binding was nok">
+        Informs the client that binding to the agl_shell interface was
+        unsuccesfull. Clients are required to wait for this event for
+        continuing further.
+      </description>
+    </event>
 
-        <request name="destroy" type="destructor" since="2">
-            <description summary="destroys the factory object">
-            </description>
-        </request>
+    <request name="destroy" type="destructor" since="2">
+      <description summary="destroys the factory object">
+      </description>
+    </request>
 
-
-    </interface>
+  </interface>
 </protocol>


### PR DESCRIPTION
This patch series includes updates up to agl-shell version 4. Plan is to bump these to latest currently available (which is version 8). 

- includes the minor fixes from https://github.com/toyota-connected/ivi-homescreen/pull/109/commits, which are need in both trees 
- includes a fix for bound_ok/nok v2 protocol update
- includes agl-shell version 3 update for receives different events
- includes agl-shell version 4 update to allow specifying a custom activation area (AGL has been using this for a while now, but this was only been done using the weston ini configuration  file): this adds the ability to do it programatically but also from the json configuration file. 