### PR TITLE
[wayland_vulkan] measure-only frame profiler (IVI_VK_PROFILE=1)

### DIFF
--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -100,6 +100,37 @@ FlutterCompositor WaylandVulkanBackend::GetCompositorConfig() {
 }
 
 WaylandVulkanBackend::~WaylandVulkanBackend() {
+  // Session-aggregate profile summary (IVI_VK_PROFILE=1). Logged from
+  // the dtor so it captures the whole run regardless of which present
+  // path was active. No-op when the env-var was unset (counters never
+  // accumulated).
+  const auto& s = session_totals_;
+  if (s.presented_frames > 0) {
+    const uint32_t samples =
+        (s.interval_sum_ns > 0) ? s.presented_frames - 1 : s.presented_frames;
+    const uint64_t mean_ns = samples > 0 ? s.interval_sum_ns / samples : 0;
+    const double fps = mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
+    const uint32_t total = s.bucket_60hz + s.bucket_30hz + s.bucket_20hz +
+                           s.bucket_slow + s.bucket_idle;
+    spdlog::info(
+        "[WaylandVulkanBackend] session summary: frames={} fps={:.2f} "
+        "mean_interval={}us max_interval={}us present_failures={}",
+        s.presented_frames, fps, mean_ns / 1000, s.interval_max_ns / 1000,
+        s.present_failures);
+    if (total > 0) {
+      const double inv = 100.0 / static_cast<double>(total);
+      spdlog::info(
+          "[WaylandVulkanBackend] session buckets: "
+          "60Hz(≤17ms)={} ({:.1f}%) 30Hz(18-33ms)={} ({:.1f}%) "
+          "20Hz(34-50ms)={} ({:.1f}%) slow(51-100ms)={} ({:.1f}%) "
+          "idle(>100ms)={} ({:.1f}%)",
+          s.bucket_60hz, s.bucket_60hz * inv, s.bucket_30hz,
+          s.bucket_30hz * inv, s.bucket_20hz, s.bucket_20hz * inv,
+          s.bucket_slow, s.bucket_slow * inv, s.bucket_idle,
+          s.bucket_idle * inv);
+    }
+  }
+
   if (device_ != nullptr) {
 #if BUILD_COMPOSITOR
     CompositorPipeliningCleanup();
@@ -805,6 +836,8 @@ bool WaylandVulkanBackend::PresentCallback(
   }
   d.vkQueueWaitIdle(b->queue_);
 
+  b->ProfilePresent(result == VK_SUCCESS);
+
   return result == VK_SUCCESS;
 }
 
@@ -815,6 +848,76 @@ void* WaylandVulkanBackend::GetInstanceProcAddressCallback(
   auto* proc =
       d.vkGetInstanceProcAddr(static_cast<VkInstance>(instance), procname);
   return reinterpret_cast<void*>(proc);
+}
+
+void WaylandVulkanBackend::ProfilePresent(const bool ok) {
+  // Single env-var probe per process; the lookup is O(strlen) and we
+  // call this on every frame.
+  static const bool profile_enabled = std::getenv("IVI_VK_PROFILE") != nullptr;
+  if (!profile_enabled) {
+    return;
+  }
+  timespec ts{};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  const uint64_t now_ns = static_cast<uint64_t>(ts.tv_sec) * 1'000'000'000ULL +
+                          static_cast<uint64_t>(ts.tv_nsec);
+
+  auto& p = profile_;
+  if (!ok) {
+    ++p.present_failures;
+    return;
+  }
+  if (p.last_present_ns != 0) {
+    const uint64_t dt = now_ns - p.last_present_ns;
+    p.interval_sum_ns += dt;
+    if (dt > p.interval_max_ns) {
+      p.interval_max_ns = dt;
+    }
+    // Same bucket thresholds as wayland_egl so histograms line up.
+    if (dt <= 17'000'000ULL) {
+      ++p.bucket_60hz;
+    } else if (dt <= 33'000'000ULL) {
+      ++p.bucket_30hz;
+    } else if (dt <= 50'000'000ULL) {
+      ++p.bucket_20hz;
+    } else if (dt <= 100'000'000ULL) {
+      ++p.bucket_slow;
+    } else {
+      ++p.bucket_idle;
+    }
+  }
+  p.last_present_ns = now_ns;
+  ++p.presented_frames;
+
+  constexpr uint32_t kProfileWindow = 60;
+  if (p.presented_frames < kProfileWindow) {
+    return;
+  }
+  const uint32_t samples =
+      (p.interval_sum_ns > 0) ? p.presented_frames - 1 : p.presented_frames;
+  const uint64_t mean_ns = samples > 0 ? p.interval_sum_ns / samples : 0;
+  const double fps = mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
+  spdlog::info(
+      "[WaylandVulkanBackend] profile (n={}): fps={:.2f} mean_interval={}us "
+      "max_interval={}us present_failures={} "
+      "buckets[60Hz/30Hz/20Hz/slow/idle]={}/{}/{}/{}/{}",
+      p.presented_frames, fps, mean_ns / 1000, p.interval_max_ns / 1000,
+      p.present_failures, p.bucket_60hz, p.bucket_30hz, p.bucket_20hz,
+      p.bucket_slow, p.bucket_idle);
+
+  auto& s = session_totals_;
+  s.presented_frames += p.presented_frames;
+  s.present_failures += p.present_failures;
+  s.interval_sum_ns += p.interval_sum_ns;
+  if (p.interval_max_ns > s.interval_max_ns) {
+    s.interval_max_ns = p.interval_max_ns;
+  }
+  s.bucket_60hz += p.bucket_60hz;
+  s.bucket_30hz += p.bucket_30hz;
+  s.bucket_20hz += p.bucket_20hz;
+  s.bucket_slow += p.bucket_slow;
+  s.bucket_idle += p.bucket_idle;
+  p = FrameProfile{.last_present_ns = p.last_present_ns};
 }
 
 void WaylandVulkanBackend::Resize(size_t /* index */,
@@ -1367,6 +1470,8 @@ bool WaylandVulkanBackend::PresentLayersImpl(const FlutterLayer** layers,
   if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR) {
     resize_pending_ = true;
   }
+
+  ProfilePresent(result == VK_SUCCESS);
 
   ++m_compositor_current_frame_;
   return ok;

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -395,4 +395,33 @@ class WaylandVulkanBackend final : public Backend {
   void CompositorPipeliningInit();
   void CompositorPipeliningCleanup();
 #endif
+
+  // Per-frame cadence profile (IVI_VK_PROFILE=1). Measure-only: samples
+  // CLOCK_MONOTONIC immediately after each successful vkQueuePresentKHR
+  // on the rasterizer thread (the only writer for either present path —
+  // PresentCallback for non-compositor, PresentLayersImpl for compositor —
+  // and only one of those is active per build). Same shape as the
+  // wayland_egl FrameProfile so the bucket histograms are directly
+  // comparable. Inter-present interval is the only signal available
+  // without wp_presentation_feedback wiring; "discarded" and "flags"
+  // are intentionally absent from the Vulkan path.
+  struct FrameProfile {
+    uint64_t last_present_ns{0};
+    uint64_t interval_sum_ns{0};
+    uint64_t interval_max_ns{0};
+    uint32_t presented_frames{0};
+    uint32_t present_failures{0};  // vkQueuePresentKHR != VK_SUCCESS
+    uint32_t bucket_60hz{0};       // ≤17ms
+    uint32_t bucket_30hz{0};       // 18-33ms
+    uint32_t bucket_20hz{0};       // 34-50ms
+    uint32_t bucket_slow{0};       // 51-100ms
+    uint32_t bucket_idle{0};       // >100ms
+  };
+  FrameProfile profile_{};
+  FrameProfile session_totals_{};
+
+  // Called from both present paths after vkQueuePresentKHR returns.
+  // No-op when IVI_VK_PROFILE is unset. Mutates profile_/session_totals_
+  // without locks because the rasterizer thread is the only writer.
+  void ProfilePresent(bool ok);
 };


### PR DESCRIPTION
## Summary
- Adds an opt-in (`IVI_VK_PROFILE=1`) per-frame cadence profiler to the Wayland Vulkan backend so its real-world pacing can be measured before deciding whether to wire `vsync_callback`.
- Same bucket thresholds and per-60-frame window / session-summary log shape as the existing `IVI_WL_PROFILE` in the EGL backend, so histograms line up exactly and existing log scrapers reuse.
- No behavior change unless the env-var is set. `ProfilePresent()` samples `CLOCK_MONOTONIC` after `vkQueuePresentKHR` in both present paths (non-compositor `PresentCallback` and `BUILD_COMPOSITOR=ON` `PresentLayersImpl`); rasterizer thread is the only writer so no locks.

## Baseline gathered (the motivation)
KWin (`wayland-0`), wonderous bundle, ~15 s session, same machine, same workload:

| Backend | Vsync wiring | ≤17ms bucket | 18-33ms |
|---|---|---:|---:|
| Wayland EGL | `vsync_callback` via `wp_presentation_feedback` | **96.7%** | 0.0% |
| Wayland Vulkan | none (Mesa WSI backpressure only) | 76.9% | 22.3% |

The ~20pp on-vblank gap and the 22.3% in the 30Hz bucket show the Vulkan path's `beginFrame` is slipping by one vblank often enough to matter — Mesa's WSI throttles the rasterizer but doesn't fix Flutter's wall-clock scheduling drift. This patch is the measurement vehicle; a follow-up will wire `vsync_callback` on the Vulkan path (~80% copy-paste from EGL — same `wp_presentation_feedback` listener, same Display event-thread dispatch, only the hook site changes).

## Test plan
- [x] Built with `BUILD_BACKEND_WAYLAND_VULKAN=ON`, no regressions in normal runs (env-var unset = zero overhead beyond one `static const bool` check per frame).
- [x] `IVI_VK_PROFILE=1` run on KWin produced the per-window logs and session summary above.
- [x] Verified the non-compositor `PresentCallback` path also fires `ProfilePresent` (covered both branches of the `#if BUILD_COMPOSITOR` matrix at the call sites).
- [x] `scripts/format.sh --check` clean. `clang-tidy-19` on the new code clean (three pre-existing complaints in `debugReportCallback`/`debugUtilsCallback` branch-clones and a `CollectBackingStore` parameter-name mismatch are unrelated and left for a separate cleanup PR — the lint CI doesn't currently lint `wayland_vulkan.cc` because the lint workflow's build dir uses the EGL backend).

## Out of scope
- Wiring `vsync_callback` itself (follow-up, justified by this baseline).
- Cleaning up the pre-existing `wayland_vulkan.cc` tidy warnings.