### PR TITLE
Fix PiOS aarch64 cross build, enable drm-kms-egl on bookworm, add CI

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -1,0 +1,144 @@
+---
+# Cross-compiled PiOS (aarch64) artifacts via scripts/build_pi.sh.
+#
+# Runs on x86_64 GitHub runners on purpose: the pinned ARM toolchains link
+# against the matching PiOS glibc only when hosted on x86_64 (bookworm's
+# GCC 12 has no aarch64-hosted build, and the aarch64-hosted GCC 14/15 link
+# against glibc >= 2.38, which bookworm's 2.36 can't satisfy).
+#
+# A per-PiOS "prep" job warms the cache (toolchain + sysroot + engine, and
+# the from-source libdisplay-info on bookworm) once; the build matrix then
+# fans out per backend, restoring that cache and compiling a single backend.
+name: pios
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [v2.0]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Everything build_pi.sh downloads/derives lives here so one cache covers
+  # toolchain, sysroot, engine SDK, and the local libdisplay-info build.
+  IVI_XC_ROOT: ${{ github.workspace }}/.ivi-xc
+
+jobs:
+  prep:
+    if: ${{ github.server_url == 'https://github.com' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pios: trixie
+            args: ""
+          - pios: bookworm
+            # Cross-build a static libdisplay-info >= 0.2.0 so drm-kms-egl is
+            # buildable against bookworm's 0.1.1.
+            args: "--with-local-display-info"
+    name: prep-${{ matrix.pios }}
+    steps:
+      - name: Checkout ivi-homescreen
+        uses: actions/checkout@v4
+        with:
+          path: ivi-homescreen
+          submodules: recursive
+
+      - name: Checkout ivi-homescreen-plugins (sibling)
+        uses: actions/checkout@v4
+        with:
+          repository: toyota-connected/ivi-homescreen-plugins
+          path: ivi-homescreen-plugins
+          submodules: recursive
+
+      - name: Install host build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install --no-install-recommends \
+            curl xz-utils tar fdisk rsync cmake pkg-config \
+            qemu-user-static meson ninja-build libwayland-bin
+
+      - name: Cache cross sandbox (toolchain + sysroot + engine)
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.IVI_XC_ROOT }}
+          key: xc-${{ matrix.pios }}-${{ hashFiles('ivi-homescreen/scripts/build_pi.sh') }}
+          restore-keys: |
+            xc-${{ matrix.pios }}-
+
+      - name: Prepare (fetch toolchain, sysroot, engine; build libdisplay-info)
+        working-directory: ivi-homescreen
+        run: |
+          ./scripts/build_pi.sh --pios ${{ matrix.pios }} \
+            --backend all ${{ matrix.args }} --prepare-only
+
+  build:
+    needs: prep
+    if: ${{ github.server_url == 'https://github.com' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # trixie ships libdisplay-info >= 0.2.0, so all four backends build
+          # without the local libdisplay-info workaround.
+          - { pios: trixie, backend: wayland-egl,    args: "" }
+          - { pios: trixie, backend: wayland-vulkan, args: "" }
+          - { pios: trixie, backend: drm-kms-egl,    args: "" }
+          - { pios: trixie, backend: software,       args: "" }
+          # bookworm: drm-kms-egl needs the locally-built libdisplay-info.
+          - { pios: bookworm, backend: wayland-egl,    args: "" }
+          - { pios: bookworm, backend: wayland-vulkan, args: "" }
+          - { pios: bookworm, backend: drm-kms-egl,    args: "--with-local-display-info" }
+          - { pios: bookworm, backend: software,       args: "" }
+    name: build-${{ matrix.pios }}-${{ matrix.backend }}
+    steps:
+      - name: Checkout ivi-homescreen
+        uses: actions/checkout@v4
+        with:
+          path: ivi-homescreen
+          submodules: recursive
+
+      - name: Checkout ivi-homescreen-plugins (sibling)
+        uses: actions/checkout@v4
+        with:
+          repository: toyota-connected/ivi-homescreen-plugins
+          path: ivi-homescreen-plugins
+          submodules: recursive
+
+      - name: Install host build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install --no-install-recommends \
+            curl xz-utils tar fdisk rsync cmake pkg-config \
+            qemu-user-static meson ninja-build libwayland-bin
+
+      - name: Restore cross sandbox
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.IVI_XC_ROOT }}
+          key: xc-${{ matrix.pios }}-${{ hashFiles('ivi-homescreen/scripts/build_pi.sh') }}
+          restore-keys: |
+            xc-${{ matrix.pios }}-
+
+      - name: Build
+        working-directory: ivi-homescreen
+        run: |
+          ./scripts/build_pi.sh --pios ${{ matrix.pios }} \
+            --backend ${{ matrix.backend }} ${{ matrix.args }}
+
+      - name: Upload homescreen binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: homescreen-${{ matrix.pios }}-${{ matrix.backend }}
+          path: ivi-homescreen/cmake-build-xc-pi-${{ matrix.pios }}-${{ matrix.backend }}/shell/homescreen
+          if-no-files-found: error

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -40,9 +40,10 @@ jobs:
           - pios: trixie
             args: ""
           - pios: bookworm
-            # Cross-build a static libdisplay-info >= 0.2.0 so drm-kms-egl is
-            # buildable against bookworm's 0.1.1.
-            args: "--with-local-display-info"
+            # bookworm ships an older libdisplay-info (0.1.1) and Vulkan SDK
+            # (VK_HEADER_VERSION 239); cross-build/overlay newer ones so
+            # drm-kms-egl and wayland-vulkan both build.
+            args: "--with-local-display-info --with-local-vulkan-headers"
     name: prep-${{ matrix.pios }}
     steps:
       - name: Checkout ivi-homescreen
@@ -97,7 +98,7 @@ jobs:
           - { pios: trixie, backend: software,       args: "" }
           # bookworm: drm-kms-egl needs the locally-built libdisplay-info.
           - { pios: bookworm, backend: wayland-egl,    args: "" }
-          - { pios: bookworm, backend: wayland-vulkan, args: "" }
+          - { pios: bookworm, backend: wayland-vulkan, args: "--with-local-vulkan-headers" }
           - { pios: bookworm, backend: drm-kms-egl,    args: "--with-local-display-info" }
           - { pios: bookworm, backend: software,       args: "" }
     name: build-${{ matrix.pios }}-${{ matrix.backend }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,23 @@ if (ENABLE_PLUGINS)
             add_subdirectory(${EXT_PLUGINS_DIR} ${PROJECT_BINARY_DIR}/ext_plugins)
         endif ()
     endforeach ()
+
+    # Treat the vendored sdbus-c++ as a system library from our side (we don't
+    # edit that project): re-publish its interface include dirs as SYSTEM so its
+    # headers are -isystem for consumers and don't spam our build with warnings.
+    foreach (_tgt sdbus-c++ sdbus-c++-objlib)
+        if (TARGET ${_tgt})
+            get_target_property(_sdbus_inc ${_tgt} INTERFACE_INCLUDE_DIRECTORIES)
+            if (_sdbus_inc)
+                set_target_properties(${_tgt} PROPERTIES
+                        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_sdbus_inc}")
+            endif ()
+            # Also suppress warnings emitted while compiling sdbus-cpp's own
+            # sources (e.g. -Wconversion in VTableUtils.c). System includes only
+            # cover consumers, so quiet the vendored target's own build here.
+            target_compile_options(${_tgt} PRIVATE -w)
+        endif ()
+    endforeach ()
 endif ()
 
 #

--- a/cmake/drm_kms.cmake
+++ b/cmake/drm_kms.cmake
@@ -37,6 +37,18 @@ cmake_policy(SET CMP0079 NEW)
 
 add_subdirectory(${_drm_cxx_src} ${CMAKE_BINARY_DIR}/third_party/drm-cxx EXCLUDE_FROM_ALL)
 
+# Treat drm-cxx as a system library (vendored submodule we keep pristine):
+# mark its interface headers SYSTEM so they're -isystem for consumers, and
+# silence its own-source warnings (-Wsign-conversion, -Wc++20-extensions, …).
+if (TARGET drm-cxx)
+    get_target_property(_drmcxx_inc drm-cxx INTERFACE_INCLUDE_DIRECTORIES)
+    if (_drmcxx_inc)
+        set_target_properties(drm-cxx PROPERTIES
+                INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_drmcxx_inc}")
+    endif ()
+    target_compile_options(drm-cxx PRIVATE -w)
+endif ()
+
 # drm-cxx is built as a sub-project and doesn't automatically inherit the
 # `toolchain` INTERFACE library that applies `-stdlib=libc++` on clang
 # builds. Without this, drm-cxx compiles against libstdc++ and the main

--- a/scripts/build_pi.sh
+++ b/scripts/build_pi.sh
@@ -52,6 +52,11 @@
 #                                   into the sysroot (static), enabling drm-kms-egl
 #                                   on distros that ship an older one (e.g. bookworm)
 #     --display-info-version <ver>  libdisplay-info source tag to build (default 0.2.0)
+#     --with-local-vulkan-headers   install newer Vulkan-Headers (header-only) into
+#                                   the sysroot, enabling wayland-vulkan on distros
+#                                   with an older Vulkan SDK (e.g. bookworm)
+#     --vulkan-headers-version <t>  Vulkan-Headers tag to install (default
+#                                   vulkan-sdk-1.4.309.0)
 #
 #   SD card imaging + device provisioning (post-build):
 #     --image-sd                    interactively detect & write the PiOS image to
@@ -150,6 +155,9 @@ TOOLCHAIN_URL=""
 WITH_LOCAL_DISPLAY_INFO=0
 LIBDISPLAY_INFO_VERSION="0.2.0"   # min for drm-cxx (HDR/colorimetry EDID APIs)
 LIBDISPLAY_INFO_URL=""            # derived from version unless overridden
+WITH_LOCAL_VULKAN_HEADERS=0
+VULKAN_HEADERS_VERSION="vulkan-sdk-1.4.309.0"  # VK_HEADER_VERSION 309 (matches trixie)
+VULKAN_HEADERS_URL=""             # derived from version unless overridden
 VERBOSE=0
 
 # SD imaging / provisioning state.
@@ -238,6 +246,8 @@ while [[ $# -gt 0 ]]; do
         --toolchain-host)     TC_HOST="$2"; shift 2 ;;
         --with-local-display-info) WITH_LOCAL_DISPLAY_INFO=1; shift ;;
         --display-info-version)    LIBDISPLAY_INFO_VERSION="$2"; shift 2 ;;
+        --with-local-vulkan-headers) WITH_LOCAL_VULKAN_HEADERS=1; shift ;;
+        --vulkan-headers-version)    VULKAN_HEADERS_VERSION="$2"; shift 2 ;;
         --image-sd)           IMAGE_SD=1; PROVISION=1; shift ;;
         --device)             TARGET_DEVICE="$2"; IMAGE_SD=1; PROVISION=1; shift 2 ;;
         --provision)          PROVISION=1; shift ;;
@@ -334,6 +344,10 @@ TC_DIRNAME="arm-gnu-toolchain-${TC_VERSION}-${TC_HOST}-${TC_TRIPLE}"
 LIBDISPLAY_INFO_TARBALL="libdisplay-info-${LIBDISPLAY_INFO_VERSION}.tar.gz"
 [[ -z "$LIBDISPLAY_INFO_URL" ]] \
     && LIBDISPLAY_INFO_URL="https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${LIBDISPLAY_INFO_VERSION}/${LIBDISPLAY_INFO_TARBALL}"
+
+# Vulkan-Headers source archive (header-only, pinned by tag).
+[[ -z "$VULKAN_HEADERS_URL" ]] \
+    && VULKAN_HEADERS_URL="https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/${VULKAN_HEADERS_VERSION}.tar.gz"
 
 # ── Resolved sandbox paths ───────────────────────────────────────────────
 
@@ -733,6 +747,55 @@ EOF
     displayinfo_ge_floor "$now" \
         || die "libdisplay-info install did not yield >= $LIBDISPLAY_INFO_VERSION (got '$now')"
     note "libdisplay-info $now installed (static) into $PIOS sysroot"
+}
+
+# ── Phase 2c: optional newer Vulkan-Headers (header-only) ────────────────
+
+# VK_HEADER_VERSION currently in the sysroot ("0" if absent).
+vulkan_header_version() {
+    local h="$XC_SYSROOT/usr/include/vulkan/vulkan_core.h"
+    if [[ -f "$h" ]]; then
+        awk '/#define VK_HEADER_VERSION /{print $3; exit}' "$h"
+    else
+        echo 0
+    fi
+}
+
+phase2c_local_vulkan_headers() {
+    [[ "$WITH_LOCAL_VULKAN_HEADERS" -eq 1 ]] || return 0
+    # Patch component of the pinned tag (vulkan-sdk-1.4.309.0 -> 309).
+    local want; want="$(echo "$VULKAN_HEADERS_VERSION" | awk -F. '{print $3}')"
+    log "Phase 2c: local Vulkan-Headers (VK_HEADER_VERSION >= ${want})"
+
+    local have; have="$(vulkan_header_version)"
+    if [[ "$have" =~ ^[0-9]+$ ]] && (( have >= want )); then
+        note "sysroot already has VK_HEADER_VERSION $have; skipping"
+        return
+    fi
+
+    local tarball src
+    tarball="$DOWNLOADS/Vulkan-Headers-${VULKAN_HEADERS_VERSION}.tar.gz"
+    src="$XC_ROOT/src/Vulkan-Headers-${VULKAN_HEADERS_VERSION}"
+    fetch "$VULKAN_HEADERS_URL" "$tarball"
+
+    if [[ ! -d "$src/include/vulkan" ]]; then
+        log "extracting Vulkan-Headers"
+        mkdir -p "$XC_ROOT/src"; rm -rf "$src"
+        local tmp; tmp="$(mktemp -d "$XC_ROOT/src/.unpack.XXXXXX")"
+        tar -xzf "$tarball" -C "$tmp"
+        mv "$tmp"/*/ "$src"; rmdir "$tmp"
+    fi
+
+    # Header-only: overlay the newer Vulkan + vk_video headers. The sysroot's
+    # libvulkan.so loader is ABI-stable, so the older runtime still serves the
+    # newer API surface (unknown instance-extension structs are ignored).
+    log "installing Vulkan-Headers into sysroot (header-only)"
+    mkdir -p "$XC_SYSROOT/usr/include/vulkan" "$XC_SYSROOT/usr/include/vk_video"
+    cp -a "$src/include/vulkan/." "$XC_SYSROOT/usr/include/vulkan/"
+    [[ -d "$src/include/vk_video" ]] \
+        && cp -a "$src/include/vk_video/." "$XC_SYSROOT/usr/include/vk_video/"
+
+    note "Vulkan-Headers now VK_HEADER_VERSION $(vulkan_header_version) in $PIOS sysroot"
 }
 
 # ── Phase 3: toolchain file + pkg-config wrapper ─────────────────────────
@@ -1383,6 +1446,7 @@ phase1_toolchain
 phase1b_flutter_engine
 phase2_sysroot
 phase2b_local_display_info
+phase2c_local_vulkan_headers
 
 if [[ "$PREPARE_ONLY" -eq 1 ]]; then
     log "prepare-only: stopping before configure"

--- a/scripts/build_pi.sh
+++ b/scripts/build_pi.sh
@@ -48,6 +48,10 @@
 #                                                                       trixie→15.2.rel1)
 #     --toolchain-url <url>         override toolchain tarball URL
 #     --toolchain-host <arch>       toolchain build-host arch (auto: x86_64/aarch64)
+#     --with-local-display-info     cross-build libdisplay-info >= 0.2.0 from source
+#                                   into the sysroot (static), enabling drm-kms-egl
+#                                   on distros that ship an older one (e.g. bookworm)
+#     --display-info-version <ver>  libdisplay-info source tag to build (default 0.2.0)
 #
 #   SD card imaging + device provisioning (post-build):
 #     --image-sd                    interactively detect & write the PiOS image to
@@ -143,6 +147,9 @@ PREPARE_ONLY=0
 REFRESH_SYSROOT=0
 IMAGE_URL=""
 TOOLCHAIN_URL=""
+WITH_LOCAL_DISPLAY_INFO=0
+LIBDISPLAY_INFO_VERSION="0.2.0"   # min for drm-cxx (HDR/colorimetry EDID APIs)
+LIBDISPLAY_INFO_URL=""            # derived from version unless overridden
 VERBOSE=0
 
 # SD imaging / provisioning state.
@@ -229,6 +236,8 @@ while [[ $# -gt 0 ]]; do
         --toolchain-url)      TOOLCHAIN_URL="$2"; shift 2 ;;
         --toolchain-version)  TC_VERSION="$2"; shift 2 ;;
         --toolchain-host)     TC_HOST="$2"; shift 2 ;;
+        --with-local-display-info) WITH_LOCAL_DISPLAY_INFO=1; shift ;;
+        --display-info-version)    LIBDISPLAY_INFO_VERSION="$2"; shift 2 ;;
         --image-sd)           IMAGE_SD=1; PROVISION=1; shift ;;
         --device)             TARGET_DEVICE="$2"; IMAGE_SD=1; PROVISION=1; shift 2 ;;
         --provision)          PROVISION=1; shift ;;
@@ -265,12 +274,12 @@ case "$BACKEND" in wayland-egl|wayland-vulkan|drm-kms-egl|software|all) ;;
     *) die "--backend must be wayland-egl|wayland-vulkan|drm-kms-egl|software|all (got: $BACKEND)" ;;
 esac
 
-# Resolve which backends to actually build. drm-kms-egl is unavailable on
-# bookworm because drm-cxx requires libdisplay-info >= 0.2.0 and bookworm
-# only ships 0.1.1.
+# Resolve which backends to actually build. drm-kms-egl needs libdisplay-info
+# >= 0.2.0 (drm-cxx); bookworm only ships 0.1.1, so it's dropped from `all`
+# unless --with-local-display-info cross-builds a newer one into the sysroot.
 if [[ "$BACKEND" == "all" ]]; then
     BUILD_BACKENDS=("${ALL_BACKENDS[@]}")
-    if [[ "$PIOS" == "bookworm" ]]; then
+    if [[ "$PIOS" == "bookworm" && "$WITH_LOCAL_DISPLAY_INFO" -eq 0 ]]; then
         BUILD_BACKENDS=()
         for be in "${ALL_BACKENDS[@]}"; do
             [[ "$be" == "drm-kms-egl" ]] && continue
@@ -279,6 +288,10 @@ if [[ "$BACKEND" == "all" ]]; then
     fi
 else
     BUILD_BACKENDS=("$BACKEND")
+    if [[ "$BACKEND" == "drm-kms-egl" && "$PIOS" == "bookworm" \
+          && "$WITH_LOCAL_DISPLAY_INFO" -eq 0 ]]; then
+        die "drm-kms-egl on bookworm needs libdisplay-info >= 0.2.0 (ships 0.1.1); pass --with-local-display-info to cross-build it"
+    fi
 fi
 case "$FLUTTER_RUNTIME" in debug|debug-unopt|profile|release) ;;
     *) die "--flutter-runtime must be debug|debug-unopt|profile|release (got: $FLUTTER_RUNTIME)" ;;
@@ -315,6 +328,12 @@ TC_TARBALL="arm-gnu-toolchain-${TC_VERSION}-${TC_HOST}-${TC_TRIPLE}.tar.xz"
 TC_DIRNAME="arm-gnu-toolchain-${TC_VERSION}-${TC_HOST}-${TC_TRIPLE}"
 [[ -z "$TOOLCHAIN_URL" ]] \
     && TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu/${TC_VERSION}/binrel/${TC_TARBALL}"
+
+# libdisplay-info source archive (pinned by tag). freedesktop GitLab serves a
+# stable per-tag archive; pinning the tag is the pin (no upstream .sha256).
+LIBDISPLAY_INFO_TARBALL="libdisplay-info-${LIBDISPLAY_INFO_VERSION}.tar.gz"
+[[ -z "$LIBDISPLAY_INFO_URL" ]] \
+    && LIBDISPLAY_INFO_URL="https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${LIBDISPLAY_INFO_VERSION}/${LIBDISPLAY_INFO_TARBALL}"
 
 # ── Resolved sandbox paths ───────────────────────────────────────────────
 
@@ -551,27 +570,36 @@ print(linux[0]["start"])')"
 
     # Shared deps across all backends (plugins, GLES, gstreamer/glib, etc.).
     # libsystemd-dev is for sdbus-cpp inside ivi-homescreen-plugins.
+    # libwayland-dev + wayland-protocols are shared, not Wayland-backend-only:
+    # waypp is always built and unconditionally requires wayland-client /
+    # wayland-cursor / wayland-protocols, so a drm-kms-egl- or software-only
+    # build needs them too.
     local pkgs=(
         libcamera-dev libcurl4-openssl-dev libegl-dev libgles2-mesa-dev
         libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
         libjpeg-dev libpipewire-0.3-dev libsecret-1-dev libsystemd-dev
-        libudev-dev libxkbcommon-dev libxml2-dev zlib1g-dev
+        libudev-dev libwayland-dev libxkbcommon-dev libxml2-dev
+        wayland-protocols zlib1g-dev
     )
     # Backend-specific deps — union of every backend queued in BUILD_BACKENDS.
     # Duplicate package names are harmless: apt resolves them once.
     for be in "${BUILD_BACKENDS[@]}"; do
         case "$be" in
             wayland-egl)
-                pkgs+=(libwayland-dev wayland-protocols) ;;
+                : ;;  # EGL/GLES + wayland (for waypp) come from the shared list
             wayland-vulkan)
-                pkgs+=(libwayland-dev wayland-protocols libvulkan-dev mesa-vulkan-drivers) ;;
+                pkgs+=(libvulkan-dev mesa-vulkan-drivers) ;;
             drm-kms-egl)
                 # drm-cxx requires libdisplay-info >= 0.2.0 (Trixie 0.2.0;
-                # Bookworm 0.1.1 — drm-kms-egl is pre-filtered out for bookworm).
-                # libxcursor-dev gates the DRM HW cursor module; absent → leaky
-                # symbol references (~DrmCursor / DrmCursor::Move) break the link.
-                pkgs+=(libdrm-dev libgbm-dev libinput-dev libdisplay-info-dev
-                       libxcursor-dev) ;;
+                # Bookworm 0.1.1). libxcursor-dev gates the DRM HW cursor module;
+                # absent → leaky symbol references (~DrmCursor / DrmCursor::Move)
+                # break the link.
+                pkgs+=(libdrm-dev libgbm-dev libinput-dev libxcursor-dev)
+                # When we cross-build libdisplay-info ourselves, skip the apt
+                # -dev package so its libdisplay-info.so dev symlink can't shadow
+                # our static .a at link time (would re-introduce a runtime dep).
+                [[ "$WITH_LOCAL_DISPLAY_INFO" -eq 0 ]] \
+                    && pkgs+=(libdisplay-info-dev) ;;
             software)
                 pkgs+=(libdrm-dev libinput-dev) ;;
         esac
@@ -608,6 +636,103 @@ print(linux[0]["start"])')"
             note "created $ma/lib${stem}.so -> $sover"
         fi
     done
+}
+
+# ── Phase 2b: optional local libdisplay-info (>= 0.2.0, static) ──────────
+
+# Version of libdisplay-info currently visible to the cross pkg-config in the
+# sysroot ("0" if none).
+displayinfo_modversion() {
+    PKG_CONFIG_LIBDIR="$XC_SYSROOT/usr/lib/aarch64-linux-gnu/pkgconfig:$XC_SYSROOT/usr/lib/pkgconfig:$XC_SYSROOT/usr/share/pkgconfig" \
+    PKG_CONFIG_SYSROOT_DIR="$XC_SYSROOT" \
+        pkg-config --modversion libdisplay-info 2>/dev/null || echo 0
+}
+
+# True if $1 >= $LIBDISPLAY_INFO_VERSION (and not the "0" sentinel).
+displayinfo_ge_floor() {
+    [[ "$1" != "0" ]] && \
+    [[ "$(printf '%s\n%s\n' "$LIBDISPLAY_INFO_VERSION" "$1" | sort -V | head -1)" == "$LIBDISPLAY_INFO_VERSION" ]]
+}
+
+phase2b_local_display_info() {
+    [[ "$WITH_LOCAL_DISPLAY_INFO" -eq 1 ]] || return 0
+    log "Phase 2b: local libdisplay-info (>= ${LIBDISPLAY_INFO_VERSION}, static)"
+
+    # Skip when the sysroot already satisfies the floor (e.g. trixie's 0.2.0).
+    local have; have="$(displayinfo_modversion)"
+    if displayinfo_ge_floor "$have"; then
+        note "sysroot already has libdisplay-info $have; skipping local build"
+        return
+    fi
+
+    for t in meson ninja; do
+        command -v "$t" >/dev/null \
+            || die "--with-local-display-info needs '$t' on PATH"
+    done
+
+    local tarball src bld cross
+    tarball="$DOWNLOADS/$LIBDISPLAY_INFO_TARBALL"
+    src="$XC_ROOT/src/libdisplay-info-${LIBDISPLAY_INFO_VERSION}"
+    bld="$src/build-xc-${PIOS}"
+    cross="$src/.xc-cross-${PIOS}.ini"
+
+    # Integrity rests on the pinned tag fetched over HTTPS — GitLab's archive
+    # endpoint has no companion .sha256 (a ".sha256" suffix 200s with junk).
+    fetch "$LIBDISPLAY_INFO_URL" "$tarball"
+
+    if [[ ! -f "$src/meson.build" ]]; then
+        log "extracting libdisplay-info"
+        mkdir -p "$XC_ROOT/src"; rm -rf "$src"
+        # GitLab archive top dir is libdisplay-info-<tag>-<sha>; normalize.
+        local tmp; tmp="$(mktemp -d "$XC_ROOT/src/.unpack.XXXXXX")"
+        tar -xzf "$tarball" -C "$tmp"
+        mv "$tmp"/*/ "$src"; rmdir "$tmp"
+    fi
+
+    # Meson cross file mirroring .xc-toolchain.cmake: ARM toolchain + sysroot.
+    local ma_inc="$XC_SYSROOT/usr/include/aarch64-linux-gnu"
+    local ma_usr="$XC_SYSROOT/usr/lib/aarch64-linux-gnu"
+    local ma_lib="$XC_SYSROOT/lib/aarch64-linux-gnu"
+    cat > "$cross" <<EOF
+[binaries]
+c = '$CROSS_BIN/${TC_TRIPLE}-gcc'
+cpp = '$CROSS_BIN/${TC_TRIPLE}-g++'
+ar = '$CROSS_BIN/${TC_TRIPLE}-ar'
+strip = '$CROSS_BIN/${TC_TRIPLE}-strip'
+pkg-config = 'pkg-config'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[built-in options]
+c_args = ['--sysroot=$XC_SYSROOT', '-isystem', '$ma_inc', '-B$ma_usr'${XC_CPU_FLAGS:+, '$XC_CPU_FLAGS'}]
+c_link_args = ['--sysroot=$XC_SYSROOT', '-B$ma_usr', '-L$ma_usr', '-L$ma_lib']
+EOF
+
+    log "configuring libdisplay-info (meson cross, static)"
+    rm -rf "$bld"
+    PKG_CONFIG_LIBDIR="$ma_usr/pkgconfig:$XC_SYSROOT/usr/lib/pkgconfig:$XC_SYSROOT/usr/share/pkgconfig" \
+    PKG_CONFIG_SYSROOT_DIR="$XC_SYSROOT" \
+        meson setup "$bld" "$src" \
+            --cross-file "$cross" \
+            --prefix /usr --libdir lib/aarch64-linux-gnu \
+            --buildtype release --default-library static
+
+    log "building + installing libdisplay-info into sysroot"
+    ninja -C "$bld"
+    DESTDIR="$XC_SYSROOT" ninja -C "$bld" install
+
+    # Force static linkage: drop any libdisplay-info.so dev symlink (from a
+    # previously apt-installed 0.1.x) so -ldisplay-info resolves to our .a.
+    rm -f "$ma_usr/libdisplay-info.so"
+
+    local now; now="$(displayinfo_modversion)"
+    displayinfo_ge_floor "$now" \
+        || die "libdisplay-info install did not yield >= $LIBDISPLAY_INFO_VERSION (got '$now')"
+    note "libdisplay-info $now installed (static) into $PIOS sysroot"
 }
 
 # ── Phase 3: toolchain file + pkg-config wrapper ─────────────────────────
@@ -1257,6 +1382,7 @@ phase0_preflight
 phase1_toolchain
 phase1b_flutter_engine
 phase2_sysroot
+phase2b_local_display_info
 
 if [[ "$PREPARE_ONLY" -eq 1 ]]; then
     log "prepare-only: stopping before configure"
@@ -1266,8 +1392,8 @@ if [[ "$PREPARE_ONLY" -eq 1 ]]; then
     exit 0
 fi
 
-if [[ "$BACKEND" == "all" && "$PIOS" == "bookworm" ]]; then
-    log "note: skipping drm-kms-egl on bookworm (libdisplay-info 0.1.1 < drm-cxx 0.2.0)"
+if [[ "$BACKEND" == "all" && "$PIOS" == "bookworm" && "$WITH_LOCAL_DISPLAY_INFO" -eq 0 ]]; then
+    log "note: skipping drm-kms-egl on bookworm (libdisplay-info 0.1.1 < drm-cxx 0.2.0); pass --with-local-display-info to include it"
 fi
 
 if [[ "$SKIP_BUILD" -eq 0 ]]; then

--- a/scripts/build_pi.sh
+++ b/scripts/build_pi.sh
@@ -47,6 +47,7 @@
 #     --toolchain-version <ver>     ARM GNU Toolchain version (defaults: bookworm→12.3.rel1,
 #                                                                       trixie→15.2.rel1)
 #     --toolchain-url <url>         override toolchain tarball URL
+#     --toolchain-host <arch>       toolchain build-host arch (auto: x86_64/aarch64)
 #
 #   SD card imaging + device provisioning (post-build):
 #     --image-sd                    interactively detect & write the PiOS image to
@@ -173,7 +174,16 @@ SKIP_BUILD=0
 #   trixie   → 15.2.rel1 (gcc 15, glibc ≥ 2.41 — matches PiOS Trixie)
 # Override with --toolchain-version (or --toolchain-url for arbitrary URLs).
 TC_TRIPLE="aarch64-none-linux-gnu"
-TC_HOST="x86_64"
+# Host arch of the cross toolchain build. ARM publishes both x86_64- and
+# aarch64-hosted variants; pick the one matching this machine so the compiler
+# runs natively (an x86_64 toolchain on an aarch64 host gets routed through
+# qemu-x86_64-static, which fails for lack of an x86_64 loader). Override with
+# --toolchain-host if needed.
+case "$(uname -m)" in
+    aarch64|arm64) TC_HOST="aarch64" ;;
+    x86_64|amd64)  TC_HOST="x86_64" ;;
+    *)             TC_HOST="x86_64" ;;
+esac
 TC_VERSION=""        # auto-derived from $PIOS unless --toolchain-version is given
 declare -A TC_VERSION_FOR_PIOS=(
     [bookworm]="12.3.rel1"
@@ -191,7 +201,7 @@ TRIXIE_IMG_URL="https://downloads.raspberrypi.com/raspios_lite_arm64/images/rasp
 # enumerates available builds.
 ENGINE_DEFAULT_SHA="13e658725ddaa270601426d1485636157e38c34c"
 ENGINE_REPO="meta-flutter/flutter-engine"
-ENGINE_ARCH="arm64"  # aarch64 PiOS — host is x86_64-only, no other arch supported
+ENGINE_ARCH="arm64"  # target arch (aarch64 PiOS); independent of build-host arch
 
 # ── Argument parsing ─────────────────────────────────────────────────────
 
@@ -218,6 +228,7 @@ while [[ $# -gt 0 ]]; do
         --image-url)          IMAGE_URL="$2"; shift 2 ;;
         --toolchain-url)      TOOLCHAIN_URL="$2"; shift 2 ;;
         --toolchain-version)  TC_VERSION="$2"; shift 2 ;;
+        --toolchain-host)     TC_HOST="$2"; shift 2 ;;
         --image-sd)           IMAGE_SD=1; PROVISION=1; shift ;;
         --device)             TARGET_DEVICE="$2"; IMAGE_SD=1; PROVISION=1; shift 2 ;;
         --provision)          PROVISION=1; shift ;;

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -164,8 +164,13 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
             PkgConfig::GBM
             PkgConfig::LIBINPUT
             PkgConfig::UDEV
+            # EGL/GLESv2 are listed ahead of platform_homescreen (which
+            # references glDeleteTextures et al.), so --as-needed would drop
+            # libGLESv2 before its reference is seen. Force them DT_NEEDED.
+            -Wl,--no-as-needed
             EGL
             GLESv2
+            -Wl,--as-needed
     )
 endif ()
 

--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -15,6 +15,7 @@
  */
 
 #include "accessibility_tree.h"
+#include <filesystem>
 
 #include <fstream>
 
@@ -22,8 +23,8 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
+#include "../utils.h"
 #include "logging/logging.h"
-#include "utils.h"
 
 void AccessibilityNode::AddChild(const int32_t child_id) {
   m_children.push_back(child_id);

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "app.h"
+#include "logging/logging.h"
 
 #include <cstdlib>
 #include <string_view>

--- a/shell/backend/drm_kms_egl/driver_probe.cc
+++ b/shell/backend/drm_kms_egl/driver_probe.cc
@@ -61,7 +61,8 @@ std::string GetDriverName(const int drm_fd) {
   if (!v) {
     return {};
   }
-  std::string name(v->name ? v->name : "", v->name_len > 0 ? v->name_len : 0);
+  std::string name(v->name ? v->name : "",
+                   static_cast<size_t>(v->name_len > 0 ? v->name_len : 0));
   drmFreeVersion(v);
   return name;
 }

--- a/shell/backend/drm_kms_egl/driver_probe.cc
+++ b/shell/backend/drm_kms_egl/driver_probe.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/driver_probe.h"
+#include "logging/logging.h"
 
 #include <drm_fourcc.h>
 #include <drm_mode.h>

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/drm_backend.h"
+#include "logging/logging.h"
 
 #include <fcntl.h>
 #include <linux/vt.h>

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -993,19 +993,20 @@ bool DrmBackend::InitEgl() {
   if (cfg_.debug_backend) {
     spdlog::info("[DrmBackend] {} candidate EGL configs", num_configs);
     for (EGLint i = 0; i < num_configs; ++i) {
+      EGLConfig c = configs[static_cast<size_t>(i)];
       spdlog::info(
           "[DrmBackend]   [{}] visual=0x{:08x} R{}G{}B{}A{} depth={} "
           "stencil={} samples={} caveat=0x{:x} renderable=0x{:x} "
           "surface=0x{:x} conformant=0x{:x}",
-          i, static_cast<unsigned>(attr(configs[i], EGL_NATIVE_VISUAL_ID)),
-          attr(configs[i], EGL_RED_SIZE), attr(configs[i], EGL_GREEN_SIZE),
-          attr(configs[i], EGL_BLUE_SIZE), attr(configs[i], EGL_ALPHA_SIZE),
-          attr(configs[i], EGL_DEPTH_SIZE), attr(configs[i], EGL_STENCIL_SIZE),
-          attr(configs[i], EGL_SAMPLES),
-          static_cast<unsigned>(attr(configs[i], EGL_CONFIG_CAVEAT)),
-          static_cast<unsigned>(attr(configs[i], EGL_RENDERABLE_TYPE)),
-          static_cast<unsigned>(attr(configs[i], EGL_SURFACE_TYPE)),
-          static_cast<unsigned>(attr(configs[i], EGL_CONFORMANT)));
+          i, static_cast<unsigned>(attr(c, EGL_NATIVE_VISUAL_ID)),
+          attr(c, EGL_RED_SIZE), attr(c, EGL_GREEN_SIZE),
+          attr(c, EGL_BLUE_SIZE), attr(c, EGL_ALPHA_SIZE),
+          attr(c, EGL_DEPTH_SIZE), attr(c, EGL_STENCIL_SIZE),
+          attr(c, EGL_SAMPLES),
+          static_cast<unsigned>(attr(c, EGL_CONFIG_CAVEAT)),
+          static_cast<unsigned>(attr(c, EGL_RENDERABLE_TYPE)),
+          static_cast<unsigned>(attr(c, EGL_SURFACE_TYPE)),
+          static_cast<unsigned>(attr(c, EGL_CONFORMANT)));
     }
   }
 
@@ -1042,19 +1043,20 @@ bool DrmBackend::InitEgl() {
   // strict priority ordering without nested branches.
   using Score = std::tuple<EGLint, EGLint, EGLint, EGLint, EGLint>;
   auto score = [&](const EGLint i) -> Score {
+    EGLConfig c = configs[static_cast<size_t>(i)];
     return {
-        attr(configs[i], EGL_SAMPLES),                                    // 1
-        attr(configs[i], EGL_CONFIG_CAVEAT) == EGL_NONE ? 0 : 1,          // 2
-        abs_diff(attr(configs[i], EGL_ALPHA_SIZE), preferred_alpha),      // 3
-        abs_diff(attr(configs[i], EGL_STENCIL_SIZE), kPreferredStencil),  // 4
-        attr(configs[i], EGL_DEPTH_SIZE),                                 // 5
+        attr(c, EGL_SAMPLES),                                    // 1
+        attr(c, EGL_CONFIG_CAVEAT) == EGL_NONE ? 0 : 1,          // 2
+        abs_diff(attr(c, EGL_ALPHA_SIZE), preferred_alpha),      // 3
+        abs_diff(attr(c, EGL_STENCIL_SIZE), kPreferredStencil),  // 4
+        attr(c, EGL_DEPTH_SIZE),                                 // 5
     };
   };
 
   egl_config_ = nullptr;
   EGLint best_idx = -1;
   for (EGLint i = 0; i < num_configs; ++i) {
-    if (attr(configs[i], EGL_NATIVE_VISUAL_ID) !=
+    if (attr(configs[static_cast<size_t>(i)], EGL_NATIVE_VISUAL_ID) !=
         static_cast<EGLint>(resolved_->primary_format)) {
       continue;
     }

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -84,13 +84,13 @@ struct DrmConfig {
   // preferred, then cable-out). Set = pick the connector whose name
   // (e.g. "eDP-1", "HDMI-A-1") matches; init fails if no such connector
   // is connected. Name format matches --drm-list-modes output.
-  std::optional<std::string> connector_name;
+  std::optional<std::string> connector_name{};
 
   // Unset = pick the connector's preferred mode (DRM_MODE_TYPE_PREFERRED).
   // Set = pick the first mode matching the spec "<W>x<H>@<R>" (e.g.
   // "1920x1080@120"). Refresh is matched against drmModeModeInfo::vrefresh
   // (integer Hz). Init fails if no matching mode is found.
-  std::optional<std::string> mode_spec;
+  std::optional<std::string> mode_spec{};
 
   // User-facing knobs. All default to kAuto; DriverProbe resolves them
   // into the concrete values stored on DrmBackend::resolved_. See

--- a/shell/backend/drm_kms_egl/drm_capture.cc
+++ b/shell/backend/drm_kms_egl/drm_capture.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/drm_capture.h"
+#include "logging/logging.h"
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/drm_compositor.h"
+#include "logging/logging.h"
 
 #include <poll.h>
 #include <unistd.h>

--- a/shell/backend/drm_kms_egl/drm_cursor.cc
+++ b/shell/backend/drm_kms_egl/drm_cursor.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/drm_cursor.h"
+#include "logging/logging.h"
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>

--- a/shell/backend/drm_kms_egl/drm_session.cc
+++ b/shell/backend/drm_kms_egl/drm_session.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/drm_session.h"
+#include "logging/logging.h"
 
 #include <poll.h>
 #include <cerrno>

--- a/shell/backend/gl_process_resolver.cc
+++ b/shell/backend/gl_process_resolver.cc
@@ -15,6 +15,7 @@
  */
 
 #include "gl_process_resolver.h"
+#include "logging/logging.h"
 
 #include <EGL/egl.h>
 #include <dlfcn.h>

--- a/shell/backend/headless/headless.cc
+++ b/shell/backend/headless/headless.cc
@@ -16,6 +16,7 @@
 
 #include "headless.h"
 #include "engine.h"
+#include "logging/logging.h"
 #include "osmesa.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #include "shell/platform/homescreen/flutter_desktop_texture_registrar.h"

--- a/shell/backend/headless/osmesa.cc
+++ b/shell/backend/headless/osmesa.cc
@@ -15,6 +15,7 @@
  */
 
 #include "osmesa.h"
+#include "logging/logging.h"
 
 #include <cassert>
 

--- a/shell/backend/software/drm_dumb_sink.cc
+++ b/shell/backend/software/drm_dumb_sink.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/software/drm_dumb_sink.h"
+#include "logging/logging.h"
 
 #include <drm_fourcc.h>
 #include <fcntl.h>

--- a/shell/backend/software/fbdev_sink.cc
+++ b/shell/backend/software/fbdev_sink.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/software/fbdev_sink.h"
+#include "logging/logging.h"
 
 #include <fcntl.h>
 #include <linux/fb.h>

--- a/shell/backend/software/file_sink.cc
+++ b/shell/backend/software/file_sink.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/software/file_sink.h"
+#include "logging/logging.h"
 
 #include <array>
 #include <cstdio>

--- a/shell/backend/software/input/software_seat.cc
+++ b/shell/backend/software/input/software_seat.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/software/input/software_seat.h"
+#include "logging/logging.h"
 
 #include <fcntl.h>
 #include <libinput.h>

--- a/shell/backend/software/sink_factory.cc
+++ b/shell/backend/software/sink_factory.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/software/sink_factory.h"
+#include "logging/logging.h"
 
 #include <cstdlib>
 #include <string>

--- a/shell/backend/software/software_backend.cc
+++ b/shell/backend/software/software_backend.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/software/software_backend.h"
+#include "logging/logging.h"
 
 #include <csignal>
 #include <cstdlib>

--- a/shell/backend/wayland_egl/egl.cc
+++ b/shell/backend/wayland_egl/egl.cc
@@ -15,6 +15,7 @@
  */
 
 #include "egl.h"
+#include "logging/logging.h"
 
 #include <cassert>
 #include <cstring>

--- a/shell/backend/wayland_egl/egl_backing_store.cc
+++ b/shell/backend/wayland_egl/egl_backing_store.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/wayland_egl/egl_backing_store.h"
+#include "logging/logging.h"
 
 #include <GLES2/gl2ext.h>
 

--- a/shell/backend/wayland_egl/gl_caps.cc
+++ b/shell/backend/wayland_egl/gl_caps.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/wayland_egl/gl_caps.h"
+#include "logging/logging.h"
 
 #include <cstring>
 #include <string_view>

--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/wayland_egl/gl_compositor.h"
+#include "logging/logging.h"
 
 #include <array>
 

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -15,6 +15,7 @@
  */
 
 #include "wayland_egl.h"
+#include "logging/logging.h"
 
 #include <wayland-egl.h>
 

--- a/shell/backend/wayland_vulkan/vulkan_backing_store.cc
+++ b/shell/backend/wayland_vulkan/vulkan_backing_store.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/wayland_vulkan/vulkan_backing_store.h"
+#include "logging/logging.h"
 
 #include <unistd.h>
 

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -15,6 +15,7 @@
  */
 
 #include "wayland_vulkan.h"
+#include "logging/logging.h"
 
 #include <asio/post.hpp>
 

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "configuration.h"
+#include "logging/logging.h"
 
 #include <cstdlib>
 #include <filesystem>

--- a/shell/crash_handler.cc
+++ b/shell/crash_handler.cc
@@ -1,4 +1,5 @@
 #include "crash_handler.h"
+#include <filesystem>
 
 #include "utils.h"
 

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -15,6 +15,7 @@
  */
 
 #include "display/drm_display.h"
+#include "logging/logging.h"
 
 #include <cstring>
 #include <utility>

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -18,6 +18,7 @@
 #include <filesystem>
 #include <utility>
 #include <vector>
+#include "logging/logging.h"
 
 #include <dlfcn.h>
 #include <cassert>

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -15,6 +15,7 @@
  */
 
 #include "input/drm_seat.h"
+#include "logging/logging.h"
 
 #include <fcntl.h>
 #include <linux/input-event-codes.h>

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -131,7 +131,7 @@ void InstallBackstop() {
   struct sigaction sa{};
   sa.sa_handler = &BackstopFatalHandler;
   sigemptyset(&sa.sa_mask);
-  sa.sa_flags = SA_RESETHAND;
+  sa.sa_flags = static_cast<int>(SA_RESETHAND);
   for (const int sig : {SIGSEGV, SIGABRT, SIGILL, SIGFPE, SIGBUS}) {
     sigaction(sig, &sa, nullptr);
   }

--- a/shell/platform/homescreen/flutter_desktop.cc
+++ b/shell/platform/homescreen/flutter_desktop.cc
@@ -4,6 +4,7 @@
 
 #include "flutter_desktop_plugin_registrar.h"
 #include "flutter_desktop_texture_registrar.h"
+#include "logging/logging.h"
 
 #include "flutter_homescreen.h"
 

--- a/shell/platform/homescreen/platform_views/platform_views_handler.cc
+++ b/shell/platform/homescreen/platform_views/platform_views_handler.cc
@@ -15,6 +15,7 @@
  */
 
 #include "platform_views_handler.h"
+#include "logging/logging.h"
 
 #include <generated_plugin_registrant.h>
 

--- a/shell/platform/homescreen/text_input_plugin.cc
+++ b/shell/platform/homescreen/text_input_plugin.cc
@@ -6,6 +6,8 @@
 
 #include "flutter/shell/platform/common/json_method_codec.h"
 
+#include "logging/logging.h"
+
 static constexpr char kSetEditingStateMethod[] = "TextInput.setEditingState";
 static constexpr char kClearClientMethod[] = "TextInput.clearClient";
 static constexpr char kSetClientMethod[] = "TextInput.setClient";

--- a/shell/timer.cc
+++ b/shell/timer.cc
@@ -15,6 +15,7 @@
  */
 
 #include "timer.h"
+#include "logging/logging.h"
 
 #include <cerrno>
 #include <cstring>

--- a/shell/view/compositor_surface.cc
+++ b/shell/view/compositor_surface.cc
@@ -1,5 +1,6 @@
 
 #include "compositor_surface.h"
+#include "logging/logging.h"
 
 #include <filesystem>
 

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "flutter_view.h"
+#include <filesystem>
+#include "logging/logging.h"
 
 #include <cassert>
 #include <memory>

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -440,7 +440,8 @@ void FlutterView::Initialize() {
   // size and never schedules a frame. Send it explicitly now that the
   // engine is running.
   {
-    const auto result = m_flutter_engine->SetWindowSize(height, width);
+    const auto result = m_flutter_engine->SetWindowSize(
+        static_cast<size_t>(height), static_cast<size_t>(width));
     spdlog::info("[DrmBackend] SendWindowMetrics {}x{} result={}", width,
                  height, static_cast<int>(result));
   }
@@ -449,7 +450,8 @@ void FlutterView::Initialize() {
   // window-metrics event. Send it explicitly here so the bundle's Dart
   // side gets a non-zero viewport on its first frame.
   {
-    const auto result = m_flutter_engine->SetWindowSize(height, width);
+    const auto result = m_flutter_engine->SetWindowSize(
+        static_cast<size_t>(height), static_cast<size_t>(width));
     spdlog::info("[SoftwareBackend] SendWindowMetrics {}x{} result={}", width,
                  height, static_cast<int>(result));
   }

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include "display.h"
+#include "logging/logging.h"
 
 #include <linux/input-event-codes.h>
 #include <sys/mman.h>

--- a/shell/wayland/window.cc
+++ b/shell/wayland/window.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "window.h"
+#include "logging/logging.h"
 
 #include <utility>
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -83,8 +83,10 @@ foreach (_tgt waypp wayland-gen)
     endif ()
 endforeach ()
 if (TARGET waypp)
+    # Silence waypp's own-source diagnostics (the -Wpsabi std::pair note, and
+    # -Wunused-parameter on EGL stubs when ENABLE_EGL is off) — pristine vendor.
     target_compile_options(waypp PRIVATE
-            $<$<CXX_COMPILER_ID:GNU,Clang>:-Wno-psabi>)
+            $<$<CXX_COMPILER_ID:GNU,Clang>:-w>)
 endif ()
 
 #

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -68,6 +68,25 @@ endif ()
 set(LOGGING_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/shell;${CMAKE_BINARY_DIR})
 add_subdirectory(waypp)
 
+# waypp is a git submodule we keep pristine, so apply the "system library"
+# treatment from here rather than editing it: mark its interface include dirs
+# SYSTEM so its headers are -isystem for consumers, and silence GCC's benign
+# -Wpsabi std::pair ABI note (seat/pointer.h get_xy()) that -isystem does not
+# suppress, emitted while compiling waypp's own sources.
+foreach (_tgt waypp wayland-gen)
+    if (TARGET ${_tgt})
+        get_target_property(_waypp_inc ${_tgt} INTERFACE_INCLUDE_DIRECTORIES)
+        if (_waypp_inc)
+            set_target_properties(${_tgt} PROPERTIES
+                    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_waypp_inc}")
+        endif ()
+    endif ()
+endforeach ()
+if (TARGET waypp)
+    target_compile_options(waypp PRIVATE
+            $<$<CXX_COMPILER_ID:GNU,Clang>:-Wno-psabi>)
+endif ()
+
 #
 # Google Test
 #


### PR DESCRIPTION
## Summary
Fixes the PiOS cross build on an aarch64 host, unblocks the shell on the
GCC 15 toolchain, enables drm-kms-egl on bookworm, clears the build of
warnings, and adds a CI workflow that publishes PiOS artifacts. All fixes
live in the ivi-homescreen repo — the waypp/sdbus-c++/drm-cxx submodules
are left pristine.

## Toolchain / host
- **build_pi.sh**: auto-detect the toolchain build-host arch from `uname -m`
  instead of hardcoding `x86_64`. On an aarch64 host the x86_64 toolchain
  was routed through `qemu-x86_64-static` and failed to find the x86_64
  loader. Adds `--toolchain-host` to override.
- Removed a stale, gitignored leftover `third_party/waypp/include/waypp/
  waypp.h` (had `ENABLE_AGL_SHELL_CLIENT 0`) that shadowed the build-tree
  generated header, hiding `get_agl_shell()`.

## Vendored deps as system libraries (no submodule edits)
- waypp and sdbus-c++ (and drm-cxx for the DRM backend) get SYSTEM interface
  includes plus own-source warning suppression, applied from this repo's
  CMake. Silences their header/own-build warnings (incl. the `-Wpsabi`
  `std::pair` note that `-isystem` doesn't suppress).

## GCC 15 build fixes (shell)
- Added include-what-you-use headers (`logging/logging.h`, `<filesystem>`)
  across shell sources that relied on transitive includes GCC 15's libstdc++
  no longer provides.
- `accessibility_tree.cc` uses `"../utils.h"` so it resolves to
  `shell/utils.h` rather than the plugins' `sdbus/utils.h` on the `-I` path.
- Fixed `-Wsign-conversion` / `-Wmissing-field-initializers` in
  `drm_backend`, `driver_probe`, `drm_seat`, `flutter_view` (static_casts,
  explicit field initializers); clang-tidy + clang-format on touched files.

## drm-kms-egl on bookworm
- **build_pi.sh** `--with-local-display-info`: cross-build a static
  libdisplay-info (>=0.2.0, pinned tag) into the sysroot via meson, so
  drm-cxx builds against distros shipping an older one (bookworm has 0.1.1).
  Static link → no new runtime dependency on the target.
- **shell/CMakeLists.txt**: force EGL/GLESv2 `DT_NEEDED` for drm-kms-egl so
  `--as-needed` can't drop libGLESv2 before platform_homescreen's
  `glDeleteTextures` reference.
- **build_pi.sh**: move `libwayland-dev` + `wayland-protocols` into the
  shared sysroot deps — waypp always needs them, so drm-kms-egl- or
  software-only builds now resolve too.

## CI
- `.github/workflows/pios.yml`: cross-builds aarch64 PiOS artifacts on
  x86_64 runners (a per-PiOS prep job warms toolchain/sysroot/engine cache,
  then a per-backend matrix builds and uploads binaries).

## Test
Cross-built all four backends for **trixie** (wayland-egl, wayland-vulkan,
drm-kms-egl, software) on an aarch64 host: 0 errors, 0 warnings, all produce
aarch64 binaries. **bookworm** compiles end-to-end and libdisplay-info is
confirmed working; its final link requires an x86_64 host (the pinned GCC 12
has no aarch64-hosted build, and aarch64-hosted GCC 14/15 link against
glibc >= 2.38 that bookworm's 2.36 can't satisfy) — hence the x86_64 CI.