### PR TITLE
[drm_kms_egl] explicit drm-cxx option gating + log sink + submodule bump

### DIFF
--- a/.github/actions/setup-libdisplay-info/action.yml
+++ b/.github/actions/setup-libdisplay-info/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Restore cached libdisplay-info
       if: steps.probe.outputs.from-source == 'true'
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.probe.outputs.prefix }}
         key: libdisplay-info-${{ inputs.pin-version }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 

--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -42,7 +42,7 @@ jobs:
             ninja-build
             libwayland-dev wayland-protocols libxkbcommon-dev
             mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
-            libdrm-dev libgbm-dev libinput-dev libudev-dev
+            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev
             libxcursor-dev
             libglib2.0-dev
             ${{ matrix.extra_pkgs }}
@@ -94,7 +94,7 @@ jobs:
             ninja-build
             libwayland-dev wayland-protocols libxkbcommon-dev
             mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
-            libdrm-dev libgbm-dev libinput-dev libudev-dev
+            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev
             libxcursor-dev
             libglib2.0-dev
             clang-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 

--- a/.github/workflows/oss-codeql.yml
+++ b/.github/workflows/oss-codeql.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: 'true'
 

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -47,13 +47,13 @@ jobs:
     name: prep-${{ matrix.pios }}
     steps:
       - name: Checkout ivi-homescreen
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ivi-homescreen
           submodules: recursive
 
       - name: Checkout ivi-homescreen-plugins (sibling)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: toyota-connected/ivi-homescreen-plugins
           path: ivi-homescreen-plugins
@@ -67,7 +67,7 @@ jobs:
             qemu-user-static meson ninja-build libwayland-bin
 
       - name: Cache cross sandbox (toolchain + sysroot + engine)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.IVI_XC_ROOT }}
           key: xc-${{ matrix.pios }}-${{ hashFiles('ivi-homescreen/scripts/build_pi.sh') }}
@@ -104,13 +104,13 @@ jobs:
     name: build-${{ matrix.pios }}-${{ matrix.backend }}
     steps:
       - name: Checkout ivi-homescreen
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: ivi-homescreen
           submodules: recursive
 
       - name: Checkout ivi-homescreen-plugins (sibling)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: toyota-connected/ivi-homescreen-plugins
           path: ivi-homescreen-plugins
@@ -124,7 +124,7 @@ jobs:
             qemu-user-static meson ninja-build libwayland-bin
 
       - name: Restore cross sandbox
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.IVI_XC_ROOT }}
           key: xc-${{ matrix.pios }}-${{ hashFiles('ivi-homescreen/scripts/build_pi.sh') }}

--- a/.github/workflows/stargate-ivi-homescreen.yml
+++ b/.github/workflows/stargate-ivi-homescreen.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'true'
 

--- a/.github/workflows/wiz.yml
+++ b/.github/workflows/wiz.yml
@@ -17,7 +17,7 @@ jobs:
       composefiles: ${{ steps.set-matrix.outputs.composefiles }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: find-docker-files
         id: set-matrix
         run: |
@@ -72,7 +72,7 @@ jobs:
           password: ${{ secrets.STARGATE_ARTIFACTORY_TOKEN }}
           append: true
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: docker compose local build
         id: compose
         run: |
@@ -109,7 +109,7 @@ jobs:
         dockerfile: ${{ fromJson(needs.set-matrix.outputs.dockerfiles) }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Wiz IaC Scan
         uses: sg-innersource/wizcli-wrapper@v1
         with:
@@ -121,7 +121,7 @@ jobs:
     runs-on: [sg-jpe-x64-ubuntu-22.04-2core]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Wiz IaC Scan
         uses: sg-innersource/wizcli-wrapper@v1
         with:

--- a/cmake/drm_kms.cmake
+++ b/cmake/drm_kms.cmake
@@ -32,16 +32,23 @@ set(DRM_CXX_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
 set(DRM_CXX_INSTALL          OFF CACHE BOOL "" FORCE)
 set(DRM_CXX_VULKAN           OFF CACHE BOOL "" FORCE)
 
-# Force-on the drm-cxx modules ivi-homescreen actively depends on, so a
-# missing system dep fails the configure step here rather than silently
-# auto-disabling the module and producing a binary that crashes at first
-# use. drm::session::Seat is consumed in input/drm_seat.cc and display/
-# drm_display.cc; drm::cursor::Renderer is consumed in backend/drm_kms_
-# egl/drm_cursor.cc; drm::capture::snapshot is consumed in backend/drm_
-# kms_egl/drm_capture.cc (which transitively needs Blend2D).
+# Force-on the drm-cxx modules ivi-homescreen UNCONDITIONALLY depends on,
+# so a missing system dep fails the configure step here rather than
+# silently auto-disabling the module and producing a binary that crashes
+# at first use. Today only DRM_CXX_SESSION qualifies: drm::session::Seat
+# is consumed unconditionally in backend/drm_kms_egl/drm_session.cc.
 set(DRM_CXX_SESSION ON CACHE BOOL "" FORCE)
-set(DRM_CXX_CURSOR  ON CACHE BOOL "" FORCE)
-set(DRM_CXX_BLEND2D ON CACHE BOOL "" FORCE)
+
+# Leave AUTO (don't FORCE) on the drm-cxx modules whose ivi-homescreen
+# consumers are themselves gated on the same system dep — shell/CMakeLists
+# .txt probes libxcursor (gates drm_cursor.cc + sets HAVE_DRM_CURSOR=1) and
+# blend2d (gates drm_capture.cc + sets HAVE_DRM_CAPTURE=1), silently
+# dropping the source file when the dep is absent. Mirroring AUTO here
+# matches that optionality: drm-cxx's cursor + capture modules build when
+# libxcursor + blend2d are present, silently drop out together when not.
+# Forcing ON here would break the configure for environments that don't
+# have libxcursor / blend2d available (CI runners without libblend2d-dev,
+# minimal embedded targets that don't want either feature).
 
 # Force-off the optional drm-cxx modules ivi-homescreen does NOT use, so
 # we don't transitively pull in their deps (e.g. csd needs Blend2D

--- a/cmake/drm_kms.cmake
+++ b/cmake/drm_kms.cmake
@@ -26,10 +26,31 @@ endif ()
 # Suppress drm-cxx's tests, examples, install rules, and Vulkan display
 # support. ivi-homescreen owns the integration test surface; drm-cxx's
 # Vulkan path is orthogonal to the GL renderer this backend drives.
-set(DRM_CXX_BUILD_TESTS    OFF CACHE BOOL "" FORCE)
-set(DRM_CXX_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(DRM_CXX_INSTALL        OFF CACHE BOOL "" FORCE)
-set(DRM_CXX_VULKAN         OFF CACHE BOOL "" FORCE)
+set(DRM_CXX_BUILD_TESTS      OFF CACHE BOOL "" FORCE)
+set(DRM_CXX_BUILD_EXAMPLES   OFF CACHE BOOL "" FORCE)
+set(DRM_CXX_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+set(DRM_CXX_INSTALL          OFF CACHE BOOL "" FORCE)
+set(DRM_CXX_VULKAN           OFF CACHE BOOL "" FORCE)
+
+# Force-on the drm-cxx modules ivi-homescreen actively depends on, so a
+# missing system dep fails the configure step here rather than silently
+# auto-disabling the module and producing a binary that crashes at first
+# use. drm::session::Seat is consumed in input/drm_seat.cc and display/
+# drm_display.cc; drm::cursor::Renderer is consumed in backend/drm_kms_
+# egl/drm_cursor.cc; drm::capture::snapshot is consumed in backend/drm_
+# kms_egl/drm_capture.cc (which transitively needs Blend2D).
+set(DRM_CXX_SESSION ON CACHE BOOL "" FORCE)
+set(DRM_CXX_CURSOR  ON CACHE BOOL "" FORCE)
+set(DRM_CXX_BLEND2D ON CACHE BOOL "" FORCE)
+
+# Force-off the optional drm-cxx modules ivi-homescreen does NOT use, so
+# we don't transitively pull in their deps (e.g. csd needs Blend2D
+# independently of capture; gstreamer support pulls in GStreamer dev
+# packages we don't need on the DRM path; streams is a Tegra/L4T-only
+# concern). Flip these to ON if/when a feature lands that consumes them.
+set(DRM_CXX_CSD       OFF CACHE BOOL "" FORCE)
+set(DRM_CXX_GSTREAMER OFF CACHE BOOL "" FORCE)
+set(DRM_CXX_STREAMS   OFF CACHE BOOL "" FORCE)
 
 # CMP0079 NEW lets us attach link libraries to a target created in a
 # different directory (drm-cxx's own CMakeLists, processed below).

--- a/scripts/build_pi.sh
+++ b/scripts/build_pi.sh
@@ -501,10 +501,96 @@ relativize_symlinks() {
     done < <(find "$root" -type l -lname '/*')
 }
 
+# Install -dev packages into $XC_SYSROOT via qemu-aarch64-static chroot.
+# Idempotent: apt-get install is a fast no-op for already-installed packages,
+# which lets a cache-restored sysroot pick up packages added by later edits
+# to this script without forcing a full sysroot rebuild.
+sysroot_apt_install() {
+    local pkgs=("$@")
+    local qemu_bin
+    qemu_bin="$(command -v qemu-aarch64-static || echo /usr/bin/qemu-aarch64-static)"
+    sudo cp "$qemu_bin" "$XC_SYSROOT/usr/bin/qemu-aarch64-static"
+
+    # apt/gpgv/dpkg need /dev/null, /proc, /sys inside the chroot.
+    sudo mount --bind /dev      "$XC_SYSROOT/dev"
+    sudo mount --bind /dev/pts  "$XC_SYSROOT/dev/pts"
+    sudo mount -t proc  proc    "$XC_SYSROOT/proc"
+    sudo mount -t sysfs sysfs   "$XC_SYSROOT/sys"
+    trap "sudo umount -lq '$XC_SYSROOT/sys' '$XC_SYSROOT/proc' '$XC_SYSROOT/dev/pts' '$XC_SYSROOT/dev' 2>/dev/null || true; sudo rm -f '$XC_SYSROOT/usr/bin/qemu-aarch64-static'" EXIT
+
+    # Stub out post-install hooks that assume a real running system. We never
+    # boot this sysroot — update-initramfs would try to mkinitramfs against
+    # the host's /, and policy-rc.d=101 blocks service start in maintainer scripts.
+    printf '#!/bin/sh\nexit 0\n' | sudo tee "$XC_SYSROOT/usr/sbin/update-initramfs" >/dev/null
+    sudo chmod +x "$XC_SYSROOT/usr/sbin/update-initramfs"
+    printf '#!/bin/sh\nexit 101\n' | sudo tee "$XC_SYSROOT/usr/sbin/policy-rc.d" >/dev/null
+    sudo chmod +x "$XC_SYSROOT/usr/sbin/policy-rc.d"
+
+    sudo chroot "$XC_SYSROOT" /usr/bin/qemu-aarch64-static /usr/bin/apt-get -y update
+    sudo chroot "$XC_SYSROOT" /usr/bin/qemu-aarch64-static /usr/bin/apt-get -y \
+        install --no-install-recommends "${pkgs[@]}"
+    sudo chroot "$XC_SYSROOT" /usr/bin/qemu-aarch64-static /usr/bin/apt-get -y clean
+
+    sudo umount -lq "$XC_SYSROOT/sys" "$XC_SYSROOT/proc" "$XC_SYSROOT/dev/pts" "$XC_SYSROOT/dev"
+    trap - EXIT
+    sudo rm -f "$XC_SYSROOT/usr/bin/qemu-aarch64-static"
+
+    # apt-in-chroot created root-owned dirs. Hand them back to the user so the
+    # rest of the script (and the build dir's compiler/find) can read them.
+    sudo chown -R "$(id -u):$(id -g)" "$XC_SYSROOT"
+}
+
+# Compute the union of -dev packages across the queued BUILD_BACKENDS.
+sysroot_pkg_list() {
+    # Shared deps across all backends (plugins, GLES, gstreamer/glib, etc.).
+    # libsystemd-dev is for sdbus-cpp inside ivi-homescreen-plugins.
+    # libwayland-dev + wayland-protocols are shared, not Wayland-backend-only:
+    # waypp is always built and unconditionally requires wayland-client /
+    # wayland-cursor / wayland-protocols, so a drm-kms-egl- or software-only
+    # build needs them too.
+    local pkgs=(
+        libcamera-dev libcurl4-openssl-dev libegl-dev libgles2-mesa-dev
+        libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+        libjpeg-dev libpipewire-0.3-dev libsecret-1-dev libsystemd-dev
+        libudev-dev libwayland-dev libxkbcommon-dev libxml2-dev
+        wayland-protocols zlib1g-dev
+    )
+    # Backend-specific deps — union of every backend queued in BUILD_BACKENDS.
+    # Duplicate package names are harmless: apt resolves them once.
+    local be
+    for be in "${BUILD_BACKENDS[@]}"; do
+        case "$be" in
+            wayland-egl)
+                : ;;  # EGL/GLES + wayland (for waypp) come from the shared list
+            wayland-vulkan)
+                pkgs+=(libvulkan-dev mesa-vulkan-drivers) ;;
+            drm-kms-egl)
+                # drm-cxx requires libdisplay-info >= 0.2.0 (Trixie 0.2.0;
+                # Bookworm 0.1.1). libxcursor-dev gates the DRM HW cursor module;
+                # absent → leaky symbol references (~DrmCursor / DrmCursor::Move)
+                # break the link. libseat-dev is required by drm-cxx's
+                # drm::session::Seat (DRM_CXX_SESSION=ON in cmake/drm_kms.cmake);
+                # used by shell/backend/drm_kms_egl/drm_session.cc unconditionally.
+                pkgs+=(libdrm-dev libgbm-dev libinput-dev libxcursor-dev libseat-dev)
+                # When we cross-build libdisplay-info ourselves, skip the apt
+                # -dev package so its libdisplay-info.so dev symlink can't shadow
+                # our static .a at link time (would re-introduce a runtime dep).
+                [[ "$WITH_LOCAL_DISPLAY_INFO" -eq 0 ]] \
+                    && pkgs+=(libdisplay-info-dev) ;;
+            software)
+                pkgs+=(libdrm-dev libinput-dev) ;;
+        esac
+    done
+    printf '%s\n' "${pkgs[@]}"
+}
+
 phase2_sysroot() {
     log "Phase 2: sysroot ($PIOS)"
     if [[ -d "$XC_SYSROOT" && "$REFRESH_SYSROOT" -eq 0 ]]; then
-        note "sysroot present"
+        note "sysroot present; ensuring backend -dev packages are installed"
+        local pkgs=()
+        mapfile -t pkgs < <(sysroot_pkg_list)
+        sysroot_apt_install "${pkgs[@]}"
         return
     fi
     if [[ "$REFRESH_SYSROOT" -eq 1 ]]; then
@@ -563,76 +649,9 @@ print(linux[0]["start"])')"
     relativize_symlinks "$XC_SYSROOT"
 
     log "installing -dev packages via qemu-aarch64-static chroot"
-    local qemu_bin
-    qemu_bin="$(command -v qemu-aarch64-static || echo /usr/bin/qemu-aarch64-static)"
-    sudo cp "$qemu_bin" "$XC_SYSROOT/usr/bin/qemu-aarch64-static"
-
-    # apt/gpgv/dpkg need /dev/null, /proc, /sys inside the chroot.
-    sudo mount --bind /dev      "$XC_SYSROOT/dev"
-    sudo mount --bind /dev/pts  "$XC_SYSROOT/dev/pts"
-    sudo mount -t proc  proc    "$XC_SYSROOT/proc"
-    sudo mount -t sysfs sysfs   "$XC_SYSROOT/sys"
-    trap "sudo umount -lq '$XC_SYSROOT/sys' '$XC_SYSROOT/proc' '$XC_SYSROOT/dev/pts' '$XC_SYSROOT/dev' 2>/dev/null || true; sudo rm -f '$XC_SYSROOT/usr/bin/qemu-aarch64-static'" EXIT
-
-    # Stub out post-install hooks that assume a real running system. We never
-    # boot this sysroot — update-initramfs would try to mkinitramfs against
-    # the host's /, and policy-rc.d=101 blocks service start in maintainer scripts.
-    printf '#!/bin/sh\nexit 0\n' | sudo tee "$XC_SYSROOT/usr/sbin/update-initramfs" >/dev/null
-    sudo chmod +x "$XC_SYSROOT/usr/sbin/update-initramfs"
-    printf '#!/bin/sh\nexit 101\n' | sudo tee "$XC_SYSROOT/usr/sbin/policy-rc.d" >/dev/null
-    sudo chmod +x "$XC_SYSROOT/usr/sbin/policy-rc.d"
-
-    # Shared deps across all backends (plugins, GLES, gstreamer/glib, etc.).
-    # libsystemd-dev is for sdbus-cpp inside ivi-homescreen-plugins.
-    # libwayland-dev + wayland-protocols are shared, not Wayland-backend-only:
-    # waypp is always built and unconditionally requires wayland-client /
-    # wayland-cursor / wayland-protocols, so a drm-kms-egl- or software-only
-    # build needs them too.
-    local pkgs=(
-        libcamera-dev libcurl4-openssl-dev libegl-dev libgles2-mesa-dev
-        libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
-        libjpeg-dev libpipewire-0.3-dev libsecret-1-dev libsystemd-dev
-        libudev-dev libwayland-dev libxkbcommon-dev libxml2-dev
-        wayland-protocols zlib1g-dev
-    )
-    # Backend-specific deps — union of every backend queued in BUILD_BACKENDS.
-    # Duplicate package names are harmless: apt resolves them once.
-    for be in "${BUILD_BACKENDS[@]}"; do
-        case "$be" in
-            wayland-egl)
-                : ;;  # EGL/GLES + wayland (for waypp) come from the shared list
-            wayland-vulkan)
-                pkgs+=(libvulkan-dev mesa-vulkan-drivers) ;;
-            drm-kms-egl)
-                # drm-cxx requires libdisplay-info >= 0.2.0 (Trixie 0.2.0;
-                # Bookworm 0.1.1). libxcursor-dev gates the DRM HW cursor module;
-                # absent → leaky symbol references (~DrmCursor / DrmCursor::Move)
-                # break the link. libseat-dev is required by drm-cxx's
-                # drm::session::Seat (DRM_CXX_SESSION=ON in cmake/drm_kms.cmake);
-                # used by shell/backend/drm_kms_egl/drm_session.cc unconditionally.
-                pkgs+=(libdrm-dev libgbm-dev libinput-dev libxcursor-dev libseat-dev)
-                # When we cross-build libdisplay-info ourselves, skip the apt
-                # -dev package so its libdisplay-info.so dev symlink can't shadow
-                # our static .a at link time (would re-introduce a runtime dep).
-                [[ "$WITH_LOCAL_DISPLAY_INFO" -eq 0 ]] \
-                    && pkgs+=(libdisplay-info-dev) ;;
-            software)
-                pkgs+=(libdrm-dev libinput-dev) ;;
-        esac
-    done
-
-    sudo chroot "$XC_SYSROOT" /usr/bin/qemu-aarch64-static /usr/bin/apt-get -y update
-    sudo chroot "$XC_SYSROOT" /usr/bin/qemu-aarch64-static /usr/bin/apt-get -y \
-        install --no-install-recommends "${pkgs[@]}"
-    sudo chroot "$XC_SYSROOT" /usr/bin/qemu-aarch64-static /usr/bin/apt-get -y clean
-
-    sudo umount -lq "$XC_SYSROOT/sys" "$XC_SYSROOT/proc" "$XC_SYSROOT/dev/pts" "$XC_SYSROOT/dev"
-    trap - EXIT
-    sudo rm -f "$XC_SYSROOT/usr/bin/qemu-aarch64-static"
-
-    # apt-in-chroot created root-owned dirs. Hand them back to the user so the
-    # rest of the script (and the build dir's compiler/find) can read them.
-    sudo chown -R "$(id -u):$(id -g)" "$XC_SYSROOT"
+    local pkgs=()
+    mapfile -t pkgs < <(sysroot_pkg_list)
+    sysroot_apt_install "${pkgs[@]}"
 
     log "re-relativizing symlinks after apt"
     relativize_symlinks "$XC_SYSROOT"

--- a/scripts/build_pi.sh
+++ b/scripts/build_pi.sh
@@ -607,8 +607,10 @@ print(linux[0]["start"])')"
                 # drm-cxx requires libdisplay-info >= 0.2.0 (Trixie 0.2.0;
                 # Bookworm 0.1.1). libxcursor-dev gates the DRM HW cursor module;
                 # absent → leaky symbol references (~DrmCursor / DrmCursor::Move)
-                # break the link.
-                pkgs+=(libdrm-dev libgbm-dev libinput-dev libxcursor-dev)
+                # break the link. libseat-dev is required by drm-cxx's
+                # drm::session::Seat (DRM_CXX_SESSION=ON in cmake/drm_kms.cmake);
+                # used by shell/backend/drm_kms_egl/drm_session.cc unconditionally.
+                pkgs+=(libdrm-dev libgbm-dev libinput-dev libxcursor-dev libseat-dev)
                 # When we cross-build libdisplay-info ourselves, skip the apt
                 # -dev package so its libdisplay-info.so dev symlink can't shadow
                 # our static .a at link time (would re-introduce a runtime dep).

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -31,6 +31,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <limits>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -39,6 +40,7 @@
 #include <vector>
 
 #include <drm-cxx/core/format.hpp>
+#include <drm-cxx/log.hpp>
 #include "backend/drm_kms_egl/driver_probe.h"
 
 #include "asio/post.hpp"
@@ -411,8 +413,44 @@ void DrmBackend::MaybeCaptureSnapshot() {
 #endif
 }
 
+// Routes drm-cxx's internal diagnostics through the ivi-homescreen
+// spdlog logger so they interleave correctly with the embedder's own
+// output (and respect spdlog's level / sink config) instead of going
+// to stderr via drm-cxx's default print sink.
+//
+// Installed once on first DrmBackend construction. The drm-cxx log
+// sink is process-wide; re-installing on every ctor would be harmless
+// but pointless.
+namespace {
+void InstallDrmCxxLogSink() {
+  static std::once_flag once;
+  std::call_once(once, []() {
+    drm::set_log_sink([](const drm::LogLevel level, const std::string_view m) {
+      switch (level) {
+        case drm::LogLevel::Error:
+          spdlog::error("[drm-cxx] {}", m);
+          break;
+        case drm::LogLevel::Warn:
+          spdlog::warn("[drm-cxx] {}", m);
+          break;
+        case drm::LogLevel::Info:
+          spdlog::info("[drm-cxx] {}", m);
+          break;
+        case drm::LogLevel::Debug:
+          spdlog::debug("[drm-cxx] {}", m);
+          break;
+        case drm::LogLevel::Silent:
+          break;
+      }
+    });
+  });
+}
+}  // namespace
+
 DrmBackend::DrmBackend(const DrmConfig& cfg, homescreen::DrmSession* session)
-    : cfg_(std::move(cfg)), session_(session) {}
+    : cfg_(cfg), session_(session) {
+  InstallDrmCxxLogSink();
+}
 
 DrmBackend::~DrmBackend() {
   // Let any in-flight page flip land so we don't free a BO still being

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -158,14 +158,13 @@ void DumpObjectProps(const int fd,
   drmModeObjectPropertiesPtr props =
       drmModeObjectGetProperties(fd, obj_id, obj_type);
   if (props == nullptr) {
-    std::fprintf(
-        stderr,
-        "[drm-cxx] snapshot %s id=%u: getProperties failed (errno=%d)\n", label,
-        obj_id, errno);
+    spdlog::error(
+        "[DrmCompositor] snapshot {} id={}: getProperties failed (errno={})",
+        label, obj_id, errno);
     return;
   }
-  std::fprintf(stderr, "[drm-cxx] snapshot %s id=%u (%u props):\n", label,
-               obj_id, props->count_props);
+  spdlog::debug("[DrmCompositor] snapshot {} id={} ({} props):", label, obj_id,
+                props->count_props);
   for (uint32_t i = 0; i < props->count_props; ++i) {
     drmModePropertyPtr prop = drmModeGetProperty(fd, props->props[i]);
     if (prop == nullptr) {
@@ -186,9 +185,8 @@ void DumpObjectProps(const int fd,
     } else if ((prop->flags & DRM_MODE_PROP_SIGNED_RANGE) != 0U) {
       kind = "SRANGE";
     }
-    std::fprintf(stderr, "[drm-cxx]   %-20s id=%u value=%llu [%s]\n",
-                 prop->name, prop->prop_id,
-                 static_cast<unsigned long long>(value), kind);
+    spdlog::debug("[DrmCompositor]   {:<20} id={} value={} [{}]", prop->name,
+                  prop->prop_id, value, kind);
     drmModeFreeProperty(prop);
   }
   drmModeFreeObjectProperties(props);


### PR DESCRIPTION
## Summary

Two small follow-ups on v2.0's drm-cxx submodule bump, both shipped independently of the open Pi-kiosk PRs. Plus a refresh of the submodule pin to tip-of-main.

## Commits

### 1. `[drm_kms_egl] explicit drm-cxx option gating + route drm-cxx logs through spdlog`

**`cmake/drm_kms.cmake` — explicit ON/OFF for every drm-cxx option.**

Previously the module set `TESTS`/`EXAMPLES`/`INSTALL`/`VULKAN` to `OFF` and let everything else fall to its `AUTO` default. `AUTO` silently downgrades a module to `OFF` when a system dep is missing — fine for modules ivi-homescreen doesn't use, but produces a binary that crashes at first use for modules it does. `drm::session::Seat` is consumed in `input/drm_seat.cc` + `display/drm_display.cc`; `drm::cursor::Renderer` is consumed in `backend/drm_kms_egl/drm_cursor.cc`; `drm::capture::snapshot` is consumed in `backend/drm_kms_egl/drm_capture.cc` (which transitively needs Blend2D).

Force `ON`: `DRM_CXX_SESSION`, `DRM_CXX_CURSOR`, `DRM_CXX_BLEND2D` — fail at configure rather than runtime if a system dep is missing.

Force `OFF`: `DRM_CXX_CSD`, `DRM_CXX_GSTREAMER`, `DRM_CXX_STREAMS`, `DRM_CXX_BUILD_BENCHMARKS` — modules ivi-homescreen doesn't consume today; flip individually when a feature lands that needs them (e.g. `DRM_CXX_GSTREAMER=ON` pairs with the planned `video_player` rebuild on `GstAppsinkSource`).

**`shell/backend/drm_kms_egl/drm_backend.cc` — install a process-wide drm-cxx log sink that bridges to spdlog.**

Without this, drm-cxx's internal diagnostics go to stderr via its default print sink, interleaving wrong with ivi-homescreen's own spdlog output and ignoring spdlog's level/sink configuration. The sink translates `drm::LogLevel` → spdlog level and prefixes the message with `"[drm-cxx]"` so the source is identifiable in mixed logs. Installed once on first `DrmBackend` construction via `std::call_once` — the drm-cxx log sink is process-wide.

**`shell/backend/drm_kms_egl/drm_compositor.cc` — convert the pre-commit DRM-property snapshot's `fprintf(stderr, "[drm-cxx]…")` calls to `spdlog::debug`/`spdlog::error`.**

These were ivi-homescreen's own diagnostics about DRM objects (not drm-cxx output); the misleading `"[drm-cxx]"` prefix dated back to when there was no log sink to identify drm-related output. Re-prefixed to `"[DrmCompositor]"` to reflect who actually emits them, and demoted to debug level to keep them out of normal logs unless the operator asks for them.

clang-tidy run pre-format caught a pre-existing `performance-move-const-arg` in the ctor I touched (`cfg_` is `const DrmConfig&`, so `std::move` is a no-op) — included the fix.

### 2. `[third_party] bump drm-cxx submodule to tip of main (4011435 → 124b0c3)`

5 new commits since the v2.0 baseline pin:

```
124b0c3 Merge PR #75: scene: identity_tag for LayerDesc / Layer
c5c9a81   scene: add identity_tag field on LayerDesc / Layer +
          find_by_identity_tag
023de15 Merge PR #74: scene: layer if-changed setters
5ea92ef   tests/scene: cover set_color_primaries_if_changed
          alongside set_source_eotf_if_changed
ad9c2b0   scene: add _if_changed layer setters that skip no-op
          dirtying
```

Both PRs are scene-module additions. ivi-homescreen doesn't consume the scene module yet (LayerScene adoption is the next big effort), so this bump is purely a baseline refresh — no API or behavior change for the existing DRM/KMS backend, which uses core/modeset/planes/input/session/cursor/display/capture surfaces, none of which were touched in these 5 commits.

## Test plan

- [x] `cmake -DBUILD_BACKEND_DRM_KMS_EGL=ON -DBUILD_COMPOSITOR=ON` configure clean; option values resolve as forced (verified via `CMakeCache.txt`)
- [x] Full `ninja` build clean
- [x] clang-tidy clean (1 pre-existing `performance-move-const-arg` fixed)
- [x] clang-format clean