### PR TITLE
[compositor] wire EGL compositor and fix overlay compositing

### DIFF
--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -31,9 +31,11 @@ constexpr GLenum kDrawFramebuffer = 0x8CA9;
 constexpr char kVertSrc[] =
     "attribute vec2 a_pos;\n"
     "attribute vec2 a_uv;\n"
+    "uniform float u_uv_y_scale;\n"
+    "uniform float u_uv_y_offset;\n"
     "varying vec2 v_uv;\n"
     "void main() {\n"
-    "  v_uv = a_uv;\n"
+    "  v_uv = vec2(a_uv.x, a_uv.y * u_uv_y_scale + u_uv_y_offset);\n"
     "  gl_Position = vec4(a_pos, 0.0, 1.0);\n"
     "}\n";
 
@@ -119,6 +121,8 @@ bool GlCompositor::EnsureQuad() {
   attr_pos_ = glGetAttribLocation(program_, "a_pos");
   attr_uv_ = glGetAttribLocation(program_, "a_uv");
   uni_tex_ = glGetUniformLocation(program_, "u_tex");
+  uni_uv_y_scale_ = glGetUniformLocation(program_, "u_uv_y_scale");
+  uni_uv_y_offset_ = glGetUniformLocation(program_, "u_uv_y_offset");
 
   // Fullscreen triangle strip in NDC: (x, y, u, v) per vertex.
   constexpr std::array<GLfloat, 16> verts = {{
@@ -150,7 +154,9 @@ void GlCompositor::CompositeViaQuad(GLuint src_color_tex,
                                     GLint dst_x,
                                     GLint dst_y,
                                     GLsizei dst_w,
-                                    GLsizei dst_h) {
+                                    GLsizei dst_h,
+                                    bool blend,
+                                    bool flip_y) {
   if (!EnsureQuad()) {
     return;
   }
@@ -158,7 +164,13 @@ void GlCompositor::CompositeViaQuad(GLuint src_color_tex,
   // Snapshot minimal state: we don't implement full state save/restore,
   // but we set everything we rely on so the engine's next render isn't
   // surprised. Flutter resets its own GL state on entry.
-  glDisable(GL_BLEND);
+  if (blend) {
+    // Flutter / Skia backing stores are premultiplied alpha.
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+  } else {
+    glDisable(GL_BLEND);
+  }
   glDisable(GL_DEPTH_TEST);
   glDisable(GL_STENCIL_TEST);
   glDisable(GL_SCISSOR_TEST);
@@ -171,6 +183,12 @@ void GlCompositor::CompositeViaQuad(GLuint src_color_tex,
   glBindTexture(GL_TEXTURE_2D, src_color_tex);
   if (uni_tex_ >= 0) {
     glUniform1i(uni_tex_, 0);
+  }
+  if (uni_uv_y_scale_ >= 0) {
+    glUniform1f(uni_uv_y_scale_, flip_y ? -1.0f : 1.0f);
+  }
+  if (uni_uv_y_offset_ >= 0) {
+    glUniform1f(uni_uv_y_offset_, flip_y ? 1.0f : 0.0f);
   }
 
   glBindBuffer(GL_ARRAY_BUFFER, vbo_);
@@ -210,14 +228,22 @@ void GlCompositor::CompositeToDefault(GLuint src_fbo,
                                       GLint dst_x,
                                       GLint dst_y,
                                       GLsizei dst_w,
-                                      GLsizei dst_h) {
-  if (caps_ && caps_->has_blit_framebuffer && caps_->blit_framebuffer) {
+                                      GLsizei dst_h,
+                                      bool blend,
+                                      bool flip_y) {
+  // Blit can't alpha-blend, so overlay layers must take the quad path.
+  // glBlitFramebuffer flips vertically when dstY1 < dstY0; we use that for
+  // GL-native-origin sources that need to land top-down.
+  if (!blend && caps_ && caps_->has_blit_framebuffer &&
+      caps_->blit_framebuffer) {
     glBindFramebuffer(kReadFramebuffer, src_fbo);
     glBindFramebuffer(kDrawFramebuffer, 0);
-    caps_->blit_framebuffer(0, 0, src_w, src_h, dst_x, dst_y, dst_x + dst_w,
-                            dst_y + dst_h, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+    const GLint dst_y0 = flip_y ? dst_y + dst_h : dst_y;
+    const GLint dst_y1 = flip_y ? dst_y : dst_y + dst_h;
+    caps_->blit_framebuffer(0, 0, src_w, src_h, dst_x, dst_y0, dst_x + dst_w,
+                            dst_y1, GL_COLOR_BUFFER_BIT, GL_LINEAR);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     return;
   }
-  CompositeViaQuad(src_color_tex, dst_x, dst_y, dst_w, dst_h);
+  CompositeViaQuad(src_color_tex, dst_x, dst_y, dst_w, dst_h, blend, flip_y);
 }

--- a/shell/backend/wayland_egl/gl_compositor.h
+++ b/shell/backend/wayland_egl/gl_compositor.h
@@ -51,6 +51,13 @@ class GlCompositor {
    * @param dst_x,dst_y     Destination origin on the default framebuffer,
    *                        in OpenGL coordinates (origin bottom-left).
    * @param dst_w,dst_h     Destination dimensions in pixels.
+   * @param blend           When true, force the quad path with premultiplied
+   *                        alpha blending so transparent pixels preserve the
+   *                        underlying framebuffer content. Required for
+   *                        overlay layers stacked on top of other layers.
+   * @param flip_y          When true, flip the source vertically. Use for
+   *                        textures drawn in GL-native (bottom-left) origin
+   *                        that need to land in Flutter's top-down layout.
    */
   void CompositeToDefault(GLuint src_fbo,
                           GLuint src_color_tex,
@@ -59,7 +66,9 @@ class GlCompositor {
                           GLint dst_x,
                           GLint dst_y,
                           GLsizei dst_w,
-                          GLsizei dst_h);
+                          GLsizei dst_h,
+                          bool blend = false,
+                          bool flip_y = false);
 
  private:
   const GlCaps* caps_;
@@ -77,5 +86,10 @@ class GlCompositor {
                         GLint dst_x,
                         GLint dst_y,
                         GLsizei dst_w,
-                        GLsizei dst_h);
+                        GLsizei dst_h,
+                        bool blend,
+                        bool flip_y);
+
+  GLint uni_uv_y_scale_{-1};
+  GLint uni_uv_y_offset_{-1};
 };

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -447,7 +447,8 @@ void WaylandEglBackend::CompositeLayer(const FlutterBackingStore* store,
                                        GLint dst_x,
                                        GLint dst_y,
                                        GLsizei dst_w,
-                                       GLsizei dst_h) {
+                                       GLsizei dst_h,
+                                       bool blend) {
   auto* baton = static_cast<StoreBaton*>(store->user_data);
   if (!baton) {
     spdlog::error("WaylandEglBackend: present layer missing baton");
@@ -460,7 +461,7 @@ void WaylandEglBackend::CompositeLayer(const FlutterBackingStore* store,
     auto* fbo = baton->fbo_store;
     m_gl_compositor->CompositeToDefault(fbo->Framebuffer(), fbo->ColorTexture(),
                                         fbo->Width(), fbo->Height(), dst_x,
-                                        dst_y, dst_w, dst_h);
+                                        dst_y, dst_w, dst_h, blend);
     return;
   }
 
@@ -469,7 +470,7 @@ void WaylandEglBackend::CompositeLayer(const FlutterBackingStore* store,
   // a scratch FBO and use the blit path, or (b) use the quad path directly.
   // Favour the blit path when available since it's a fixed-function copy.
   auto* tex = baton->tex_store;
-  if (m_gl_caps.has_blit_framebuffer) {
+  if (!blend && m_gl_caps.has_blit_framebuffer) {
     if (!m_texture_blit_fbo_) {
       glGenFramebuffers(1, &m_texture_blit_fbo_);
     }
@@ -478,14 +479,15 @@ void WaylandEglBackend::CompositeLayer(const FlutterBackingStore* store,
                            tex->Texture(), 0);
     m_gl_compositor->CompositeToDefault(m_texture_blit_fbo_, tex->Texture(),
                                         tex->Width(), tex->Height(), dst_x,
-                                        dst_y, dst_w, dst_h);
+                                        dst_y, dst_w, dst_h, blend);
     // Leave the attachment in place — rebinding before next composite is
     // cheaper than detaching every frame.
   } else {
-    // Quad path doesn't need an FBO; pass 0.
+    // Quad path doesn't need a scratch FBO; pass 0. This is the only path
+    // that supports alpha blending.
     m_gl_compositor->CompositeToDefault(0, tex->Texture(), tex->Width(),
                                         tex->Height(), dst_x, dst_y, dst_w,
-                                        dst_h);
+                                        dst_h, blend);
   }
 }
 
@@ -525,21 +527,27 @@ bool WaylandEglBackend::PresentLayers(const FlutterLayer** layers,
                       });
 
   bool ok = true;
+  // Engine emits layers bottom-to-top. The first composited layer lands on
+  // the window backbuffer with an opaque copy; every subsequent layer is an
+  // overlay whose transparent pixels must preserve what's underneath, so it
+  // has to alpha-blend rather than overwrite. Without this, a Flutter
+  // overlay backing store (mostly alpha-0 around platform view cutouts)
+  // paints black over the platform view textures we just drew.
+  bool composited_any = false;
   for (size_t i = 0; i < count; ++i) {
     const FlutterLayer* layer = layers[i];
     if (!layer) {
       continue;
     }
+    const bool blend = composited_any;
     if (layer->type == kFlutterLayerContentTypeBackingStore &&
         layer->backing_store) {
-      // For multi-layer: composite each backing store onto FBO 0 at its
-      // layer offset. Clipping and mutation handling arrives with plugin
-      // integration in Phase 4.
       const auto dx = static_cast<GLint>(layer->offset.x);
       const auto dy = static_cast<GLint>(layer->offset.y);
       const auto dw = static_cast<GLsizei>(layer->size.width);
       const auto dh = static_cast<GLsizei>(layer->size.height);
-      CompositeLayer(layer->backing_store, dx, dy, dw, dh);
+      CompositeLayer(layer->backing_store, dx, dy, dw, dh, blend);
+      composited_any = true;
     } else if (layer->type == kFlutterLayerContentTypePlatformView &&
                layer->platform_view) {
       const auto composed = MutationStack::Compose(layer->platform_view);
@@ -575,10 +583,17 @@ bool WaylandEglBackend::PresentLayers(const FlutterLayer** layers,
           const auto sw = surface.GetGlTextureWidth();
           const auto sh = surface.GetGlTextureHeight();
           const auto dx = static_cast<GLint>(layer->offset.x);
-          const auto dy = static_cast<GLint>(layer->offset.y);
           const auto dw = static_cast<GLsizei>(layer->size.width);
           const auto dh = static_cast<GLsizei>(layer->size.height);
-          if (m_gl_caps.has_blit_framebuffer) {
+          // layer->offset.y is Flutter top-left-origin; the default GL
+          // framebuffer is bottom-left-origin. Convert so the plugin texture
+          // lands where Flutter's overlay markers are drawn.
+          const auto dy = static_cast<GLint>(m_initial_height) -
+                          static_cast<GLint>(layer->offset.y) - dh;
+          // Plugin textures are drawn in GL-native (bottom-left origin) and
+          // must be vertically flipped to match Flutter's top-down layout.
+          constexpr bool kFlipY = true;
+          if (!blend && m_gl_caps.has_blit_framebuffer) {
             if (!m_texture_blit_fbo_) {
               glGenFramebuffers(1, &m_texture_blit_fbo_);
             }
@@ -586,10 +601,13 @@ bool WaylandEglBackend::PresentLayers(const FlutterLayer** layers,
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
                                    GL_TEXTURE_2D, tex, 0);
             m_gl_compositor->CompositeToDefault(m_texture_blit_fbo_, tex, sw,
-                                                sh, dx, dy, dw, dh);
+                                                sh, dx, dy, dw, dh, blend,
+                                                kFlipY);
           } else {
-            m_gl_compositor->CompositeToDefault(0, tex, sw, sh, dx, dy, dw, dh);
+            m_gl_compositor->CompositeToDefault(0, tex, sw, sh, dx, dy, dw, dh,
+                                                blend, kFlipY);
           }
+          composited_any = true;
         }
       }
     }

--- a/shell/backend/wayland_egl/wayland_egl.h
+++ b/shell/backend/wayland_egl/wayland_egl.h
@@ -203,11 +203,17 @@ class WaylandEglBackend : public Egl, public Backend {
 
   /// Composite a single layer's backing store onto FBO 0 at the given
   /// pixel rect. Handles both FBO and texture subtypes.
+  ///
+  /// When @p blend is true, the composite alpha-blends with premultiplied
+  /// alpha so transparent pixels preserve underlying framebuffer content —
+  /// required for overlay layers stacked on top of platform views or other
+  /// backing stores.
   void CompositeLayer(const FlutterBackingStore* store,
                       GLint dst_x,
                       GLint dst_y,
                       GLsizei dst_w,
-                      GLsizei dst_h);
+                      GLsizei dst_h,
+                      bool blend = false);
 
   /// True when the requested size equals the view's root dimensions.
   /// Used to pick FBO vs texture subtype at create time.

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -198,6 +198,11 @@ FlutterEngineResult Engine::Run(FlutterDesktopEngineState* state) {
   SPDLOG_TRACE("({}) +Engine::Run", m_index);
 
   const auto config = m_backend->GetRenderConfig();
+  m_compositor = m_backend->GetCompositorConfig();
+  if (m_compositor.present_layers_callback != nullptr ||
+      m_compositor.create_backing_store_callback != nullptr) {
+    m_args.compositor = &m_compositor;
+  }
   FlutterEngineResult result = LibFlutterEngine->Initialize(
       FLUTTER_ENGINE_VERSION, &config, &m_args, state, &m_flutter_engine);
   if (result != kSuccess) {

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -363,6 +363,9 @@ class Engine {
 
   FLUTTER_API_SYMBOL(FlutterEngine) m_flutter_engine;
   FlutterProjectArgs m_args{};
+  // Compositor config must outlive FlutterEngineInitialize — the engine
+  // retains a pointer to it via m_args.compositor.
+  FlutterCompositor m_compositor{};
   std::string m_clipboard_data;
 
   std::shared_ptr<TaskRunner> m_platform_task_runner;


### PR DESCRIPTION
Hook m_args.compositor so FlutterEngine actually dispatches layers through present_layers_callback; store FlutterCompositor on Engine so its address outlives FlutterEngineInitialize.

Correct layer composition in WaylandEglBackend::PresentLayers:
- alpha-blend every layer after the first so a Flutter overlay with transparent cutouts no longer paints black over the platform-view textures drawn beneath it
- Y-flip the platform-view texture composite (dst extent swap on the blit path, UV flip via vertex-shader uniforms on the quad path) so GL-native-origin plugin textures land where Flutter's top-down markers expect them

GlCompositor::CompositeToDefault / CompositeViaQuad now take blend and flip_y flags; blend forces the quad path with premultiplied-alpha blend (GL_ONE, GL_ONE_MINUS_SRC_ALPHA).