### PR TITLE
fix: Refresh rate issues

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -91,11 +91,12 @@ int App::Loop() const {
 
   const auto elapsed = end_time - start_time;
 
-  if (const auto sleep_time = 16 - elapsed; sleep_time > 0) {
+  const auto frame_time = 1000.0 / m_wayland_display->GetMaxRefreshRate();
+  if (const auto sleep_time = frame_time - elapsed; sleep_time > 0) {
 #if BUILD_WATCHDOG
     m_watch_dog->pet();
 #endif
-    std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time));
+    std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(sleep_time));
   }
 
   return 0;

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -946,6 +946,14 @@ double Display::GetRefreshRate(uint32_t index) const {
   return 0;
 }
 
+double Display::GetMaxRefreshRate() const {
+  double max_refresh_rate = 0;
+  for (const auto& output : m_all_outputs) {
+    max_refresh_rate = std::max(max_refresh_rate, output->refresh_rate);
+  }
+  return max_refresh_rate;
+}
+
 #if ENABLE_AGL_SHELL_CLIENT
 void Display::agl_shell_bound_ok(void* data, struct agl_shell* shell) {
   (void)shell;

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -304,12 +304,10 @@ void Display::display_handle_mode(void* data,
   if ((flags & WL_OUTPUT_MODE_CURRENT) == WL_OUTPUT_MODE_CURRENT) {
     oi->height = static_cast<unsigned int>(height);
     oi->width = static_cast<unsigned int>(width);
-    oi->refresh_rate = refresh;
+    oi->refresh_rate = refresh / 1000.0;
   }
 
-  SPDLOG_DEBUG(
-      "Video mode: {} x {} @ {} Hz", width, height,
-      (refresh > 1000 ? refresh / 1000.0 : static_cast<double>(refresh)));
+  SPDLOG_DEBUG("Video mode: {} x {} @ {} Hz", width, height, refresh / 1000.0);
 }
 
 void Display::display_handle_scale(void* data,
@@ -940,7 +938,7 @@ std::pair<int32_t, int32_t> Display::GetVideoModeSize(uint32_t index) const {
   return {0, 0};
 }
 
-int Display::GetRefreshRate(uint32_t index) const {
+double Display::GetRefreshRate(uint32_t index) const {
   if (index < m_all_outputs.size()) {
     return m_all_outputs[index]->refresh_rate;
   }

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -299,6 +299,15 @@ class Display {
   [[nodiscard]] double GetRefreshRate(uint32_t index) const;
 
   /**
+   * @brief Get max refresh rate of all available views
+   * @return double
+   * @retval Video Refresh Rate in Hz
+   * @relation
+   * wayland
+   */
+  [[nodiscard]] double GetMaxRefreshRate() const;
+
+  /**
    * @brief deactivate/hide the application pointed by app_id
    * @param[in] app_id the app_id
    * @relation

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -291,12 +291,12 @@ class Display {
   /**
    * @brief Get refresh rate of a specified index of a view
    * @param[in] index Index of a view
-   * @return int
-   * @retval Video Refresh Rate
+   * @return double
+   * @retval Video Refresh Rate in Hz
    * @relation
    * wayland
    */
-  [[nodiscard]] int GetRefreshRate(uint32_t index) const;
+  [[nodiscard]] double GetRefreshRate(uint32_t index) const;
 
   /**
    * @brief deactivate/hide the application pointed by app_id
@@ -399,7 +399,7 @@ class Display {
     unsigned height;
     unsigned physical_width;
     unsigned physical_height;
-    int refresh_rate;
+    double refresh_rate;
     int32_t scale;
     bool done;
     int transform;


### PR DESCRIPTION
Fixes the following:

- Flutter reporting refresh rates in **milli**-Hz instead of Hz
- Flutter reporting the incorrect refresh rate (as per Wayland spec it should always report max)
- App loop locked to 62.5Hz