### PR TITLE
[wayland_vulkan] fail cleanly when compositor lacks dmabuf

### DIFF
--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -499,8 +499,22 @@ bool WaylandVulkanBackend::InitializeSwapChain() {
   // --------------------------------------------------------------------------
 
   uint32_t format_count;
-  CHECK_VK_RESULT(d.vkGetPhysicalDeviceSurfaceFormatsKHR(
-      physical_device_, surface_, &format_count, nullptr));
+  // First touch on the Wayland-backed VkSurfaceKHR. Mesa's WSI surfaces a
+  // missing GPU-buffer-allocation protocol (zwp_linux_dmabuf_v1 / wl_drm)
+  // as VK_ERROR_SURFACE_LOST_KHR on this call — that's the root cause when
+  // the compositor was launched without dmabuf support. Soft-fail rather
+  // than asserting so CreateSurface can exit cleanly with a clear message.
+  if (const auto r =
+          static_cast<vk::Result>(d.vkGetPhysicalDeviceSurfaceFormatsKHR(
+              physical_device_, surface_, &format_count, nullptr));
+      r != vk::Result::eSuccess) {
+    spdlog::critical(
+        "vkGetPhysicalDeviceSurfaceFormatsKHR failed: {}. On Wayland this "
+        "usually means the compositor exposes neither zwp_linux_dmabuf_v1 "
+        "nor wl_drm — Mesa Vulkan WSI cannot back the swapchain.",
+        vk::to_string(r));
+    return false;
+  }
   std::vector<VkSurfaceFormatKHR> formats(format_count);
   CHECK_VK_RESULT(d.vkGetPhysicalDeviceSurfaceFormatsKHR(
       physical_device_, surface_, &format_count, formats.data()));
@@ -1043,8 +1057,8 @@ void WaylandVulkanBackend::ResizeCompositorSurface(
 bool WaylandVulkanBackend::CreateBackingStoreImpl(
     const FlutterBackingStoreConfig* config,
     FlutterBackingStore* store_out) {
-  const int32_t w = static_cast<int32_t>(config->size.width);
-  const int32_t h = static_cast<int32_t>(config->size.height);
+  const auto w = static_cast<int32_t>(config->size.width);
+  const auto h = static_cast<int32_t>(config->size.height);
 
   const bool want_dma_buf = BUILD_COMPOSITOR_DMABUF_EXPORT != 0;
   auto store =
@@ -1157,7 +1171,7 @@ void WaylandVulkanBackend::BlitStoreToSwapchain(VkCommandBuffer cmd,
                                                 int32_t dst_x,
                                                 int32_t dst_y,
                                                 int32_t dst_w,
-                                                int32_t dst_h) const {
+                                                int32_t dst_h) {
   // Transition source -> TRANSFER_SRC_OPTIMAL.
   VkImageMemoryBarrier src_to_xfer{};
   src_to_xfer.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -363,13 +363,13 @@ class WaylandVulkanBackend final : public Backend {
   /// Blit @p src onto the given swapchain image, then transition the
   /// swapchain image into PRESENT_SRC_KHR. The command buffer is submitted
   /// and waited on the queue.
-  void BlitStoreToSwapchain(VkCommandBuffer cmd,
-                            VulkanBackingStore& src,
-                            VkImage dst,
-                            int32_t dst_x,
-                            int32_t dst_y,
-                            int32_t dst_w,
-                            int32_t dst_h) const;
+  static void BlitStoreToSwapchain(VkCommandBuffer cmd,
+                                   VulkanBackingStore& src,
+                                   VkImage dst,
+                                   int32_t dst_x,
+                                   int32_t dst_y,
+                                   int32_t dst_w,
+                                   int32_t dst_h);
 
   /// Per-frame pipelining state for compositor mode. We keep one slot per
   /// swapchain image; the slot owns its command buffer and the sync

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -218,6 +218,19 @@ FlutterView::FlutterView(Configuration::Config config,
 #elif BUILD_BACKEND_WAYLAND_VULKAN
   {
     auto* wl = dynamic_cast<Display*>(display.get());
+    // Mesa's Vulkan WSI on Wayland needs zwp_linux_dmabuf_v1 (modern) or
+    // wl_drm (legacy) to allocate GPU buffers. Without one of these,
+    // vkGetPhysicalDeviceSurfaceFormatsKHR returns SURFACE_LOST on the
+    // first surface call and the swapchain init bails. Warn loudly here so
+    // the user has a one-line root cause instead of a deep VK abort.
+    if (!wl->HasLinuxDmabuf() && !wl->HasWlDrm()) {
+      spdlog::warn(
+          "[WaylandVulkanBackend] compositor advertises neither "
+          "zwp_linux_dmabuf_v1 nor wl_drm — Mesa Vulkan WSI cannot "
+          "allocate swapchain images. Swapchain init will fail; fix on the "
+          "compositor side (e.g. Weston needs --backend=drm-backend or its "
+          "linux-dmabuf support built in).");
+    }
     m_backend = std::make_shared<WaylandVulkanBackend>(
         wl->GetDisplay(), m_config.view.width.value_or(kDefaultViewWidth),
         m_config.view.height.value_or(kDefaultViewHeight),

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -174,6 +174,17 @@ void Display::registry_handle_global(void* data,
 
   SPDLOG_DEBUG("Wayland: {} version {}", interface, version);
 
+  // Note when GPU-buffer-allocation protocols are advertised. Mesa's
+  // Vulkan WSI Wayland implementation needs one of these to back the
+  // swapchain; vkGetPhysicalDeviceSurfaceFormatsKHR returns
+  // VK_ERROR_SURFACE_LOST_KHR when both are absent. The flags let the
+  // backend pre-flight and emit a clear error rather than asserting.
+  if (strcmp(interface, "zwp_linux_dmabuf_v1") == 0) {
+    d->m_has_linux_dmabuf = true;
+  } else if (strcmp(interface, "wl_drm") == 0) {
+    d->m_has_wl_drm = true;
+  }
+
   if (strcmp(interface, wl_compositor_interface.name) == 0) {
     if (version >= 3) {
       d->m_compositor = static_cast<wl_compositor*>(

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -559,6 +559,17 @@ class Display : public IDisplay {
   void NotifyOutputResized(const output_info_t* oi);
   bool m_buffer_scale_enable{};
 
+  // Tracks whether the compositor advertised a GPU buffer-allocation
+  // protocol that Mesa's Vulkan WSI can use. Set from
+  // registry_handle_global; consumed by the Vulkan backend pre-flight.
+  bool m_has_linux_dmabuf{false};
+  bool m_has_wl_drm{false};
+
+ public:
+  [[nodiscard]] bool HasLinuxDmabuf() const { return m_has_linux_dmabuf; }
+  [[nodiscard]] bool HasWlDrm() const { return m_has_wl_drm; }
+
+ private:
   static void wayland_event_mask_update(
       const std::string& ignore_wayland_events,
       struct wayland_event_mask& mask);


### PR DESCRIPTION
## Summary
- Vulkan-on-Weston (and any compositor lacking `zwp_linux_dmabuf_v1` / `wl_drm`) aborts via SIGABRT inside `InitializeSwapChain` — `vkGetPhysicalDeviceSurfaceFormatsKHR` returns `VK_ERROR_SURFACE_LOST_KHR` on first touch of the `VkSurfaceKHR` and the existing `CHECK_VK_RESULT` trips `vk::detail::resultCheck`'s assert. The error code is opaque; the WSI is really saying "this compositor exposes no GPU buffer-alloc protocol."
- Two-tier diagnostic: `Display` tracks dmabuf/wl_drm globals (no binding, just flags) and `FlutterView` warns at Vulkan-backend construction time with the compositor-side fix. `InitializeSwapChain`'s first surface query unwraps from `CHECK_VK_RESULT` to soft-fail; `CreateSurface` already `exit(EXIT_FAILURE)`s on swapchain failure, so the user gets a one-line message and exit code 1 instead of SIGABRT.
- No EGL impact (`#elif BUILD_BACKEND_WAYLAND_VULKAN` guards the warn block).

## Test plan
- [x] **wayland-1 (AGL Weston, no dmabuf)**: exit 1; startup warn + critical at the failure point. No more SIGABRT.
- [x] **wayland-2 (compositor advertising `zwp_linux_dmabuf_v1`)**: no warning, Vulkan navigates wonders cleanly, exit 124.
- [x] **EGL build** unaffected — wayland-1 + wayland-2 both navigate normally.
- [x] `scripts/clang_tidy.sh` + `scripts/format.sh --check` pass.

## Root-cause confirmation
Compared `wayland-info` output between working and failing compositors:
- KWin (wayland-0, Vulkan works): advertises `zwp_linux_dmabuf_v1` v5
- AGL Weston (wayland-1, Vulkan aborted): exposes neither `zwp_linux_dmabuf_v1` nor `wl_drm`

The compositor-side fix is to enable `linux-dmabuf` in the Weston build / launch config; this PR just makes the client-side failure mode actionable.