### PR TITLE
shell/wayland/display: Handle flags as bitfield entries

### DIFF
--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -258,11 +258,13 @@ void Display::display_handle_mode(void* data,
   (void)flags;
   auto* oi = static_cast<output_info_t*>(data);
 
-  if (flags == WL_OUTPUT_MODE_CURRENT) {
+  if ((flags & WL_OUTPUT_MODE_CURRENT) == WL_OUTPUT_MODE_CURRENT) {
     oi->height = static_cast<unsigned int>(height);
     oi->width = static_cast<unsigned int>(width);
     oi->refresh_rate = refresh;
   }
+
+  assert(oi->height && oi->width);
 
   FML_DLOG(INFO) << "Video mode: " << width << " x " << height << " @ "
                  << (refresh > 1000 ? refresh / 1000.0 : (double)refresh)


### PR DESCRIPTION
We can have preferred and current mode or'ed in the same time, so we can't really check just for current mode. Make sure we do get a valid width/height for the outputs to avoid going further.

Bug-AGL: SPEC-4841