### PR TITLE
fix building with crash handling enabled

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -113,10 +113,12 @@ endif ()
 #
 option(BUILD_CRASH_HANDLER "Build Crash Handler" OFF)
 if (BUILD_CRASH_HANDLER)
+    find_package(PkgConfig)
+    pkg_check_modules(LIBUNWIND REQUIRED libunwind)
     add_compile_definitions(
             BUILD_CRASH_HANDLER
             CRASH_HANDLER_DSN="${CRASH_HANDLER_DSN}"
-            CRASH_HANDLER_RELEASE= "${PROJECT_NAME}@${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+            CRASH_HANDLER_RELEASE="${PROJECT_NAME}@${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 else ()
     add_compile_definitions(
             CRASH_HANDLER_DSN=""

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -150,7 +150,7 @@ target_link_libraries(homescreen PRIVATE
 )
 
 if (BUILD_CRASH_HANDLER)
-    target_link_libraries(homescreen PRIVATE unwind)
+    target_link_libraries(homescreen PRIVATE ${LIBUNWIND_LIBRARIES})
 endif ()
 
 


### PR DESCRIPTION
Two fixes needed:
  - The space after "CRASH_HANDLER_RELEASE=" results in the following error:
     """ ./constants.h:86:69: error: expected primary-expression before ‘;’ token 86 | static constexpr char 
           kCrashHandlerRelease[] = CRASH_HANDLER_RELEASE; 
     """
Remove the space

  - homescreen links against libunwind when BUILD_CRASH_HANDLER is set, however libunwind is not searched for when configuring. Use pkg_check_modules as libunwind does not install a .cmake file.