### PR TITLE
Add pixel-buffer texture support and EGL context accessor

### DIFF
--- a/shell/backend/backend.h
+++ b/shell/backend/backend.h
@@ -29,6 +29,18 @@
 
 class Engine;
 
+// Carries an EGL context handle set that lets a plugin create its own EGL
+// context sharing GL objects with the embedder's raster context. All handles
+// are |void*| so the public embedder header can avoid a hard EGL include;
+// callers cast them back to the matching EGL types.
+struct BackendEglContext {
+  void* display;         // EGLDisplay
+  void* config;          // EGLConfig
+  void* share_context;   // EGLContext suitable as share_context for a
+                         // plugin-owned context that uploads GL objects
+                         // visible on the raster thread.
+};
+
 class Backend {
  public:
   enum Type {
@@ -78,6 +90,15 @@ class Backend {
   virtual bool TextureMakeCurrent() = 0;
 
   virtual bool TextureClearCurrent() = 0;
+
+  /**
+   * @brief Fill |out| with EGL handles usable as a |share_context| for a
+   *        plugin-created EGL context. Only EGL-based backends override this;
+   *        the default returns false.
+   */
+  virtual bool GetEglContext(BackendEglContext* /* out */) const {
+    return false;
+  }
 
   /**
    * @brief Get an empty FlutterRendererConfig

--- a/shell/backend/backend.h
+++ b/shell/backend/backend.h
@@ -34,11 +34,11 @@ class Engine;
 // are |void*| so the public embedder header can avoid a hard EGL include;
 // callers cast them back to the matching EGL types.
 struct BackendEglContext {
-  void* display;         // EGLDisplay
-  void* config;          // EGLConfig
-  void* share_context;   // EGLContext suitable as share_context for a
-                         // plugin-owned context that uploads GL objects
-                         // visible on the raster thread.
+  void* display;        // EGLDisplay
+  void* config;         // EGLConfig
+  void* share_context;  // EGLContext suitable as share_context for a
+                        // plugin-owned context that uploads GL objects
+                        // visible on the raster thread.
 };
 
 class Backend {

--- a/shell/backend/headless/headless.cc
+++ b/shell/backend/headless/headless.cc
@@ -18,6 +18,7 @@
 #include "engine.h"
 #include "osmesa.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
+#include "shell/platform/homescreen/flutter_desktop_texture_registrar.h"
 
 struct FlutterDesktopEngineState;
 
@@ -102,27 +103,9 @@ FlutterRendererConfig HeadlessBackend::GetRenderConfig() {
                      FlutterOpenGLTexture* texture_out) -> bool {
                 const auto state =
                     static_cast<FlutterDesktopEngineState*>(userdata);
-                auto& texture_registry =
-                    state->texture_registrar->texture_registry;
-                const auto it = std::find_if(
-                    std::begin(texture_registry), std::end(texture_registry),
-                    [&texture_id](auto&& p) { return p.first == texture_id; });
-                // texture not found in registry
-                if (it == std::end(texture_registry))
-                  return false;
-                const auto& target = texture_registry[texture_id];
-                *texture_out = {
-                    .target = target->target,
-                    .name = target->name,
-                    .format = target->format,
-                    .user_data = target->release_context,
-                    .destruction_callback = target->release_callback,
-                    .width = target->width,
-                    .height = target->height,
-                };
-                target->visible_width = width;
-                target->visible_width = height;
-                return true;
+                return PopulateExternalGlTextureFrame(
+                    state->texture_registrar.get(), texture_id, width, height,
+                    texture_out);
               },
               .fbo_with_frame_info_callback = nullptr,
               .present_with_info = nullptr,

--- a/shell/backend/wayland_egl/egl.h
+++ b/shell/backend/wayland_egl/egl.h
@@ -143,6 +143,8 @@ class Egl {
 
   [[nodiscard]] EGLDisplay GetDisplay() const { return m_dpy; }
 
+  [[nodiscard]] EGLConfig GetConfig() const { return m_config; }
+
   [[nodiscard]] EGLContext GetTextureContext() const {
     return m_texture_context;
   }

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -23,6 +23,7 @@
 #include "engine.h"
 #include "logging.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
+#include "shell/platform/homescreen/flutter_desktop_texture_registrar.h"
 
 #if BUILD_COMPOSITOR
 #include <GLES2/gl2.h>
@@ -80,24 +81,9 @@ FlutterRendererConfig WaylandEglBackend::GetRenderConfig() {
       [](void* userdata, const int64_t texture_id, const size_t width,
          const size_t height, FlutterOpenGLTexture* texture_out) -> bool {
     const auto state = static_cast<FlutterDesktopEngineState*>(userdata);
-    auto& texture_registry = state->texture_registrar->texture_registry;
-    const auto it =
-        std::find_if(std::begin(texture_registry), std::end(texture_registry),
-                     [&texture_id](auto&& p) { return p.first == texture_id; });
-    // texture not found in registry
-    if (it == std::end(texture_registry))
-      return false;
-    const auto& target = texture_registry[texture_id];
-    *texture_out = {.target = target->target,
-                    .name = target->name,
-                    .format = target->format,
-                    .user_data = target->release_context,
-                    .destruction_callback = target->release_callback,
-                    .width = target->width,
-                    .height = target->height};
-    target->visible_width = width;
-    target->visible_width = height;
-    return true;
+    return PopulateExternalGlTextureFrame(state->texture_registrar.get(),
+                                          texture_id, width, height,
+                                          texture_out);
   };
 
   config.open_gl.present_with_info =
@@ -319,6 +305,20 @@ bool WaylandEglBackend::TextureMakeCurrent() {
 
 bool WaylandEglBackend::TextureClearCurrent() {
   return ClearCurrent();
+}
+
+bool WaylandEglBackend::GetEglContext(BackendEglContext* out) const {
+  if (!out) {
+    return false;
+  }
+  out->display = GetDisplay();
+  out->config = GetConfig();
+  // |m_texture_context| is created with the main render context as its
+  // share_context, so a plugin context created with this as its own
+  // share_context transitively shares GL objects with Flutter's raster
+  // context.
+  out->share_context = GetTextureContext();
+  return out->display != EGL_NO_DISPLAY && out->share_context != EGL_NO_CONTEXT;
 }
 
 void WaylandEglBackend::JoinFlutterRect(FlutterRect* rect,

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -81,9 +81,8 @@ FlutterRendererConfig WaylandEglBackend::GetRenderConfig() {
       [](void* userdata, const int64_t texture_id, const size_t width,
          const size_t height, FlutterOpenGLTexture* texture_out) -> bool {
     const auto state = static_cast<FlutterDesktopEngineState*>(userdata);
-    return PopulateExternalGlTextureFrame(state->texture_registrar.get(),
-                                          texture_id, width, height,
-                                          texture_out);
+    return PopulateExternalGlTextureFrame(
+        state->texture_registrar.get(), texture_id, width, height, texture_out);
   };
 
   config.open_gl.present_with_info =

--- a/shell/backend/wayland_egl/wayland_egl.h
+++ b/shell/backend/wayland_egl/wayland_egl.h
@@ -93,6 +93,8 @@ class WaylandEglBackend : public Egl, public Backend {
 
   bool TextureClearCurrent() override;
 
+  bool GetEglContext(BackendEglContext* out) const override;
+
   /**
    * @brief Get FlutterRendererConfig
    * @return FlutterRendererConfig

--- a/shell/platform/homescreen/CMakeLists.txt
+++ b/shell/platform/homescreen/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(platform_homescreen STATIC
         flutter_desktop.cc
         flutter_desktop_messenger.cc
+        flutter_desktop_texture_registrar.cc
         key_event_handler.cc
         logging_handler.cc
         mouse_cursor_handler.cc

--- a/shell/platform/homescreen/flutter_desktop.cc
+++ b/shell/platform/homescreen/flutter_desktop.cc
@@ -8,6 +8,7 @@
 #include "flutter_homescreen.h"
 
 #include <algorithm>
+#include <atomic>
 #include <filesystem>
 #include <string>
 
@@ -18,6 +19,7 @@
 #include "flutter_desktop_view.h"
 #include "flutter_desktop_view_controller_state.h"
 
+#include "backend/backend.h"
 #include "view/flutter_view.h"
 
 #include "libflutter_engine.h"
@@ -274,6 +276,34 @@ FlutterDesktopTextureRegistrarRef FlutterDesktopRegistrarGetTextureRegistrar(
   return registrar->engine->texture_registrar.get();
 }
 
+bool FlutterDesktopPluginRegistrarGetEglContext(
+    FlutterDesktopPluginRegistrarRef registrar,
+    FlutterDesktopEglContext* out) {
+  if (!out) {
+    return false;
+  }
+  out->display = nullptr;
+  out->config = nullptr;
+  out->share_context = nullptr;
+  if (!registrar || !registrar->engine ||
+      !registrar->engine->view_controller ||
+      !registrar->engine->view_controller->view) {
+    return false;
+  }
+  auto* backend = registrar->engine->view_controller->view->GetBackend();
+  if (!backend) {
+    return false;
+  }
+  BackendEglContext ctx{};
+  if (!backend->GetEglContext(&ctx)) {
+    return false;
+  }
+  out->display = ctx.display;
+  out->config = ctx.config;
+  out->share_context = ctx.share_context;
+  return true;
+}
+
 int64_t FlutterDesktopTextureRegistrarRegisterExternalTexture(
     FlutterDesktopTextureRegistrarRef texture_registrar,
     const FlutterDesktopTextureInfo* texture_info) {
@@ -281,8 +311,42 @@ int64_t FlutterDesktopTextureRegistrarRegisterExternalTexture(
   int64_t result = -1;
 
   if (texture_info->type == kFlutterDesktopPixelBufferTexture) {
-    spdlog::error("RegisterExternalTexture: Pixel Buffer not implemented.");
+    const auto& pb_config = texture_info->pixel_buffer_config;
+    if (!pb_config.callback) {
+      spdlog::error(
+          "RegisterExternalTexture: pixel_buffer_config.callback is null");
+      return result;
+    }
 
+    // Pixel-buffer texture ids live in a disjoint range from GPU-surface
+    // ids (which reuse the plugin-owned GLuint name, at most 32 bits), so
+    // they can never collide in the registry.
+    static std::atomic<int64_t> next_pixel_buffer_id{1LL << 48};
+    const int64_t id = next_pixel_buffer_id.fetch_add(1);
+
+    auto desc = std::make_unique<GL_TEXTURE_2D_DESC>();
+    desc->target = 0;
+    desc->name = 0;
+    desc->format = 0;
+    desc->width = 0;
+    desc->height = 0;
+    desc->visible_width = 0;
+    desc->visible_height = 0;
+    desc->release_callback = nullptr;
+    desc->release_context = nullptr;
+    desc->pixel_buffer_callback = pb_config.callback;
+    desc->pixel_buffer_user_data = pb_config.user_data;
+
+    texture_registrar->texture_registry[id] = std::move(desc);
+
+    SPDLOG_TRACE("RegisterExternalTexture (pixel-buffer): {}, {}",
+                 fmt::ptr(texture_registrar->engine->flutter_engine), id);
+    if (kSuccess == LibFlutterEngine->RegisterExternalTexture(
+                        texture_registrar->engine->flutter_engine, id)) {
+      result = id;
+    } else {
+      texture_registrar->texture_registry.erase(id);
+    }
   } else if (texture_info->type == kFlutterDesktopGpuSurfaceTexture) {
     auto [struct_size, type, callback, user_data] =
         texture_info->gpu_surface_config;
@@ -354,9 +418,21 @@ void FlutterDesktopTextureRegistrarUnregisterExternalTexture(
   std::scoped_lock<std::mutex> lock(texture_mutex);
   LibFlutterEngine->UnregisterExternalTexture(
       texture_registrar->engine->flutter_engine, texture_id);
-  if (const auto& val = texture_registrar->texture_registry[texture_id];
-      val && val->release_callback != nullptr) {
-    val->release_callback(val->release_context);
+  if (const auto& val = texture_registrar->texture_registry[texture_id]; val) {
+    // Pixel-buffer textures: the embedder owns the GL texture, so free it
+    // under a currently-made texture context.
+    if (val->pixel_buffer_callback && val->name != 0) {
+      auto* backend =
+          texture_registrar->engine->view_controller->view->GetBackend();
+      if (backend->TextureMakeCurrent()) {
+        GLuint name = val->name;
+        glDeleteTextures(1, &name);
+        backend->TextureClearCurrent();
+      }
+    }
+    if (val->release_callback != nullptr) {
+      val->release_callback(val->release_context);
+    }
   }
   texture_registrar->texture_registry[texture_id].reset();
   texture_registrar->texture_registry.erase(texture_id);

--- a/shell/platform/homescreen/flutter_desktop.cc
+++ b/shell/platform/homescreen/flutter_desktop.cc
@@ -33,8 +33,6 @@ struct FlutterDesktopView;
 
 static_assert(FLUTTER_ENGINE_VERSION == 1, "Engine version does not match");
 
-std::mutex texture_mutex;
-
 // Attempts to load AOT data from the given path, which must be absolute and
 // non-empty. Logs and returns nullptr on failure.
 std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter> LoadAotData(
@@ -285,8 +283,7 @@ bool FlutterDesktopPluginRegistrarGetEglContext(
   out->display = nullptr;
   out->config = nullptr;
   out->share_context = nullptr;
-  if (!registrar || !registrar->engine ||
-      !registrar->engine->view_controller ||
+  if (!registrar || !registrar->engine || !registrar->engine->view_controller ||
       !registrar->engine->view_controller->view) {
     return false;
   }
@@ -307,7 +304,7 @@ bool FlutterDesktopPluginRegistrarGetEglContext(
 int64_t FlutterDesktopTextureRegistrarRegisterExternalTexture(
     FlutterDesktopTextureRegistrarRef texture_registrar,
     const FlutterDesktopTextureInfo* texture_info) {
-  std::scoped_lock lock(texture_mutex);
+  std::scoped_lock lock(texture_registrar->texture_mutex);
   int64_t result = -1;
 
   if (texture_info->type == kFlutterDesktopPixelBufferTexture) {
@@ -415,27 +412,45 @@ void FlutterDesktopTextureRegistrarUnregisterExternalTexture(
     const int64_t texture_id,
     void (*callback)(void* user_data),
     void* user_data) {
-  std::scoped_lock<std::mutex> lock(texture_mutex);
-  LibFlutterEngine->UnregisterExternalTexture(
-      texture_registrar->engine->flutter_engine, texture_id);
-  if (const auto& val = texture_registrar->texture_registry[texture_id]; val) {
-    // Pixel-buffer textures: the embedder owns the GL texture, so free it
-    // under a currently-made texture context.
-    if (val->pixel_buffer_callback && val->name != 0) {
-      auto* backend =
-          texture_registrar->engine->view_controller->view->GetBackend();
-      if (backend->TextureMakeCurrent()) {
-        GLuint name = val->name;
-        glDeleteTextures(1, &name);
-        backend->TextureClearCurrent();
-      }
-    }
-    if (val->release_callback != nullptr) {
-      val->release_callback(val->release_context);
+  std::unique_ptr<GL_TEXTURE_2D_DESC> removed;
+  {
+    std::scoped_lock<std::mutex> lock(texture_registrar->texture_mutex);
+    LibFlutterEngine->UnregisterExternalTexture(
+        texture_registrar->engine->flutter_engine, texture_id);
+    if (const auto it = texture_registrar->texture_registry.find(texture_id);
+        it != texture_registrar->texture_registry.end()) {
+      removed = std::move(it->second);
+      texture_registrar->texture_registry.erase(it);
     }
   }
-  texture_registrar->texture_registry[texture_id].reset();
-  texture_registrar->texture_registry.erase(texture_id);
+
+  if (removed) {
+    // Pixel-buffer textures: the embedder owns the GL texture, so free it
+    // under a currently-made texture context. Guard the full backend chain
+    // in case the engine is mid-teardown.
+    if (removed->pixel_buffer_callback && removed->name != 0) {
+      Backend* backend = nullptr;
+      if (texture_registrar->engine &&
+          texture_registrar->engine->view_controller &&
+          texture_registrar->engine->view_controller->view) {
+        backend =
+            texture_registrar->engine->view_controller->view->GetBackend();
+      }
+      if (backend && backend->TextureMakeCurrent()) {
+        GLuint name = removed->name;
+        glDeleteTextures(1, &name);
+        backend->TextureClearCurrent();
+      } else {
+        spdlog::warn(
+            "UnregisterExternalTexture: backend texture context unavailable; "
+            "GL texture {} leaked",
+            removed->name);
+      }
+    }
+    if (removed->release_callback != nullptr) {
+      removed->release_callback(removed->release_context);
+    }
+  }
   if (callback != nullptr) {
     callback(user_data);
   }

--- a/shell/platform/homescreen/flutter_desktop_texture_registrar.cc
+++ b/shell/platform/homescreen/flutter_desktop_texture_registrar.cc
@@ -1,0 +1,97 @@
+// Copyright 2026 Toyota Connected North America
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter_desktop_texture_registrar.h"
+
+#include <GLES2/gl2.h>
+
+#if !defined(GL_RGBA8)
+#define GL_RGBA8 0x8058
+#endif
+
+bool PopulateExternalGlTextureFrame(
+    FlutterDesktopTextureRegistrar* texture_registrar,
+    int64_t texture_id,
+    size_t width,
+    size_t height,
+    FlutterOpenGLTexture* texture_out) {
+  auto& registry = texture_registrar->texture_registry;
+  const auto it = registry.find(texture_id);
+  if (it == registry.end() || !it->second) {
+    return false;
+  }
+  auto& desc = it->second;
+
+  // GPU-surface path: the plugin owns the GL texture.
+  if (!desc->pixel_buffer_callback) {
+    texture_out->target = desc->target;
+    texture_out->name = desc->name;
+    texture_out->format = desc->format;
+    texture_out->user_data = desc->release_context;
+    texture_out->destruction_callback = desc->release_callback;
+    texture_out->width = desc->width;
+    texture_out->height = desc->height;
+    desc->visible_width = width;
+    desc->visible_height = height;
+    return true;
+  }
+
+  // Pixel-buffer path: invoke the plugin callback, upload into an
+  // embedder-owned GL texture that is allocated lazily on first frame.
+  const FlutterDesktopPixelBuffer* pb = desc->pixel_buffer_callback(
+      width, height, desc->pixel_buffer_user_data);
+  if (!pb || !pb->buffer || pb->width == 0 || pb->height == 0) {
+    return false;
+  }
+
+  const bool first_frame = desc->name == 0;
+  if (first_frame) {
+    GLuint name = 0;
+    glGenTextures(1, &name);
+    if (name == 0) {
+      return false;
+    }
+    glBindTexture(GL_TEXTURE_2D, name);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    desc->name = name;
+    desc->target = GL_TEXTURE_2D;
+    desc->format = GL_RGBA8;
+    desc->width = 0;
+    desc->height = 0;
+  } else {
+    glBindTexture(GL_TEXTURE_2D, desc->name);
+  }
+
+  const auto pb_w = static_cast<GLsizei>(pb->width);
+  const auto pb_h = static_cast<GLsizei>(pb->height);
+  if (static_cast<uint32_t>(pb->width) != desc->width ||
+      static_cast<uint32_t>(pb->height) != desc->height) {
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pb_w, pb_h, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, pb->buffer);
+    desc->width = static_cast<uint32_t>(pb->width);
+    desc->height = static_cast<uint32_t>(pb->height);
+  } else {
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, pb_w, pb_h, GL_RGBA,
+                    GL_UNSIGNED_BYTE, pb->buffer);
+  }
+
+  desc->visible_width = width;
+  desc->visible_height = height;
+
+  texture_out->target = desc->target;
+  texture_out->name = desc->name;
+  texture_out->format = desc->format;
+  texture_out->user_data = nullptr;
+  texture_out->destruction_callback = nullptr;
+  texture_out->width = desc->width;
+  texture_out->height = desc->height;
+
+  if (pb->release_callback) {
+    pb->release_callback(pb->release_context);
+  }
+  return true;
+}

--- a/shell/platform/homescreen/flutter_desktop_texture_registrar.cc
+++ b/shell/platform/homescreen/flutter_desktop_texture_registrar.cc
@@ -6,6 +6,8 @@
 
 #include <GLES2/gl2.h>
 
+#include <limits>
+
 #if !defined(GL_RGBA8)
 #define GL_RGBA8 0x8058
 #endif
@@ -16,6 +18,12 @@ bool PopulateExternalGlTextureFrame(
     size_t width,
     size_t height,
     FlutterOpenGLTexture* texture_out) {
+  // Hold the registrar mutex for the whole call: it protects the registry
+  // map against concurrent Register/Unregister, and keeps |desc| alive while
+  // we mutate its cached GL state. The plugin pixel-buffer callback runs
+  // under the lock, so plugins must not re-enter the registrar from inside
+  // it.
+  std::scoped_lock<std::mutex> lock(texture_registrar->texture_mutex);
   auto& registry = texture_registrar->texture_registry;
   const auto it = registry.find(texture_id);
   if (it == registry.end() || !it->second) {
@@ -39,9 +47,17 @@ bool PopulateExternalGlTextureFrame(
 
   // Pixel-buffer path: invoke the plugin callback, upload into an
   // embedder-owned GL texture that is allocated lazily on first frame.
-  const FlutterDesktopPixelBuffer* pb = desc->pixel_buffer_callback(
-      width, height, desc->pixel_buffer_user_data);
+  const FlutterDesktopPixelBuffer* pb =
+      desc->pixel_buffer_callback(width, height, desc->pixel_buffer_user_data);
   if (!pb || !pb->buffer || pb->width == 0 || pb->height == 0) {
+    return false;
+  }
+  // Reject sizes that would not round-trip through GLsizei/uint32_t. A
+  // plugin supplying an over-sized dimension is either buggy or hostile;
+  // truncating would desync |desc|'s cached dims from the actual upload.
+  constexpr auto kMaxDim =
+      static_cast<size_t>(std::numeric_limits<GLsizei>::max());
+  if (pb->width > kMaxDim || pb->height > kMaxDim) {
     return false;
   }
 

--- a/shell/platform/homescreen/flutter_desktop_texture_registrar.h
+++ b/shell/platform/homescreen/flutter_desktop_texture_registrar.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <GLES2/gl2.h>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
+
+#include <flutter_texture_registrar.h>
+#include <shell/platform/embedder/embedder.h>
 
 struct FlutterDesktopEngineState;
 
@@ -21,6 +25,13 @@ struct GL_TEXTURE_2D_DESC {
   size_t visible_height;
   void (*release_callback)(void* release_context);
   void* release_context;
+
+  // Pixel-buffer mode. When |pixel_buffer_callback| is non-null the embedder
+  // owns the GL texture named by |name| (lazy-allocated on first upload from
+  // the raster thread); for GPU-surface mode the plugin owns the GL texture
+  // and this pair stays null.
+  FlutterDesktopPixelBufferTextureCallback pixel_buffer_callback;
+  void* pixel_buffer_user_data;
 };
 
 // State associated with the texture registrar.
@@ -33,3 +44,17 @@ struct FlutterDesktopTextureRegistrar {
   std::unordered_map<int64_t, std::unique_ptr<GL_TEXTURE_2D_DESC>>
       texture_registry;
 };
+
+// Resolve a registered external texture for the Flutter engine's
+// |gl_external_texture_frame_callback|. For pixel-buffer textures this
+// invokes the plugin callback, lazily allocates the embedder-owned GL
+// texture, and uploads the pixel data. For GPU-surface textures it returns
+// the plugin-owned GL texture unchanged. Must be called with the raster GL
+// context current. Returns false if |texture_id| is not registered or the
+// plugin callback produced no frame.
+bool PopulateExternalGlTextureFrame(
+    FlutterDesktopTextureRegistrar* texture_registrar,
+    int64_t texture_id,
+    size_t width,
+    size_t height,
+    FlutterOpenGLTexture* texture_out);

--- a/shell/platform/homescreen/public/flutter_homescreen.h
+++ b/shell/platform/homescreen/public/flutter_homescreen.h
@@ -59,6 +59,28 @@ FLUTTER_EXPORT FlutterDesktopPluginRegistrarRef
 FlutterDesktopGetPluginRegistrar(FlutterDesktopEngineRef engine,
                                  const char* plugin_name);
 
+// EGL handles that let a plugin create its own EGL context sharing GL
+// objects with the embedder's raster context. Fields are |void*| so the
+// header does not require |<EGL/egl.h>|; callers cast to the matching EGL
+// types (|EGLDisplay|, |EGLConfig|, |EGLContext|).
+typedef struct {
+  void* display;
+  void* config;
+  void* share_context;
+} FlutterDesktopEglContext;
+
+// Populates |out| with EGL handles the plugin can use to create an EGL
+// context on its own thread. The plugin must pass |share_context| as the
+// |share_context| argument of |eglCreateContext| so that GL objects (e.g.
+// textures) it creates are visible on Flutter's raster thread for use with
+// |kFlutterDesktopGpuSurfaceTypeGlTexture2D| external textures.
+//
+// Returns false if the embedder's current backend is not EGL-based
+// (e.g. headless OSMesa, Vulkan) or the handles are not yet initialized.
+FLUTTER_EXPORT bool FlutterDesktopPluginRegistrarGetEglContext(
+    FlutterDesktopPluginRegistrarRef registrar,
+    FlutterDesktopEglContext* out);
+
 #if defined(__cplusplus)
 }  // extern "C"
 #endif


### PR DESCRIPTION
External-texture plugins using flutter::PixelBufferTexture (e.g. flutter-webrtc's video renderer) previously failed to register: both the flutter_desktop.cc registrar and the wayland_egl backend logged "Pixel Buffer not implemented" and bailed out. This wires up the path end-to-end and adds a public accessor that lets plugins create a shared EGL context for the GPU-surface path as a follow-up.

Pixel-buffer path
* GL_TEXTURE_2D_DESC gains pixel_buffer_callback / user_data; when set the embedder owns the GL texture (lazy-allocated on first upload).
* New PopulateExternalGlTextureFrame() helper consolidates the two backends' gl_external_texture_frame_callback bodies. On the raster thread it invokes the plugin callback, glTexImage2D / glTexSubImage2D uploads the RGBA pixels, fires the buffer's release_callback, and returns the embedder-owned GL texture to the engine.
* RegisterExternalTexture allocates a fresh int64 id from 1<<48 so the pixel-buffer id space never collides with the GPU-surface path's 32-bit GLuint names. UnregisterExternalTexture deletes embedder-owned textures under TextureMakeCurrent().
* wayland_egl and headless backends now call the shared helper.

EGL context accessor
* BackendEglContext POD (display / config / share_context as void*) and virtual Backend::GetEglContext(), overridden by WaylandEglBackend to return the texture context as share_context so plugin-created GL objects are visible on Flutter's raster thread.
* New public C API FlutterDesktopPluginRegistrarGetEglContext() in flutter_homescreen.h lets plugins build a shared EGL context on a worker thread and drive a kFlutterDesktopGpuSurfaceTypeGlTexture2D external texture without CPU-side YUV->RGB conversion.