### PR TITLE
[wayland_vulkan] wire vsync_callback via wp_presentation_feedback + IVI_VK_PRESENT_MODE lever

### DIFF
--- a/shell/backend/wayland_vulkan/README.md
+++ b/shell/backend/wayland_vulkan/README.md
@@ -1,0 +1,270 @@
+# wayland_vulkan backend
+
+Vulkan presenter on Wayland. Pairs Mesa's `VK_KHR_wayland_surface` WSI
+with the optional homescreen Vulkan compositor for platform views. This
+README covers the parts that aren't obvious from the source — the
+compositor-mediated vsync path, the present-mode lever, and the
+profiler used to characterize them.
+
+## Vsync via `wp_presentation_feedback`
+
+Architecturally identical to `wayland_egl`'s wiring — same baton dance,
+same Display event-thread dispatch — but with two practical differences
+that turn out to matter:
+
+1. **The hook site is `vkQueuePresentKHR`, not `eglSwapBuffers`.** The
+   feedback object must be minted before the `wl_surface.commit` baked
+   into the present call. `RequestPresentationFeedback()` is called in
+   both Vulkan present paths (`PresentCallback` for non-compositor
+   builds, `PresentLayersImpl` for `BUILD_COMPOSITOR=ON`).
+
+2. **Mesa's Vulkan WSI already does its own `wp_presentation_feedback`
+   bookkeeping internally** — that's how `vkAcquireNextImageKHR` and
+   `vkQueuePresentKHR` know when to block under `VK_PRESENT_MODE_FIFO_KHR`.
+   So when the embedder ALSO requests feedback, the compositor sees
+   two outstanding feedback objects per commit. This is harmless
+   (compositors are spec-required to answer all of them), but it does
+   mean our wiring isn't adding any compositor-side pacing intelligence
+   that wasn't already in play. What our wiring *does* add is delivering
+   the timestamps to the Flutter Engine — Mesa keeps them to itself.
+
+```
+Flutter raster thread                Display event_thread_
+─────────────────────                ────────────────────
+PresentCallback / PresentLayersImpl
+  RequestPresentationFeedback()      ───┐
+  vkQueuePresentKHR (commits)           │  compositor scans out
+  …                                     │
+                                        ▼
+                                     on_feedback_presented(tv_ns, refresh)
+                                        ├─ update last_refresh_ns_
+                                        ├─ exchange vsync_baton_
+                                        ├─ store last_begin_frame_ns_
+                                        └─ asio::post(strand, [&]{ OnVsync() })
+```
+
+`SetVsyncBaton` includes the same idle-wake kick as the EGL backend —
+if no feedback is in flight (first frame, post-idle wake from input)
+it drains the baton inline so Flutter doesn't sit forever waiting on
+a commit that hasn't been scheduled.
+
+## When `vsync_callback` is wired
+
+`WaylandVulkanBackend::GetVsyncCallback()` returns `&VsyncTrampoline`
+iff all three of:
+
+1. The compositor advertised `wp_presentation`.
+2. The announced `clock_id` is `CLOCK_MONOTONIC`.
+3. `IVI_VK_VSYNC` is not `0`.
+
+Otherwise it returns `nullptr` and the engine falls back to its
+internal wall-clock scheduler. The decision is logged once at startup.
+
+## Env vars
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `IVI_VK_VSYNC` | (on) | `0` disables both the `vsync_callback` wiring AND the per-commit `wp_presentation_feedback` requests, falling back to Flutter's internal wall-clock scheduler. Use to bisect pacing regressions or to A/B against the no-feedback path. |
+| `IVI_VK_PROFILE` | (off) | Anything non-empty enables per-frame cadence profiling. Every 60 frames the profiler logs `profile (n=60): fps=X mean_interval=Yus max_interval=Zus present_failures=N discarded=M refresh=Rus flags=0xF pipeline_mean=Lus pipeline_max=Lmaxus buckets[60Hz/30Hz/20Hz/slow/idle]=…`. `pipeline_*` measures beginFrame-to-present latency (time from the `frame_start_time` handed to Flutter via OnVsync to the next `vkQueuePresentKHR` return). |
+| `IVI_VK_PRESENT_MODE` | `fifo` | One of `fifo`, `fifo_relaxed`, `mailbox`, `immediate`. Selects the swapchain present mode if the compositor advertises it; otherwise falls back to FIFO with a warn. See "Present-mode interaction" below — `mailbox` is the only setting where `vsync_callback`'s contribution becomes large. |
+
+## Present-mode interaction (the surprising part)
+
+Profiling against KWin Wayland (wonderous-app, IVI_VK_PROFILE=1, 25s
+sessions, 3 reps per cell) shows that under the default FIFO mode the
+vsync_callback wiring **doesn't measurably move** the per-frame
+interval histogram — but under MAILBOX it transforms the workload:
+
+| Mode | Vsync | fps | 60Hz bucket | Discarded | pipeline_mean |
+|---|---|---:|---:|---:|---:|
+| `fifo` | ON | 56 ± 1 | 70-73% | 0 | 2.4-2.7ms |
+| `fifo` | OFF | 55 ± 1 | 71-83% (wider variance) | 0 | — (no instrument) |
+| `mailbox` | ON | 297-765 | 97-99% (artifact, see below) | 5957-17294 | 0.29-0.95ms |
+| `mailbox` | OFF | 56-58 | 71-85% | 0 | — |
+
+Three things worth understanding:
+
+1. **Under FIFO, vsync_callback is invisible at the present layer.**
+   Mesa's WSI already gates `vkAcquireNextImageKHR` / `vkQueuePresentKHR`
+   strictly on compositor vblanks via its own internal feedback
+   bookkeeping. The rasterizer can't outrun scanout regardless of
+   what Flutter thinks the schedule is, so the present-interval
+   histogram looks the same with or without our wiring. Justification
+   for keeping the wiring on by default is parity with DRM and EGL +
+   richer diagnostics in `IVI_VK_PROFILE` (the `flags`, `discarded`,
+   `refresh`, and `pipeline_*` fields all require it).
+
+2. **Under MAILBOX, vsync_callback is what lets Flutter exploit the
+   lower-latency headroom.** Without it, Flutter's wall-clock scheduler
+   produces ~60 frames/sec regardless of how willing the compositor
+   is to drop them. With it, Flutter sees accurate vblank timestamps,
+   schedules beginFrame immediately after each reported vblank, and
+   the rasterizer runs at 300-700 fps. The compositor still presents
+   at the panel's refresh rate; the "extra" frames are `discarded`
+   (newer commit superseded them) and that's the point — input
+   events get reflected in the next presented frame within one
+   vblank, instead of waiting for an already-queued frame to age out.
+
+3. **The MAILBOX "97-99% on-vblank" reading is partially a
+   measurement artifact.** When the rasterizer fires
+   `vkQueuePresentKHR` every ~1.3-3ms, every inter-present interval
+   trivially lands in the ≤17ms bucket regardless of true compositor
+   pacing — the bucket thresholds were calibrated against a 60Hz
+   FIFO baseline. The real signal under MAILBOX is the
+   `pipeline_mean` drop (2.5ms → ~0.5ms) and the rasterizer
+   outpacing scanout: Flutter is reacting to vblanks within a
+   millisecond instead of within a vblank-period.
+
+For typical desktop / automotive workloads, FIFO + vsync ON is the
+right default. MAILBOX + vsync ON is the right choice when input
+responsiveness matters more than rasterizer power: telematics
+dashboards reacting to vehicle data, low-latency map panning, etc.
+MAILBOX + vsync OFF is a degenerate case — pick FIFO instead.
+
+## Architectural notes
+
+**Single-threaded vs platform-runner dispatch.** Same as
+`wayland_egl`: the `on_feedback_presented` / `on_feedback_discarded`
+listeners fire on `Display::event_thread_`, so `feedback_in_flight_`
+is guarded by a mutex and `OnVsync` is always posted via the
+platform runner's strand. The future refactor of moving Wayland
+dispatch onto the platform task runner via asio applies here too.
+
+**Per-commit feedback object.** Identical lifecycle to EGL —
+`feedback_in_flight_` tracks outstanding objects so `StopVsyncMonitor`
+can destroy them before engine teardown. Race-safe destroy in both
+the listener paths and the shutdown path: the path that successfully
+removes the object from `feedback_in_flight_` owns its destruction.
+
+**Mesa's internal feedback dups our requests.** The compositor sees
+two `wp_presentation_feedback` objects per commit — one minted by
+the embedder, one by Mesa's WSI. The compositor answers both. No
+behavioral impact, but `WAYLAND_DEBUG=client` traces show twice as
+many feedback exchanges as committed frames; that's expected.
+
+**`pipeline_mean` is an approximation under pipelining.** Flutter
+maintains a small queue of in-flight frames. The instrument samples
+`last_begin_frame_ns_` (the most recent `frame_start_time` handed
+to `OnVsync`) against `vkQueuePresentKHR` return time, so a given
+present may not correspond to the most recent OnVsync. The running
+mean still tracks the difference between vsync-aware and wall-clock
+scheduling under load — it's the right metric for comparing wiring
+configurations, not for precise per-frame attribution.
+
+---
+
+## Benchmarks
+
+Measured on KWin Wayland (Fedora 43, kernel 6.19, AMD RADV
+RAPHAEL_MENDOCINO iGPU), `feat/vulkan-vsync-callback` branch,
+running the flutter-wonderous-app bundle, 3 reps per configuration.
+Window size 1024×768. Compositor's primary output 3440×1440 @ 60Hz.
+
+### Methodology
+
+`IVI_VK_PROFILE=1` adds a log line every 60 presented frames with
+mean/max interval, present failures, compositor discards, the
+compositor-reported refresh, a flag OR (`VSYNC|HW_CLOCK|HW_COMPLETION`),
+the beginFrame-to-present latency mean+max, and the 5-bucket histogram
+(matches the wayland_egl bucket thresholds). On clean shutdown, the
+backend's dtor emits a one-line session summary covering the whole run.
+
+The matrix above varies `IVI_VK_VSYNC` and `IVI_VK_PRESENT_MODE` so
+the contribution of each lever is separable.
+
+### Session summary — FIFO + vsync (default)
+
+Aggregate across 3 sessions, ~75 seconds, ~4000 presented frames:
+
+| Metric | Value |
+|---|---:|
+| Compositor refresh | 16.668 ms (60 Hz) |
+| Weighted mean interval | ~17.5 ms (≈ 57 Hz under load) |
+| Worst single interval | ~600-800 ms (engine pause / content load) |
+| Compositor discards | 0 |
+| Feedback flags (OR) | `0x7` (VSYNC \| HW_CLOCK \| HW_COMPLETION) |
+| beginFrame-to-present mean | 2.4 - 2.7 ms |
+| 60Hz on-vblank bucket | 69 - 73% |
+| 30Hz bucket (one miss) | 26 - 29% |
+
+The 60Hz bucket sits below the wayland_egl headline (97%) because the
+Vulkan WSI's blocking interferes with Flutter's pacing during
+interactive load — Flutter aims for the next vblank, Mesa releases
+the swapchain image at the same instant, and the small extra
+serialization shifts the bucket toward the 30Hz bracket. Steady-state
+(idle scrolling, no input) the bucket recovers to mid-90s.
+
+### Session summary — MAILBOX + vsync
+
+| Metric | Value |
+|---|---:|
+| Compositor refresh | 16.668 ms (60 Hz) |
+| Mean inter-present interval | ~1.3 - 3.4 ms (rasterizer outpaces scanout) |
+| beginFrame-to-present mean | 0.29 - 0.95 ms (5-9× lower than FIFO) |
+| Compositor discards | 5957 - 17294 per ~25s session |
+| Frames per session | 7260 - 18720 |
+| Feedback flags (OR) | `0x7` (still HW-vblank-confirmed) |
+
+Discards are NOT failures — they're the deliberate effect of MAILBOX
+replacing queued frames with newer ones. Each presented frame is still
+hardware-vblank-aligned (`flags=0x7`); the difference is that the
+*latest* state reaches the panel instead of the oldest queued state.
+
+### Comparison to wayland_egl
+
+| Aspect | wayland_egl | wayland_vulkan (FIFO) | wayland_vulkan (MAILBOX) |
+|---|---|---|---|
+| Vsync source | `wp_presentation_feedback` per commit | same | same |
+| Backpressure | `eglSwapBuffers` blocks at commit time | `vkQueuePresentKHR` blocks on vblank | non-blocking; rasterizer runs free |
+| Mesa-side feedback | n/a (EGL has no internal WSI feedback) | duplicates embedder request | duplicates embedder request |
+| Typical 60Hz bucket | ~97% (steady) | ~70% (active load) | artifact bucket — see pipeline_mean instead |
+| pipeline_mean | n/a (no instrument) | ~2.5 ms | ~0.5 ms |
+| Discards under load | 0 (KWin) | 0 | thousands (expected) |
+| Best for | balanced power / smoothness | parity with EGL, simplest model | low input-to-photon latency |
+
+### Comparison to drm_kms_egl
+
+DRM benchmark (from `shell/backend/drm_kms_egl/README.md`): amdgpu
+RDNA / Polaris @ 240Hz, same wonderous bundle, `IVI_DRM_VSYNC=1`,
+64,769-frame sample.
+
+| Metric | DRM @ 240Hz | wayland_vulkan @ 60Hz FIFO | wayland_vulkan @ 60Hz MAILBOX |
+|---|---:|---:|---:|
+| Frame budget | 4.17 ms | 16.67 ms | 16.67 ms (compositor) |
+| Native hit-rate | 98.0% | ~70% | n/a (artifact) |
+| pipeline_mean | n/a | 2.5 ms | 0.5 ms |
+| Discards | n/a (kernel can't drop) | 0 | thousands |
+
+DRM and wayland_egl both have natural backpressure that bounds frame
+rate to refresh. Vulkan under FIFO has *strict* backpressure that's
+slightly more brittle under load. Vulkan under MAILBOX deliberately
+gives up backpressure for input latency — different operating point.
+
+---
+
+## Known limitations / follow-ups
+
+1. **VK_ERROR_SURFACE_LOST_KHR on compositors lacking dmabuf** — Mesa's
+   Vulkan WSI requires either `zwp_linux_dmabuf_v1` or `wl_drm` to
+   allocate swapchain images. Compositors built without dmabuf (some
+   Weston/AGL configurations) will fail `vkGetPhysicalDeviceSurfaceFormatsKHR`
+   with SURFACE_LOST. The backend pre-flights the dmabuf check at
+   startup and emits a clear warning; if the assertion still fires,
+   the failure exits cleanly with `exit(EXIT_FAILURE)` and a critical
+   log line naming the missing protocol. See commit `dba2bef1`.
+2. **MAILBOX discard rate is workload-dependent.** A wonderous-style
+   animation-heavy bundle produces thousands of discards per session
+   under MAILBOX. A static dashboard with infrequent updates would
+   produce essentially zero. Discards aren't dropped frames — they're
+   superseded ones — but they do represent GPU work that didn't
+   reach the panel.
+3. **Cross-clock translation not implemented** — same as wayland_egl,
+   compositors announcing a `clock_id` other than `CLOCK_MONOTONIC`
+   fall back to the wall-clock scheduler. No mainline compositor
+   needs this today.
+4. **Pre-existing tidy warnings on `wayland_vulkan.cc`** — three
+   `bugprone-branch-clone` / `readability-inconsistent-declaration-parameter-name`
+   complaints in `debugReportCallback`, `debugUtilsCallback`, and
+   `CollectBackingStore` predate this work. The lint CI doesn't
+   catch them because the lint workflow's build dir uses the EGL
+   backend; left for a separate cleanup PR.

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -16,14 +16,19 @@
 
 #include "wayland_vulkan.h"
 
+#include <asio/post.hpp>
+
 #include <cassert>
 #include <cstdlib>
 #include <optional>
 #include <queue>
+#include <string_view>
 
 #include "config/common.h"
 #include "engine.h"
 #include "logging.h"
+#include "task_runner.h"
+#include "wayland/display.h"
 
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
@@ -38,7 +43,8 @@ const auto& d = vk::detail::defaultDispatchLoaderDynamic;
     vk::detail::resultCheck(static_cast<vk::Result>(x), LOCATION); \
   } while (0)
 
-WaylandVulkanBackend::WaylandVulkanBackend(wl_display* display,
+WaylandVulkanBackend::WaylandVulkanBackend(Display* shell_display,
+                                           wl_display* display,
                                            const uint32_t width,
                                            const uint32_t height,
                                            const bool enable_validation_layers)
@@ -48,6 +54,29 @@ WaylandVulkanBackend::WaylandVulkanBackend(wl_display* display,
       wl_display_(display),
       width_(width),
       height_(height) {
+  if (shell_display != nullptr) {
+    wp_presentation_ = shell_display->GetWpPresentation();
+    presentation_clock_id_ = shell_display->GetPresentationClockId();
+    // FlutterEngineGetCurrentTime() returns CLOCK_MONOTONIC ns; only when
+    // the compositor announced the same domain can we hand its presented
+    // timestamps to OnVsync without a cross-clock translation. Mainline
+    // compositors all use CLOCK_MONOTONIC; anything else falls back to
+    // the engine wall-clock scheduler.
+    clock_compatible_ = (presentation_clock_id_ == CLOCK_MONOTONIC);
+    if (wp_presentation_ == nullptr) {
+      spdlog::info(
+          "[WaylandVulkanBackend] wp_presentation not advertised — "
+          "vsync_callback disabled, falling back to engine wall-clock "
+          "scheduler");
+    } else if (!clock_compatible_) {
+      spdlog::warn(
+          "[WaylandVulkanBackend] wp_presentation clock_id={} != "
+          "CLOCK_MONOTONIC ({}); vsync_callback disabled (cross-clock "
+          "translation NYI)",
+          static_cast<int>(presentation_clock_id_),
+          static_cast<int>(CLOCK_MONOTONIC));
+    }
+  }
   VULKAN_HPP_DEFAULT_DISPATCHER.init();
   createInstance();
   setupDebugMessenger();
@@ -112,11 +141,17 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
     const double fps = mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
     const uint32_t total = s.bucket_60hz + s.bucket_30hz + s.bucket_20hz +
                            s.bucket_slow + s.bucket_idle;
+    const uint64_t s_lat_mean_us =
+        s.pipeline_latency_samples > 0
+            ? (s.pipeline_latency_sum_ns / s.pipeline_latency_samples) / 1000
+            : 0;
     spdlog::info(
         "[WaylandVulkanBackend] session summary: frames={} fps={:.2f} "
-        "mean_interval={}us max_interval={}us present_failures={}",
+        "mean_interval={}us max_interval={}us present_failures={} "
+        "discarded={} flags=0x{:x} pipeline_mean={}us pipeline_max={}us",
         s.presented_frames, fps, mean_ns / 1000, s.interval_max_ns / 1000,
-        s.present_failures);
+        s.present_failures, s.discarded_frames, s.flags_or, s_lat_mean_us,
+        s.pipeline_latency_max_ns / 1000);
     if (total > 0) {
       const double inv = 100.0 / static_cast<double>(total);
       spdlog::info(
@@ -616,14 +651,54 @@ bool WaylandVulkanBackend::InitializeSwapChain() {
       physical_device_, surface_, &mode_count, modes.data()));
   assert(!formats.empty());  // Shouldn't be possible.
 
-  // If the preferred mode isn't available, just choose the first one.
+  // Default = FIFO (strict vblank gating, the spec-mandated mode). Env
+  // override IVI_VK_PRESENT_MODE picks an alternative IFF the compositor
+  // advertises it; otherwise warn and fall back to FIFO. MAILBOX is the
+  // interesting case for vsync_callback profiling: it lets the rasterizer
+  // outpace scanout, weakening Mesa's WSI backpressure so Flutter's
+  // own scheduling drift becomes visible at the present-interval layer.
+  VkPresentModeKHR requested_mode = kPreferredPresentMode;
+  if (const char* env = std::getenv("IVI_VK_PRESENT_MODE"); env != nullptr) {
+    const std::string_view name(env);
+    if (name == "mailbox") {
+      requested_mode = VK_PRESENT_MODE_MAILBOX_KHR;
+    } else if (name == "fifo_relaxed") {
+      requested_mode = VK_PRESENT_MODE_FIFO_RELAXED_KHR;
+    } else if (name == "immediate") {
+      requested_mode = VK_PRESENT_MODE_IMMEDIATE_KHR;
+    } else if (name != "fifo") {
+      spdlog::warn(
+          "[WaylandVulkanBackend] IVI_VK_PRESENT_MODE='{}' unrecognized; "
+          "valid: fifo|fifo_relaxed|mailbox|immediate. Falling back to fifo.",
+          env);
+    }
+  }
   VkPresentModeKHR present_mode = modes[0];
+  bool got_requested = false;
   for (const auto& mode : modes) {
-    if (mode == kPreferredPresentMode) {
+    if (mode == requested_mode) {
       present_mode = mode;
+      got_requested = true;
       break;
     }
   }
+  if (!got_requested && requested_mode != kPreferredPresentMode) {
+    // Requested mode wasn't advertised — fall back to FIFO if present
+    // (it's required by the spec for any compositor that supports a
+    // swapchain at all), else first available.
+    for (const auto& mode : modes) {
+      if (mode == kPreferredPresentMode) {
+        present_mode = mode;
+        break;
+      }
+    }
+    spdlog::warn(
+        "[WaylandVulkanBackend] requested present mode {} not advertised "
+        "by compositor; using {}.",
+        static_cast<int>(requested_mode), static_cast<int>(present_mode));
+  }
+  spdlog::info("[WaylandVulkanBackend] present mode: {}",
+               static_cast<int>(present_mode));
 
   // --------------------------------------------------------------------------
   // Create the swap chain.
@@ -827,6 +902,11 @@ bool WaylandVulkanBackend::PresentCallback(
   present_info.swapchainCount = 1;
   present_info.pSwapchains = &b->swapchain_;
   present_info.pImageIndices = &b->last_image_index_;
+  // Mint the wp_presentation_feedback BEFORE vkQueuePresentKHR — Mesa's
+  // Wayland WSI does wl_surface.commit inside that call, and the
+  // feedback object binds to the most recent surface request prior to
+  // the commit.
+  b->RequestPresentationFeedback();
   const VkResult result = d.vkQueuePresentKHR(b->queue_, &present_info);
 
   // If the swap chain is no longer compatible with the surface, discard the
@@ -889,6 +969,22 @@ void WaylandVulkanBackend::ProfilePresent(const bool ok) {
   p.last_present_ns = now_ns;
   ++p.presented_frames;
 
+  // beginFrame-to-present latency. last_begin_frame_ns_ is 0 when
+  // vsync_callback isn't wired; in that case we have no Flutter-scheduled
+  // start time to compare against, so skip. Pipelining (multiple frames
+  // in flight) means a given present may not correspond to the *most
+  // recent* OnVsync — the running mean still tracks the difference
+  // between vsync-aware and wall-clock scheduling under load.
+  const uint64_t begin = last_begin_frame_ns_.load(std::memory_order_acquire);
+  if (begin > 0 && now_ns > begin) {
+    const uint64_t latency = now_ns - begin;
+    p.pipeline_latency_sum_ns += latency;
+    if (latency > p.pipeline_latency_max_ns) {
+      p.pipeline_latency_max_ns = latency;
+    }
+    ++p.pipeline_latency_samples;
+  }
+
   constexpr uint32_t kProfileWindow = 60;
   if (p.presented_frames < kProfileWindow) {
     return;
@@ -897,17 +993,26 @@ void WaylandVulkanBackend::ProfilePresent(const bool ok) {
       (p.interval_sum_ns > 0) ? p.presented_frames - 1 : p.presented_frames;
   const uint64_t mean_ns = samples > 0 ? p.interval_sum_ns / samples : 0;
   const double fps = mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
+  const uint64_t lat_mean_us =
+      p.pipeline_latency_samples > 0
+          ? (p.pipeline_latency_sum_ns / p.pipeline_latency_samples) / 1000
+          : 0;
   spdlog::info(
       "[WaylandVulkanBackend] profile (n={}): fps={:.2f} mean_interval={}us "
-      "max_interval={}us present_failures={} "
+      "max_interval={}us present_failures={} discarded={} "
+      "refresh={}us flags=0x{:x} pipeline_mean={}us pipeline_max={}us "
       "buckets[60Hz/30Hz/20Hz/slow/idle]={}/{}/{}/{}/{}",
       p.presented_frames, fps, mean_ns / 1000, p.interval_max_ns / 1000,
-      p.present_failures, p.bucket_60hz, p.bucket_30hz, p.bucket_20hz,
-      p.bucket_slow, p.bucket_idle);
+      p.present_failures, p.discarded_frames,
+      last_refresh_ns_.load(std::memory_order_relaxed) / 1000, p.flags_or,
+      lat_mean_us, p.pipeline_latency_max_ns / 1000, p.bucket_60hz,
+      p.bucket_30hz, p.bucket_20hz, p.bucket_slow, p.bucket_idle);
 
   auto& s = session_totals_;
   s.presented_frames += p.presented_frames;
   s.present_failures += p.present_failures;
+  s.discarded_frames += p.discarded_frames;
+  s.flags_or |= p.flags_or;
   s.interval_sum_ns += p.interval_sum_ns;
   if (p.interval_max_ns > s.interval_max_ns) {
     s.interval_max_ns = p.interval_max_ns;
@@ -917,7 +1022,278 @@ void WaylandVulkanBackend::ProfilePresent(const bool ok) {
   s.bucket_20hz += p.bucket_20hz;
   s.bucket_slow += p.bucket_slow;
   s.bucket_idle += p.bucket_idle;
+  s.pipeline_latency_sum_ns += p.pipeline_latency_sum_ns;
+  s.pipeline_latency_samples += p.pipeline_latency_samples;
+  if (p.pipeline_latency_max_ns > s.pipeline_latency_max_ns) {
+    s.pipeline_latency_max_ns = p.pipeline_latency_max_ns;
+  }
   p = FrameProfile{.last_present_ns = p.last_present_ns};
+}
+
+// -----------------------------------------------------------------------------
+// wp_presentation-driven vsync. Mirrors WaylandEglBackend; the only path
+// differences are (a) the present-path hook fires before vkQueuePresentKHR
+// instead of eglSwapBuffers, and (b) the Vulkan backend has no
+// `clock_compatible_` shortcut in the present path because there's
+// nothing equivalent to EGL's MakeCurrent/dispatch interleaving.
+// -----------------------------------------------------------------------------
+
+VsyncCallback WaylandVulkanBackend::GetVsyncCallback() const {
+  static const bool env_disabled = []() {
+    const char* env = std::getenv("IVI_VK_VSYNC");
+    return env != nullptr && std::string_view(env) == "0";
+  }();
+  if (env_disabled) {
+    spdlog::info(
+        "[WaylandVulkanBackend] IVI_VK_VSYNC=0 — wall-clock scheduler");
+    return nullptr;
+  }
+  if (wp_presentation_ == nullptr || !clock_compatible_) {
+    return nullptr;
+  }
+  return &VsyncTrampoline;
+}
+
+void WaylandVulkanBackend::VsyncTrampoline(void* user_data,
+                                           const intptr_t baton) {
+  auto* state = static_cast<FlutterDesktopEngineState*>(user_data);
+  if (state == nullptr || state->view_controller == nullptr ||
+      state->view_controller->engine == nullptr) {
+    return;
+  }
+  auto* engine_obj = state->view_controller->engine;
+  auto* backend = dynamic_cast<WaylandVulkanBackend*>(engine_obj->GetBackend());
+  if (backend == nullptr) {
+    return;
+  }
+  backend->SetVsyncBaton(engine_obj->GetFlutterEngine(), baton);
+}
+
+void WaylandVulkanBackend::PostOnVsync(FLUTTER_API_SYMBOL(FlutterEngine) engine,
+                                       const intptr_t baton) const {
+  if (engine == nullptr || baton == 0) {
+    return;
+  }
+  auto* runner = platform_task_runner_.load(std::memory_order_acquire);
+  if (runner == nullptr || runner->GetStrandContext() == nullptr) {
+    return;
+  }
+  const uint64_t now = LibFlutterEngine->GetCurrentTime();
+  const uint64_t period_ns = last_refresh_ns_.load(std::memory_order_acquire);
+  last_begin_frame_ns_.store(now, std::memory_order_release);
+  asio::post(*runner->GetStrandContext(), [engine, baton, now, period_ns]() {
+    LibFlutterEngine->OnVsync(engine, baton, now, now + period_ns);
+  });
+}
+
+void WaylandVulkanBackend::SetVsyncBaton(FLUTTER_API_SYMBOL(FlutterEngine)
+                                             engine,
+                                         const intptr_t baton) {
+  engine_handle_.store(engine, std::memory_order_release);
+  vsync_baton_.store(baton, std::memory_order_release);
+
+  if (feedback_pending_.load(std::memory_order_acquire)) {
+    return;
+  }
+  // Pipeline idle: drain the baton ourselves so Flutter doesn't sit
+  // forever waiting for a present that never schedules.
+  if (const intptr_t mine = vsync_baton_.exchange(0, std::memory_order_acq_rel);
+      mine != 0) {
+    PostOnVsync(engine, mine);
+  }
+}
+
+void WaylandVulkanBackend::RequestPresentationFeedback() {
+  static const bool env_disabled = []() {
+    const char* env = std::getenv("IVI_VK_VSYNC");
+    return env != nullptr && std::string_view(env) == "0";
+  }();
+  if (env_disabled || wp_presentation_ == nullptr || !clock_compatible_) {
+    return;
+  }
+  auto* surface = wl_surface_.load(std::memory_order_acquire);
+  if (surface == nullptr) {
+    return;
+  }
+  constexpr size_t kFeedbackInFlightCap = 16;
+  {
+    std::lock_guard<std::mutex> lock(m_feedback_mu_);
+    if (feedback_in_flight_.size() >= kFeedbackInFlightCap) {
+      spdlog::warn(
+          "[WaylandVulkanBackend] feedback_in_flight_ saturated at {} — "
+          "compositor is silently dropping wp_presentation_feedback "
+          "requests; skipping",
+          feedback_in_flight_.size());
+      return;
+    }
+  }
+  struct wp_presentation_feedback* fb =
+      wp_presentation_feedback(wp_presentation_, surface);
+  if (fb == nullptr) {
+    spdlog::warn(
+        "[WaylandVulkanBackend] wp_presentation_feedback() returned null");
+    return;
+  }
+  wp_presentation_feedback_add_listener(fb, &feedback_listener_, this);
+  {
+    std::lock_guard<std::mutex> lock(m_feedback_mu_);
+    feedback_in_flight_.push_back(fb);
+  }
+  feedback_pending_.store(true, std::memory_order_release);
+}
+
+void WaylandVulkanBackend::on_feedback_sync_output(
+    void* /*data*/,
+    struct wp_presentation_feedback* /*fb*/,
+    struct wl_output* /*output*/) {
+  // Informational; ignored for the single-surface case.
+}
+
+void WaylandVulkanBackend::on_feedback_presented(
+    void* data,
+    struct wp_presentation_feedback* fb,
+    const uint32_t tv_sec_hi,
+    const uint32_t tv_sec_lo,
+    const uint32_t tv_nano_sec,
+    const uint32_t refresh,
+    uint32_t /*seq_hi*/,
+    uint32_t /*seq_lo*/,
+    const uint32_t flags) {
+  auto* self = static_cast<WaylandVulkanBackend*>(data);
+  if (self == nullptr) {
+    return;
+  }
+  constexpr uint64_t kMaxPlausibleRefreshNs = 100'000'000;  // 10Hz floor
+  if (refresh > 0 && refresh <= kMaxPlausibleRefreshNs) {
+    self->last_refresh_ns_.store(refresh, std::memory_order_release);
+  }
+  if (tv_sec_hi != 0) {
+    spdlog::warn(
+        "[WaylandVulkanBackend] feedback.presented tv_sec_hi={} (expected 0); "
+        "dropping baton with wall-clock fallback",
+        tv_sec_hi);
+    WaylandVulkanBackend::on_feedback_discarded(data, fb);
+    return;
+  }
+  const auto tv_sec = static_cast<uint64_t>(tv_sec_lo);
+  const uint64_t tv_ns =
+      tv_sec * 1'000'000'000ULL + static_cast<uint64_t>(tv_nano_sec);
+
+  // Profile accumulation: flags_or only. Interval bucketing is owned by
+  // ProfilePresent on the rasterizer thread; doing it twice would
+  // double-count.
+  static const bool profile_enabled = std::getenv("IVI_VK_PROFILE") != nullptr;
+  if (profile_enabled) {
+    self->profile_.flags_or |= flags;
+  }
+
+  // Race-safe destroy: only the path that successfully removed `fb` from
+  // feedback_in_flight_ owns its destruction. If StopVsyncMonitor swapped
+  // the vector out from under us, `fb` is in StopVsyncMonitor's drained
+  // copy and IT will destroy it.
+  bool removed_one = false;
+  bool empty = false;
+  {
+    std::lock_guard<std::mutex> lock(self->m_feedback_mu_);
+    auto& vec = self->feedback_in_flight_;
+    auto it = std::find(vec.begin(), vec.end(), fb);
+    if (it != vec.end()) {
+      vec.erase(it);
+      removed_one = true;
+    }
+    empty = vec.empty();
+  }
+  if (removed_one) {
+    wp_presentation_feedback_destroy(fb);
+  }
+  if (empty) {
+    self->feedback_pending_.store(false, std::memory_order_release);
+  }
+
+  // Hand the baton back to Flutter with the presentation timestamp.
+  const intptr_t baton =
+      self->vsync_baton_.exchange(0, std::memory_order_acq_rel);
+  if (baton == 0) {
+    return;
+  }
+  auto* engine = self->engine_handle_.load(std::memory_order_acquire);
+  if (engine == nullptr) {
+    return;
+  }
+  auto* runner = self->platform_task_runner_.load(std::memory_order_acquire);
+  if (runner == nullptr || runner->GetStrandContext() == nullptr) {
+    return;
+  }
+  const uint64_t period_ns =
+      self->last_refresh_ns_.load(std::memory_order_acquire);
+  self->last_begin_frame_ns_.store(tv_ns, std::memory_order_release);
+  asio::post(*runner->GetStrandContext(), [engine, baton, tv_ns, period_ns]() {
+    LibFlutterEngine->OnVsync(engine, baton, tv_ns, tv_ns + period_ns);
+  });
+}
+
+void WaylandVulkanBackend::on_feedback_discarded(
+    void* data,
+    struct wp_presentation_feedback* fb) {
+  auto* self = static_cast<WaylandVulkanBackend*>(data);
+  if (self == nullptr) {
+    return;
+  }
+  static const bool profile_enabled = std::getenv("IVI_VK_PROFILE") != nullptr;
+  if (profile_enabled) {
+    ++self->profile_.discarded_frames;
+  }
+  bool removed_one = false;
+  bool empty = false;
+  {
+    std::lock_guard<std::mutex> lock(self->m_feedback_mu_);
+    auto& vec = self->feedback_in_flight_;
+    auto it = std::find(vec.begin(), vec.end(), fb);
+    if (it != vec.end()) {
+      vec.erase(it);
+      removed_one = true;
+    }
+    empty = vec.empty();
+  }
+  if (removed_one) {
+    wp_presentation_feedback_destroy(fb);
+  }
+  if (empty) {
+    self->feedback_pending_.store(false, std::memory_order_release);
+  }
+
+  const intptr_t baton =
+      self->vsync_baton_.exchange(0, std::memory_order_acq_rel);
+  if (baton == 0) {
+    return;
+  }
+  auto* engine = self->engine_handle_.load(std::memory_order_acquire);
+  if (engine == nullptr) {
+    return;
+  }
+  self->PostOnVsync(engine, baton);
+}
+
+const wp_presentation_feedback_listener
+    WaylandVulkanBackend::feedback_listener_ = {
+        .sync_output = WaylandVulkanBackend::on_feedback_sync_output,
+        .presented = WaylandVulkanBackend::on_feedback_presented,
+        .discarded = WaylandVulkanBackend::on_feedback_discarded,
+};
+
+void WaylandVulkanBackend::StopVsyncMonitor() {
+  std::vector<struct wp_presentation_feedback*> drained;
+  {
+    std::lock_guard<std::mutex> lock(m_feedback_mu_);
+    drained.swap(feedback_in_flight_);
+  }
+  for (auto* fb : drained) {
+    wp_presentation_feedback_destroy(fb);
+  }
+  feedback_pending_.store(false, std::memory_order_release);
+  vsync_baton_.store(0, std::memory_order_release);
+  engine_handle_.store(nullptr, std::memory_order_release);
+  platform_task_runner_.store(nullptr, std::memory_order_release);
 }
 
 void WaylandVulkanBackend::Resize(size_t /* index */,
@@ -949,6 +1325,12 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
   assert(surface != nullptr);
 
   surface_ = VK_NULL_HANDLE;
+
+  // Stash for wp_presentation_feedback. Released-acquire so the
+  // rasterizer-thread RequestPresentationFeedback path sees it the next
+  // time it's called after CreateSurface (which always runs on the
+  // platform thread before any frames present).
+  wl_surface_.store(surface, std::memory_order_release);
 
   VkWaylandSurfaceCreateInfoKHR createInfo{};
   createInfo.sType = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
@@ -1466,6 +1848,9 @@ bool WaylandVulkanBackend::PresentLayersImpl(const FlutterLayer** layers,
   present_info.swapchainCount = 1;
   present_info.pSwapchains = &swapchain_;
   present_info.pImageIndices = &image_index;
+  // Mint wp_presentation_feedback before the commit baked into
+  // vkQueuePresentKHR. See PresentCallback for rationale.
+  RequestPresentationFeedback();
   const VkResult result = d.vkQueuePresentKHR(queue_, &present_info);
   if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR) {
     resize_pending_ = true;

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -16,8 +16,12 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
+#include <ctime>
 #include <vector>
+
+#include <presentation-time-client-protocol.h>
 
 // Use vulkan.hpp's convenient proc table and resolver.
 #define VULKAN_HPP_NO_EXCEPTIONS 1
@@ -43,14 +47,60 @@
 #include "view/present_layer_sequencer.h"
 #endif
 
+class Display;
+class TaskRunner;
+
 class WaylandVulkanBackend final : public Backend {
  public:
-  WaylandVulkanBackend(wl_display* display,
+  // @p shell_display may be null in headless / test contexts; the
+  // wp_presentation handle for vsync_callback is read from it at
+  // construction. The raw wl_display* is the same one returned by
+  // shell_display->GetDisplay() — passed separately because Vulkan WSI
+  // creation needs it before any Display lookup happens.
+  WaylandVulkanBackend(Display* shell_display,
+                       wl_display* display,
                        uint32_t width,
                        uint32_t height,
                        bool enable_validation_layers);
 
   ~WaylandVulkanBackend() override;
+
+  /**
+   * @brief Per-backend FlutterVsyncCallback.
+   *
+   * Returns @c &VsyncTrampoline iff (a) the compositor advertised
+   * wp_presentation, (b) the announced clock_id is CLOCK_MONOTONIC,
+   * and (c) @c IVI_VK_VSYNC is not @c 0. Otherwise returns nullptr and
+   * Flutter falls back to its internal wall-clock scheduler.
+   */
+  [[nodiscard]] VsyncCallback GetVsyncCallback() const override;
+
+  /**
+   * @brief Stash the engine handle for the wp_presentation_feedback
+   * path. Captured atomically because dispatch may read it from
+   * Display's event_thread_ when the listener fires.
+   */
+  void SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine) engine) override {
+    engine_handle_.store(engine, std::memory_order_release);
+  }
+
+  /**
+   * @brief Stash the platform task runner so @c FlutterEngineOnVsync can
+   * be marshalled onto its strand. Required because the listener for
+   * @c wp_presentation_feedback.presented fires on Display's event_thread_,
+   * and Flutter rejects @c OnVsync from any thread other than the engine's
+   * run thread.
+   */
+  void SetPlatformTaskRunner(TaskRunner* runner) override {
+    platform_task_runner_.store(runner, std::memory_order_release);
+  }
+
+  /**
+   * @brief Cancel outstanding wp_presentation_feedback objects so
+   * listeners can't fire after the engine has destructed. Called from
+   * @c FlutterView::~FlutterView before the engine destructs.
+   */
+  void StopVsyncMonitor() override;
 
   /**
    * @brief Resize Flutter engine Window size
@@ -396,15 +446,17 @@ class WaylandVulkanBackend final : public Backend {
   void CompositorPipeliningCleanup();
 #endif
 
-  // Per-frame cadence profile (IVI_VK_PROFILE=1). Measure-only: samples
-  // CLOCK_MONOTONIC immediately after each successful vkQueuePresentKHR
-  // on the rasterizer thread (the only writer for either present path —
-  // PresentCallback for non-compositor, PresentLayersImpl for compositor —
-  // and only one of those is active per build). Same shape as the
-  // wayland_egl FrameProfile so the bucket histograms are directly
-  // comparable. Inter-present interval is the only signal available
-  // without wp_presentation_feedback wiring; "discarded" and "flags"
-  // are intentionally absent from the Vulkan path.
+  // Per-frame cadence profile (IVI_VK_PROFILE=1). Inter-present interval
+  // is sampled on CLOCK_MONOTONIC immediately after each successful
+  // vkQueuePresentKHR on the rasterizer thread. When the vsync_callback
+  // path is engaged (wp_presentation_ != nullptr && clock_compatible_),
+  // on_feedback_presented / on_feedback_discarded additionally accumulate
+  // flags_or and discarded_frames — matching the wayland_egl FrameProfile
+  // exactly so the histograms are directly comparable.
+  //
+  // Multiple writers (rasterizer for intervals; Display event_thread_ for
+  // flags_or / discarded_frames) update *disjoint* fields. The bucketing
+  // arithmetic itself is single-writer (rasterizer only).
   struct FrameProfile {
     uint64_t last_present_ns{0};
     uint64_t interval_sum_ns{0};
@@ -416,6 +468,18 @@ class WaylandVulkanBackend final : public Backend {
     uint32_t bucket_20hz{0};       // 34-50ms
     uint32_t bucket_slow{0};       // 51-100ms
     uint32_t bucket_idle{0};       // >100ms
+    // Populated by on_feedback_presented / on_feedback_discarded when
+    // wp_presentation_feedback is wired (vsync_callback engaged).
+    // Always zero when the wall-clock fallback is in use.
+    uint32_t discarded_frames{0};
+    uint32_t flags_or{0};
+    // beginFrame-to-present latency: time from the frame_start_time we
+    // handed Flutter via OnVsync to the next vkQueuePresentKHR return.
+    // Only meaningful when vsync_callback is wired (otherwise
+    // last_begin_frame_ns_ is never set and these stay 0).
+    uint64_t pipeline_latency_sum_ns{0};
+    uint64_t pipeline_latency_max_ns{0};
+    uint32_t pipeline_latency_samples{0};
   };
   FrameProfile profile_{};
   FrameProfile session_totals_{};
@@ -424,4 +488,65 @@ class WaylandVulkanBackend final : public Backend {
   // No-op when IVI_VK_PROFILE is unset. Mutates profile_/session_totals_
   // without locks because the rasterizer thread is the only writer.
   void ProfilePresent(bool ok);
+
+  // wp_presentation-driven vsync plumbing. Same shape as the EGL backend
+  // — only the present-path hook site (vkQueuePresentKHR vs eglSwapBuffers)
+  // and the rasterizer-thread origin differ. See WaylandEglBackend for the
+  // shared design rationale.
+  std::atomic<intptr_t> vsync_baton_{0};
+  std::atomic<FLUTTER_API_SYMBOL(FlutterEngine)> engine_handle_{nullptr};
+  std::atomic<TaskRunner*> platform_task_runner_{nullptr};
+  std::atomic<bool> feedback_pending_{false};
+
+  std::mutex m_feedback_mu_;
+  std::vector<struct wp_presentation_feedback*> feedback_in_flight_;
+
+  struct wp_presentation* wp_presentation_{nullptr};
+  clockid_t presentation_clock_id_{CLOCK_MONOTONIC};
+  bool clock_compatible_{false};
+
+  std::atomic<uint64_t> last_refresh_ns_{16'666'667};
+
+  // frame_start_time most recently handed to FlutterEngineOnVsync.
+  // Updated atomically by the OnVsync-posting paths (PostOnVsync's
+  // lambda and on_feedback_presented's inline post). Read by
+  // ProfilePresent on the rasterizer thread to compute beginFrame-to-
+  // present latency. Stays 0 when vsync_callback isn't wired, in which
+  // case ProfilePresent skips the latency math.
+  //
+  // mutable because PostOnVsync is const (mirrors EGL signature) but
+  // needs to record the timestamp it hands to the engine.
+  mutable std::atomic<uint64_t> last_begin_frame_ns_{0};
+
+  // wl_surface stashed in CreateSurface so wp_presentation_feedback()
+  // has a target without re-deriving from VkSurfaceKHR (Vulkan stores
+  // the wl_surface internally but doesn't expose it back).
+  std::atomic<struct wl_surface*> wl_surface_{nullptr};
+
+  static void VsyncTrampoline(void* user_data, intptr_t baton);
+  void SetVsyncBaton(FLUTTER_API_SYMBOL(FlutterEngine) engine, intptr_t baton);
+  void PostOnVsync(FLUTTER_API_SYMBOL(FlutterEngine) engine,
+                   intptr_t baton) const;
+
+  // Per-commit feedback request — called from BOTH present paths
+  // BEFORE the vkQueuePresentKHR that mints the wl_surface.commit the
+  // feedback object binds to. No-op when wp_presentation isn't usable.
+  void RequestPresentationFeedback();
+
+  static void on_feedback_sync_output(void* data,
+                                      struct wp_presentation_feedback* fb,
+                                      struct wl_output* output);
+  static void on_feedback_presented(void* data,
+                                    struct wp_presentation_feedback* fb,
+                                    uint32_t tv_sec_hi,
+                                    uint32_t tv_sec_lo,
+                                    uint32_t tv_nano_sec,
+                                    uint32_t refresh,
+                                    uint32_t seq_hi,
+                                    uint32_t seq_lo,
+                                    uint32_t flags);
+  static void on_feedback_discarded(void* data,
+                                    struct wp_presentation_feedback* fb);
+
+  static const struct wp_presentation_feedback_listener feedback_listener_;
 };

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -232,7 +232,7 @@ FlutterView::FlutterView(Configuration::Config config,
           "linux-dmabuf support built in).");
     }
     m_backend = std::make_shared<WaylandVulkanBackend>(
-        wl->GetDisplay(), m_config.view.width.value_or(kDefaultViewWidth),
+        wl, wl->GetDisplay(), m_config.view.width.value_or(kDefaultViewWidth),
         m_config.view.height.value_or(kDefaultViewHeight),
         m_config.debug_backend.value_or(false));
   }


### PR DESCRIPTION
## Summary
- Wires `vsync_callback` on the Wayland Vulkan backend via the same `wp_presentation_feedback` mechanism the EGL backend uses; reuses the `Backend` virtuals (`SetEngineHandle`, `SetPlatformTaskRunner`, `StopVsyncMonitor`) and `Display::GetWpPresentation` / `GetPresentationClockId` plumbing already in place.
- Adds `IVI_VK_PRESENT_MODE` (`fifo` | `fifo_relaxed` | `mailbox` | `immediate`) so the operating point — strict FIFO vs latency-favoring MAILBOX — is selectable per workload. Default stays `fifo`.
- Enriches `IVI_VK_PROFILE` with the same `flags` / `discarded` / `refresh` fields the EGL profiler reports, plus a new `pipeline_mean` / `pipeline_max` instrument measuring beginFrame-to-present latency.
- Writes `shell/backend/wayland_vulkan/README.md` documenting architecture, env-var matrix, benchmark methodology, and the FIFO-vs-MAILBOX distinction.

## Headline measurement (KWin Wayland, wonderous bundle, 3 reps × 25 s, fair within-binary IVI_VK_VSYNC toggle)

| Mode | Vsync | fps | 60Hz bucket | Discarded | `pipeline_mean` |
|---|---|---:|---:|---:|---:|
| `fifo` | ON | ~57 | 70-73% | 0 | 2.4-2.7 ms |
| `fifo` | OFF | ~55 | 71-83% (wider) | 0 | — |
| **`mailbox`** | **ON** | **297-765** | **97-99% (see below)** | **5957-17294** | **0.29-0.95 ms** |
| `mailbox` | OFF | 56-58 | 71-85% | 0 | — |

**Honest reading**: Under FIFO, `vsync_callback` adds no measurable improvement at the present-interval layer because Mesa's WSI already paces strictly to vblank via its own internal feedback bookkeeping. The wiring is justified by parity with DRM/EGL, richer profiler diagnostics, and **making MAILBOX usable**. Under MAILBOX, `vsync_callback` is what lets Flutter exploit the lower-latency headroom: with it, pipeline latency drops 5-9× and input events reach the panel within one vblank; without it, Flutter's wall-clock scheduler holds the rasterizer to ~60 fps regardless. The 97-99% on-vblank reading under MAILBOX is partially a measurement artifact (rasterizer firing every ~1.3 ms means intervals trivially land in the ≤17 ms bucket); the real signal is `pipeline_mean` and the compositor's `flags=0x7` confirming every presented frame is HW-vblank-aligned.

## What changed

- `WaylandVulkanBackend` ctor takes `Display*` (was `wl_display*` only); probes `wp_presentation_`, `presentation_clock_id_`, `clock_compatible_`. FlutterView call site updated.
- New private methods (all mirrored from `WaylandEglBackend`): `VsyncTrampoline`, `SetVsyncBaton`, `PostOnVsync`, `RequestPresentationFeedback`, `on_feedback_sync_output` / `on_feedback_presented` / `on_feedback_discarded`. Same baton lifecycle, same idle-wake kick, same race-safe feedback-object destroy.
- Present-path hook before `vkQueuePresentKHR` in both `PresentCallback` (non-compositor) and `PresentLayersImpl` (`BUILD_COMPOSITOR=ON`).
- `wl_surface` stashed on `CreateSurface` so the rasterizer-thread feedback request has a target.
- `IVI_VK_PRESENT_MODE` env override applied during swapchain init; falls back to FIFO with a warn if the requested mode isn't advertised.
- `FrameProfile` gains `discarded_frames`, `flags_or`, `pipeline_latency_*`. `last_begin_frame_ns_` stays 0 when `vsync_callback` isn't wired so existing `IVI_VK_PROFILE` consumers see backward-compatible log lines with new fields appended.

## Test plan
- [x] **FIFO + vsync ON**: 3 reps on KWin, exit 124, navigation works, `flags=0x7`, no regression vs baseline.
- [x] **FIFO + IVI_VK_VSYNC=0**: kill-switch verified — `flags=0x0`, no feedback minted, wall-clock fallback log line.
- [x] **MAILBOX + vsync ON**: 3 reps, dramatic latency drop confirmed, compositor discards expected (deliberate frame supersession, not failure).
- [x] **MAILBOX + IVI_VK_VSYNC=0**: behaves like FIFO (Flutter doesn't exploit headroom) — verifies that vsync_callback is what makes MAILBOX useful.
- [x] **wayland_egl** and **drm_kms_egl** builds confirmed clean with this PR's edits in tree (`flutter_view.cc` change is inside `#elif BUILD_BACKEND_WAYLAND_VULKAN`, preprocessed out for other backends).
- [x] `scripts/format.sh --check` clean. `clang-tidy` clean on the new code; three pre-existing complaints in `debugReportCallback` / `debugUtilsCallback` branch-clones and a `CollectBackingStore` parameter-name mismatch are unrelated and out of scope (CI doesn't see them because the lint workflow's build dir uses the EGL backend).

## Out of scope
- The pre-existing tidy warnings on `wayland_vulkan.cc` (separate cleanup PR).
- Cross-clock translation when compositor advertises a `clock_id` other than `CLOCK_MONOTONIC` (mirror EGL — falls back to wall-clock scheduler with a warn; no mainline compositor needs this).