### PR TITLE
fix: apply clang-format-18 Chromium style to resolve CI violations (issue #172)

### DIFF
--- a/shell/platform/homescreen/flutter_desktop_engine_state.h
+++ b/shell/platform/homescreen/flutter_desktop_engine_state.h
@@ -38,7 +38,7 @@ using UniqueAotDataPtr = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;
 // Struct for storing state of a Flutter engine instance.
 struct FlutterDesktopEngineState {
   // The handle to the Flutter engine instance.
-  FLUTTER_API_SYMBOL(FlutterEngine) flutter_engine {};
+  FLUTTER_API_SYMBOL(FlutterEngine) flutter_engine{};
 
   // The platform channel execution thread.
   TaskRunner* platform_task_runner{};

--- a/test/unit_test/app-headless-test/test_case_app_headless.cc
+++ b/test/unit_test/app-headless-test/test_case_app_headless.cc
@@ -12,8 +12,6 @@
 #include "logging.h"
 #include "unit_test_utils.h"
 
-
-
 /****************************************************************
 Test Case Name.Test Name： HomescreenAppHeadless_Lv1Normal001
 Use Case Name: Initialization
@@ -58,4 +56,3 @@ TEST(HomescreenAppHeadless, Lv1Normal001) {
   EXPECT_EQ(images_are_equal, 1);
 #endif
 }
-

--- a/test/unit_test/configuration-test-case/test_case_configuration.cc
+++ b/test/unit_test/configuration-test-case/test_case_configuration.cc
@@ -125,7 +125,7 @@ TEST(HomescreenConfigurationGetTomlConfig, Lv1Normal001) {
   EXPECT_EQ(true, config.disable_cursor.value_or(false));
   EXPECT_EQ("keyboard", config.wayland_event_mask);
   EXPECT_EQ(false, config.debug_backend.value_or(false));
-  
+
   EXPECT_EQ("NORMAL", config.view.window_type);
   EXPECT_EQ(2, config.view.wl_output_index.value_or(0));
   EXPECT_EQ(1920, config.view.width.value_or(kDefaultViewWidth));
@@ -163,7 +163,7 @@ TEST(HomescreenConfigurationGetTomlConfig, Lv1Normal002) {
   EXPECT_EQ(true, config.disable_cursor.value_or(false));
   EXPECT_EQ("keyboard", config.wayland_event_mask);
   EXPECT_EQ(false, config.debug_backend.value_or(false));
-  
+
   EXPECT_EQ("", config.view.bundle_path);
   EXPECT_EQ("", config.view.window_type);
   EXPECT_EQ(0, config.view.wl_output_index.value_or(0));
@@ -181,4 +181,3 @@ TEST(HomescreenConfigurationGetTomlConfig, Lv1Normal002) {
   EXPECT_EQ(0, config.view.activation_area_width);
   EXPECT_EQ(0, config.view.activation_area_height);
 }
-

--- a/test/unit_test/configuration-test-case/test_case_configuration_PrintConfig.cc
+++ b/test/unit_test/configuration-test-case/test_case_configuration_PrintConfig.cc
@@ -1,7 +1,7 @@
-#include <filesystem>
-#include <stdexcept>
 #include <gtest/gtest.h>
+#include <filesystem>
 #include <iostream>
+#include <stdexcept>
 
 #include <configuration/configuration.h>
 
@@ -32,31 +32,60 @@ TEST(HomescreenConfigurationPrintConfig, Lv1Normal001) {
   config.view.ivi_surface_id = 1;
   config.view.fullscreen = true;
 
-  std::cout << "\n##################### Reference Output #######################\n" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] {branch} @ {commit id}" << std::endl;
+  std::cout
+      << "\n##################### Reference Output #######################\n"
+      << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] {branch} @ {commit id}"
+            << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] **********" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] * Global *" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] **********" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Application Id: .......... homescreen" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Cursor Theme: ............ DMZ-White" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Disable Cursor: .......... true" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Wayland Event Mask: ...... keyboard" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Debug Backend: ........... true" << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Application Id: .......... "
+               "homescreen"
+            << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Cursor Theme: ............ DMZ-White"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Disable Cursor: .......... true"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Wayland Event Mask: ...... keyboard"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Debug Backend: ........... true"
+      << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] ********" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] * View *" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] ********" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] VM Args:" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] --enable-asserts" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] --pause-isolates-on-start" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Bundle Path: .............. /home/" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Window Type: .............. NORMAL" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Output Index: ............. 1" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Size: ..................... 1280 x 720" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Pixel Ratio: .............. 1.2" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Fullscreen: ............... true" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Accessibility Features: ... 1" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Ivi Surface ID: ........... 1" << std::endl;
-  std::cout << "\n################## Please check visually #####################\n" << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] --pause-isolates-on-start"
+            << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Bundle Path: .............. /home/"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Window Type: .............. NORMAL"
+      << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Output Index: ............. 1"
+            << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Size: ..................... "
+               "1280 x 720"
+            << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Pixel Ratio: .............. 1.2"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Fullscreen: ............... true"
+      << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Accessibility Features: ... 1"
+            << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Ivi Surface ID: ........... 1"
+            << std::endl;
+  std::cout
+      << "\n################## Please check visually #####################\n"
+      << std::endl;
 
   Configuration::PrintConfig(config);
 }

--- a/test/unit_test/configuration-test-case/test_case_configuration_getCliOverrides.cc
+++ b/test/unit_test/configuration-test-case/test_case_configuration_getCliOverrides.cc
@@ -1,9 +1,9 @@
 #include <stdlib.h>
 #include "gtest/gtest.h"
 
+#include <configuration/configuration.h>
 #include <flutter/fml/command_line.h>
 #include <rapidjson/document.h>
-#include <configuration/configuration.h>
 
 /****************************************************************
 Test Case Name.Test Name： HomescreenConfigurationGetCliOverrides_Lv1Normal001
@@ -54,7 +54,7 @@ TEST(HomescreenConfigurationGetCliOverrides, Lv1Normal001) {
   EXPECT_EQ(1, config.view.pixel_ratio);
   EXPECT_EQ(1, config.view.ivi_surface_id);
   EXPECT_EQ(true, config.view.fullscreen);
-  EXPECT_EQ(1,1);
+  EXPECT_EQ(1, 1);
 }
 /****************************************************************
 Test Case Name.Test Name： HomescreenConfigurationGetCliOverrides_Lv1Normal002
@@ -83,8 +83,10 @@ TEST(HomescreenConfigurationGetCliOverrides, Lv1Normal002) {
   EXPECT_EQ("", config.view.window_type);
   EXPECT_EQ(0, config.view.wl_output_index.value_or(0));
   EXPECT_EQ(kDefaultViewWidth, config.view.width.value_or(kDefaultViewWidth));
-  EXPECT_EQ(kDefaultViewHeight, config.view.height.value_or(kDefaultViewHeight));
-  EXPECT_EQ(kDefaultPixelRatio, config.view.pixel_ratio.value_or(kDefaultPixelRatio));
+  EXPECT_EQ(kDefaultViewHeight,
+            config.view.height.value_or(kDefaultViewHeight));
+  EXPECT_EQ(kDefaultPixelRatio,
+            config.view.pixel_ratio.value_or(kDefaultPixelRatio));
   EXPECT_EQ(0, config.view.ivi_surface_id.value_or(0));
   EXPECT_EQ(0, config.view.accessibility_features.value_or(0));
   EXPECT_EQ(false, config.view.fullscreen.value_or(false));

--- a/test/unit_test/flutter_view-test/test_case_flutter_view.cc
+++ b/test/unit_test/flutter_view-test/test_case_flutter_view.cc
@@ -1,15 +1,14 @@
 #include <stdexcept>
 #include "gtest/gtest.h"
-#include "utils.h"
-#include "view/flutter_view.h"
-#include "view/compositor_surface_api.h"
-#include "wayland/display.h"
 #include "unit_test_utils.h"
+#include "utils.h"
+#include "view/compositor_surface_api.h"
+#include "view/flutter_view.h"
+#include "wayland/display.h"
 
 FlutterView* createFlutterViewInstance() {
   int argc = 3;
-  const char* argv[3] = {"homescreen",
-                         "-b",kBundlePath};
+  const char* argv[3] = {"homescreen", "-b", kBundlePath};
   char** argv_p = reinterpret_cast<char**>(&argv);
 
   // call target function

--- a/test/unit_test/texture-test/test_case_texture.cc
+++ b/test/unit_test/texture-test/test_case_texture.cc
@@ -1,16 +1,18 @@
-#include "gtest/gtest.h"
-#include "utils.h"
 #include "engine.h"
+#include "gtest/gtest.h"
+#include "textures/texture.h"
+#include "utils.h"
 #include "view/flutter_view.h"
 #include "wayland/display.h"
-#include "textures/texture.h"
 
 static constexpr char kBundlePath[] = TEST_APP_BUNDLE_PATH;
 static constexpr char kSourceRoot[] = SOURCE_ROOT_DIR;
 constexpr int64_t kTestTextureObjectId = 5150;
 const std::string kCallCreateCb = "Call Create Callback";
-const flutter::EncodableValue kFlutterTestKey = flutter::EncodableValue("Test Key");
-const flutter::EncodableValue kFlutterTestVal = flutter::EncodableValue("Test Val");
+const flutter::EncodableValue kFlutterTestKey =
+    flutter::EncodableValue("Test Key");
+const flutter::EncodableValue kFlutterTestVal =
+    flutter::EncodableValue("Test Val");
 bool callDisposeCallback = false;
 
 /**
@@ -36,7 +38,7 @@ Engine* createEngineInstance() {
   FlutterView* view = createFlutterViewInstance();
   std::vector<const char*> vm_args_c;
 
-  Engine *engine = new Engine(view, 1, vm_args_c, kBundlePath, 1);
+  Engine* engine = new Engine(view, 1, vm_args_c, kBundlePath, 1);
   return engine;
 }
 
@@ -44,7 +46,7 @@ Engine* createEngineInstance() {
  * @brief Callback function to registered instead of Texture::Create
  */
 flutter::EncodableValue create_callback(void* userdata,
-    const flutter::EncodableMap* args) {
+                                        const flutter::EncodableMap* args) {
   // check object Texture-ID
   auto* obj = reinterpret_cast<Texture*>(userdata);
   int64_t texture_id = obj->GetId();
@@ -78,8 +80,8 @@ Test Summary: Check that the value set in the constructor can be retrieved
 ***************************************************************/
 TEST(HomescreenTextureGetFlutterOpenGLTexture, Lv1Normal001) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, nullptr, nullptr);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 nullptr, nullptr);
   ASSERT_TRUE(texture != nullptr);
 
   // call target function
@@ -98,20 +100,19 @@ Test Summary: Dont set callback and check default encodable value
 ***************************************************************/
 TEST(HomescreenTextureCreate, Lv1Normal001) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, nullptr, nullptr);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 nullptr, nullptr);
   ASSERT_TRUE(texture != nullptr);
 
   // call target function
   flutter::EncodableValue create = texture->Create(100, 200, nullptr);
 
   // confirm to create instance
-  flutter::EncodableValue expect_val = flutter::EncodableValue(
-    flutter::EncodableMap{
-      {flutter::EncodableValue("result"),
-       flutter::EncodableValue(-1)},
-      {flutter::EncodableValue("error"),
-       flutter::EncodableValue("Create callback not set")}});
+  flutter::EncodableValue expect_val =
+      flutter::EncodableValue(flutter::EncodableMap{
+          {flutter::EncodableValue("result"), flutter::EncodableValue(-1)},
+          {flutter::EncodableValue("error"),
+           flutter::EncodableValue("Create callback not set")}});
   EXPECT_TRUE(expect_val == create);
 }
 
@@ -122,12 +123,12 @@ Test Summary: set create callback and check if the callback is called
 ***************************************************************/
 TEST(HomescreenTextureCreate, Lv1Normal002) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, create_callback, nullptr);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 create_callback, nullptr);
   ASSERT_TRUE(texture != nullptr);
 
-  flutter::EncodableMap test_args = flutter::EncodableMap{
-        {kFlutterTestKey, kFlutterTestVal}};
+  flutter::EncodableMap test_args =
+      flutter::EncodableMap{{kFlutterTestKey, kFlutterTestVal}};
 
   // call target function
   flutter::EncodableValue create = texture->Create(100, 200, &test_args);
@@ -144,13 +145,13 @@ Test Summary: set dispose callback and check if the callback is called
 ***************************************************************/
 TEST(HomescreenTextureDispose, Lv1Normal001) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, nullptr, dispose_callback);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 nullptr, dispose_callback);
   ASSERT_TRUE(texture != nullptr);
   callDisposeCallback = false;
 
-  flutter::EncodableMap test_args = flutter::EncodableMap{
-        {kFlutterTestKey, kFlutterTestVal}};
+  flutter::EncodableMap test_args =
+      flutter::EncodableMap{{kFlutterTestKey, kFlutterTestVal}};
 
   // call target function
   texture->Dispose(kTestTextureObjectId);
@@ -166,13 +167,13 @@ Test Summary: Dont set dispose callback and check if the callback is not called
 ***************************************************************/
 TEST(HomescreenTextureDispose, Lv1Normal002) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, nullptr, nullptr);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 nullptr, nullptr);
   ASSERT_TRUE(texture != nullptr);
   callDisposeCallback = false;
 
-  flutter::EncodableMap test_args = flutter::EncodableMap{
-        {kFlutterTestKey, kFlutterTestVal}};
+  flutter::EncodableMap test_args =
+      flutter::EncodableMap{{kFlutterTestKey, kFlutterTestVal}};
 
   // call target function
   texture->Dispose(kTestTextureObjectId);
@@ -181,8 +182,7 @@ TEST(HomescreenTextureDispose, Lv1Normal002) {
   EXPECT_FALSE(callDisposeCallback);
 }
 
-
-#if 0 // TODO ME: Update tests for new Texture implementation
+#if 0  // TODO ME: Update tests for new Texture implementation
 /****************************************************************
 Test Case Name.Test Name： HomescreenTextureEnable_Lv1Normal001
 Use Case Name: Set OpenGL texture


### PR DESCRIPTION
# fix: apply clang-format-18 Chromium style to resolve CI violations (issue #172)

PR #171 introduced clang-format-18 and clang-tidy CI enforcement for the `v2.0` codebase.
This PR applies the mechanical format fixes to the 7 files that fail the new `format` CI job,
resolving issue #172.

## Files changed (7)

- `shell/platform/homescreen/flutter_desktop_engine_state.h` — brace spacing
- `test/unit_test/app-headless-test/test_case_app_headless.cc` — trailing whitespace / include spacing
- `test/unit_test/configuration-test-case/test_case_configuration.cc` — brace + blank line alignment
- `test/unit_test/configuration-test-case/test_case_configuration_PrintConfig.cc` — long line wrapping, stream operator alignment
- `test/unit_test/configuration-test-case/test_case_configuration_getCliOverrides.cc` — indent alignment
- `test/unit_test/flutter_view-test/test_case_flutter_view.cc` — brace alignment
- `test/unit_test/texture-test/test_case_texture.cc` — indent + brace alignment

All changes are purely cosmetic (whitespace, brace placement, line wrapping).
No logic changes. Generated with `clang-format-18 -i` using the repo's `.clang-format`
(`BasedOnStyle: Chromium, Standard: c++17`).

## Relation to PR #171

PR #171 adds the `format` and `tidy` CI jobs. This PR makes the existing codebase
pass the `format` job. The `tidy` job (clang-tidy violations, tracked separately in #172)
is out of scope for this PR.

*AI-assisted — authored with Claude, reviewed by Komada.*