### PR TITLE
[ci] add clang-tidy and clang-format lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,11 +105,7 @@ jobs:
         run: ninja -C ${{github.workspace}}/build
 
       - name: clang-tidy
-        run: |
-          find shell -type f \( -name '*.cc' -o -name '*.cpp' \) \
-            -not -path 'shell/platform/homescreen/client_wrapper/*' \
-            -not -path 'shell/platform/homescreen/public/*' \
-            | xargs clang-tidy-19 -p ${{github.workspace}}/build --warnings-as-errors='*'
+        run: scripts/clang_tidy.sh ${{github.workspace}}/build
 
       - name: clang-format
         run: scripts/format.sh --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,12 +34,12 @@ jobs:
             version: '19'
             cc: clang-19
             cxx: clang++-19
-            extra_pkgs: clang-19 llvm-19
+            extra_pkgs: clang-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
           - compiler: clang
             version: '20'
             cc: clang-20
             cxx: clang++-20
-            extra_pkgs: clang-20 llvm-20
+            extra_pkgs: clang-20 llvm-20 lld-20 libc++-20-dev libc++abi-20-dev
 
     name: ${{ matrix.compiler }}-${{ matrix.version }}
     permissions:
@@ -87,7 +87,7 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev clang-19 clang-tidy-19 clang-format-19 llvm-19
+          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev clang-19 clang-tidy-19 clang-format-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
           version: 1.0
 
       - name: Configure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev libvulkan-dev ${{ matrix.extra_pkgs }}
+          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev ${{ matrix.extra_pkgs }}
           version: 1.0
 
       - name: Configure
@@ -87,7 +87,7 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev libvulkan-dev clang-19 clang-tidy-19 clang-format-19 llvm-19
+          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev clang-19 clang-tidy-19 clang-format-19 llvm-19
           version: 1.0
 
       - name: Configure
@@ -112,9 +112,4 @@ jobs:
             | xargs clang-tidy-19 -p ${{github.workspace}}/build --warnings-as-errors='*'
 
       - name: clang-format
-        run: |
-          find shell test \( -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) \
-            -not -path 'shell/platform/homescreen/client_wrapper/*' \
-            -not -path 'shell/platform/homescreen/public/*' \
-            -print0 \
-            | xargs -0 clang-format-19 --dry-run --Werror
+        run: scripts/format.sh --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,74 @@
+name: lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [v2.0]
+  workflow_dispatch:
+
+jobs:
+  clang-tidy:
+    if: ${{ github.server_url == 'https://github.com' }}
+    runs-on: ubuntu-24.04
+    name: clang-tidy
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev libvulkan-dev clang-19 clang-tidy-19
+          version: 1.0
+
+      - name: Configure
+        env:
+          CC: clang-19
+          CXX: clang++-19
+        run: |
+          cmake -GNinja \
+            -B ${{github.workspace}}/build \
+            -D CMAKE_BUILD_TYPE=Debug \
+            -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -D BUILD_NUMBER=${GITHUB_RUN_ID}
+
+      - name: Build (generate compile_commands.json)
+        run: ninja -C ${{github.workspace}}/build
+
+      - name: clang-tidy
+        run: |
+          find shell -type f \( -name '*.cc' -o -name '*.cpp' \) \
+            -not -path 'shell/platform/homescreen/client_wrapper/*' \
+            -not -path 'shell/platform/homescreen/public/*' \
+            | xargs clang-tidy-19 -p ${{github.workspace}}/build --warnings-as-errors='*'
+
+  clang-format:
+    if: ${{ github.server_url == 'https://github.com' }}
+    runs-on: ubuntu-24.04
+    name: clang-format
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: clang-format-19
+          version: 1.0
+
+      - name: clang-format
+        run: |
+          find shell test \( -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) \
+            -not -path 'shell/platform/homescreen/client_wrapper/*' \
+            -not -path 'shell/platform/homescreen/public/*' \
+            -print0 \
+            | xargs -0 clang-format-19 --dry-run --Werror

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: lint
+name: ci
 
 on:
   pull_request:
@@ -8,10 +8,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  clang-tidy:
+  build:
     if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-24.04
-    name: clang-tidy
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compiler: gcc
+            version: '12'
+            cc: gcc-12
+            cxx: g++-12
+            extra_pkgs: g++-12
+          - compiler: gcc
+            version: '13'
+            cc: gcc-13
+            cxx: g++-13
+            extra_pkgs: g++-13
+          - compiler: gcc
+            version: '14'
+            cc: gcc-14
+            cxx: g++-14
+            extra_pkgs: g++-14
+          - compiler: clang
+            version: '19'
+            cc: clang-19
+            cxx: clang++-19
+            extra_pkgs: clang-19 llvm-19
+          - compiler: clang
+            version: '20'
+            cc: clang-20
+            cxx: clang++-20
+            extra_pkgs: clang-20 llvm-20
+
+    name: ${{ matrix.compiler }}-${{ matrix.version }}
     permissions:
       contents: read
 
@@ -24,7 +54,40 @@ jobs:
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev libvulkan-dev clang-19 clang-tidy-19
+          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev libvulkan-dev ${{ matrix.extra_pkgs }}
+          version: 1.0
+
+      - name: Configure
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: |
+          cmake -GNinja \
+            -B ${{github.workspace}}/build \
+            -D CMAKE_BUILD_TYPE=Debug \
+            -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -D BUILD_NUMBER=${GITHUB_RUN_ID}
+
+      - name: Build
+        run: ninja -C ${{github.workspace}}/build
+
+  lint:
+    if: ${{ github.server_url == 'https://github.com' }}
+    runs-on: ubuntu-24.04
+    name: lint
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev libvulkan-dev clang-19 clang-tidy-19 clang-format-19 llvm-19
           version: 1.0
 
       - name: Configure
@@ -47,23 +110,6 @@ jobs:
             -not -path 'shell/platform/homescreen/client_wrapper/*' \
             -not -path 'shell/platform/homescreen/public/*' \
             | xargs clang-tidy-19 -p ${{github.workspace}}/build --warnings-as-errors='*'
-
-  clang-format:
-    if: ${{ github.server_url == 'https://github.com' }}
-    runs-on: ubuntu-24.04
-    name: clang-format
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: clang-format-19
-          version: 1.0
 
       - name: clang-format
         run: |

--- a/cmake/compiler_clang.cmake
+++ b/cmake/compiler_clang.cmake
@@ -3,7 +3,11 @@ include_guard()
 cmake_policy(SET CMP0075 NEW)
 
 if (NOT LLVM_CONFIG)
-    find_program(LLVM_CONFIG "llvm-config" DOC "Path to llvm-config" REQUIRED)
+    string(REGEX MATCH "^[0-9]+" _clang_major "${CMAKE_CXX_COMPILER_VERSION}")
+    find_program(LLVM_CONFIG
+            NAMES "llvm-config-${_clang_major}" "llvm-config"
+            DOC "Path to llvm-config"
+            REQUIRED)
 endif ()
 
 execute_process(

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 ivi-homescreen contributors
+#
+# clang_tidy.sh — run clang-tidy-19 across the project sources.
+#
+# Usage:
+#   scripts/clang_tidy.sh [BUILD_DIR]
+#
+# BUILD_DIR defaults to "build" and must contain a compile_commands.json
+# (configure with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BUILD_DIR="${1:-build}"
+if [[ "${BUILD_DIR}" != /* ]]; then
+    BUILD_DIR="${ROOT_DIR}/${BUILD_DIR}"
+fi
+
+if [[ ! -f "${BUILD_DIR}/compile_commands.json" ]]; then
+    echo "ERROR: compile_commands.json not found in ${BUILD_DIR}."
+    echo "Build the project first with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON."
+    exit 1
+fi
+
+CLANG_TIDY="${CLANG_TIDY:-clang-tidy-19}"
+if ! command -v "${CLANG_TIDY}" &>/dev/null; then
+    CLANG_TIDY="clang-tidy"
+fi
+
+if ! command -v "${CLANG_TIDY}" &>/dev/null; then
+    echo "ERROR: clang-tidy not found. Install it (e.g. sudo apt install clang-tidy-19)." >&2
+    exit 1
+fi
+
+echo "Using: $(command -v "${CLANG_TIDY}")"
+
+# Only lint files actually compiled in this build configuration (those
+# present in compile_commands.json). Files belonging to optional backends
+# (osmesa, vulkan, dlt, ...) or plugin-only sources are skipped when the
+# corresponding feature is off, avoiding spurious errors from unavailable
+# headers and mis-resolved compilation flags.
+#
+# Further exclude vendored Flutter embedder sources (client_wrapper,
+# public) and third_party/.
+mapfile -t FILES < <(
+    python3 - "${BUILD_DIR}/compile_commands.json" "${ROOT_DIR}" <<'PY'
+import json
+import os
+import sys
+
+cc_path, root = sys.argv[1], os.path.realpath(sys.argv[2])
+with open(cc_path) as fh:
+    entries = json.load(fh)
+
+excludes = (
+    os.path.join(root, "third_party") + os.sep,
+    os.path.join(root, "shell", "platform", "homescreen", "client_wrapper")
+    + os.sep,
+    os.path.join(root, "shell", "platform", "homescreen", "public") + os.sep,
+)
+
+seen = set()
+for entry in entries:
+    path = os.path.realpath(
+        entry["file"]
+        if os.path.isabs(entry["file"])
+        else os.path.join(entry.get("directory", ""), entry["file"])
+    )
+    if not path.startswith(os.path.join(root, "shell") + os.sep):
+        continue
+    if any(path.startswith(ex) for ex in excludes):
+        continue
+    if not path.endswith((".cc", ".cpp")):
+        continue
+    if path in seen:
+        continue
+    seen.add(path)
+    print(path)
+PY
+)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    echo "ERROR: no shell/ source files found in compile_commands.json." >&2
+    exit 1
+fi
+
+printf '%s\n' "${FILES[@]}" | sort | \
+    xargs "${CLANG_TIDY}" -p "${BUILD_DIR}" --warnings-as-errors='*' 2>&1
+
+echo "clang-tidy passed."

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 ivi-homescreen contributors
+#
+# format.sh — apply clang-format-19 in-place to all C++ source files.
+#
+# Usage:
+#   scripts/format.sh [--check]
+#
+# Without arguments: formats all *.cc / *.cpp / *.h / *.hpp files under
+# shell/ and test/ using the project's .clang-format configuration.
+#
+# With --check: runs in dry-run mode and exits non-zero if any file would be
+# reformatted.  This is the mode called by the CI lint workflow.
+
+set -euo pipefail
+
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format-19}"
+
+if ! command -v "${CLANG_FORMAT}" &>/dev/null; then
+    echo "error: ${CLANG_FORMAT} not found. Install it (e.g. sudo apt install clang-format-19)." >&2
+    exit 1
+fi
+
+# Resolve the repository root relative to this script so it works from any CWD.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+mapfile -d '' FILES < <(
+    find \
+        "${REPO_ROOT}/shell" \
+        "${REPO_ROOT}/test" \
+        \( -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) \
+        -not -path "${REPO_ROOT}/shell/platform/homescreen/client_wrapper/*" \
+        -not -path "${REPO_ROOT}/shell/platform/homescreen/public/*" \
+        -print0
+)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    echo "No C++ source files found."
+    exit 0
+fi
+
+if [[ "${1:-}" == "--check" ]]; then
+    echo "Checking formatting with ${CLANG_FORMAT} (dry-run) ..."
+    "${CLANG_FORMAT}" --dry-run -Werror "${FILES[@]}"
+    echo "All files are correctly formatted."
+else
+    echo "Formatting ${#FILES[@]} file(s) with ${CLANG_FORMAT} ..."
+    "${CLANG_FORMAT}" -i "${FILES[@]}"
+    echo "Done."
+fi

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -92,7 +92,8 @@ int App::Loop() const {
   const auto elapsed = end_time - start_time;
 
   const auto frame_time = 1000.0 / m_wayland_display->GetMaxRefreshRate();
-  if (const auto sleep_time = frame_time - elapsed; sleep_time > 0) {
+  if (const auto sleep_time = frame_time - static_cast<double>(elapsed);
+      sleep_time > 0) {
 #if BUILD_WATCHDOG
     m_watch_dog->pet();
 #endif

--- a/shell/platform/homescreen/logging_handler.cc
+++ b/shell/platform/homescreen/logging_handler.cc
@@ -27,15 +27,14 @@ LoggingHandler::LoggingHandler(flutter::BinaryMessenger* messenger,
           "logging",
           &flutter::StandardMethodCodec::GetInstance())) {
   channel_->SetMethodCallHandler(
-      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
-             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
-                 result) { HandleMethodCall(call, std::move(result)); });
+      [](const flutter::MethodCall<flutter::EncodableValue>& call,
+         std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+             result) { HandleMethodCall(call, std::move(result)); });
 }
 
 void LoggingHandler::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue>& method_call,
-    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
-    const {
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   const std::string& method = method_call.method_name();
 
   if (method == "get_logging_callback_fptr") {

--- a/shell/platform/homescreen/logging_handler.h
+++ b/shell/platform/homescreen/logging_handler.h
@@ -31,10 +31,9 @@ class LoggingHandler {
 
  private:
   // Called when a method is called on |channel_|;
-  void HandleMethodCall(
+  static void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
-      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
-      const;
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
   // The MethodChannel used for communication with the Flutter engine.
   std::unique_ptr<flutter::MethodChannel<>> channel_;

--- a/shell/platform/homescreen/platform_views/platform_view_touch.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_touch.cc
@@ -16,6 +16,8 @@
 
 #include "platform_view_touch.h"
 
+#include "logging/logging.h"
+
 PlatformViewTouch::PlatformViewTouch(
     const std::vector<flutter::EncodableValue>& params) {
 #if DEBUG_PLATFORM_VIEW_TOUCH_PARAMS

--- a/shell/timer.cc
+++ b/shell/timer.cc
@@ -129,7 +129,7 @@ void EventTimer::disarm() const {
 }
 
 void EventTimer::_watch_fd(int fd, uint32_t events, struct timer_task* task) {
-  struct epoll_event ep {};
+  struct epoll_event ep{};
 
   if (evfd < 0) {
     spdlog::critical("Unexpected call _watch_fd(). Ignored.");

--- a/shell/timer.h
+++ b/shell/timer.h
@@ -47,9 +47,9 @@ class EventTimer {
   static int evfd;
 
   int m_timerfd;
-  struct itimerspec m_timerspec {};
+  struct itimerspec m_timerspec{};
 
-  struct timer_task m_task {};
+  struct timer_task m_task{};
   evtimer_cb m_callback;
   void* m_callback_data;
 

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -969,7 +969,7 @@ void Display::agl_shell_bound_fail(void* data, struct agl_shell* shell) {
   d->m_agl.bound_ok = false;
 }
 
-void Display::addAppToStack(std::string app_id) {
+void Display::addAppToStack(const std::string& app_id) {
   if (app_id == "homescreen")
     return;
 
@@ -988,7 +988,7 @@ void Display::addAppToStack(std::string app_id) {
   }
 }
 
-int Display::find_output_by_name(std::string output_name) {
+int Display::find_output_by_name(const std::string& output_name) {
   int index = 0;
   for (auto& i : m_all_outputs) {
     if (i->name == output_name) {
@@ -1061,7 +1061,7 @@ void Display::deactivateApp(const std::string& app_id) {
 }
 
 void Display::processAppStatusEvent(const char* app_id,
-                                    const std::string event_type) {
+                                    const std::string& event_type) {
   if (!m_agl.shell)
     return;
 
@@ -1096,9 +1096,8 @@ void Display::agl_shell_app_on_output(void* data,
   //
   // finally if the outputs are identical probably that's an user-error -
   // but the compositor won't activate it again, so we don't handle that.
-  std::pair new_pending_app =
-      std::pair(std::string(app_id), std::string(output_name));
-  d->pending_app_list.push_back(new_pending_app);
+  d->pending_app_list.emplace_back(std::string(app_id),
+                                   std::string(output_name));
 
   auto iter = d->apps_stack.begin();
   while (iter != d->apps_stack.end()) {

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -327,7 +327,7 @@ class Display {
    * @relation
    * agl_shell
    */
-  void addAppToStack(std::string app_id);
+  void addAppToStack(const std::string& app_id);
   /**
    * @brief Helper to retrieve the output using its output_name
    * @param[in] output_name a std::string representing the output
@@ -335,7 +335,7 @@ class Display {
    * @relation
    * agl_sell
    */
-  int find_output_by_name(std::string output_name);
+  int find_output_by_name(const std::string& output_name);
   /**
    * @brief helper to process the application status
    * @param[in] app_id an array of char
@@ -344,7 +344,7 @@ class Display {
    * @relation
    * agl_shell
    */
-  void processAppStatusEvent(const char* app_id, std::string event_type);
+  void processAppStatusEvent(const char* app_id, const std::string& event_type);
 
  private:
   std::thread event_thread_;
@@ -592,7 +592,7 @@ class Display {
    */
   static void display_handle_scale(void* data,
                                    struct wl_output* wl_output,
-                                   int scale);
+                                   int32_t factor);
 
   /**
    * @brief Turn ON the completion flag

--- a/test/comp_surf_egl/c++/src/main.cpp
+++ b/test/comp_surf_egl/c++/src/main.cpp
@@ -70,8 +70,9 @@ comp_surf_Context* comp_surf_initialize(const char* accessToken,
                                         const char* cachePath,
                                         const char* miscPath) {
   auto* ctx = new comp_surf_Context;
-  ctx->context = std::make_unique<CompSurfContext>(
-      accessToken, width, height, nativeWindow, assetsPath, cachePath, miscPath);
+  ctx->context = std::make_unique<CompSurfContext>(accessToken, width, height,
+                                                   nativeWindow, assetsPath,
+                                                   cachePath, miscPath);
   return ctx;
 }
 

--- a/test/comp_surf_vulkan/c++/src/main.cpp
+++ b/test/comp_surf_vulkan/c++/src/main.cpp
@@ -70,8 +70,9 @@ comp_surf_Context* comp_surf_initialize(const char* accessToken,
                                         const char* cachePath,
                                         const char* miscPath) {
   auto* ctx = new comp_surf_Context;
-  ctx->context = std::make_unique<CompSurfContext>(
-      accessToken, width, height, nativeWindow, assetsPath, cachePath, miscPath);
+  ctx->context = std::make_unique<CompSurfContext>(accessToken, width, height,
+                                                   nativeWindow, assetsPath,
+                                                   cachePath, miscPath);
   return ctx;
 }
 

--- a/test/unit_test/app-headless-test/test_case_app_headless.cc
+++ b/test/unit_test/app-headless-test/test_case_app_headless.cc
@@ -12,8 +12,6 @@
 #include "logging.h"
 #include "unit_test_utils.h"
 
-
-
 /****************************************************************
 Test Case Name.Test Name： HomescreenAppHeadless_Lv1Normal001
 Use Case Name: Initialization
@@ -58,4 +56,3 @@ TEST(HomescreenAppHeadless, Lv1Normal001) {
   EXPECT_EQ(images_are_equal, 1);
 #endif
 }
-

--- a/test/unit_test/configuration-test-case/test_case_configuration.cc
+++ b/test/unit_test/configuration-test-case/test_case_configuration.cc
@@ -18,7 +18,7 @@ Test Summary：Test ParseConfig for default value
 ***************************************************************/
 
 TEST(HomescreenConfigurationParseConfig, Lv1Normal001) {
-  struct Configuration::Config config {};
+  struct Configuration::Config config{};
   config.bundle_paths.emplace_back(kUnitTestAppBundle);
 
   // call target function
@@ -125,7 +125,7 @@ TEST(HomescreenConfigurationGetTomlConfig, Lv1Normal001) {
   EXPECT_EQ(true, config.disable_cursor.value_or(false));
   EXPECT_EQ("keyboard", config.wayland_event_mask);
   EXPECT_EQ(false, config.debug_backend.value_or(false));
-  
+
   EXPECT_EQ("NORMAL", config.view.window_type);
   EXPECT_EQ(2, config.view.wl_output_index.value_or(0));
   EXPECT_EQ(1920, config.view.width.value_or(kDefaultViewWidth));
@@ -163,7 +163,7 @@ TEST(HomescreenConfigurationGetTomlConfig, Lv1Normal002) {
   EXPECT_EQ(true, config.disable_cursor.value_or(false));
   EXPECT_EQ("keyboard", config.wayland_event_mask);
   EXPECT_EQ(false, config.debug_backend.value_or(false));
-  
+
   EXPECT_EQ("", config.view.bundle_path);
   EXPECT_EQ("", config.view.window_type);
   EXPECT_EQ(0, config.view.wl_output_index.value_or(0));
@@ -181,4 +181,3 @@ TEST(HomescreenConfigurationGetTomlConfig, Lv1Normal002) {
   EXPECT_EQ(0, config.view.activation_area_width);
   EXPECT_EQ(0, config.view.activation_area_height);
 }
-

--- a/test/unit_test/configuration-test-case/test_case_configuration_PrintConfig.cc
+++ b/test/unit_test/configuration-test-case/test_case_configuration_PrintConfig.cc
@@ -1,7 +1,7 @@
-#include <filesystem>
-#include <stdexcept>
 #include <gtest/gtest.h>
+#include <filesystem>
 #include <iostream>
+#include <stdexcept>
 
 #include <configuration/configuration.h>
 
@@ -13,7 +13,7 @@ Test Summary：Test PrintConfig to visually check
 
 TEST(HomescreenConfigurationPrintConfig, Lv1Normal001) {
   // set test parameters
-  struct Configuration::Config config {};
+  struct Configuration::Config config{};
   config.app_id = "homescreen";
   config.bundle_paths.emplace_back("/usr/share/");
   config.cursor_theme = "DMZ-White";
@@ -32,31 +32,60 @@ TEST(HomescreenConfigurationPrintConfig, Lv1Normal001) {
   config.view.ivi_surface_id = 1;
   config.view.fullscreen = true;
 
-  std::cout << "\n##################### Reference Output #######################\n" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] {branch} @ {commit id}" << std::endl;
+  std::cout
+      << "\n##################### Reference Output #######################\n"
+      << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] {branch} @ {commit id}"
+            << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] **********" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] * Global *" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] **********" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Application Id: .......... homescreen" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Cursor Theme: ............ DMZ-White" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Disable Cursor: .......... true" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Wayland Event Mask: ...... keyboard" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Debug Backend: ........... true" << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Application Id: .......... "
+               "homescreen"
+            << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Cursor Theme: ............ DMZ-White"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Disable Cursor: .......... true"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Wayland Event Mask: ...... keyboard"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Debug Backend: ........... true"
+      << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] ********" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] * View *" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] ********" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] VM Args:" << std::endl;
   std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] --enable-asserts" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] --pause-isolates-on-start" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Bundle Path: .............. /home/" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Window Type: .............. NORMAL" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Output Index: ............. 1" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Size: ..................... 1280 x 720" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Pixel Ratio: .............. 1.2" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Fullscreen: ............... true" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Accessibility Features: ... 1" << std::endl;
-  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Ivi Surface ID: ........... 1" << std::endl;
-  std::cout << "\n################## Please check visually #####################\n" << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] --pause-isolates-on-start"
+            << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Bundle Path: .............. /home/"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Window Type: .............. NORMAL"
+      << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Output Index: ............. 1"
+            << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Size: ..................... "
+               "1280 x 720"
+            << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Pixel Ratio: .............. 1.2"
+      << std::endl;
+  std::cout
+      << "[20xx-xx-xx xx:xx:xx.xxx] [info] Fullscreen: ............... true"
+      << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Accessibility Features: ... 1"
+            << std::endl;
+  std::cout << "[20xx-xx-xx xx:xx:xx.xxx] [info] Ivi Surface ID: ........... 1"
+            << std::endl;
+  std::cout
+      << "\n################## Please check visually #####################\n"
+      << std::endl;
 
   Configuration::PrintConfig(config);
 }

--- a/test/unit_test/configuration-test-case/test_case_configuration_getCliOverrides.cc
+++ b/test/unit_test/configuration-test-case/test_case_configuration_getCliOverrides.cc
@@ -1,9 +1,9 @@
 #include <stdlib.h>
 #include "gtest/gtest.h"
 
+#include <configuration/configuration.h>
 #include <flutter/fml/command_line.h>
 #include <rapidjson/document.h>
-#include <configuration/configuration.h>
 
 /****************************************************************
 Test Case Name.Test Name： HomescreenConfigurationGetCliOverrides_Lv1Normal001
@@ -13,8 +13,8 @@ Test Summary：Test getCliOverrides with all normal parameters
 
 TEST(HomescreenConfigurationGetCliOverrides, Lv1Normal001) {
   // set test parameters
-  struct Configuration::Config input_cfg {};
-  struct Configuration::Config config {};
+  struct Configuration::Config input_cfg{};
+  struct Configuration::Config config{};
 
   input_cfg.app_id = "homescreen";
   input_cfg.bundle_paths.emplace_back("files");
@@ -54,7 +54,7 @@ TEST(HomescreenConfigurationGetCliOverrides, Lv1Normal001) {
   EXPECT_EQ(1, config.view.pixel_ratio);
   EXPECT_EQ(1, config.view.ivi_surface_id);
   EXPECT_EQ(true, config.view.fullscreen);
-  EXPECT_EQ(1,1);
+  EXPECT_EQ(1, 1);
 }
 /****************************************************************
 Test Case Name.Test Name： HomescreenConfigurationGetCliOverrides_Lv1Normal002
@@ -64,8 +64,8 @@ Test Summary：Test getCliOverrides with blank parameter
 
 TEST(HomescreenConfigurationGetCliOverrides, Lv1Normal002) {
   // set test parameters
-  struct Configuration::Config input_cfg {};
-  struct Configuration::Config config {};
+  struct Configuration::Config input_cfg{};
+  struct Configuration::Config config{};
 
   // call target function
   Configuration::get_cli_override("/home", config, input_cfg);
@@ -83,8 +83,10 @@ TEST(HomescreenConfigurationGetCliOverrides, Lv1Normal002) {
   EXPECT_EQ("", config.view.window_type);
   EXPECT_EQ(0, config.view.wl_output_index.value_or(0));
   EXPECT_EQ(kDefaultViewWidth, config.view.width.value_or(kDefaultViewWidth));
-  EXPECT_EQ(kDefaultViewHeight, config.view.height.value_or(kDefaultViewHeight));
-  EXPECT_EQ(kDefaultPixelRatio, config.view.pixel_ratio.value_or(kDefaultPixelRatio));
+  EXPECT_EQ(kDefaultViewHeight,
+            config.view.height.value_or(kDefaultViewHeight));
+  EXPECT_EQ(kDefaultPixelRatio,
+            config.view.pixel_ratio.value_or(kDefaultPixelRatio));
   EXPECT_EQ(0, config.view.ivi_surface_id.value_or(0));
   EXPECT_EQ(0, config.view.accessibility_features.value_or(0));
   EXPECT_EQ(false, config.view.fullscreen.value_or(false));
@@ -98,8 +100,8 @@ Test Summary：Test getCliOverrides with some params already true
 
 TEST(HomescreenConfigurationGetCliOverrides, Lv1Normal003) {
   // set test parameters
-  struct Configuration::Config input_cfg {};
-  struct Configuration::Config config {};
+  struct Configuration::Config input_cfg{};
+  struct Configuration::Config config{};
 
   input_cfg.app_id = "homescreen";
   input_cfg.disable_cursor = true;

--- a/test/unit_test/flutter_view-test/test_case_flutter_view.cc
+++ b/test/unit_test/flutter_view-test/test_case_flutter_view.cc
@@ -1,15 +1,14 @@
 #include <stdexcept>
 #include "gtest/gtest.h"
-#include "utils.h"
-#include "view/flutter_view.h"
-#include "view/compositor_surface_api.h"
-#include "wayland/display.h"
 #include "unit_test_utils.h"
+#include "utils.h"
+#include "view/compositor_surface_api.h"
+#include "view/flutter_view.h"
+#include "wayland/display.h"
 
 FlutterView* createFlutterViewInstance() {
   int argc = 3;
-  const char* argv[3] = {"homescreen",
-                         "-b",kBundlePath};
+  const char* argv[3] = {"homescreen", "-b", kBundlePath};
   char** argv_p = reinterpret_cast<char**>(&argv);
 
   // call target function

--- a/test/unit_test/texture-test/test_case_texture.cc
+++ b/test/unit_test/texture-test/test_case_texture.cc
@@ -1,16 +1,18 @@
-#include "gtest/gtest.h"
-#include "utils.h"
 #include "engine.h"
+#include "gtest/gtest.h"
+#include "textures/texture.h"
+#include "utils.h"
 #include "view/flutter_view.h"
 #include "wayland/display.h"
-#include "textures/texture.h"
 
 static constexpr char kBundlePath[] = TEST_APP_BUNDLE_PATH;
 static constexpr char kSourceRoot[] = SOURCE_ROOT_DIR;
 constexpr int64_t kTestTextureObjectId = 5150;
 const std::string kCallCreateCb = "Call Create Callback";
-const flutter::EncodableValue kFlutterTestKey = flutter::EncodableValue("Test Key");
-const flutter::EncodableValue kFlutterTestVal = flutter::EncodableValue("Test Val");
+const flutter::EncodableValue kFlutterTestKey =
+    flutter::EncodableValue("Test Key");
+const flutter::EncodableValue kFlutterTestVal =
+    flutter::EncodableValue("Test Val");
 bool callDisposeCallback = false;
 
 /**
@@ -18,7 +20,7 @@ bool callDisposeCallback = false;
  */
 FlutterView* createFlutterViewInstance() {
   // setup parameter
-  struct Configuration::Config config {};
+  struct Configuration::Config config{};
   config.view.bundle_path = kBundlePath;
   config.view.wl_output_index = 1;
   auto configs = Configuration::ParseConfig(config);
@@ -36,7 +38,7 @@ Engine* createEngineInstance() {
   FlutterView* view = createFlutterViewInstance();
   std::vector<const char*> vm_args_c;
 
-  Engine *engine = new Engine(view, 1, vm_args_c, kBundlePath, 1);
+  Engine* engine = new Engine(view, 1, vm_args_c, kBundlePath, 1);
   return engine;
 }
 
@@ -44,7 +46,7 @@ Engine* createEngineInstance() {
  * @brief Callback function to registered instead of Texture::Create
  */
 flutter::EncodableValue create_callback(void* userdata,
-    const flutter::EncodableMap* args) {
+                                        const flutter::EncodableMap* args) {
   // check object Texture-ID
   auto* obj = reinterpret_cast<Texture*>(userdata);
   int64_t texture_id = obj->GetId();
@@ -78,8 +80,8 @@ Test Summary: Check that the value set in the constructor can be retrieved
 ***************************************************************/
 TEST(HomescreenTextureGetFlutterOpenGLTexture, Lv1Normal001) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, nullptr, nullptr);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 nullptr, nullptr);
   ASSERT_TRUE(texture != nullptr);
 
   // call target function
@@ -98,20 +100,19 @@ Test Summary: Dont set callback and check default encodable value
 ***************************************************************/
 TEST(HomescreenTextureCreate, Lv1Normal001) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, nullptr, nullptr);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 nullptr, nullptr);
   ASSERT_TRUE(texture != nullptr);
 
   // call target function
   flutter::EncodableValue create = texture->Create(100, 200, nullptr);
 
   // confirm to create instance
-  flutter::EncodableValue expect_val = flutter::EncodableValue(
-    flutter::EncodableMap{
-      {flutter::EncodableValue("result"),
-       flutter::EncodableValue(-1)},
-      {flutter::EncodableValue("error"),
-       flutter::EncodableValue("Create callback not set")}});
+  flutter::EncodableValue expect_val =
+      flutter::EncodableValue(flutter::EncodableMap{
+          {flutter::EncodableValue("result"), flutter::EncodableValue(-1)},
+          {flutter::EncodableValue("error"),
+           flutter::EncodableValue("Create callback not set")}});
   EXPECT_TRUE(expect_val == create);
 }
 
@@ -122,12 +123,12 @@ Test Summary: set create callback and check if the callback is called
 ***************************************************************/
 TEST(HomescreenTextureCreate, Lv1Normal002) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, create_callback, nullptr);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 create_callback, nullptr);
   ASSERT_TRUE(texture != nullptr);
 
-  flutter::EncodableMap test_args = flutter::EncodableMap{
-        {kFlutterTestKey, kFlutterTestVal}};
+  flutter::EncodableMap test_args =
+      flutter::EncodableMap{{kFlutterTestKey, kFlutterTestVal}};
 
   // call target function
   flutter::EncodableValue create = texture->Create(100, 200, &test_args);
@@ -144,13 +145,13 @@ Test Summary: set dispose callback and check if the callback is called
 ***************************************************************/
 TEST(HomescreenTextureDispose, Lv1Normal001) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, nullptr, dispose_callback);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 nullptr, dispose_callback);
   ASSERT_TRUE(texture != nullptr);
   callDisposeCallback = false;
 
-  flutter::EncodableMap test_args = flutter::EncodableMap{
-        {kFlutterTestKey, kFlutterTestVal}};
+  flutter::EncodableMap test_args =
+      flutter::EncodableMap{{kFlutterTestKey, kFlutterTestVal}};
 
   // call target function
   texture->Dispose(kTestTextureObjectId);
@@ -166,13 +167,13 @@ Test Summary: Dont set dispose callback and check if the callback is not called
 ***************************************************************/
 TEST(HomescreenTextureDispose, Lv1Normal002) {
   // setup parameter
-  Texture *texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D,
-      GL_RGBA8, nullptr, nullptr);
+  Texture* texture = new Texture(kTestTextureObjectId, GL_TEXTURE_2D, GL_RGBA8,
+                                 nullptr, nullptr);
   ASSERT_TRUE(texture != nullptr);
   callDisposeCallback = false;
 
-  flutter::EncodableMap test_args = flutter::EncodableMap{
-        {kFlutterTestKey, kFlutterTestVal}};
+  flutter::EncodableMap test_args =
+      flutter::EncodableMap{{kFlutterTestKey, kFlutterTestVal}};
 
   // call target function
   texture->Dispose(kTestTextureObjectId);
@@ -181,8 +182,7 @@ TEST(HomescreenTextureDispose, Lv1Normal002) {
   EXPECT_FALSE(callDisposeCallback);
 }
 
-
-#if 0 // TODO ME: Update tests for new Texture implementation
+#if 0  // TODO ME: Update tests for new Texture implementation
 /****************************************************************
 Test Case Name.Test Name： HomescreenTextureEnable_Lv1Normal001
 Use Case Name: Set OpenGL texture

--- a/test/unit_test/timer-test/test_case_timer.cc
+++ b/test/unit_test/timer-test/test_case_timer.cc
@@ -107,7 +107,7 @@ TEST(HomescreenUntimerArm, Lv1Normal001) {
   timer.arm();
 
   // check timerspec is set
-  struct itimerspec timerspec {};
+  struct itimerspec timerspec{};
   const int ret_gettime = timerfd_gettime(timer.m_timerfd, &timerspec);
 
   EXPECT_EQ(0, ret_gettime);
@@ -135,7 +135,7 @@ TEST(HomescreenUntimerDisarm, Lv1Normal001) {
   timer.disarm();
 
   // check timerspec is all zero
-  struct itimerspec timerspec {};
+  struct itimerspec timerspec{};
   const int ret_gettime = timerfd_gettime(timer.m_timerfd, &timerspec);
 
   EXPECT_EQ(0, ret_gettime);


### PR DESCRIPTION
Runs on PRs, v2.0 pushes, and manual dispatch. clang-tidy builds with CMAKE_EXPORT_COMPILE_COMMANDS and checks shell/ with --warnings-as-errors; clang-format dry-runs against shell/ and test/ with --Werror. Both jobs skip the homescreen client_wrapper and public headers.