### PR TITLE
[build] gate wayland sources + waypp linkage on a Wayland backend

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -28,13 +28,27 @@ add_executable(${PROJECT_NAME}
         main.cc
         timer.cc
         view/flutter_view.cc
-        view/present_layer_sequencer.cc
         watchdog.cc
-        wayland/display.cc
-        wayland/window.cc
         task_runner.cc
         accessibility/accessibility_tree.cc
 )
+
+# Wayland-specific TUs:
+#   - wayland/display.cc + wayland/window.cc            — Display/Window
+#   - view/present_layer_sequencer.cc                   — wl_subsurface
+#                                                         layer-ordering
+# All call sites in the main shell are already
+# #if-gated on a Wayland backend. Skipping these for non-Wayland
+# binaries drops the libwayland-client + libwayland-cursor link/runtime
+# deps; drm-kms-egl and software builds become truly Wayland-free.
+if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN OR
+    BUILD_BACKEND_HEADLESS_EGL)
+    target_sources(${PROJECT_NAME} PRIVATE
+            wayland/display.cc
+            wayland/window.cc
+            view/present_layer_sequencer.cc
+    )
+endif ()
 set_target_properties(${PROJECT_NAME}
         PROPERTIES OUTPUT_NAME "${EXE_OUTPUT_NAME}"
 )
@@ -207,13 +221,25 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
         asio
         flutter
         cxxopts::cxxopts
-        wayland-gen
         dl
         ${GST_LIBRARIES}
         ${GST_VIDEO_LIBRARIES}
         ${AVFORMAT_LIBRARIES}
         platform_homescreen
 )
+
+# Propagate wayland-gen's include dirs unconditionally (config/common.h
+# pulls <waypp/waypp.h> regardless of backend for the AGL/XDG client
+# compile defines) but link the static library only on Wayland builds
+# so non-Wayland binaries don't drag in libwayland-client /
+# libwayland-cursor as runtime deps.
+target_include_directories(${PROJECT_NAME} PRIVATE
+        $<TARGET_PROPERTY:wayland-gen,INTERFACE_INCLUDE_DIRECTORIES>
+)
+if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN OR
+    BUILD_BACKEND_HEADLESS_EGL)
+    target_link_libraries(${PROJECT_NAME} PRIVATE wayland-gen)
+endif ()
 
 target_link_directories(${PROJECT_NAME} PRIVATE
         ${CMAKE_BINARY_DIR}

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -24,7 +24,11 @@
 #include "timer.h"
 #include "view/flutter_view.h"
 
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+    BUILD_BACKEND_HEADLESS_EGL
 #include "wayland/display.h"
+#include "wayland/window.h"
+#endif
 #if BUILD_BACKEND_DRM_KMS_EGL
 #include "display/drm_display.h"
 #endif
@@ -91,7 +95,13 @@ std::shared_ptr<IDisplay> MakeDisplay(
 App::App(const std::vector<Configuration::Config>& configs)
     : m_display(MakeDisplay(configs)) {
   SPDLOG_DEBUG("+App::App");
-#if ENABLE_AGL_SHELL_CLIENT
+// AGL Shell needs a Wayland backend — its WaylandWindow / Display
+// usage is meaningless on DRM / software. ENABLE_AGL_SHELL_CLIENT
+// defaults ON in waypp's CMake regardless of backend, so combine
+// with a Wayland-backend gate here.
+#if ENABLE_AGL_SHELL_CLIENT &&                                    \
+    (BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+     BUILD_BACKEND_HEADLESS_EGL)
   bool found_view_with_bg = false;
 #endif
 
@@ -103,7 +113,13 @@ App::App(const std::vector<Configuration::Config>& configs)
     m_views.emplace_back(std::move(view));
     index++;
 
-#if ENABLE_AGL_SHELL_CLIENT
+// AGL Shell needs a Wayland backend — its WaylandWindow / Display
+// usage is meaningless on DRM / software. ENABLE_AGL_SHELL_CLIENT
+// defaults ON in waypp's CMake regardless of backend, so combine
+// with a Wayland-backend gate here.
+#if ENABLE_AGL_SHELL_CLIENT &&                                    \
+    (BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+     BUILD_BACKEND_HEADLESS_EGL)
     if (WaylandWindow::get_window_type(cfg.view.window_type) ==
         WaylandWindow::WINDOW_BG) {
       found_view_with_bg = true;
@@ -111,7 +127,13 @@ App::App(const std::vector<Configuration::Config>& configs)
 #endif
   }
 
-#if ENABLE_AGL_SHELL_CLIENT
+// AGL Shell needs a Wayland backend — its WaylandWindow / Display
+// usage is meaningless on DRM / software. ENABLE_AGL_SHELL_CLIENT
+// defaults ON in waypp's CMake regardless of backend, so combine
+// with a Wayland-backend gate here.
+#if ENABLE_AGL_SHELL_CLIENT &&                                    \
+    (BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+     BUILD_BACKEND_HEADLESS_EGL)
   // check that if we had a BG type and issue a ready() request for it,
   // otherwise we're going to assume that this is a NORMAL/REGULAR application.
   if (found_view_with_bg)

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -32,6 +32,17 @@
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #endif
 
+// WaylandWindow's complete type is required for the m_egl_window->
+// ActivateSystemCursor() call in this TU (and for the shared_ptr
+// constructor in the initializer list). flutter_view.h
+// forward-declares WaylandWindow unconditionally so the header
+// compiles without Wayland; the .cc needs the real definition only
+// when Wayland is selected.
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+    BUILD_BACKEND_HEADLESS_EGL
+#include "wayland/window.h"
+#endif
+
 extern void EngineOnFlutterPlatformMessage(
     const FlutterPlatformMessage* engine_message,
     void* user_data);
@@ -643,7 +654,17 @@ bool Engine::ActivateSystemCursor(const int32_t device,
   if (!m_egl_window) {
     return true;
   }
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+    BUILD_BACKEND_HEADLESS_EGL
   return m_egl_window->ActivateSystemCursor(device, kind);
+#else
+  // Forward-declaration only on non-Wayland builds; m_egl_window is
+  // always null here, so this branch is unreachable at runtime. The
+  // unused parameter cast keeps the signature stable.
+  (void)device;
+  (void)kind;
+  return true;
+#endif
 }
 
 void Engine::OnFlutterPlatformMessage(

--- a/shell/platform/homescreen/CMakeLists.txt
+++ b/shell/platform/homescreen/CMakeLists.txt
@@ -31,9 +31,23 @@ target_link_libraries(platform_homescreen PUBLIC
         flutter
         rapidjson
         spdlog
-        wayland-gen
         tomlplusplus::tomlplusplus
 )
+
+# config/common.h includes <waypp/waypp.h> unconditionally for the
+# ENABLE_AGL_SHELL_CLIENT / ENABLE_XDG_CLIENT compile defines,
+# regardless of backend. Propagate wayland-gen's INTERFACE include
+# dirs without linking the library so non-Wayland builds get the
+# headers but not the libwayland-client / libwayland-cursor
+# runtime deps (the static library archive carries every protocol
+# binding's wl_proxy_* references).
+target_include_directories(platform_homescreen PUBLIC
+        $<TARGET_PROPERTY:wayland-gen,INTERFACE_INCLUDE_DIRECTORIES>
+)
+if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN OR
+    BUILD_BACKEND_HEADLESS_EGL)
+    target_link_libraries(platform_homescreen PUBLIC wayland-gen)
+endif ()
 
 find_package(ACCESSKIT QUIET)
 if (ACCESSKIT_FOUND)

--- a/shell/platform/homescreen/mouse_cursor_handler.cc
+++ b/shell/platform/homescreen/mouse_cursor_handler.cc
@@ -19,6 +19,15 @@
 
 #include "engine.h"
 
+// Complete WaylandWindow type required at line ~69 for the
+// window->ActivateSystemCursor() call. Forward-decl in flutter_view.h
+// is enough for everything else (GetWindow's return type, the
+// `if (!window)` null check).
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+    BUILD_BACKEND_HEADLESS_EGL
+#include "wayland/window.h"
+#endif
+
 static constexpr char kNoWindowError[] = "Missing window error";
 
 MouseCursorHandler::MouseCursorHandler(flutter::BinaryMessenger* messenger,
@@ -61,14 +70,25 @@ void MouseCursorHandler::HandleMethodCall(
     }
     auto window = view_->GetWindow();
     if (!window) {
-      // DRM/KMS path has no WaylandWindow; cursor is handled at the
-      // KMS plane level (or not at all until HW cursor is implemented).
+      // DRM/KMS + software paths have no WaylandWindow; cursor is
+      // handled at the KMS plane level (or not at all). Same
+      // behaviour on non-Wayland builds where GetWindow() is
+      // always null and WaylandWindow is forward-declared only.
       result->Success(flutter::EncodableValue(true));
       return;
     }
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+    BUILD_BACKEND_HEADLESS_EGL
     auto res = window->ActivateSystemCursor(device, kind);
-
     result->Success(flutter::EncodableValue(res));
+#else
+    // Unreachable — window is always null without a Wayland backend
+    // (see the early return above). The branch exists only so the
+    // compiler doesn't need WaylandWindow's complete type here.
+    (void)device;
+    (void)kind;
+    result->Success(flutter::EncodableValue(true));
+#endif
   } else {
     result->NotImplemented();
   }

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -54,8 +54,11 @@ extern void PluginsApiRegisterPlugins(FlutterDesktopEngineRef engine);
 #endif
 
 #if !BUILD_BACKEND_DRM_KMS_EGL && !BUILD_BACKEND_SOFTWARE
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+    BUILD_BACKEND_HEADLESS_EGL
 #include "wayland/display.h"
 #include "wayland/window.h"
+#endif
 #endif
 
 extern void SetUpCommonEngineState(FlutterDesktopEngineState* state,

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -23,7 +23,10 @@
 #include "flutter/fml/macros.h"
 #include "flutter_desktop_view_controller_state.h"
 #include "shell/accessibility/accessibility_tree.h"
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+    BUILD_BACKEND_HEADLESS_EGL
 #include "wayland/window.h"
+#endif
 
 #include <flutter_homescreen.h>
 
@@ -39,12 +42,21 @@
 #endif
 
 class IDisplay;
+// WaylandWindow / Display are forward-declared unconditionally so
+// shared_ptr<WaylandWindow> members and the GetWindow() accessor
+// compile across all backends. The class definitions are only
+// available when a Wayland backend is selected (wayland/window.h
+// is conditionally included above); make_shared<WaylandWindow> +
+// any method call require the complete type, so those sites are
+// guarded with #if BUILD_BACKEND_WAYLAND_EGL || …_VULKAN. The
+// non-Wayland binaries hold a default-null shared_ptr; callers
+// (engine.cc, mouse_cursor_handler.cc) already null-check.
 class Display;
+class WaylandWindow;
 class Engine;
 class Backend;
 class PlatformHandler;
 class PlatformChannel;
-class WaylandWindow;
 #if BUILD_BACKEND_HEADLESS_EGL
 class HeadlessBackend;
 #elif BUILD_BACKEND_DRM_KMS_EGL
@@ -89,11 +101,10 @@ class FlutterView {
   void Initialize();
 
   /**
-   * @brief Get Egl Window
-   * @return shared_ptr<WaylandWindow>
-   * @retval Egl Window
-   * @relation
-   * wayland, flutter
+   * @brief Get the WaylandWindow associated with this view.
+   * @return The shared_ptr; default-constructed null on the DRM and
+   *         software backends (no Wayland surface). Callers must
+   *         null-check before dereferencing.
    */
   std::shared_ptr<WaylandWindow> GetWindow() { return m_wayland_window; }
 
@@ -246,6 +257,8 @@ class FlutterView {
 #error "no Flutter backend selected (see forward-decl block above)"
 #endif
   std::shared_ptr<IDisplay> m_display;
+  // Default-null on non-Wayland backends (only assigned under the
+  // BUILD_BACKEND_WAYLAND_* gate in flutter_view.cc::Initialize).
   std::shared_ptr<WaylandWindow> m_wayland_window;
   std::shared_ptr<Engine> m_flutter_engine;
   std::shared_ptr<AccessibilityTree> m_accessibility_tree;


### PR DESCRIPTION
## Summary

The drm-kms-egl and software backends previously dragged in `libwayland-client` + `libwayland-cursor` at runtime — needlessly, since neither backend touches Wayland at all. Visible during PiOS Lite deployments where these libraries aren't installed by default and the kiosk fails at dlopen with:

```
/usr/local/bin/ivi-homescreen: error while loading shared libraries:
    libwayland-cursor.so.0: cannot open shared object file: No such file or directory
```

After this PR: drm-kms-egl + software binaries are fully Wayland-free.

## What was coupled

Three layers, all gated now:

### 1. CMake (`shell/CMakeLists.txt`)

- `wayland/display.cc` + `wayland/window.cc` + `view/present_layer_sequencer.cc` (uses `wl_subsurface_*`) now compile only under `BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || BUILD_BACKEND_HEADLESS_EGL`.
- `target_link_libraries(wayland-gen)` is conditional too.
- `wayland-gen`'s `INTERFACE_INCLUDE_DIRECTORIES` still propagates unconditionally via `$<TARGET_PROPERTY:...>` so `config/common.h` keeps finding `<waypp/waypp.h>` for the `ENABLE_AGL_SHELL_CLIENT` compile-time macros.

### 2. CMake (`shell/platform/homescreen/CMakeLists.txt`)

Same split — include dirs always propagate, library only links on Wayland (or headless, which historically uses the Wayland Display class).

### 3. C++ surface gating

- `shell/view/flutter_view.h` forward-declares `WaylandWindow` / `Display` unconditionally so the `shared_ptr<WaylandWindow>` member + `GetWindow()` accessor compile on every backend (shared_ptr's destructor doesn't need T's complete type when only default-constructed).
- The `wayland/window.h` include is gated on a Wayland/headless backend.
- `shell/view/flutter_view.cc`, `shell/app.cc`, `shell/engine.cc`, `shell/platform/homescreen/mouse_cursor_handler.cc` gate the `wayland/{window,display}.h` includes the same way.
- Call sites that need `WaylandWindow`'s complete type (`make_shared<WaylandWindow>`, `->ActivateSystemCursor`, `WaylandWindow::WINDOW_BG`, `dynamic_cast<Display*>`) are wrapped in matching `#if` blocks. The non-Wayland branches are unreachable at runtime (`m_egl_window` is always null without a Wayland backend) — the `#ifdef` exists purely so the compiler doesn't need the complete type at those sites.
- `app.cc`'s AGL Shell block is additionally gated on a Wayland backend — `ENABLE_AGL_SHELL_CLIENT` defaults ON in waypp's CMake regardless of backend, but AGL Shell is a Wayland-only feature.

## Verification

Clean rebuild of each backend, `readelf -d` on the resulting binary:

| Backend | Wayland NEEDED |
|--|--|
| `wayland-egl` | ✓ `libwayland-client.so.0`, `libwayland-cursor.so.0`, `libwayland-egl.so.1` (expected) |
| `wayland-vulkan` | ✓ `libwayland-client.so.0`, `libwayland-cursor.so.0` (expected) |
| `headless` | ✓ `libwayland-client.so.0`, `libwayland-cursor.so.0` (kept — historically uses Wayland Display infra) |
| **`drm-kms-egl`** | **clean — no wayland deps** |
| **`software`** | **clean — no wayland deps** |

## Downstream impact

On PiOS Lite this lets a `drm-kms-egl` + `software` kiosk drop `libwayland-client0` + `libwayland-cursor0` from its runtime apt install list (companion change in the `build_pi.sh` deps installer can move them back to per-backend wayland-only lists where they actually belong). The dropped runtime deps + smaller binary size + simpler per-backend dep matrix are the operational wins.

## Test plan

- [x] All five backend configurations (`wayland-egl`, `wayland-vulkan`, `headless`, `drm-kms-egl`, `software`) build clean from a fresh CMake dir
- [x] `readelf -d` confirms the wayland deps are present only where expected
- [x] Real hardware (Pi 4 + PiOS Trixie) — drm-kms-egl kiosk service starts and runs without `libwayland-client0` / `libwayland-cursor0` installed (validated via the existing kiosk path)
- [x] clang-format clean

## Related

- [PR #194](https://github.com/toyota-connected/ivi-homescreen/pull/194) (feat/pi-sd-provision) — its runtime-deps installer currently puts `libwayland-cursor0` + `libwayland-client0` in the *common* list because they were unconditional binary deps. After this PR lands, those can move back to the per-backend `wayland-egl` / `wayland-vulkan` lists.