### PR TITLE
Fixed semantics log verbosity

### DIFF
--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -123,7 +123,7 @@ AccessibilityNode* AccessibilityTree::GetNode(
 
   auto new_node = new AccessibilityNode(fl_node);
   nodes.emplace_back(new_node);
-  spdlog::debug(
+  SPDLOG_TRACE(
       "New AccessibilityNode created with ID: {}, number of nodes: {}",
       new_node->GetId(), nodes.size());
   return nodes.back();

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -578,12 +578,12 @@ void Engine::OnFlutterPlatformMessage(
        .response_handle = engine_message->response_handle},
       [view] {
         if (view) {
-          spdlog::debug("input_block_cb");
+          SPDLOG_TRACE("input_block_cb");
         }
       },
       [view] {
         if (view) {
-          spdlog::debug("input_unblock_cb");
+          SPDLOG_TRACE("input_unblock_cb");
         }
       });
 }
@@ -600,7 +600,7 @@ void Engine::onSemanticsUpdateCallback(const FlutterSemanticsUpdate2* update,
       static_cast<FlutterDesktopEngineState*>(user_data);
 
   auto* accessibility_tree = engine_state->accessibility_tree;
-  spdlog::debug(
+  SPDLOG_TRACE(
       "[onSemanticsUpdateCallback] struct_size: {}, node_count: {} "
       "custom_action_count: {}",
       update->struct_size, update->node_count, update->custom_action_count);


### PR DESCRIPTION
Fixes log spam of lines such as:
- `[D] [onSemanticsUpdateCallback] struct_size: 48, node_count: 13 custom_action_count: 0`
- `[D] New AccessibilityNode created with ID: 0, number of nodes: 1`

...by changing the log level to `trace` in line with the rest of the codebase