### PR TITLE
Use pkgconfig for EGL and GLES libraries

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -88,7 +88,9 @@ target_include_directories(${PROJECT_NAME}
 )
 
 if (BUILD_BACKEND_WAYLAND_EGL)
-    target_link_libraries(${PROJECT_NAME} PRIVATE EGL GLESv2)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(EGL egl glesv2 IMPORTED_TARGET REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::EGL)
 endif ()
 if (BUILD_BACKEND_WAYLAND_VULKAN)
     target_link_libraries(${PROJECT_NAME} PRIVATE vulkan_headers)


### PR DESCRIPTION
Mali GPU platforms that do not use Mesa have EGL and GLES implemented via libmali instead of the typical libEGL, etc.  Using pkgconfig for the link library options for those libraries allows that to work transparently when building the wayland backend.