### PR TITLE
fix: make GlProcessResolver/EglProcessResolver thread-safe

### DIFF
--- a/shell/backend/gl_process_resolver.cc
+++ b/shell/backend/gl_process_resolver.cc
@@ -27,8 +27,6 @@
 #include <GL/osmesa.h>
 #endif
 
-std::shared_ptr<EglProcessResolver> GlProcessResolver::sInstance = nullptr;
-
 EglProcessResolver::~EglProcessResolver() {
   for (auto const& item : m_handles) {
     dlclose(item.first);
@@ -52,7 +50,7 @@ int EglProcessResolver::GetHandle(const std::string& lib, void** out_handle) {
   return 1;
 }
 
-void EglProcessResolver::Initialize() {
+EglProcessResolver::EglProcessResolver() {
   void* handle;
   const std::vector<std::string> libs(kGlSoNames,
                                       kGlSoNames + std::size(kGlSoNames));

--- a/shell/backend/gl_process_resolver.h
+++ b/shell/backend/gl_process_resolver.h
@@ -16,28 +16,25 @@
 
 #pragma once
 
-#include <memory>
+#include <string>
 #include <vector>
 
 class EglProcessResolver {
  public:
 #if BUILD_BACKEND_HEADLESS_EGL
   static constexpr char kGlSoNames[3UL][15UL] = {{"libOSMesa.so.8"},
-                                                 {"libGLESv2.so.2"},
-                                                 {"libEGL.so.1"}};
+                                                   {"libGLESv2.so.2"},
+                                                   {"libEGL.so.1"}};
 #else
   static constexpr char kGlSoNames[2UL][15UL] = {{"libGLESv2.so.2"},
-                                                 {"libEGL.so.1"}};
+                                                   {"libEGL.so.1"}};
 #endif
   ~EglProcessResolver();
 
-  /**
-   * @brief Initialize
-   * @return void
-   * @relation
-   * internal
-   */
-  void Initialize();
+  EglProcessResolver(const EglProcessResolver&) = delete;
+  EglProcessResolver& operator=(const EglProcessResolver&) = delete;
+  EglProcessResolver(EglProcessResolver&&) = delete;
+  EglProcessResolver& operator=(EglProcessResolver&&) = delete;
 
   /**
    * @brief Get DLL handle
@@ -62,6 +59,8 @@ class EglProcessResolver {
   void* process_resolver(const char* name) const;
 
  private:
+  friend class GlProcessResolver;
+  EglProcessResolver();
   std::vector<std::pair<void*, std::string>> m_handles;
 };
 
@@ -79,13 +78,7 @@ class GlProcessResolver {
    * internal
    */
   static EglProcessResolver& GetInstance() {
-    if (!sInstance) {
-      sInstance = std::make_shared<EglProcessResolver>();
-      sInstance->Initialize();
-    }
-    return *sInstance;
+    static EglProcessResolver instance;
+    return instance;
   }
-
- protected:
-  static std::shared_ptr<EglProcessResolver> sInstance;
 };

--- a/test/unit_test/gl_process_resolver-test/test_case_gl_process_resolver.cc
+++ b/test/unit_test/gl_process_resolver-test/test_case_gl_process_resolver.cc
@@ -10,7 +10,7 @@ Initialization Test Summary：Test process_resolver func with valid process name
                 by calling the API via the GetInstance() method.
 ***************************************************************/
 TEST(HomescreenGlProcessResolver, Lv1Normal001) {
-  const auto gl_process = GlProcessResolver::GetInstance();
+  const auto& gl_process = GlProcessResolver::GetInstance();
   const auto process_resolver = gl_process.process_resolver("glGetString");
 
   EXPECT_TRUE(process_resolver != nullptr);
@@ -23,7 +23,7 @@ Initialization Test Summary：Test process_resolver func with invalid process
 name
 ***************************************************************/
 TEST(HomescreenGlProcessResolver, Lv1Abnormal001) {
-  const auto gl_process = GlProcessResolver::GetInstance();
+  const auto& gl_process = GlProcessResolver::GetInstance();
   const auto process_resolver = gl_process.process_resolver("InvalidProcess");
 
   EXPECT_TRUE(process_resolver == nullptr);
@@ -35,7 +35,7 @@ HomescreenGlProcessResolverProcessResolver_Lv1Abnormal002 Use Case Name:
 Initialization Test Summary：Test process_resolver func with null param
 ***************************************************************/
 TEST(HomescreenGlProcessResolver, Lv1Abnormal002) {
-  const auto gl_process = GlProcessResolver::GetInstance();
+  const auto& gl_process = GlProcessResolver::GetInstance();
   const auto process_resolver = gl_process.process_resolver(nullptr);
 
   EXPECT_TRUE(process_resolver == nullptr);


### PR DESCRIPTION
Convert GlProcessResolver::GetInstance() from shared_ptr + lazy init to a Meyers Singleton (function-local static), matching the pattern used in Presentation class on jw/presentation.

- Replace shared_ptr + Initialize() with function-local static instance
- Delete copy/move constructors and assignment operators on EglProcessResolver to prevent accidental object slicing
- Make EglProcessResolver constructor private with friend access
- Fix test references: const auto -> const auto& to avoid copies that caused use-after-dlclose when tests ran sequentially
- Replace #include <memory> with #include <string> (direct dependency)

The copy semantics bug caused a real SIGSEGV in sequential test execution: test N's copy destructor called dlclose() on shared library handles, then test N+1's dlsym() accessed freed memory.

## Summary

Convert `GlProcessResolver::GetInstance()` from a non-thread-safe
`if (!sInstance)` pattern to the Meyers Singleton pattern (function-local
`static` variable), leveraging the C++11 §6.7 [stmt.dcl] guarantee that
initialization of block-scope variables with static storage duration is
thread-safe.

This applies the same pattern already used in `Presentation::GetInstance()`
(`jw/presentation` branch).

## Problem

The current singleton pattern is vulnerable to a TOCTOU race condition:

```cpp
static EglProcessResolver& GetInstance() {
    if (!sInstance) {                                        // Thread A reads nullptr
        sInstance = std::make_shared<EglProcessResolver>();  // Thread B also reads nullptr → race
        sInstance->Initialize();
    }
    return *sInstance;
}
```

If two threads call `GetInstance()` concurrently before initialization,
both may create separate `EglProcessResolver` instances, loading duplicate
`dlopen` handles.

## Fix

Replace with Meyers Singleton and move `Initialize()` body into constructor:

```cpp
static EglProcessResolver& GetInstance() {
    static EglProcessResolver instance;  // thread-safe, initialized once
    return instance;
}
```

The constructor now performs the `dlopen` calls that were previously in
`Initialize()`. This also eliminates the `std::shared_ptr` indirection.

## Changes

| File | Change |
|------|--------|
| `shell/backend/gl_process_resolver.h` | Replace `GetInstance()` body, remove `sInstance` member, move `Initialize()` to ctor, delete copy/move on `EglProcessResolver` |
| `shell/backend/gl_process_resolver.cc` | Remove `sInstance` definition, rename `Initialize()` → constructor |
| `test/.../test_case_gl_process_resolver.cc` | `const auto` → `const auto&` on 3 lines (required by copy deletion) |

Additionally, copy/move constructors are deleted on `EglProcessResolver`,
matching the pattern used in `Presentation` (`jw/presentation` branch).
This prevents accidental copies whose destructors would call `dlclose()`
on handles they don't own.

## What This Does NOT Change

- **Return type**: Still returns `EglProcessResolver&`
- **Construction timing**: Still lazy (first call to `GetInstance()`)
- **`dlopen`/`dlclose` behavior**: Same libraries loaded, same cleanup
- **Production caller code**: Zero changes (`wayland_egl.cc:71` uses inline reference)

## Testing

Unit tests in `test/unit_test/gl_process_resolver-test/` are updated to
capture `GetInstance()` by reference (`const auto&`) instead of by value.
This is required because copy constructors are now deleted.

**Before this fix** (Headless EGL + OSMesa build configuration):
- Individual tests pass in isolation
- Sequential execution causes SIGSEGV on the second test —
  first test's copy destructor calls `dlclose()` on shared handles,
  second test's `dlsym()` accesses freed memory

**After this fix**: All 5 tests pass in sequential execution with
identical assertions and expected results.

## References

- [C++11 §6.7 stmt.dcl](https://timsong-cpp.github.io/cppwp/n4140/stmt.dcl#4):
  "If control enters the declaration concurrently while the variable is being
  initialized, the concurrent execution shall wait for completion of the
  initialization."
- `Presentation::GetInstance()` in `jw/presentation` branch uses the same pattern
````