### PR TITLE
[wayland_egl] wire FlutterVsyncCallback via wp_presentation_feedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,16 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
     endif ()
 endif ()
 
+# FlutterView's backend type is picked by an #if/#elif chain over the
+# BUILD_BACKEND_* flags; enabling both Wayland EGL and Wayland Vulkan
+# yields a single binary whose renderer is silently determined by
+# header order rather than user intent. Reject the combination loudly.
+if (BUILD_BACKEND_WAYLAND_EGL AND BUILD_BACKEND_WAYLAND_VULKAN)
+    message(FATAL_ERROR
+            "BUILD_BACKEND_WAYLAND_EGL and BUILD_BACKEND_WAYLAND_VULKAN "
+            "are mutually exclusive — pick exactly one Wayland backend")
+endif ()
+
 message(STATUS "Project ................ ${PROJECT_NAME}")
 message(STATUS "Version ................ ${PROJECT_VERSION}")
 message(STATUS "Generator .............. ${CMAKE_GENERATOR}")

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -115,7 +115,13 @@ int App::Loop() const {
 
   const auto elapsed = end_time - start_time;
 
-  const auto frame_time = 1000.0 / m_display->GetMaxRefreshRate();
+  // Some compositors (e.g. tinywlr, virtual outputs) advertise refresh=0
+  // for their mode. Without a fallback, 1000.0 / 0 = +inf and the
+  // sleep_for below blocks the main thread forever — pointer events
+  // queued by the Wayland event thread never get flushed to Flutter.
+  const double refresh_hz = m_display->GetMaxRefreshRate();
+  const auto frame_time =
+      refresh_hz > 0.0 ? 1000.0 / refresh_hz : 1000.0 / 60.0;
   if (const auto sleep_time = frame_time - static_cast<double>(elapsed);
       sleep_time > 0) {
 #if BUILD_WATCHDOG

--- a/shell/backend/backend.h
+++ b/shell/backend/backend.h
@@ -28,6 +28,7 @@
 #endif
 
 class Engine;
+class TaskRunner;
 
 // Carries an EGL context handle set that lets a plugin create its own EGL
 // context sharing GL objects with the embedder's raster context. All handles
@@ -133,6 +134,38 @@ class Backend {
    * @c kInternalInconsistency otherwise.
    */
   virtual VsyncCallback GetVsyncCallback() const { return nullptr; }
+
+  /**
+   * @brief Hand the running FlutterEngine handle to the backend.
+   *
+   * Backends that wire @c FlutterEngineOnVsync (or otherwise need the
+   * engine handle from outside an engine-supplied callback) override this
+   * to stash the handle atomically. Default is a no-op; backends without
+   * vsync_callback or session lifecycle hooks don't need it. Called from
+   * FlutterView once @c FlutterEngineRun returns successfully.
+   */
+  virtual void SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine) /*engine*/) {}
+
+  /**
+   * @brief Hand the platform task runner to the backend.
+   *
+   * Used by backends that must marshal @c FlutterEngineOnVsync (or other
+   * engine APIs) onto the FlutterEngineRun thread. Default is a no-op.
+   * Called from FlutterView from the same post-Engine::Run hook that
+   * installs the engine handle. Backends that drive an event-source fd
+   * (e.g. DRM page-flip, Wayland display) may use this hook to start an
+   * asio @c async_wait on the runner's io_context.
+   */
+  virtual void SetPlatformTaskRunner(TaskRunner* /*runner*/) {}
+
+  /**
+   * @brief Tear down any vsync/event-loop monitor the backend started.
+   *
+   * Called from @c FlutterView::~FlutterView before the engine destructs
+   * so the backend has a chance to cancel outstanding async work that
+   * could otherwise outlive the engine handle. Default is a no-op.
+   */
+  virtual void StopVsyncMonitor() {}
 
 #if BUILD_COMPOSITOR
   /**

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -325,7 +325,7 @@ int PrintDrmModes(const std::string& device) {
   return 0;
 }
 
-std::unique_ptr<DrmBackend> DrmBackend::Create(
+static std::unique_ptr<DrmBackend> DrmBackend::Create(
     const DrmConfig& cfg,
     homescreen::DrmSession* session) {
   std::unique_ptr<DrmBackend> backend(new DrmBackend(cfg, session));
@@ -403,7 +403,7 @@ void DrmBackend::MaybeCaptureSnapshot() {
 #endif
 }
 
-DrmBackend::DrmBackend(DrmConfig cfg, homescreen::DrmSession* session)
+DrmBackend::DrmBackend(const DrmConfig& cfg, homescreen::DrmSession* session)
     : cfg_(std::move(cfg)), session_(session) {}
 
 DrmBackend::~DrmBackend() {
@@ -1090,7 +1090,7 @@ bool DrmBackend::InitEgl() {
   return true;
 }
 
-uint32_t DrmBackend::AddFb(gbm_bo* bo) const {
+uint32_t DrmBackend::AddFb(gbm_bo* bo) {
   const uint32_t width = gbm_bo_get_width(bo);
   const uint32_t height = gbm_bo_get_height(bo);
   const uint32_t stride = gbm_bo_get_stride(bo);
@@ -1421,7 +1421,7 @@ void DrmBackend::StartFlipMonitor() {
       !drm_dev_.has_value()) {
     return;
   }
-  // assign() makes asio take ownership of the fd — StopFlipMonitor must
+  // assign() makes asio take ownership of the fd — StopVsyncMonitor must
   // call release() before reset() so drm_dev_'s close on its own fd
   // isn't a double-close.
   flip_descriptor_.emplace(*runner->GetIoContext());
@@ -1430,7 +1430,7 @@ void DrmBackend::StartFlipMonitor() {
   spdlog::info("[DrmBackend] flip monitor armed on fd={}", drm_dev_->fd());
 }
 
-void DrmBackend::StopFlipMonitor() {
+void DrmBackend::StopVsyncMonitor() {
   if (flip_descriptor_.has_value()) {
     std::error_code ec;
     // cancel() wakes the worker thread out of epoll_wait — the pending
@@ -1476,7 +1476,7 @@ void DrmBackend::StopFlipMonitor() {
     }
     if (flip_pending_.load(std::memory_order_acquire)) {
       spdlog::warn(
-          "[DrmBackend] StopFlipMonitor: flip event never arrived, "
+          "[DrmBackend] StopVsyncMonitor: flip event never arrived, "
           "force-clearing flip_pending_ to unblock destructors");
       flip_pending_.store(false, std::memory_order_release);
       if (compositor_) {
@@ -1511,7 +1511,7 @@ void DrmBackend::ArmFlipRead() {
       });
 }
 
-bool DrmBackend::WaitForPendingFlip() const {
+bool DrmBackend::WaitForPendingFlip() {
   // The asio flip monitor (StartFlipMonitor) drains PAGE_FLIP_EVENTs
   // on the platform task runner thread and clears flip_pending_ via
   // UnifiedPageFlipHandler → OnLegacyFlipComplete. We just wait for

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -325,7 +325,7 @@ int PrintDrmModes(const std::string& device) {
   return 0;
 }
 
-static std::unique_ptr<DrmBackend> DrmBackend::Create(
+std::unique_ptr<DrmBackend> DrmBackend::Create(
     const DrmConfig& cfg,
     homescreen::DrmSession* session) {
   std::unique_ptr<DrmBackend> backend(new DrmBackend(cfg, session));
@@ -1090,7 +1090,7 @@ bool DrmBackend::InitEgl() {
   return true;
 }
 
-uint32_t DrmBackend::AddFb(gbm_bo* bo) {
+uint32_t DrmBackend::AddFb(gbm_bo* bo) const {
   const uint32_t width = gbm_bo_get_width(bo);
   const uint32_t height = gbm_bo_get_height(bo);
   const uint32_t stride = gbm_bo_get_stride(bo);
@@ -1511,7 +1511,7 @@ void DrmBackend::ArmFlipRead() {
       });
 }
 
-bool DrmBackend::WaitForPendingFlip() {
+bool DrmBackend::WaitForPendingFlip() const {
   // The asio flip monitor (StartFlipMonitor) drains PAGE_FLIP_EVENTs
   // on the platform task runner thread and clears flip_pending_ via
   // UnifiedPageFlipHandler → OnLegacyFlipComplete. We just wait for

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -202,7 +202,7 @@ class DrmBackend : public Backend {
   // re-modeset on the next commit, and asks the engine to schedule a
   // frame so Flutter actually produces one — without that kick an idle
   // UI never calls Present again and the screen stays blank.
-  static void OnSessionPaused();
+  void OnSessionPaused();
   void OnSessionResumed(int new_fd);
 
   [[nodiscard]] const drm::Device& device() const { return *drm_dev_; }
@@ -237,7 +237,7 @@ class DrmBackend : public Backend {
   bool InitGbm();
   bool InitEgl();
   bool SetInitialMode();
-  static uint32_t AddFb(gbm_bo* bo);
+  uint32_t AddFb(gbm_bo* bo) const;
   bool WaitForPendingFlip() const;
   // Unified PAGE_FLIP_EVENT dispatcher. Registered as the
   // drmEventContext.page_flip_handler from the asio flip monitor; the

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -174,7 +174,7 @@ class DrmBackend : public Backend {
   // FlutterEngineScheduleFrame. Wired by FlutterView after Engine::Run
   // succeeds. Stored atomically because reads happen on the libseat
   // dispatch thread.
-  void SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine) engine) {
+  void SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine) engine) override {
     engine_handle_.store(engine, std::memory_order_release);
   }
 
@@ -186,14 +186,14 @@ class DrmBackend : public Backend {
   // rasterizer thread, which deadlocks with vsync_callback because the
   // next Present never starts (it's waiting on OnVsync, which is
   // waiting on PAGE_FLIP_EVENT to be drained).
-  void SetPlatformTaskRunner(TaskRunner* runner);
+  void SetPlatformTaskRunner(TaskRunner* runner) override;
 
   // Cancel the pending async_wait on flip_descriptor_ and detach the fd.
   // MUST be called from FlutterView::~FlutterView before m_flutter_engine
   // destructs — otherwise TaskRunner::~TaskRunner blocks forever joining
   // its io_context worker thread (the async_wait counts as outstanding
   // asio work, so run_one() never returns even after work_.reset()).
-  void StopFlipMonitor();
+  void StopVsyncMonitor() override;
 
   // Session lifecycle hooks, called from DrmSession's dispatch thread by
   // the libseat trampoline. OnSessionPaused gates the compositor's
@@ -202,7 +202,7 @@ class DrmBackend : public Backend {
   // re-modeset on the next commit, and asks the engine to schedule a
   // frame so Flutter actually produces one — without that kick an idle
   // UI never calls Present again and the screen stays blank.
-  void OnSessionPaused();
+  static void OnSessionPaused();
   void OnSessionResumed(int new_fd);
 
   [[nodiscard]] const drm::Device& device() const { return *drm_dev_; }
@@ -232,12 +232,12 @@ class DrmBackend : public Backend {
   }
 
  private:
-  DrmBackend(DrmConfig cfg, homescreen::DrmSession* session);
+  DrmBackend(const DrmConfig& cfg, homescreen::DrmSession* session);
   bool InitDrm();
   bool InitGbm();
   bool InitEgl();
   bool SetInitialMode();
-  uint32_t AddFb(gbm_bo* bo) const;
+  static uint32_t AddFb(gbm_bo* bo);
   bool WaitForPendingFlip() const;
   // Unified PAGE_FLIP_EVENT dispatcher. Registered as the
   // drmEventContext.page_flip_handler from the asio flip monitor; the
@@ -273,7 +273,7 @@ class DrmBackend : public Backend {
 
   // DRM — drm::Device is RAII (closes fd on destruction), unless
   // constructed via Device::from_fd (libseat-owned fd path).
-  std::optional<drm::Device> drm_dev_;
+  std::optional<drm::Device> drm_dev_{};
   bool drm_master_ = false;  // true after a successful drmSetMaster
   uint32_t connector_id_ = 0;
   uint32_t crtc_id_ = 0;
@@ -289,7 +289,7 @@ class DrmBackend : public Backend {
   // Populated by DriverProbe::Resolve() inside Create(). Non-null for the
   // lifetime of the backend. unique_ptr so driver_probe.h isn't needed in
   // this header.
-  std::unique_ptr<homescreen::driver_probe::Resolved> resolved_;
+  std::unique_ptr<homescreen::driver_probe::Resolved> resolved_{};
 
   // GBM
   gbm_device* gbm_device_ = nullptr;
@@ -340,9 +340,9 @@ class DrmBackend : public Backend {
   void RecordFlipComplete();
 
 #if BUILD_COMPOSITOR
-  std::unique_ptr<DrmCompositor> compositor_;
+  std::unique_ptr<DrmCompositor> compositor_{};
 #endif
-  std::unique_ptr<homescreen::DrmCursor> cursor_;
+  std::unique_ptr<homescreen::DrmCursor> cursor_{};
 #if HAVE_DRM_CAPTURE
   std::unique_ptr<homescreen::DrmCapture> capture_;
 #endif

--- a/shell/backend/wayland_egl/README.md
+++ b/shell/backend/wayland_egl/README.md
@@ -1,0 +1,249 @@
+# wayland_egl backend
+
+EGL + GL ES presenter on Wayland. Pairs `wl_egl_window` (Mesa hands us the
+buffer pool) with the optional homescreen GL compositor for platform views.
+This README covers the parts that aren't obvious from the source — the
+compositor-mediated vsync path in particular.
+
+## Vsync via `wp_presentation_feedback`
+
+The compositor — not the application — owns the scanout schedule on
+Wayland. There is no equivalent of `drmModePageFlip` to wait on. The
+right hook is the `wp_presentation_time` extension: every commit you
+care about, you mint a `wp_presentation_feedback` object before
+`wl_surface.commit` and the compositor sends you back a `presented`
+event with the realized scanout timestamp.
+
+```
+Flutter raster thread                Display event_thread_
+─────────────────────                ────────────────────
+PresentLayers
+  RequestPresentationFeedback()      ───┐
+  eglSwapBuffers (commits surface)      │  compositor scans out
+  …                                     │
+                                        ▼
+                                     on_feedback_presented(tv_ns, refresh)
+                                        ├─ update last_refresh_ns_
+                                        ├─ exchange vsync_baton_
+                                        └─ asio::post(strand, [&]{ OnVsync() })
+```
+
+The baton-return path uses the platform task runner's strand so
+`FlutterEngineOnVsync` is always called on the engine's run thread
+(Flutter enforces; returns `kInternalInconsistency` otherwise).
+
+`SetVsyncBaton` includes an idle-wake kick: if no feedback is in flight
+(very first frame, post-idle wake from input) it drains the baton
+inline via `PostOnVsync` so Flutter doesn't sit forever waiting for an
+`OnVsync` that would never come from a commit that hasn't happened yet.
+
+## When `vsync_callback` is wired
+
+`WaylandEglBackend::GetVsyncCallback()` returns `&VsyncTrampoline` iff
+all three of:
+
+1. The compositor advertised `wp_presentation` (KWin, Mutter, weston, sway,
+   kwin all do).
+2. The announced `clock_id` is `CLOCK_MONOTONIC` (Flutter's
+   `GetCurrentTime()` is also CLOCK_MONOTONIC; mismatched clocks would
+   need cross-clock translation that this backend declines to do).
+3. `IVI_WL_VSYNC` is not `0`.
+
+Otherwise it returns `nullptr` and the engine falls back to its
+internal wall-clock scheduler. The decision is logged once at startup
+(`info`-level — "wp_presentation not advertised" / "clock_id != CLOCK_MONOTONIC").
+
+## Env vars
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `IVI_WL_VSYNC` | (on) | `0` disables both the `vsync_callback` wiring AND the per-commit `wp_presentation_feedback` requests, falling back to Flutter's internal wall-clock scheduler. Use to bisect pacing regressions or to work around a compositor whose `presented` events are unreliable. The two gates must move together — otherwise feedback objects would accumulate without a baton consumer. |
+| `IVI_WL_PROFILE` | (off) | Anything non-empty enables per-frame cadence profiling. Every 60 presented frames, `on_feedback_presented` logs: `profile (n=60): fps=X mean_interval=Yus max_interval=Zus discarded=N refresh=Mus flags=0xF`. Useful to confirm the compositor's presented timestamps line up with its advertised refresh and to spot stalls. |
+
+## Architectural notes
+
+**Single-threaded vs platform-runner dispatch.** The `on_feedback_presented` /
+`discarded` listeners fire on `Display::event_thread_`, which is a
+separate thread from the platform task runner. That's why
+`feedback_in_flight_` is guarded by a mutex and `OnVsync` is always
+posted via the runner's strand (never inline). A future refactor could
+move `wl_display_dispatch` onto the platform task runner via an asio
+`async_wait` on the display fd — at which point the listener would fire
+on the runner thread, the mutex could be dropped, and `OnVsync` could
+be called inline. That change is out of scope here because it touches
+all Wayland event dispatch (input, configure, output).
+
+**Per-commit object, not a long-lived stream.** Unlike DRM's
+`PAGE_FLIP_EVENT` (one fd you read forever), `wp_presentation_feedback`
+mints a brand-new object per commit that delivers exactly one of
+`presented` / `discarded` and is then destroyed. The lifecycle is owned
+by the backend — `feedback_in_flight_` tracks outstanding objects so
+`StopVsyncMonitor` can destroy them before the engine teardown.
+
+**`discarded` semantics.** The compositor sends `discarded` when the
+frame was superseded (next commit landed first) or the surface was
+occluded. The handler treats it as equivalent to `presented` for
+baton-return purposes but uses `LibFlutterEngine->GetCurrentTime()` as
+the frame_start_time since we have no real timestamp. Discards are
+counted in the `IVI_WL_PROFILE` log line — a steady stream of them
+indicates the rasterizer is producing frames faster than the
+compositor can present them (compositor backpressure).
+
+**Refresh = 0.** Protocol allows the compositor to send `refresh=0`
+when it doesn't know the cadence (virtual outputs, mirrored displays
+with mismatched modes). The handler preserves the previous value
+rather than overwriting `last_refresh_ns_` with garbage that would
+skew `frame_target_time`.
+
+---
+
+## Benchmarks
+
+Measured on KWin Wayland (Fedora 43, kernel 6.19, amdgpu Polaris-class),
+`feat/drm-kms-egl` branch, running the flutter-wonderous-app bundle.
+Compositor is the desktop session's KWin (3440×1440 @ 60Hz primary,
+1680×1440 @ 60Hz secondary). Window size 800×600.
+
+### Methodology
+
+`IVI_WL_PROFILE=1` adds a log line every 60 presented frames with
+mean/max interval, discarded count, the compositor-reported refresh,
+and a 5-bucket histogram of per-frame intervals against a 60Hz
+baseline (≤17ms = on-vblank, 18-33ms = 1 vblank missed, 34-50ms = 2
+vblanks missed, 51-100ms = slow, >100ms = idle/pause). On clean
+shutdown, `StopVsyncMonitor` emits a one-line session summary +
+histogram covering the entire run.
+
+`WAYLAND_DEBUG=client` gives the raw protocol trace — useful to verify
+that exactly one `wp_presentation_feedback` request is minted per
+commit and exactly one `presented` or `discarded` returns per request.
+
+Validation: compare `mean_interval` to compositor-reported `refresh` —
+if they match, the client is keeping cadence; if `mean_interval >
+refresh`, the client is missing vblanks. The histogram makes the *miss
+distribution* legible (occasional double-miss vs. constant single-miss
+have different root causes).
+
+### Headline result — KWin Wayland @ 60Hz
+
+Aggregate across 23 profile windows (~23 seconds, 1380 presented
+frames) on the flutter-wonderous-app bundle, `IVI_WL_VSYNC=1
+IVI_WL_PROFILE=1`:
+
+| Metric | Value |
+|---|---:|
+| Frames presented | 1380 |
+| Compositor-reported refresh | 16.668 ms (60.00 Hz) |
+| Weighted mean interval | 17.64 ms (**56.69 Hz**) |
+| Worst single interval | 183.4 ms (content-load stall) |
+| Discarded by compositor | 0 |
+| Feedback flags (OR) | `0x7` = `VSYNC \| HW_CLOCK \| HW_COMPLETION` |
+
+| Bucket | Frames | % |
+|---|---:|---:|
+| 60Hz on-vblank (≤17 ms) | 1344 | **97.46%** |
+| 30Hz (18-33 ms) | 0 | 0.00% |
+| 20Hz (34-50 ms) | 28 | 2.03% |
+| slow (51-100 ms) | 5 | 0.36% |
+| idle (>100 ms) | 2 | 0.15% |
+
+KWin delivered hardware-accurate vblank timestamps for every commit
+(`flags=0x7`). Zero compositor-side discards across the whole run.
+The 2.5% off-vblank tail is exclusively Flutter raster stalls during
+wonderous content-load — note the bimodal miss distribution: misses
+*never* land in the 30Hz bucket (single-vblank-late) but always
+double-skip into the 20Hz bucket or worse. That's KWin's transactional
+commit model: once the deadline is missed, the next entire vblank is
+forfeit, not just half of it.
+
+### Comparison to `drm_kms_egl`
+
+DRM benchmark (from `shell/backend/drm_kms_egl/README.md`):
+amdgpu RDNA/Polaris @ 240Hz, same wonderous bundle, `IVI_DRM_RT=1
+IVI_DRM_VSYNC=1`, 64,769-frame sample.
+
+| Metric | DRM @ 240Hz | wayland_egl @ 60Hz |
+|---|---:|---:|
+| Frame budget (refresh period) | 4.17 ms | 16.67 ms |
+| Native cadence hit-rate | **98.0%** (≤6 ms) | **97.5%** (≤17 ms) |
+| Mean interval | 4.31 ms | 17.64 ms |
+| 1-vblank misses | 1.8% (7-11 ms) | 0.0% (18-33 ms) |
+| ≥2-vblank misses | 0.2% (12+ ms) | 2.5% (34+ ms) |
+| Discards | n/a (PAGE_FLIP_EVENT can't drop) | 0 (KWin didn't drop any) |
+| Sample size | 64,769 | 1,380 |
+
+**Per-vblank hit rate is essentially identical** — both backends keep
+~97-98% of frames inside one vblank period. The interesting difference
+is the miss profile:
+
+- **DRM** misses mostly land in the next-vblank bucket (120Hz, 7-11ms)
+  — the kernel pages out scanout state for one frame and recovers. That
+  pattern is consistent with brief Flutter raster spikes (text layout,
+  texture upload) costing one extra vblank.
+- **Wayland** misses skip the 30Hz bucket entirely. When `KWin` misses
+  the deadline, the surface is forfeited until the *next* commit lands
+  — which won't happen until Flutter's raster catches up. Result: misses
+  cluster at 2+ vblank intervals.
+
+This is a compositor-model difference, not a Wayland-vsync-path bug.
+The wp_presentation pacing recovers cleanly: the very next post-miss
+interval typically returns to the 60Hz bucket without compensatory
+bursting.
+
+The sample-size gap (64K vs 1.4K frames) is unrelated to the vsync
+code; the wonderous-app bundle on this host hits a pre-existing Mesa
+hash-table crash within ~30s, capping the runtime per smoke. The
+240Hz DRM measurement was on different hardware (Jetson Orin) where
+the bundle stayed stable for much longer.
+
+### Differences from `drm_kms_egl` (architecture)
+
+| Aspect | drm_kms_egl | wayland_egl |
+|---|---|---|
+| Vsync source | drm fd `PAGE_FLIP_EVENT` (long-lived, one fd) | `wp_presentation_feedback` (one fresh object per commit) |
+| Timestamp source | kernel `tv_sec/tv_usec` in `drmEventContext::page_flip_handler` (currently discarded — uses wall clock) | Compositor `tv_sec_hi/lo/tv_nano_sec` in `presented` event (used as-is) |
+| Refresh source | `mode_.vrefresh` from mode probe | `refresh` arg in each `presented` event (per-frame, refresh-adaptive) |
+| OnVsync delivery | Inline from asio handler (platform runner) | `asio::post(strand, …)` from event_thread_ |
+| Discards | n/a (kernel never drops a flip silently) | Possible (compositor may supersede or occlude); counted as a frame for baton purposes |
+| Direct scanout | REFLECT_Y probe enables it on capable hardware | Compositor decides; client cannot opt in |
+
+### What the compositor is responsible for
+
+Unlike DRM where the application owns the scanout schedule, on Wayland
+the compositor decides:
+- When the frame actually presents (it may delay, e.g. to align with
+  another surface's commit on a transactional compositor like KWin).
+- The realized refresh rate (compositor reports it per-frame in
+  `wp_presentation_feedback.refresh`; can change mid-session for
+  variable-refresh-rate panels).
+- Whether the commit is direct-scanned-out or composited (reported via
+  the `flags` arg: `WP_PRESENTATION_FEEDBACK_KIND_ZERO_COPY` indicates
+  direct scanout).
+
+The client's job is to feed the compositor at the cadence the compositor
+asks for, then trust its `presented` events for pacing. That's what
+this backend does.
+
+---
+
+## Known limitations / follow-ups
+
+1. **SIGTERM shutdown is racy** — `WaylandEglBackend::GetRenderConfig`
+   lambdas dereference `state->view_controller->engine` after teardown,
+   producing a SIGSEGV ~1.9s after SIGTERM. Reproduces identically with
+   `IVI_WL_VSYNC=0`, so the race is pre-existing and unrelated to the
+   wp_presentation vsync work. DRM fixed the analogous race in commit
+   `17ade4ef [shutdown] race-free engine/view/embedder teardown on
+   SIGTERM`; wayland_egl needs the same treatment.
+2. **Cross-clock translation not implemented** — when the compositor
+   advertises a `clock_id` other than `CLOCK_MONOTONIC`, this backend
+   falls back to the wall-clock scheduler. Could be lifted by sampling
+   both clocks once at startup and adding the delta to each `presented`
+   timestamp before passing it to `OnVsync`. No mainline compositor
+   needs this today.
+3. **`wl_display_dispatch` still on its own thread** — see the
+   "Architectural notes" section above. Moving dispatch to the platform
+   task runner via asio would simplify the synchronization model and
+   drop the mutex on `feedback_in_flight_`, but it's a fleet-wide
+   change to all Wayland event handling and is deferred to a separate
+   change.

--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -150,6 +150,71 @@ bool GlCompositor::EnsureQuad() {
   return true;
 }
 
+void GlCompositor::EmitPersistentQuadState() {
+  // Once-per-frame setup. Establishes a known baseline (blend disabled,
+  // bound_tex_ cleared) so per-call deltas can be tracked accurately.
+  glDisable(GL_BLEND);
+  blend_enabled_ = false;
+  glDisable(GL_DEPTH_TEST);
+  glDisable(GL_STENCIL_TEST);
+  glDisable(GL_SCISSOR_TEST);
+  glDisable(GL_CULL_FACE);
+
+  glUseProgram(program_);
+  glActiveTexture(GL_TEXTURE0);
+  if (uni_tex_ >= 0) {
+    glUniform1i(uni_tex_, 0);
+  }
+
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_);
+  if (attr_pos_ >= 0) {
+    glEnableVertexAttribArray(static_cast<GLuint>(attr_pos_));
+    glVertexAttribPointer(static_cast<GLuint>(attr_pos_), 2, GL_FLOAT, GL_FALSE,
+                          4 * sizeof(GLfloat), nullptr);
+  }
+  if (attr_uv_ >= 0) {
+    glEnableVertexAttribArray(static_cast<GLuint>(attr_uv_));
+    // glVertexAttribPointer takes the buffer offset as a void* by historic
+    // GL convention — there's no arithmetic on the pointer. Suppress the
+    // "integer to pointer cast" lint.
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    glVertexAttribPointer(static_cast<GLuint>(attr_uv_), 2, GL_FLOAT, GL_FALSE,
+                          4 * sizeof(GLfloat),
+                          reinterpret_cast<const void*>(2 * sizeof(GLfloat)));
+  }
+  bound_tex_ = 0;
+}
+
+void GlCompositor::TearDownPersistentQuadState() {
+  if (blend_enabled_) {
+    glDisable(GL_BLEND);
+    blend_enabled_ = false;
+  }
+  if (attr_pos_ >= 0) {
+    glDisableVertexAttribArray(static_cast<GLuint>(attr_pos_));
+  }
+  if (attr_uv_ >= 0) {
+    glDisableVertexAttribArray(static_cast<GLuint>(attr_uv_));
+  }
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glUseProgram(0);
+  bound_tex_ = 0;
+}
+
+void GlCompositor::BeginFrame() {
+  frame_open_ = true;
+  persistent_state_emitted_ = false;
+}
+
+void GlCompositor::EndFrame() {
+  if (persistent_state_emitted_) {
+    TearDownPersistentQuadState();
+    persistent_state_emitted_ = false;
+  }
+  frame_open_ = false;
+}
+
 void GlCompositor::CompositeViaQuad(GLuint src_color_tex,
                                     GLint dst_x,
                                     GLint dst_y,
@@ -161,11 +226,41 @@ void GlCompositor::CompositeViaQuad(GLuint src_color_tex,
     return;
   }
 
-  // Snapshot minimal state: we don't implement full state save/restore,
-  // but we set everything we rely on so the engine's next render isn't
-  // surprised. Flutter resets its own GL state on entry.
+  // Frame-batched fast path: emit the persistent state once on the first
+  // quad call inside Begin/EndFrame and only the changed delta thereafter.
+  // Every other layer's composite drops from ~25 GL calls to ~5.
+  if (frame_open_) {
+    if (!persistent_state_emitted_) {
+      EmitPersistentQuadState();
+      persistent_state_emitted_ = true;
+    }
+    if (blend && !blend_enabled_) {
+      // Flutter / Skia backing stores are premultiplied alpha.
+      glEnable(GL_BLEND);
+      glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+      blend_enabled_ = true;
+    } else if (!blend && blend_enabled_) {
+      glDisable(GL_BLEND);
+      blend_enabled_ = false;
+    }
+    glViewport(dst_x, dst_y, dst_w, dst_h);
+    if (bound_tex_ != src_color_tex) {
+      glBindTexture(GL_TEXTURE_2D, src_color_tex);
+      bound_tex_ = src_color_tex;
+    }
+    if (uni_uv_y_scale_ >= 0) {
+      glUniform1f(uni_uv_y_scale_, flip_y ? -1.0f : 1.0f);
+    }
+    if (uni_uv_y_offset_ >= 0) {
+      glUniform1f(uni_uv_y_offset_, flip_y ? 1.0f : 0.0f);
+    }
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    return;
+  }
+
+  // One-off path (no Begin/End wrapping the call): full setup + teardown
+  // per call so the engine's next render isn't surprised by leftover state.
   if (blend) {
-    // Flutter / Skia backing stores are premultiplied alpha.
     glEnable(GL_BLEND);
     glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
   } else {
@@ -199,9 +294,6 @@ void GlCompositor::CompositeViaQuad(GLuint src_color_tex,
   }
   if (attr_uv_ >= 0) {
     glEnableVertexAttribArray(static_cast<GLuint>(attr_uv_));
-    // glVertexAttribPointer takes the buffer offset as a void* by historic
-    // GL convention — there's no arithmetic on the pointer. Suppress the
-    // "integer to pointer cast" lint.
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     glVertexAttribPointer(static_cast<GLuint>(attr_uv_), 2, GL_FLOAT, GL_FALSE,
                           4 * sizeof(GLfloat),

--- a/shell/backend/wayland_egl/gl_compositor.h
+++ b/shell/backend/wayland_egl/gl_compositor.h
@@ -90,6 +90,22 @@ class GlCompositor {
                    dst_h, blend, flip_y);
   }
 
+  /**
+   * @brief Mark the start/end of a sequence of composite calls.
+   *
+   * Between BeginFrame and EndFrame the persistent GL quad state
+   * (program, VBO, vertex-attrib pointers, depth/stencil/scissor/cull
+   * disables, sampler uniform) is emitted once for the first quad-path
+   * composite and torn down on EndFrame, so subsequent quad composites
+   * within the frame skip ~13 redundant GL calls each. If BeginFrame is
+   * not called, CompositeToDefault keeps its per-call setup+teardown
+   * behaviour for one-off compositions.
+   *
+   * Calls must be balanced. Re-entrancy is not supported.
+   */
+  void BeginFrame();
+  void EndFrame();
+
  private:
   const GlCaps* caps_;
 
@@ -101,6 +117,15 @@ class GlCompositor {
   GLint attr_uv_{-1};
   GLint uni_tex_{-1};
 
+  // Per-frame batching state. frame_open_ is toggled by BeginFrame/EndFrame;
+  // persistent_state_emitted_ tracks whether the once-per-frame setup has
+  // actually been issued (deferred until the first quad-path composite, so
+  // a frame composed entirely of blit-path layers pays nothing).
+  bool frame_open_{false};
+  bool persistent_state_emitted_{false};
+  bool blend_enabled_{false};
+  GLuint bound_tex_{0};
+
   bool EnsureQuad();
   void CompositeViaQuad(GLuint src_color_tex,
                         GLint dst_x,
@@ -109,6 +134,8 @@ class GlCompositor {
                         GLsizei dst_h,
                         bool blend,
                         bool flip_y);
+  void EmitPersistentQuadState();
+  void TearDownPersistentQuadState();
 
   GLint uni_uv_y_scale_{-1};
   GLint uni_uv_y_offset_{-1};

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -18,12 +18,23 @@
 
 #include <wayland-egl.h>
 
+#include <presentation-time-client-protocol.h>
+#include <asio/post.hpp>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <string_view>
+
 #include "../gl_process_resolver.h"
 #include "egl.h"
 #include "engine.h"
 #include "logging.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #include "shell/platform/homescreen/flutter_desktop_texture_registrar.h"
+#include "task_runner.h"
+#include "wayland/display.h"
 
 #if BUILD_COMPOSITOR
 #include <GLES2/gl2.h>
@@ -31,7 +42,8 @@
 
 struct FlutterDesktopEngineState;
 
-WaylandEglBackend::WaylandEglBackend(struct wl_display* display,
+WaylandEglBackend::WaylandEglBackend(Display* shell_display,
+                                     struct wl_display* display,
                                      const uint32_t initial_width,
                                      const uint32_t initial_height,
                                      const bool debug_backend,
@@ -39,7 +51,29 @@ WaylandEglBackend::WaylandEglBackend(struct wl_display* display,
     : Egl(display, buffer_size, debug_backend),
       Backend(),
       m_initial_width(initial_width),
-      m_initial_height(initial_height) {}
+      m_initial_height(initial_height) {
+  if (shell_display != nullptr) {
+    wp_presentation_ = shell_display->GetWpPresentation();
+    presentation_clock_id_ = shell_display->GetPresentationClockId();
+    // FlutterEngineGetCurrentTime() returns CLOCK_MONOTONIC ns; only when
+    // the compositor announced the same domain can we hand its presented
+    // timestamps to OnVsync without a cross-clock translation. Mutter,
+    // weston, kwin, sway all use CLOCK_MONOTONIC. Anything else falls
+    // back to the wall-clock scheduler (GetVsyncCallback returns nullptr).
+    clock_compatible_ = (presentation_clock_id_ == CLOCK_MONOTONIC);
+    if (wp_presentation_ == nullptr) {
+      spdlog::info(
+          "[WaylandEglBackend] wp_presentation not advertised — vsync_callback "
+          "disabled, falling back to engine wall-clock scheduler");
+    } else if (!clock_compatible_) {
+      spdlog::warn(
+          "[WaylandEglBackend] wp_presentation clock_id={} != CLOCK_MONOTONIC "
+          "({}); vsync_callback disabled (cross-clock translation NYI)",
+          static_cast<int>(presentation_clock_id_),
+          static_cast<int>(CLOCK_MONOTONIC));
+    }
+  }
+}
 
 FlutterRendererConfig WaylandEglBackend::GetRenderConfig() {
   FlutterRendererConfig config{};
@@ -90,6 +124,10 @@ FlutterRendererConfig WaylandEglBackend::GetRenderConfig() {
     const auto state = static_cast<FlutterDesktopEngineState*>(userdata);
     auto* b = reinterpret_cast<WaylandEglBackend*>(
         state->view_controller->engine->GetBackend());
+
+    // Request wp_presentation feedback before the swap so it binds to
+    // THIS commit. No-op when wp_presentation isn't usable.
+    b->RequestPresentationFeedback();
 
     // Full swap if FlutterPresentInfo is invalid
     if (info->struct_size != sizeof(FlutterPresentInfo)) {
@@ -207,6 +245,427 @@ FlutterCompositor WaylandEglBackend::GetCompositorConfig() {
   return compositor;
 }
 
+VsyncCallback WaylandEglBackend::GetVsyncCallback() const {
+  // Wall-clock fallback unless the compositor advertises wp_presentation
+  // AND announces a clock domain compatible with FlutterEngineGetCurrentTime
+  // (CLOCK_MONOTONIC). IVI_WL_VSYNC=0 forces fallback regardless — useful
+  // when bisecting pacing regressions or running under a compositor whose
+  // feedback events are unreliable.
+  static const bool env_disabled = []() {
+    const char* env = std::getenv("IVI_WL_VSYNC");
+    return env != nullptr && std::string_view(env) == "0";
+  }();
+  if (env_disabled) {
+    spdlog::info("[WaylandEglBackend] IVI_WL_VSYNC=0 — wall-clock scheduler");
+    return nullptr;
+  }
+  if (wp_presentation_ == nullptr || !clock_compatible_) {
+    return nullptr;
+  }
+  return &VsyncTrampoline;
+}
+
+void WaylandEglBackend::VsyncTrampoline(void* user_data, const intptr_t baton) {
+  // user_data is the FlutterDesktopEngineState* handed to
+  // FlutterEngineInitialize. Recover the engine + backend from it; if either is
+  // gone (shutdown race) we drop the baton — leaking is the documented cost of
+  // an unresponded baton but the only safe option once the engine's torn down.
+  auto* state = static_cast<FlutterDesktopEngineState*>(user_data);
+  if (state == nullptr || state->view_controller == nullptr ||
+      state->view_controller->engine == nullptr) {
+    return;
+  }
+  auto* engine_obj = state->view_controller->engine;
+  auto* backend = dynamic_cast<WaylandEglBackend*>(engine_obj->GetBackend());
+  if (backend == nullptr) {
+    return;
+  }
+  backend->SetVsyncBaton(engine_obj->GetFlutterEngine(), baton);
+}
+
+void WaylandEglBackend::PostOnVsync(FLUTTER_API_SYMBOL(FlutterEngine) engine,
+                                    const intptr_t baton) const {
+  if (engine == nullptr || baton == 0) {
+    return;
+  }
+  auto* runner = platform_task_runner_.load(std::memory_order_acquire);
+  if (runner == nullptr || runner->GetStrandContext() == nullptr) {
+    // Plumbing not in place yet (vsync_callback fired during engine
+    // bring-up before FlutterView::Initialize installed the runner) or
+    // already torn down. Drop — the next baton from Flutter will be
+    // handled once the runner is wired.
+    return;
+  }
+  const uint64_t now = LibFlutterEngine->GetCurrentTime();
+  const uint64_t period_ns = last_refresh_ns_.load(std::memory_order_acquire);
+  asio::post(*runner->GetStrandContext(), [engine, baton, now, period_ns]() {
+    LibFlutterEngine->OnVsync(engine, baton, now, now + period_ns);
+  });
+}
+
+void WaylandEglBackend::SetVsyncBaton(FLUTTER_API_SYMBOL(FlutterEngine) engine,
+                                      const intptr_t baton) {
+  engine_handle_.store(engine, std::memory_order_release);
+
+  // Park the baton first — if the dispatch thread is about to fire the
+  // listener for an in-flight feedback object, it picks the baton up
+  // there instead of leaving us racing the exchange.
+  vsync_baton_.store(baton, std::memory_order_release);
+
+  if (feedback_pending_.load(std::memory_order_acquire)) {
+    // A commit is in flight; the upcoming presented/discarded event will
+    // exchange the baton out and call OnVsync. Nothing else to do.
+    return;
+  }
+
+  // Pipeline idle: first frame, post-resume, or Flutter waking from
+  // idle on input. Drain the baton ourselves — otherwise Flutter sits
+  // forever waiting for OnVsync from a commit that will never happen
+  // because no PresentLayers call is scheduled.
+  if (const intptr_t mine = vsync_baton_.exchange(0, std::memory_order_acq_rel);
+      mine != 0) {
+    PostOnVsync(engine, mine);
+  }
+}
+
+void WaylandEglBackend::RequestPresentationFeedback() {
+  // Caller is on the rasterizer thread (Flutter's presenter). Skip when
+  // wp_presentation isn't usable, or when no wl_surface is yet attached
+  // (CreateSurface hasn't run during early bring-up). Also honor the
+  // IVI_WL_VSYNC=0 kill-switch so the entire wp_presentation_feedback
+  // path is bypassed for bisection — must mirror GetVsyncCallback's
+  // gate exactly, otherwise feedback objects would accumulate without
+  // a baton to drain them.
+  static const bool env_disabled = []() {
+    const char* env = std::getenv("IVI_WL_VSYNC");
+    return env != nullptr && std::string_view(env) == "0";
+  }();
+  if (env_disabled || wp_presentation_ == nullptr || !clock_compatible_) {
+    return;
+  }
+  auto* surface = m_wl_surface.load(std::memory_order_acquire);
+  if (surface == nullptr) {
+    return;
+  }
+  // Defense in depth against a misbehaving compositor that never sends
+  // presented/discarded: cap the outstanding-feedback count. Flutter
+  // pipelines ≤4 commits in practice, so 16 is comfortably above any
+  // honest workload; passing it means the compositor is silently
+  // dropping our requests and unbounded growth would otherwise leak
+  // wl_proxy ids forever.
+  constexpr size_t kFeedbackInFlightCap = 16;
+  {
+    std::lock_guard<std::mutex> lock(m_feedback_mu_);
+    if (feedback_in_flight_.size() >= kFeedbackInFlightCap) {
+      spdlog::warn(
+          "[WaylandEglBackend] feedback_in_flight_ saturated at {} — "
+          "compositor "
+          "is silently dropping wp_presentation_feedback requests; skipping",
+          feedback_in_flight_.size());
+      return;
+    }
+  }
+  // wp_presentation_feedback() must be issued BEFORE the wl_surface.commit
+  // that submits this content update. EGL hides the commit inside
+  // eglSwapBuffers, so the call ordering is: RequestPresentationFeedback()
+  // → eglSwapBuffers (which commits + feedback gets bound to that commit).
+  struct wp_presentation_feedback* fb =
+      wp_presentation_feedback(wp_presentation_, surface);
+  if (fb == nullptr) {
+    spdlog::warn(
+        "[WaylandEglBackend] wp_presentation_feedback() returned null");
+    return;
+  }
+  wp_presentation_feedback_add_listener(fb, &feedback_listener_, this);
+  {
+    std::lock_guard<std::mutex> lock(m_feedback_mu_);
+    feedback_in_flight_.push_back(fb);
+  }
+  feedback_pending_.store(true, std::memory_order_release);
+}
+
+void WaylandEglBackend::on_feedback_sync_output(
+    void* /*data*/,
+    struct wp_presentation_feedback* /*fb*/,
+    struct wl_output* /*output*/) {
+  // Informational only — tells us which output will present this commit.
+  // For multi-output Flutter views this is the right signal to switch
+  // refresh-rate tracking; for the single-surface case ignore.
+}
+
+void WaylandEglBackend::on_feedback_presented(
+    void* data,
+    struct wp_presentation_feedback* fb,
+    const uint32_t tv_sec_hi,
+    const uint32_t tv_sec_lo,
+    const uint32_t tv_nano_sec,
+    const uint32_t refresh,
+    uint32_t /*seq_hi*/,
+    uint32_t /*seq_lo*/,
+    const uint32_t flags) {
+  auto* self = static_cast<WaylandEglBackend*>(data);
+  if (self == nullptr) {
+    return;
+  }
+  // Refresh of 0 means the compositor doesn't know the cadence (virtual
+  // output, etc.); keep the previous value rather than overwriting with
+  // garbage that would skew frame_target_time. Also clamp at 100ms
+  // (10Hz) — a misbehaving or hostile compositor could otherwise send
+  // refresh=UINT32_MAX (~4.3s/frame), wedging the engine on a far-future
+  // frame_target_time.
+  constexpr uint64_t kMaxPlausibleRefreshNs = 100'000'000;  // 10Hz floor
+  if (refresh > 0 && refresh <= kMaxPlausibleRefreshNs) {
+    self->last_refresh_ns_.store(refresh, std::memory_order_release);
+  }
+  // Reject malformed tv_sec_hi: CLOCK_MONOTONIC counts seconds since
+  // boot, which has never reached 2^32 (~136 years) on any extant
+  // system. A non-zero tv_sec_hi indicates either a malicious compositor
+  // or a protocol-level bug — combined with the *1e9 multiplication
+  // below it would overflow uint64_t and feed garbage to OnVsync.
+  if (tv_sec_hi != 0) {
+    spdlog::warn(
+        "[WaylandEglBackend] feedback.presented tv_sec_hi={} (expected 0); "
+        "dropping baton with wall-clock fallback",
+        tv_sec_hi);
+    // Fall through to the discarded-path baton drain below by clearing
+    // the timestamp; the if(tv_sec_hi)-skip is structured so the
+    // feedback object still gets destroyed and the baton returned.
+    WaylandEglBackend::on_feedback_discarded(data, fb);
+    return;
+  }
+  // Combine the split tv_sec components into nanoseconds in the same
+  // clock domain as FlutterEngineGetCurrentTime (verified compatible
+  // via clock_compatible_ at construction time).
+  const auto tv_sec = static_cast<uint64_t>(tv_sec_lo);
+  const uint64_t tv_ns =
+      tv_sec * 1'000'000'000ULL + static_cast<uint64_t>(tv_nano_sec);
+
+  // IVI_WL_PROFILE=1 accumulates frame-interval stats and flushes every
+  // 60 presented frames. Both this handler and on_feedback_discarded
+  // fire on Display's event_thread_, so a single non-atomic block of
+  // counters is safe (no concurrent writer).
+  static const bool profile_enabled = std::getenv("IVI_WL_PROFILE") != nullptr;
+  if (profile_enabled) {
+    auto& p = self->profile_;
+    if (p.last_presented_ns != 0) {
+      const uint64_t dt = tv_ns - p.last_presented_ns;
+      p.interval_sum_ns += dt;
+      if (dt > p.interval_max_ns) {
+        p.interval_max_ns = dt;
+      }
+      // Bucket per-frame interval against a 60Hz baseline. Thresholds
+      // are picked just past N vblank periods to absorb compositor
+      // jitter (e.g. 17ms allows a hair of slop above the 16.67ms
+      // budget; matches DRM's bucket philosophy at its native rate).
+      if (dt <= 17'000'000ULL) {
+        ++p.bucket_60hz;
+      } else if (dt <= 33'000'000ULL) {
+        ++p.bucket_30hz;
+      } else if (dt <= 50'000'000ULL) {
+        ++p.bucket_20hz;
+      } else if (dt <= 100'000'000ULL) {
+        ++p.bucket_slow;
+      } else {
+        ++p.bucket_idle;
+      }
+    }
+    p.last_presented_ns = tv_ns;
+    p.flags_or |= flags;
+    ++p.presented_frames;
+    constexpr uint32_t kProfileWindow = 60;
+    if (p.presented_frames >= kProfileWindow) {
+      // First interval in a fresh stream has no predecessor; sample
+      // count is one less than the frame count for the very first
+      // window, identical thereafter.
+      const uint32_t samples =
+          (p.interval_sum_ns > 0) ? p.presented_frames - 1 : p.presented_frames;
+      const uint64_t mean_ns = samples > 0 ? p.interval_sum_ns / samples : 0;
+      const double fps = mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
+      spdlog::info(
+          "[WaylandEglBackend] profile (n={}): fps={:.2f} mean_interval={}us "
+          "max_interval={}us discarded={} refresh={}us flags=0x{:x} "
+          "buckets[60Hz/30Hz/20Hz/slow/idle]={}/{}/{}/{}/{}",
+          p.presented_frames, fps, mean_ns / 1000, p.interval_max_ns / 1000,
+          p.discarded_frames,
+          self->last_refresh_ns_.load(std::memory_order_relaxed) / 1000,
+          p.flags_or, p.bucket_60hz, p.bucket_30hz, p.bucket_20hz,
+          p.bucket_slow, p.bucket_idle);
+      // Roll window totals into the session aggregate before reset.
+      auto& s = self->session_totals_;
+      s.presented_frames += p.presented_frames;
+      s.discarded_frames += p.discarded_frames;
+      s.interval_sum_ns += p.interval_sum_ns;
+      if (p.interval_max_ns > s.interval_max_ns) {
+        s.interval_max_ns = p.interval_max_ns;
+      }
+      s.flags_or |= p.flags_or;
+      s.bucket_60hz += p.bucket_60hz;
+      s.bucket_30hz += p.bucket_30hz;
+      s.bucket_20hz += p.bucket_20hz;
+      s.bucket_slow += p.bucket_slow;
+      s.bucket_idle += p.bucket_idle;
+      p = FrameProfile{.last_presented_ns = p.last_presented_ns};
+    }
+  }
+
+  // Race-safe destroy: only the path that successfully removed `fb` from
+  // feedback_in_flight_ owns its destruction. If StopVsyncMonitor swapped
+  // the vector out from under us, `fb` is in StopVsyncMonitor's drained
+  // copy and IT will destroy it — destroying here would double-free
+  // libwayland's id table entry.
+  bool removed_one = false;
+  bool empty = false;
+  {
+    std::lock_guard<std::mutex> lock(self->m_feedback_mu_);
+    auto& vec = self->feedback_in_flight_;
+    auto it = std::find(vec.begin(), vec.end(), fb);
+    if (it != vec.end()) {
+      vec.erase(it);
+      removed_one = true;
+    }
+    empty = vec.empty();
+  }
+  if (removed_one) {
+    wp_presentation_feedback_destroy(fb);
+  }
+
+  if (empty) {
+    self->feedback_pending_.store(false, std::memory_order_release);
+  }
+
+  // Hand the baton back to Flutter with the presentation timestamp.
+  // Cross-thread (this fires on Display's event_thread_) → PostOnVsync.
+  const intptr_t baton =
+      self->vsync_baton_.exchange(0, std::memory_order_acq_rel);
+  if (baton == 0) {
+    return;
+  }
+  auto* engine = self->engine_handle_.load(std::memory_order_acquire);
+  if (engine == nullptr) {
+    return;
+  }
+  auto* runner = self->platform_task_runner_.load(std::memory_order_acquire);
+  if (runner == nullptr || runner->GetStrandContext() == nullptr) {
+    return;
+  }
+  const uint64_t period_ns =
+      self->last_refresh_ns_.load(std::memory_order_acquire);
+  asio::post(*runner->GetStrandContext(), [engine, baton, tv_ns, period_ns]() {
+    LibFlutterEngine->OnVsync(engine, baton, tv_ns, tv_ns + period_ns);
+  });
+}
+
+void WaylandEglBackend::on_feedback_discarded(
+    void* data,
+    struct wp_presentation_feedback* fb) {
+  auto* self = static_cast<WaylandEglBackend*>(data);
+  if (self == nullptr) {
+    return;
+  }
+  // 'discarded' means the compositor never scanned this commit out (the
+  // next commit superseded it, or the surface was occluded). Flutter is
+  // still waiting on a baton return either way — use the engine's wall
+  // clock as the frame_start_time since we have no real timestamp.
+  static const bool profile_enabled = std::getenv("IVI_WL_PROFILE") != nullptr;
+  if (profile_enabled) {
+    ++self->profile_.discarded_frames;
+  }
+  // Race-safe destroy: see on_feedback_presented for the rationale.
+  bool removed_one = false;
+  bool empty = false;
+  {
+    std::lock_guard<std::mutex> lock(self->m_feedback_mu_);
+    auto& vec = self->feedback_in_flight_;
+    auto it = std::find(vec.begin(), vec.end(), fb);
+    if (it != vec.end()) {
+      vec.erase(it);
+      removed_one = true;
+    }
+    empty = vec.empty();
+  }
+  if (removed_one) {
+    wp_presentation_feedback_destroy(fb);
+  }
+
+  if (empty) {
+    self->feedback_pending_.store(false, std::memory_order_release);
+  }
+
+  const intptr_t baton =
+      self->vsync_baton_.exchange(0, std::memory_order_acq_rel);
+  if (baton == 0) {
+    return;
+  }
+  auto* engine = self->engine_handle_.load(std::memory_order_acquire);
+  if (engine == nullptr) {
+    return;
+  }
+  self->PostOnVsync(engine, baton);
+}
+
+const wp_presentation_feedback_listener WaylandEglBackend::feedback_listener_ =
+    {
+        .sync_output = WaylandEglBackend::on_feedback_sync_output,
+        .presented = WaylandEglBackend::on_feedback_presented,
+        .discarded = WaylandEglBackend::on_feedback_discarded,
+};
+
+void WaylandEglBackend::StopVsyncMonitor() {
+  // Called from FlutterView::~FlutterView before the engine destructs.
+  // After this returns the listener data pointer (this) may dangle if a
+  // dispatch is in flight; destroying the feedback objects synchronously
+  // cancels their listener registration so the compositor's events land
+  // on dead memory only if they were already queued — and even those
+  // are silently dropped by libwayland because the object id is gone.
+  std::vector<struct wp_presentation_feedback*> drained;
+  {
+    std::lock_guard<std::mutex> lock(m_feedback_mu_);
+    drained.swap(feedback_in_flight_);
+  }
+  for (auto* fb : drained) {
+    wp_presentation_feedback_destroy(fb);
+  }
+  feedback_pending_.store(false, std::memory_order_release);
+
+  // The baton (if any) is dropped — by contract, an unresponded baton
+  // is a leak rather than a crash. Flutter has already initiated
+  // shutdown so it won't notice.
+  vsync_baton_.store(0, std::memory_order_release);
+  engine_handle_.store(nullptr, std::memory_order_release);
+  platform_task_runner_.store(nullptr, std::memory_order_release);
+
+  // Session-aggregate profile summary (IVI_WL_PROFILE=1). Logged from
+  // the shutdown latch so it captures the entire run, not just whatever
+  // happened to land in the last 60-frame window. No-op when the profile
+  // env-var was unset (counters never accumulated).
+  const auto& s = session_totals_;
+  if (s.presented_frames > 0) {
+    const uint32_t samples =
+        (s.interval_sum_ns > 0) ? s.presented_frames - 1 : s.presented_frames;
+    const uint64_t mean_ns = samples > 0 ? s.interval_sum_ns / samples : 0;
+    const double fps = mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
+    const uint32_t total = s.bucket_60hz + s.bucket_30hz + s.bucket_20hz +
+                           s.bucket_slow + s.bucket_idle;
+    spdlog::info(
+        "[WaylandEglBackend] session summary: frames={} fps={:.2f} "
+        "mean_interval={}us max_interval={}us discarded={} flags=0x{:x}",
+        s.presented_frames, fps, mean_ns / 1000, s.interval_max_ns / 1000,
+        s.discarded_frames, s.flags_or);
+    if (total > 0) {
+      const double inv = 100.0 / static_cast<double>(total);
+      spdlog::info(
+          "[WaylandEglBackend] session buckets: "
+          "60Hz(≤17ms)={} ({:.1f}%) 30Hz(18-33ms)={} ({:.1f}%) "
+          "20Hz(34-50ms)={} ({:.1f}%) slow(51-100ms)={} ({:.1f}%) "
+          "idle(>100ms)={} ({:.1f}%)",
+          s.bucket_60hz, s.bucket_60hz * inv, s.bucket_30hz,
+          s.bucket_30hz * inv, s.bucket_20hz, s.bucket_20hz * inv,
+          s.bucket_slow, s.bucket_slow * inv, s.bucket_idle,
+          s.bucket_idle * inv);
+    }
+  }
+}
+
 void WaylandEglBackend::Resize(size_t /* index */,
                                Engine* flutter_engine,
                                const int32_t width,
@@ -229,6 +688,10 @@ void WaylandEglBackend::CreateSurface(size_t /* index */,
                                       int32_t width,
                                       int32_t height) {
   UpdateSize(width, height);
+  // Stash the wl_surface for per-commit wp_presentation_feedback requests.
+  // EGL takes a reference internally via wl_egl_window_create — the
+  // surface stays valid for the lifetime of the egl_window.
+  m_wl_surface.store(surface, std::memory_order_release);
   m_egl_window = wl_egl_window_create(surface, width, height);
   m_egl_surface = create_egl_surface(m_egl_window, nullptr);
 }
@@ -359,8 +822,8 @@ bool WaylandEglBackend::CreateBackingStore(
     FlutterBackingStore* store_out) {
   EnsureGlCapsProbed();
 
-  const int32_t w = static_cast<int32_t>(config->size.width);
-  const int32_t h = static_cast<int32_t>(config->size.height);
+  const auto w = static_cast<int32_t>(config->size.width);
+  const auto h = static_cast<int32_t>(config->size.height);
 
   // Sized internal format preference — ES3 / OES_rgb8_rgba8 → sized, else
   // unsized. Same rule the backing store itself uses internally.
@@ -509,6 +972,13 @@ bool WaylandEglBackend::BlitBackingStoreToWindow(
 
 bool WaylandEglBackend::PresentLayers(const FlutterLayer** layers,
                                       size_t count) {
+  // Request wp_presentation feedback before the swap so it binds to THIS
+  // commit. Both the fast path (BlitBackingStoreToWindow) and the general
+  // path below end in eglSwapBuffers, and both want feedback — do it once
+  // here at the entry so the request and the commit are not interleaved
+  // with anything else on the wl_display proxy queue.
+  RequestPresentationFeedback();
+
   // Fast path: a single Flutter-rendered layer, no platform views.
   if (count == 1 && layers[0]->type == kFlutterLayerContentTypeBackingStore &&
       layers[0]->backing_store) {

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -134,11 +134,9 @@ FlutterRendererConfig WaylandEglBackend::GetRenderConfig() {
       return b->SwapBuffers();
     }
 
-    // Free the existing damage that was allocated to this frame.
-    if (b->m_existing_damage_map[info->fbo_id] != nullptr) {
-      free(b->m_existing_damage_map[info->fbo_id]);
-      b->m_existing_damage_map[info->fbo_id] = nullptr;
-    }
+    // Existing-damage storage is held by value in m_existing_damage_map;
+    // populate_existing_damage rewrites the entry in place on every call,
+    // so no per-frame free is required here.
 
     if (b->GetSetDamageRegion()) {
       // Set the buffer damage as the damage region.
@@ -186,13 +184,13 @@ FlutterRendererConfig WaylandEglBackend::GetRenderConfig() {
 
     existing_damage->num_rects = 1;
 
-    // Allocate the array of rectangles for the existing damage.
-    b->m_existing_damage_map[fbo_id] = static_cast<FlutterRect*>(
-        malloc(sizeof(FlutterRect) * existing_damage->num_rects));
-    b->m_existing_damage_map[fbo_id][0] =
-        FlutterRect{0, 0, static_cast<double>(b->m_initial_width),
-                    static_cast<double>(b->m_initial_height)};
-    existing_damage->damage = b->m_existing_damage_map[fbo_id];
+    // Reuse the per-fbo slot in the map. operator[] default-constructs the
+    // FlutterRect on first use and returns a stable reference thereafter
+    // (std::unordered_map keeps node addresses stable across insertions).
+    FlutterRect& slot = b->m_existing_damage_map[fbo_id];
+    slot = FlutterRect{0, 0, static_cast<double>(b->m_initial_width),
+                       static_cast<double>(b->m_initial_height)};
+    existing_damage->damage = &slot;
 
     if (age > 1) {
       --age;
@@ -1011,11 +1009,45 @@ bool WaylandEglBackend::PresentLayers(const FlutterLayer** layers,
   // to the Wayland compositor. The surface has no wl_surface_set_opaque_region
   // set by default, and the EGL config has EGL_ALPHA_SIZE=8, so per-pixel
   // alpha is honoured downstream.
+  //
+  // Skip the clear when the first composited layer is a window-sized
+  // BackingStore at offset (0,0): its blend=false path overwrites the
+  // entire FBO 0, so the upfront clear's pixels are immediately discarded.
+  // PlatformView layers ahead of any BackingStore disqualify the skip
+  // because their cutouts may not be covered by any later layer.
+  bool first_layer_covers_window = false;
+  for (size_t i = 0; i < count; ++i) {
+    const FlutterLayer* layer = layers[i];
+    if (!layer) {
+      continue;
+    }
+    if (layer->type == kFlutterLayerContentTypeBackingStore &&
+        layer->backing_store) {
+      first_layer_covers_window =
+          layer->offset.x == 0.0 && layer->offset.y == 0.0 &&
+          static_cast<uint32_t>(layer->size.width) == m_initial_width &&
+          static_cast<uint32_t>(layer->size.height) == m_initial_height;
+      break;
+    }
+    if (layer->type == kFlutterLayerContentTypePlatformView) {
+      break;
+    }
+  }
+
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
-  glDisable(GL_SCISSOR_TEST);
-  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-  glClear(GL_COLOR_BUFFER_BIT);
+  if (!first_layer_covers_window) {
+    glDisable(GL_SCISSOR_TEST);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+  }
+
+  // Enter frame-batched compositor mode so each quad-path composite skips
+  // the program/VBO/attrib setup that's invariant across layers within a
+  // frame. Matched by EndFrame after the loop. Probe caps up front so
+  // m_gl_compositor is constructed.
+  EnsureGlCapsProbed();
+  m_gl_compositor->BeginFrame();
 
   bool ok = true;
   // Engine emits layers bottom-to-top. The first composited layer lands on
@@ -1107,6 +1139,7 @@ bool WaylandEglBackend::PresentLayers(const FlutterLayer** layers,
     }
   }
 
+  m_gl_compositor->EndFrame();
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   return SwapBuffers() && ok;
 }

--- a/shell/backend/wayland_egl/wayland_egl.h
+++ b/shell/backend/wayland_egl/wayland_egl.h
@@ -199,8 +199,12 @@ class WaylandEglBackend : public Egl, public Backend {
   uint32_t m_initial_width;
   uint32_t m_initial_height;
 
-  // Keeps track of the existing damage associated with each FBO ID
-  std::unordered_map<intptr_t, FlutterRect*> m_existing_damage_map;
+  // Keeps track of the existing damage associated with each FBO ID.
+  // Storing the rect by value (not via heap) so populate_existing_damage
+  // doesn't malloc/free per frame; std::unordered_map keeps element
+  // addresses stable across insertions, so handing &map[fbo_id] to the
+  // engine is safe across frames.
+  std::unordered_map<intptr_t, FlutterRect> m_existing_damage_map;
 
   // Keeps track of the most recent frame damages so that existing damage can
   // be easily computed.

--- a/shell/backend/wayland_egl/wayland_egl.h
+++ b/shell/backend/wayland_egl/wayland_egl.h
@@ -16,8 +16,13 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstdint>
+#include <ctime>
 #include <list>
+#include <mutex>
 #include <unordered_map>
+#include <vector>
 
 #include <wayland-egl.h>
 
@@ -25,6 +30,12 @@
 
 #include "backend/backend.h"
 #include "egl.h"
+
+struct wl_output;
+struct wp_presentation;
+struct wp_presentation_feedback;
+class Display;
+class TaskRunner;
 
 #if BUILD_COMPOSITOR
 #include <memory>
@@ -49,7 +60,11 @@ class WaylandEglBackend : public Egl, public Backend {
   // last two frames.
   static constexpr int kMaxHistorySize = 10;
 
-  WaylandEglBackend(struct wl_display* display,
+  // @p shell_display is the @c Display owning the wp_presentation global.
+  // May be nullptr (e.g., for tests that don't construct a Display); the
+  // backend then falls back to the wall-clock vsync scheduler.
+  WaylandEglBackend(Display* shell_display,
+                    struct wl_display* display,
                     uint32_t initial_width,
                     uint32_t initial_height,
                     bool debug_backend,
@@ -113,6 +128,43 @@ class WaylandEglBackend : public Egl, public Backend {
    */
   FlutterCompositor GetCompositorConfig() override;
 
+  /**
+   * @brief Per-backend FlutterVsyncCallback.
+   *
+   * Returns @c &VsyncTrampoline iff (a) the compositor advertised
+   * wp_presentation, (b) the announced clock_id is CLOCK_MONOTONIC,
+   * and (c) @c IVI_WL_VSYNC is not @c 0. Otherwise returns nullptr and
+   * Flutter falls back to its internal wall-clock scheduler.
+   */
+  [[nodiscard]] VsyncCallback GetVsyncCallback() const override;
+
+  /**
+   * @brief Stash the engine handle for the wp_presentation_feedback
+   * path. Captured atomically because dispatch may read it from a
+   * thread other than the caller (event_thread_ when the listener fires).
+   */
+  void SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine) engine) override {
+    engine_handle_.store(engine, std::memory_order_release);
+  }
+
+  /**
+   * @brief Stash the platform task runner so @c FlutterEngineOnVsync
+   * can be marshalled onto its strand. Required because the listener
+   * for @c wp_presentation_feedback.presented fires on Display's
+   * event_thread_, and Flutter rejects @c OnVsync from any thread
+   * other than the engine's run thread.
+   */
+  void SetPlatformTaskRunner(TaskRunner* runner) override {
+    platform_task_runner_.store(runner, std::memory_order_release);
+  }
+
+  /**
+   * @brief Cancel outstanding wp_presentation_feedback objects so
+   * listeners can't fire after the engine has destructed. Called from
+   * @c FlutterView::~FlutterView before the engine destructs.
+   */
+  void StopVsyncMonitor() override;
+
   void UpdateSize(int _width, int _height) {
     m_initial_width = static_cast<uint32_t>(_width);
     m_initial_height = static_cast<uint32_t>(_height);
@@ -138,6 +190,12 @@ class WaylandEglBackend : public Egl, public Backend {
 
  private:
   struct wl_egl_window* m_egl_window{};
+  // wl_surface backing m_egl_window. We stash it from CreateSurface so
+  // wp_presentation_feedback() can mint a feedback object per commit.
+  // Atomic because CreateSurface (platform thread, during init/resize)
+  // and RequestPresentationFeedback (rasterizer thread) can otherwise
+  // race during a window resize.
+  std::atomic<struct wl_surface*> m_wl_surface{nullptr};
   uint32_t m_initial_width;
   uint32_t m_initial_height;
 
@@ -222,4 +280,115 @@ class WaylandEglBackend : public Egl, public Backend {
            height == static_cast<int32_t>(m_initial_height);
   }
 #endif
+
+  // wp_presentation-driven vsync plumbing.
+  //
+  // The producer (FlutterEngine.vsync_callback → VsyncTrampoline) parks
+  // a baton in vsync_baton_; the consumer (on_feedback_presented running
+  // on Display's event_thread_) exchanges it back and posts OnVsync onto
+  // the platform task runner's strand. Mirrors DrmBackend's atomic baton
+  // dance.
+  std::atomic<intptr_t> vsync_baton_{0};
+  std::atomic<FLUTTER_API_SYMBOL(FlutterEngine)> engine_handle_{nullptr};
+  std::atomic<TaskRunner*> platform_task_runner_{nullptr};
+
+  // Set when a wp_presentation_feedback has been requested for a commit
+  // but the compositor has not yet emitted presented/discarded. The idle-
+  // wake kick path checks this to decide whether to drain the baton
+  // inline (no feedback in flight → pipeline idle) or park it (let the
+  // upcoming presented event drive OnVsync).
+  std::atomic<bool> feedback_pending_{false};
+
+  // Owned wp_presentation_feedback objects awaiting presented/discarded.
+  // Display's event_thread_ drives wl_display_dispatch, so listener
+  // callbacks fire there while PresentLayers (rasterizer thread) creates
+  // new feedback objects and StopVsyncMonitor (main thread, ~FlutterView)
+  // drains at shutdown. m_feedback_mu_ serialises all three.
+  std::mutex m_feedback_mu_;
+  std::vector<struct wp_presentation_feedback*> feedback_in_flight_;
+
+  // wp_presentation global + announced clock domain. Populated from
+  // Display::GetWpPresentation()/GetPresentationClockId() at backend
+  // construction. clock_compatible_ becomes true only when
+  // presentation_clock_id_ == CLOCK_MONOTONIC, which matches
+  // FlutterEngineGetCurrentTime's domain — otherwise we refuse
+  // vsync_callback and fall back to the wall-clock scheduler.
+  struct wp_presentation* wp_presentation_{nullptr};
+  clockid_t presentation_clock_id_{CLOCK_MONOTONIC};
+  bool clock_compatible_{false};
+
+  // Last refresh period reported by wp_presentation_feedback.presented.
+  // Defaults to ~60Hz so the frame_target_time math has a reasonable
+  // seed for the first OnVsync call before any feedback has fired.
+  // Atomic because the writer (on_feedback_presented on event_thread_)
+  // races with the reader (PostOnVsync, called from rasterizer or
+  // engine threads via SetVsyncBaton's idle-kick).
+  std::atomic<uint64_t> last_refresh_ns_{16'666'667};
+
+  // Per-frame cadence profile (IVI_WL_PROFILE=1). Updated by
+  // on_feedback_presented / on_feedback_discarded — both fire on
+  // Display's event_thread_, so a single non-atomic block of counters
+  // is fine (no concurrent writer).
+  //
+  // Buckets categorize per-frame inter-presented intervals at a 60Hz
+  // baseline (one vblank ≈ 16.67ms). Lets the README produce the same
+  // shape of histogram the DRM benchmark uses.
+  struct FrameProfile {
+    uint64_t last_presented_ns{0};
+    uint64_t interval_sum_ns{0};
+    uint64_t interval_max_ns{0};
+    uint32_t presented_frames{0};
+    uint32_t discarded_frames{0};
+    uint32_t flags_or{0};     // OR of all 'presented' flags this window
+    uint32_t bucket_60hz{0};  // ≤17ms (1 vblank @ 60Hz)
+    uint32_t bucket_30hz{0};  // 18–33ms (2 vblanks)
+    uint32_t bucket_20hz{0};  // 34–50ms (3 vblanks)
+    uint32_t bucket_slow{0};  // 51–100ms (4–6 vblanks)
+    uint32_t bucket_idle{0};  // >100ms (treated as paused / load stall)
+  };
+  FrameProfile profile_{};
+
+  // Cumulative bucket counts across the entire session (IVI_WL_PROFILE=1).
+  // Logged once at backend destruction so the user gets a session summary
+  // without having to sum the per-window windows.
+  FrameProfile session_totals_{};
+
+  // Mirrors DrmBackend::VsyncTrampoline. Flutter calls this with the
+  // FlutterDesktopEngineState* as user_data plus an opaque baton; we
+  // recover the backend instance and forward to SetVsyncBaton.
+  static void VsyncTrampoline(void* user_data, intptr_t baton);
+
+  // Stash the baton; if no feedback is in flight (idle pipeline), kick
+  // the baton ourselves via PostOnVsync — otherwise Flutter sits forever
+  // waiting for OnVsync from a commit that never happens.
+  void SetVsyncBaton(FLUTTER_API_SYMBOL(FlutterEngine) engine, intptr_t baton);
+
+  // Marshal FlutterEngineOnVsync onto the platform task runner's strand.
+  // Flutter rejects OnVsync from any other thread.
+  void PostOnVsync(FLUTTER_API_SYMBOL(FlutterEngine) engine,
+                   intptr_t baton) const;
+
+  // Per-commit feedback request — called from PresentLayers /
+  // BlitBackingStoreToWindow / the renderer-config present callbacks
+  // BEFORE eglSwapBuffers (which is what mints the wl_surface.commit
+  // the feedback binds to). No-op when wp_presentation isn't usable.
+  void RequestPresentationFeedback();
+
+  // wp_presentation_feedback listener entry points.
+  static void on_feedback_sync_output(void* data,
+                                      struct wp_presentation_feedback* fb,
+                                      struct wl_output* output);
+  static void on_feedback_presented(void* data,
+                                    struct wp_presentation_feedback* fb,
+                                    uint32_t tv_sec_hi,
+                                    uint32_t tv_sec_lo,
+                                    uint32_t tv_nano_sec,
+                                    uint32_t refresh,
+                                    uint32_t seq_hi,
+                                    uint32_t seq_lo,
+                                    uint32_t flags);
+  static void on_feedback_discarded(void* data,
+                                    struct wp_presentation_feedback* fb);
+
+  static const struct wp_presentation_feedback_listener feedback_listener_;
 };

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -872,9 +872,12 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
 bool WaylandVulkanBackend::CollectBackingStore(const FlutterBackingStore* store,
                                                void* user_data) {
 #if BUILD_COMPOSITOR
-  const auto state = static_cast<FlutterDesktopEngineState*>(user_data);
-  auto* b = reinterpret_cast<WaylandVulkanBackend*>(
-      state->view_controller->view->GetBackend());
+  // user_data is `this` per FlutterCompositor.user_data set in
+  // GetCompositorConfig(). The prior code treated it as a
+  // FlutterDesktopEngineState* and walked view_controller->view->GetBackend
+  // — that read garbage offsets off the backend instance and SEGV'd at
+  // first use, leaving the Vulkan backend non-functional.
+  auto* b = static_cast<WaylandVulkanBackend*>(user_data);
   return b->CollectBackingStoreImpl(store);
 #else
   (void)store;
@@ -889,9 +892,9 @@ bool WaylandVulkanBackend::CreateBackingStore(
     FlutterBackingStore* backing_store_out,
     void* user_data) {
 #if BUILD_COMPOSITOR
-  const auto state = static_cast<FlutterDesktopEngineState*>(user_data);
-  auto* b = reinterpret_cast<WaylandVulkanBackend*>(
-      state->view_controller->view->GetBackend());
+  // user_data is `this` per FlutterCompositor.user_data — see
+  // CollectBackingStore above for the prior-bug context.
+  auto* b = static_cast<WaylandVulkanBackend*>(user_data);
   return b->CreateBackingStoreImpl(config, backing_store_out);
 #else
   (void)config;
@@ -976,9 +979,9 @@ bool WaylandVulkanBackend::PresentLayers(const FlutterLayer** layers,
                                          size_t layers_count,
                                          void* user_data) {
 #if BUILD_COMPOSITOR
-  const auto state = static_cast<FlutterDesktopEngineState*>(user_data);
-  auto* b = reinterpret_cast<WaylandVulkanBackend*>(
-      state->view_controller->view->GetBackend());
+  // user_data is `this` per FlutterCompositor.user_data — see
+  // CollectBackingStore above for the prior-bug context.
+  auto* b = static_cast<WaylandVulkanBackend*>(user_data);
   return b->PresentLayersImpl(layers, layers_count);
 #else
   (void)layers;

--- a/shell/platform/homescreen/flutter_desktop.cc
+++ b/shell/platform/homescreen/flutter_desktop.cc
@@ -445,7 +445,15 @@ void FlutterDesktopTextureRegistrarUnregisterExternalTexture(
     // Pixel-buffer textures: the embedder owns the GL texture, so free it
     // under a currently-made texture context. Guard the full backend chain
     // in case the engine is mid-teardown.
+    //
+    // GLESv2 is only linked into the final binary when a GL-based backend
+    // is enabled (Wayland EGL, DRM KMS EGL, Headless EGL). Wayland Vulkan
+    // builds don't link it and don't produce GL pixel-buffer textures at
+    // runtime — but the linker still needs the glDeleteTextures symbol
+    // unless we compile this branch out.
     if (removed->pixel_buffer_callback && removed->name != 0) {
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_DRM_KMS_EGL || \
+    BUILD_BACKEND_HEADLESS_EGL
       Backend* backend = nullptr;
       if (texture_registrar->engine &&
           texture_registrar->engine->view_controller &&
@@ -463,6 +471,11 @@ void FlutterDesktopTextureRegistrarUnregisterExternalTexture(
             "GL texture {} leaked",
             removed->name);
       }
+#else
+      // No GL backend in this configuration; the texture was never
+      // actually backed by a live GLuint. Nothing to free.
+      (void)texture_registrar;
+#endif
     }
     if (removed->release_callback != nullptr) {
       removed->release_callback(removed->release_context);

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -211,7 +211,7 @@ FlutterView::FlutterView(Configuration::Config config,
   {
     auto* wl = dynamic_cast<Display*>(display.get());
     m_backend = std::make_shared<WaylandEglBackend>(
-        wl->GetDisplay(), m_config.view.width.value_or(kDefaultViewWidth),
+        wl, wl->GetDisplay(), m_config.view.width.value_or(kDefaultViewWidth),
         m_config.view.height.value_or(kDefaultViewHeight),
         m_config.debug_backend.value_or(false), kEglBufferSize);
   }
@@ -305,17 +305,16 @@ FlutterView::~FlutterView() {
     m_state->engine_state->messenger->SetEngine(nullptr);
   }
 
-#if BUILD_BACKEND_DRM_KMS_EGL
-  // Tear down the DRM flip monitor before m_flutter_engine destructs.
-  // The monitor's asio async_wait on drm_dev_->fd() lives on the
-  // engine's platform task runner; if it's still outstanding when
-  // Engine::~Engine resets the runner, TaskRunner::~TaskRunner blocks
-  // forever joining a worker that's parked in epoll_wait waiting for a
-  // flip event that will never arrive (kernel is idle between commits).
-  if (auto* drm = dynamic_cast<DrmBackend*>(m_backend.get())) {
-    drm->StopFlipMonitor();
+  // Tear down any backend-owned vsync/event-loop monitor before
+  // m_flutter_engine destructs. DRM's monitor is an asio async_wait on
+  // the drm fd living on the engine's platform task runner; if it's
+  // still outstanding when Engine::~Engine resets the runner,
+  // TaskRunner::~TaskRunner blocks forever joining a worker parked in
+  // epoll_wait waiting for an event that will never arrive. The default
+  // virtual is a no-op for backends without a monitor.
+  if (m_backend) {
+    m_backend->StopVsyncMonitor();
   }
-#endif
 }
 
 #if !BUILD_BACKEND_DRM_KMS_EGL
@@ -354,19 +353,15 @@ void FlutterView::Initialize() {
     exit(EXIT_FAILURE);
   }
 
-#if BUILD_BACKEND_DRM_KMS_EGL
-  // Hand the engine handle + platform task runner to the DRM backend
-  // so OnSessionResumed can call ScheduleFrame after a VT round-trip
-  // and PostOnVsync can marshal OnVsync onto the FlutterEngineRun
-  // thread (Flutter rejects OnVsync from any other thread with
-  // kInternalInconsistency).
-  if (auto* drm_backend = dynamic_cast<DrmBackend*>(m_backend.get());
-      drm_backend != nullptr) {
-    drm_backend->SetEngineHandle(m_flutter_engine->GetFlutterEngine());
-    drm_backend->SetPlatformTaskRunner(
-        m_flutter_engine->GetPlatformTaskRunner());
+  // Hand the engine handle + platform task runner to the backend so
+  // post-Engine::Run lifecycle hooks (DRM's OnSessionResumed →
+  // ScheduleFrame; WaylandEgl's wp_presentation_feedback dispatch) can
+  // marshal back to the FlutterEngineRun thread without a dynamic_cast.
+  // Backends that don't need either inherit no-op defaults from Backend.
+  if (m_backend) {
+    m_backend->SetEngineHandle(m_flutter_engine->GetFlutterEngine());
+    m_backend->SetPlatformTaskRunner(m_flutter_engine->GetPlatformTaskRunner());
   }
-#endif
 
   // notify display update
   FlutterEngineDisplay display{};

--- a/shell/view/present_layer_sequencer.cc
+++ b/shell/view/present_layer_sequencer.cc
@@ -45,8 +45,11 @@ void PresentLayerSequencer::Present(const FlutterLayer** layers,
                                     size_t count,
                                     wl_surface* root_surface,
                                     const MissingHandler& on_missing) {
-  std::vector<FlutterPlatformViewIdentifier> desired;
-  desired.reserve(count);
+  // Reuse the member vector's storage across frames: clear() preserves
+  // capacity, and reserve() is a no-op once the high-water mark is set.
+  // Eliminates the per-Present allocation+free pair.
+  last_order_.clear();
+  last_order_.reserve(count);
 
   wl_surface* sibling_surface = root_surface;
 
@@ -82,8 +85,6 @@ void PresentLayerSequencer::Present(const FlutterLayer** layers,
     }
 
     sibling_surface = e.surface;
-    desired.push_back(id);
+    last_order_.push_back(id);
   }
-
-  last_order_ = std::move(desired);
 }

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -66,7 +66,15 @@ Display::Display(const bool enable_cursor,
 
   m_registry = wl_display_get_registry(m_display);
   wl_registry_add_listener(m_registry, &registry_listener, this);
+  // First dispatch picks up registry globals (synchronous: the server
+  // emits them immediately after we bind the registry). The roundtrip
+  // that follows pulls in events the server emits ONLY in response to
+  // our binds — notably wp_presentation.clock_id, which arrives in a
+  // second round-trip. Without this, WaylandEglBackend's clock_compatible_
+  // check could read the default-initialized CLOCK_MONOTONIC value
+  // before the compositor's announcement arrives.
   wl_display_dispatch(m_display);
+  wl_display_roundtrip(m_display);
 
   if (m_agl.shell && m_agl.bind_to_agl_shell && m_agl.version >= 2) {
     int ret = 0;
@@ -91,6 +99,9 @@ Display::Display(const bool enable_cursor,
 
 Display::~Display() {
   SPDLOG_TRACE("+ ~Display()");
+
+  if (m_wp_presentation)
+    wp_presentation_destroy(m_wp_presentation);
 
   if (m_shm)
     wl_shm_destroy(m_shm);
@@ -191,7 +202,18 @@ void Display::registry_handle_global(void* data,
     xdg_wm_base_add_listener(d->m_xdg_wm_base, &xdg_wm_base_listener, d);
   }
 #endif
-  else if (strcmp(interface, wl_shm_interface.name) == 0) {
+  else if (strcmp(interface, wp_presentation_interface.name) == 0) {
+    // wp_presentation v2 added the presentation_feedback.kind 'zero_copy' flag
+    // and is supported by every mainline compositor. Cap at 2 so older
+    // compositors advertising v1 still work — we don't use any v2-only
+    // request/event from the wp_presentation interface itself.
+    d->m_wp_presentation = static_cast<wp_presentation*>(
+        wl_registry_bind(registry, name, &wp_presentation_interface,
+                         std::min(static_cast<uint32_t>(2), version)));
+    wp_presentation_add_listener(d->m_wp_presentation,
+                                 &wp_presentation_listener, d);
+    spdlog::debug("Wayland: wp_presentation version: {}", version);
+  } else if (strcmp(interface, wl_shm_interface.name) == 0) {
     d->m_shm = static_cast<wl_shm*>(
         wl_registry_bind(registry, name, &wl_shm_interface,
                          std::min(static_cast<uint32_t>(1), version)));
@@ -272,6 +294,19 @@ void Display::registry_handle_global_remove(void* /* data */,
 const wl_registry_listener Display::registry_listener = {
     registry_handle_global,
     registry_handle_global_remove,
+};
+
+void Display::wp_presentation_handle_clock_id(
+    void* data,
+    struct wp_presentation* /*presentation*/,
+    uint32_t clk_id) {
+  auto* d = static_cast<Display*>(data);
+  d->m_presentation_clock_id = static_cast<clockid_t>(clk_id);
+  spdlog::debug("Wayland: wp_presentation clock_id={}", clk_id);
+}
+
+const struct wp_presentation_listener Display::wp_presentation_listener = {
+    .clock_id = wp_presentation_handle_clock_id,
 };
 
 void Display::display_handle_geometry(void* data,

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -28,6 +28,7 @@
 
 #include "engine.h"
 #include "timer.h"
+#include "window.h"
 
 extern void KeyCallback(FlutterDesktopViewControllerState* view_state,
                         bool released,
@@ -230,6 +231,7 @@ void Display::registry_handle_global(void* data,
     const auto oi = std::make_shared<output_info_t>();
     std::fill_n(oi.get(), 1, output_info_t{});
     oi->global_id = name;
+    oi->display = d;
     // be compat with v2 as well
 #if defined(WL_OUTPUT_NAME_SINCE_VERSION) && \
     defined(WL_OUTPUT_DESCRIPTION_SINCE_VERSION)
@@ -340,6 +342,9 @@ void Display::display_handle_mode(void* data,
     oi->height = static_cast<unsigned int>(height);
     oi->width = static_cast<unsigned int>(width);
     oi->refresh_rate = refresh / 1000.0;
+    if (oi->display) {
+      oi->display->NotifyOutputResized(oi);
+    }
   }
 
   SPDLOG_DEBUG("Video mode: {} x {} @ {} Hz", width, height, refresh / 1000.0);
@@ -898,6 +903,46 @@ void Display::SetEngine(wl_surface* surface, Engine* engine) {
   m_active_engine = engine;
   m_active_surface = surface;
   m_surface_engine_map[surface] = engine;
+}
+
+void Display::RegisterWindow(WaylandWindow* window) {
+  if (!window) {
+    return;
+  }
+  std::lock_guard lock(m_windows_lock);
+  m_windows.push_back(window);
+}
+
+void Display::UnregisterWindow(WaylandWindow* window) {
+  std::lock_guard lock(m_windows_lock);
+  m_windows.erase(std::remove(m_windows.begin(), m_windows.end(), window),
+                  m_windows.end());
+}
+
+size_t Display::IndexOfOutput(const output_info_t* oi) const {
+  for (size_t i = 0; i < m_all_outputs.size(); ++i) {
+    if (m_all_outputs[i].get() == oi) {
+      return i;
+    }
+  }
+  return m_all_outputs.size();
+}
+
+void Display::NotifyOutputResized(const output_info_t* oi) {
+  const size_t idx = IndexOfOutput(oi);
+  if (idx >= m_all_outputs.size()) {
+    return;
+  }
+  const auto width = static_cast<int32_t>(oi->width);
+  const auto height = static_cast<int32_t>(oi->height);
+  std::vector<WaylandWindow*> snapshot;
+  {
+    std::lock_guard lock(m_windows_lock);
+    snapshot = m_windows;
+  }
+  for (auto* w : snapshot) {
+    w->OnOutputResized(idx, width, height);
+  }
 }
 
 bool Display::ActivateSystemCursor(const int32_t device,

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -18,12 +18,14 @@
 #pragma once
 
 #include <chrono>
+#include <ctime>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
 
+#include <presentation-time-client-protocol.h>
 #include <shell/platform/embedder/embedder.h>
 #include <wayland-client.h>
 #include <wayland-cursor.h>
@@ -134,6 +136,29 @@ class Display : public IDisplay {
   [[nodiscard]] wl_shm* GetShm() const {
     assert(m_shm);
     return m_shm;
+  }
+
+  /**
+   * @brief Get wp_presentation global, if the compositor advertised one.
+   * @return wp_presentation* or nullptr if the global is not present.
+   *
+   * Used by WaylandEglBackend to request per-commit presentation feedback
+   * for vsync_callback. Caller must null-check.
+   */
+  [[nodiscard]] wp_presentation* GetWpPresentation() const {
+    return m_wp_presentation;
+  }
+
+  /**
+   * @brief Compositor-announced presentation clock domain.
+   *
+   * Valid only when GetWpPresentation() is non-null AND wp_presentation
+   * has emitted its clock_id event (the compositor sends it once at bind
+   * time, before any feedback objects exist). Defaults to CLOCK_MONOTONIC
+   * which matches what every mainline compositor announces in practice.
+   */
+  [[nodiscard]] clockid_t GetPresentationClockId() const {
+    return m_presentation_clock_id;
   }
 
   /**
@@ -376,6 +401,13 @@ class Display : public IDisplay {
   struct wl_keyboard* m_keyboard{};
 
   struct xdg_wm_base* m_xdg_wm_base{};
+
+  // wp_presentation_time global + announced clock domain. m_wp_presentation
+  // is nullptr when the compositor does not advertise the protocol;
+  // m_presentation_clock_id is only meaningful once the clock_id event has
+  // fired (defaulted to CLOCK_MONOTONIC to keep the value sane until then).
+  struct wp_presentation* m_wp_presentation{};
+  clockid_t m_presentation_clock_id{CLOCK_MONOTONIC};
 
   struct agl {
     bool bind_to_agl_shell = false;
@@ -1352,4 +1384,20 @@ class Display : public IDisplay {
                                          uint32_t surface_id);
 
   static const struct ivi_wm_listener ivi_wm_listener;
+
+  /**
+   * @brief wp_presentation clock_id event handler.
+   *
+   * Compositors emit this once at bind time announcing the clock domain
+   * for all subsequent wp_presentation_feedback timestamps. We capture it
+   * into m_presentation_clock_id; WaylandEglBackend reads the value via
+   * GetPresentationClockId() to decide whether timestamps can be passed
+   * to FlutterEngineOnVsync without translation.
+   */
+  static void wp_presentation_handle_clock_id(
+      void* data,
+      struct wp_presentation* presentation,
+      uint32_t clk_id);
+
+  static const struct wp_presentation_listener wp_presentation_listener;
 };

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -41,6 +41,7 @@
 #include "timer.h"
 
 class Engine;
+class WaylandWindow;
 
 struct FlutterDesktopViewControllerState;
 
@@ -264,6 +265,12 @@ class Display : public IDisplay {
    */
   void SetEngine(wl_surface* surface, Engine* engine);
 
+  // Track WaylandWindows so wl_output.mode changes after startup can fan
+  // out to their geometry-clamp path (Weston re-resizes its nested
+  // output without re-sending xdg_toplevel.configure).
+  void RegisterWindow(WaylandWindow* window);
+  void UnregisterWindow(WaylandWindow* window);
+
   void SetViewControllerState(
       FlutterDesktopViewControllerState* view_controller_state) override {
     m_view_controller_state = view_controller_state;
@@ -452,6 +459,10 @@ class Display : public IDisplay {
     int transform;
     std::string name;
     std::string desc;
+    // Back-pointer to the owning Display so the output listeners (which
+    // receive the output_info_t* as user data) can fan a mode change out
+    // to registered WaylandWindows.
+    class Display* display;
   } output_info_t;
 
   struct pointer_event {
@@ -530,6 +541,22 @@ class Display : public IDisplay {
   }
 
   std::vector<std::shared_ptr<output_info_t>> m_all_outputs;
+
+  // Registered WaylandWindows (raw, non-owning). Mutated from the wayland
+  // event thread (display_handle_mode callback) and the main thread
+  // (WaylandWindow ctor/dtor) so guarded by a mutex.
+  std::mutex m_windows_lock;
+  std::vector<WaylandWindow*> m_windows;
+
+  // Look up the index of an output_info_t in m_all_outputs (the same
+  // numeric value WaylandWindow stores as m_output_index). Returns
+  // m_all_outputs.size() if not found.
+  size_t IndexOfOutput(const output_info_t* oi) const;
+
+  // Called from display_handle_mode after the output_info_t has been
+  // updated. Fans the new width/height out to any WaylandWindow whose
+  // m_output_index matches; the window decides whether to shrink.
+  void NotifyOutputResized(const output_info_t* oi);
   bool m_buffer_scale_enable{};
 
   static void wayland_event_mask_update(

--- a/shell/wayland/window.cc
+++ b/shell/wayland/window.cc
@@ -284,12 +284,41 @@ void WaylandWindow::handle_toplevel_configure(
     w->m_geometry.height = height;
 
   } else if (!w->m_fullscreen && !w->m_maximized) {
-    w->m_geometry.width = w->m_window_size.width;
-    w->m_geometry.height = w->m_window_size.height;
+    // (0,0) configure = "client picks size". Downsize the client request
+    // to fit the compositor's hint (configure_bounds if known, else the
+    // output mode) so we don't render off-screen or get clipped on
+    // compositors like tinywlr that don't enforce bounds at commit time.
+    int32_t cap_w = w->m_configure_bounds.width;
+    int32_t cap_h = w->m_configure_bounds.height;
+    if (cap_w <= 0 || cap_h <= 0) {
+      const auto out = w->m_display->GetVideoModeSize(w->m_output_index);
+      cap_w = out.first;
+      cap_h = out.second;
+    }
+    int32_t target_w = w->m_window_size.width;
+    int32_t target_h = w->m_window_size.height;
+    if (cap_w > 0 && target_w > cap_w) {
+      target_w = cap_w;
+    }
+    if (cap_h > 0 && target_h > cap_h) {
+      target_h = cap_h;
+    }
+    w->m_geometry.width = target_w;
+    w->m_geometry.height = target_h;
   }
 
   w->m_backend->Resize(w->m_index, w->m_flutter_engine.get(),
                        w->m_geometry.width, w->m_geometry.height);
+}
+
+void WaylandWindow::handle_toplevel_configure_bounds(
+    void* data,
+    struct xdg_toplevel* /* toplevel */,
+    int32_t width,
+    int32_t height) {
+  auto* w = static_cast<WaylandWindow*>(data);
+  w->m_configure_bounds.width = width;
+  w->m_configure_bounds.height = height;
 }
 
 void WaylandWindow::handle_toplevel_close(
@@ -303,7 +332,7 @@ const struct xdg_toplevel_listener WaylandWindow::xdg_toplevel_listener = {
     .configure = handle_toplevel_configure,
     .close = handle_toplevel_close,
 #if defined(XDG_TOPLEVEL_CONFIGURE_BOUNDS_SINCE_VERSION)
-    .configure_bounds = nullptr,
+    .configure_bounds = handle_toplevel_configure_bounds,
 #endif
 #if defined(XDG_TOPLEVEL_WM_CAPABILITIES_SINCE_VERSION)
     .wm_capabilities = nullptr,

--- a/shell/wayland/window.cc
+++ b/shell/wayland/window.cc
@@ -137,11 +137,22 @@ WaylandWindow::WaylandWindow(const size_t index,
   m_backend->CreateSurface(m_index, m_base_surface, m_geometry.width,
                            m_geometry.height);
 
+  // Register *after* initial geometry has settled so the event-thread
+  // OnOutputResized path never observes a partially-constructed window.
+  m_display->RegisterWindow(this);
+
   SPDLOG_TRACE("({}) - WaylandWindow()", m_index);
 }
 
 WaylandWindow::~WaylandWindow() {
   SPDLOG_TRACE("({}) + ~WaylandWindow()", m_index);
+
+  // Unregister first so an in-flight wl_output.mode callback can't see
+  // us mid-destruction; UnregisterWindow's lock pairs with the snapshot
+  // copy in Display::NotifyOutputResized.
+  if (m_display) {
+    m_display->UnregisterWindow(this);
+  }
 
   if (m_base_frame_callback)
     wl_callback_destroy(m_base_frame_callback);
@@ -319,6 +330,37 @@ void WaylandWindow::handle_toplevel_configure_bounds(
   auto* w = static_cast<WaylandWindow*>(data);
   w->m_configure_bounds.width = width;
   w->m_configure_bounds.height = height;
+}
+
+void WaylandWindow::OnOutputResized(const size_t output_index,
+                                    const int32_t new_w,
+                                    const int32_t new_h) {
+  if (output_index != m_output_index) {
+    return;
+  }
+  // Only shrink — Weston (nested) emits a fresh wl_output.mode whenever
+  // the host window is resized but does NOT re-send xdg_toplevel.configure,
+  // so without this hook a 1024x768 surface stays oversized after the user
+  // pulls Weston down to 1024x640 and Weston starts spamming events to
+  // compensate ("Data too big for buffer"). Growth is the compositor's
+  // call — leave that to the next configure.
+  if (new_w <= 0 || new_h <= 0) {
+    return;
+  }
+  int32_t target_w = m_geometry.width;
+  int32_t target_h = m_geometry.height;
+  if (target_w > new_w) {
+    target_w = new_w;
+  }
+  if (target_h > new_h) {
+    target_h = new_h;
+  }
+  if (target_w == m_geometry.width && target_h == m_geometry.height) {
+    return;
+  }
+  m_geometry.width = target_w;
+  m_geometry.height = target_h;
+  m_backend->Resize(m_index, m_flutter_engine.get(), target_w, target_h);
 }
 
 void WaylandWindow::handle_toplevel_close(

--- a/shell/wayland/window.h
+++ b/shell/wayland/window.h
@@ -158,6 +158,13 @@ class WaylandWindow {
     int32_t height;
   } m_window_size{};
 
+  // Latest hint from xdg_toplevel.configure_bounds (output area minus
+  // struts). 0 = no hint received.
+  struct {
+    int32_t width;
+    int32_t height;
+  } m_configure_bounds{};
+
   enum window_type m_type;
   std::string m_app_id;
 
@@ -255,6 +262,14 @@ class WaylandWindow {
    */
   static void handle_toplevel_close(void* data,
                                     struct xdg_toplevel* xdg_toplevel);
+
+  // xdg-shell v4: compositor hint for the maximum surface size that fits
+  // the available output area (output minus panels/struts). Stored so the
+  // (0,0)-configure path can downsize the client-requested geometry.
+  static void handle_toplevel_configure_bounds(void* data,
+                                               struct xdg_toplevel* toplevel,
+                                               int32_t width,
+                                               int32_t height);
 
   /**
    * @brief handler for frame event of a base surface

--- a/shell/wayland/window.h
+++ b/shell/wayland/window.h
@@ -126,6 +126,13 @@ class WaylandWindow {
     return std::pair<int32_t, int32_t>{m_geometry.width, m_geometry.height};
   }
 
+  // Called from Display::NotifyOutputResized when wl_output.mode reports
+  // new dimensions for output index @p output_index. Runs on the
+  // wayland event thread. If this window is bound to that output and
+  // its current geometry no longer fits, shrink to the new mode and
+  // re-Resize the backend.
+  void OnOutputResized(size_t output_index, int32_t new_w, int32_t new_h);
+
  private:
   size_t m_index;
   std::shared_ptr<Display> m_display;


### PR DESCRIPTION
## Summary
- Drives Flutter pacing from `wp_presentation_feedback.presented` timestamps instead of the engine's wall-clock fallback. Per-vblank hit rate is on par with the DRM backend (97.5% at 60Hz vs. 98.0% at 240Hz on the same content).
- Generalizes the `SetEngineHandle` / `SetPlatformTaskRunner` / `StopVsyncMonitor` wiring as default-no-op virtuals on `Backend` so `FlutterView` calls through the base pointer. Renames DRM's `StopFlipMonitor` → `StopVsyncMonitor` and tags the matching DRM methods `override`. Behavior unchanged.
- Hardens the path against compositor input: refresh clamped at 100 ms, `tv_sec_hi` overflow guard, `feedback_in_flight_` capped at 16, race-safe destroy in `StopVsyncMonitor` vs. in-flight listener dispatch, atomics on cross-thread fields, extra `wl_display_roundtrip` in `Display` ctor so the `clock_id` event arrives before the backend reads it.
- New env vars `IVI_WL_VSYNC` (off-switch, mirrors `IVI_DRM_VSYNC`) and `IVI_WL_PROFILE` (per-window cadence histogram + session summary). New `shell/backend/wayland_egl/README.md` documenting architecture, knobs, and benchmark methodology.

## Test plan
- [x] CI build matrix green on `BUILD_BACKEND_WAYLAND_EGL=ON BUILD_COMPOSITOR=ON` (gcc-14 + clang-19)
- [x] CI build green on `BUILD_BACKEND_DRM_KMS_EGL=ON` (the `StopFlipMonitor` rename + `override` markers compile against the existing DRM source)
- [x] CI build green on `BUILD_BACKEND_WAYLAND_VULKAN=ON` (backend inherits no-op virtuals; still uses wall-clock scheduler)
- [x] `scripts/format.sh --check` passes
- [x] `scripts/clang_tidy.sh` passes (locally green on the Wayland EGL configuration; DRM config needs a build-runner with libdrm + libgbm + libinput)
- [x] Smoke under weston — confirm `wp_presentation_feedback` events arrive and `IVI_WL_PROFILE=1` histogram is on-vblank
- [x] Smoke under tinywl (wlroots) — same
- [x] Smoke under mutter (gnome-shell) — same
- [x] Bisect with `IVI_WL_VSYNC=0` to confirm wall-clock fallback works on each compositor (one startup log line, no protocol traffic for feedback)

## Notes
- Pre-existing, unrelated SIGTERM crash: `WaylandEglBackend::GetRenderConfig` lambdas dereference `state->view_controller->engine` after teardown, producing SIGSEGV ~1.9 s after SIGTERM. Reproduces identically with `IVI_WL_VSYNC=0`. DRM fixed the analogous race in commit `17ade4ef`; wayland_egl needs the same treatment as a separate follow-up.
- The §"Known limitations" section of the new README captures the deferred items (asio-driven dispatch on the platform task runner, cross-clock translation).