### PR TITLE
add missing headers to the audio-players and keyboard-manager plugin

### DIFF
--- a/shell/plugins/audio_players/audio_player.cc
+++ b/shell/plugins/audio_players/audio_player.cc
@@ -20,6 +20,7 @@
 #include <map>
 #include <sstream>
 
+#include <flutter/standard_method_codec.h>
 #include <flutter/standard_message_codec.h>
 
 #include <gst/audio/audio.h>

--- a/shell/plugins/audio_players/audio_players.cc
+++ b/shell/plugins/audio_players/audio_players.cc
@@ -19,6 +19,8 @@
 #include <memory>
 #include <vector>
 
+#include <flutter/standard_method_codec.h>
+
 #include "audio_player.h"
 #include "audio_players_registry.h"
 #include "engine.h"

--- a/shell/plugins/audio_players/audio_players_registry.cc
+++ b/shell/plugins/audio_players/audio_players_registry.cc
@@ -19,6 +19,7 @@
 #include <memory>
 #include <mutex>
 
+#include <flutter/standard_method_codec.h>
 #include <flutter/standard_message_codec.h>
 
 #include "audio_player.h"

--- a/shell/plugins/keyboard_manager/keyboard_manager.h
+++ b/shell/plugins/keyboard_manager/keyboard_manager.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "flutter/fml/macros.h"
+#include <flutter/standard_method_codec.h>
 
 #include <shell/platform/embedder/embedder.h>
 


### PR DESCRIPTION
Fixes flutter::StandardMethodCodec not being declared on the following lines: plugins/audio_players/audio_players_registry.cc:83 plugins/audio_players/audio_players_registry.cc:94 plugins/audio_players/audio_players_registry.cc:152 plugins/audio_players/audio_player.cc:257
plugins/audio_players/audio_player.cc:623
plugins/keyboard_manager/keyboard_manager.cc:25