### PR TITLE
backend/wayland_egl: Update damage area

### DIFF
--- a/shell/backend/wayland_egl.cc
+++ b/shell/backend/wayland_egl.cc
@@ -188,6 +188,7 @@ void WaylandEglBackend::Resize(void* user_data,
         spdlog::error("Failed to set Flutter Engine Window Size");
       }
     }
+    b->UpdateSize(width, height);
     wl_egl_window_resize(b->m_egl_window, width, height, 0, 0);
   }
 }
@@ -198,6 +199,7 @@ void WaylandEglBackend::CreateSurface(void* user_data,
                                       int32_t width,
                                       int32_t height) {
   auto b = reinterpret_cast<WaylandEglBackend*>(user_data);
+  b->UpdateSize(width, height);
   b->m_egl_window = wl_egl_window_create(surface, width, height);
   b->m_egl_surface = b->create_egl_surface(b->m_egl_window, nullptr);
 }

--- a/shell/backend/wayland_egl.h
+++ b/shell/backend/wayland_egl.h
@@ -88,6 +88,11 @@ class WaylandEglBackend : public Egl, public Backend {
    */
   FlutterCompositor GetCompositorConfig() override;
 
+  void UpdateSize(int _width, int _height) {
+    m_initial_width = _width;
+    m_initial_height = _height;
+  }
+
  private:
   wl_egl_window* m_egl_window{};
   uint32_t m_initial_width;


### PR DESCRIPTION
Rather than re-using the initial values from the config, update the values we are getting from the compositor to match the windows' dimensions.

This fixes some artifacts we're seeing when re-drawing with swap buffer with damage and most likely would have caused issues on other compositors when resizing the window to a higher value that the one provided in the configuration file.

Bug-AGL: SPEC-4938