### PR TITLE
[drm_kms_egl] add USE_DRM_SCENE option + LayerScene buffer-source wra…

### DIFF
--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -35,6 +35,9 @@
 #ifndef BUILD_BACKEND_DRM_KMS_EGL
 #cmakedefine01 BUILD_BACKEND_DRM_KMS_EGL
 #endif
+#ifndef USE_DRM_SCENE
+#cmakedefine01 USE_DRM_SCENE
+#endif
 #ifndef BUILD_BACKEND_DRM_KMS_VULKAN
 #cmakedefine01 BUILD_BACKEND_DRM_KMS_VULKAN
 #endif

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -102,6 +102,19 @@ option(BUILD_BACKEND_DRM_KMS_EGL
         "Build DRM/KMS EGL backend (mutually exclusive with EGL and Vulkan backends)"
         OFF)
 
+# Drive the non-framed DRM/KMS present path through drm::scene::LayerScene
+# rather than the in-tree PlaneRegistry + Allocator + AtomicRequest pipeline.
+# Off-by-default while the integration is bedding in; flip to ON to exercise
+# LayerScene-managed plane allocation, composition fallback, and session
+# pause/resume forwarding. The framed-mode path is unaffected by this flag.
+option(USE_DRM_SCENE
+        "Drive DRM/KMS non-framed present path via drm::scene::LayerScene"
+        OFF)
+if (USE_DRM_SCENE AND NOT BUILD_BACKEND_DRM_KMS_EGL)
+    message(FATAL_ERROR
+            "USE_DRM_SCENE=ON requires BUILD_BACKEND_DRM_KMS_EGL=ON")
+endif ()
+
 #
 # Headless
 #

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -157,6 +157,18 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
                 backend/wayland_egl/gl_caps.cc
                 backend/wayland_egl/gl_compositor.cc
         )
+        # LayerScene-driven non-framed present path. Sources compile only
+        # when USE_DRM_SCENE=ON; the OFF build keeps the in-tree allocator
+        # path and never references drm::scene symbols. scene_layer_source_vk
+        # is built dormant: it provides the interface for an Impeller-on-Linux
+        # backing-store wrapper that lights up once the Vulkan renderer config
+        # is wired through; nothing references it at runtime today.
+        if (USE_DRM_SCENE)
+            target_sources(${PROJECT_NAME} PRIVATE
+                    backend/drm_kms_egl/scene_layer_source_gl.cc
+                    backend/drm_kms_egl/scene_layer_source_vk.cc
+            )
+        endif ()
     endif ()
     target_link_libraries(${PROJECT_NAME} PRIVATE
             drm-cxx::drm-cxx

--- a/shell/backend/drm_kms_egl/scene_layer_source_gl.cc
+++ b/shell/backend/drm_kms_egl/scene_layer_source_gl.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/drm_kms_egl/scene_layer_source_gl.h"
+
+#include <utility>
+
+#include <drm_fourcc.h>
+#include <gbm.h>
+
+#include "backend/drm_kms_egl/drm_compositor.h"
+
+GbmBackingStoreLayerSource::GbmBackingStoreLayerSource(
+    GbmBackingStore* store,
+    EnsureFbIdFn ensure_fb_id)
+    : store_(store), ensure_fb_id_(std::move(ensure_fb_id)) {}
+
+drm::expected<drm::scene::AcquiredBuffer, std::error_code>
+GbmBackingStoreLayerSource::acquire() {
+  // The active slot is what Flutter most-recently rendered into. The
+  // scene's commit window is short enough that slot rotation (which
+  // happens in DrmCompositor::PresentLayers after commit) cannot move
+  // it under us mid-acquire.
+  if (!ensure_fb_id_(*store_) || store_->active().drm_fb_id == 0) {
+    return drm::unexpected<std::error_code>(
+        std::make_error_code(std::errc::resource_unavailable_try_again));
+  }
+  return drm::scene::AcquiredBuffer{
+      .fb_id = store_->active().drm_fb_id,
+      .opaque = &store_->active(),
+  };
+}
+
+void GbmBackingStoreLayerSource::release(
+    drm::scene::AcquiredBuffer /*acquired*/) noexcept {
+  // BS slot rotation + scanning-slot retirement are managed by
+  // DrmCompositor's in_flight_slots_ / scanning_slots_ pipeline,
+  // driven off PAGE_FLIP_EVENT on the platform task-runner thread.
+  // The wrapper has no per-acquire ownership to release.
+}
+
+drm::scene::BindingModel GbmBackingStoreLayerSource::binding_model()
+    const noexcept {
+  return drm::scene::BindingModel::SceneSubmitsFbId;
+}
+
+drm::scene::SourceFormat GbmBackingStoreLayerSource::format() const noexcept {
+  // Query the live BO's modifier rather than caching at construction —
+  // a pool-recycled store may have a different modifier than the one
+  // we last saw. width/height/format are stable across slots.
+  std::uint64_t mod = DRM_FORMAT_MOD_INVALID;
+  if (auto* bo = store_->active().bo) {
+    mod = gbm_bo_get_modifier(bo);
+  }
+  return drm::scene::SourceFormat{
+      .drm_fourcc = store_->format,
+      .modifier = mod,
+      .width = store_->width,
+      .height = store_->height,
+  };
+}

--- a/shell/backend/drm_kms_egl/scene_layer_source_gl.h
+++ b/shell/backend/drm_kms_egl/scene_layer_source_gl.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <system_error>
+
+#include <drm-cxx/detail/expected.hpp>
+#include <drm-cxx/scene/buffer_source.hpp>
+
+struct GbmBackingStore;
+
+namespace drm {
+class Device;
+}  // namespace drm
+
+// drm::scene::LayerBufferSource adapter over the GbmBackingStore that the
+// DrmCompositor hands to Flutter as a kFlutterBackingStoreTypeOpenGL FBO.
+//
+// The store already owns the GBM BO, EGLImage, GL color texture, and a
+// cached drm_fb_id that's lazily imported by DrmCompositor::EnsureDrmFbId.
+// LayerScene only needs the KMS FB ID + the buffer's format/dimensions to
+// drive direct scanout, so this adapter returns those without re-importing
+// or re-wrapping anything — acquire() returns the cached fb_id (importing
+// on first use via the EnsureFbIdFn callback), release() is a no-op (slot
+// rotation is owned by DrmCompositor across Flutter's Create/Collect
+// cycles), and the wrapper itself only borrows the store.
+//
+// BindingModel is SceneSubmitsFbId — the scene writes the cached fb_id to
+// the plane's FB_ID property directly, no driver-side binding.
+class GbmBackingStoreLayerSource final : public drm::scene::LayerBufferSource {
+ public:
+  // Callback that lazily imports the store's BO as a KMS framebuffer if
+  // not already cached. DrmCompositor::EnsureDrmFbId is the natural impl
+  // (the GL/EGL context it needs lives on the compositor); separating it
+  // out keeps this header free of the EGL/GL machinery and lets the
+  // wrapper be unit-testable against a fake.
+  using EnsureFbIdFn = std::function<bool(GbmBackingStore&)>;
+
+  // The store is borrowed — its lifetime is bounded by Flutter's
+  // Create/Collect cycle and outlives this wrapper, which is held in
+  // DrmCompositor::StoreBaton (released by CollectBackingStore).
+  GbmBackingStoreLayerSource(GbmBackingStore* store, EnsureFbIdFn ensure_fb_id);
+  ~GbmBackingStoreLayerSource() override = default;
+
+  GbmBackingStoreLayerSource(const GbmBackingStoreLayerSource&) = delete;
+  GbmBackingStoreLayerSource& operator=(const GbmBackingStoreLayerSource&) =
+      delete;
+
+  drm::expected<drm::scene::AcquiredBuffer, std::error_code> acquire() override;
+  void release(drm::scene::AcquiredBuffer acquired) noexcept override;
+
+  [[nodiscard]] drm::scene::BindingModel binding_model()
+      const noexcept override;
+  [[nodiscard]] drm::scene::SourceFormat format() const noexcept override;
+
+  // Session pause: drop nothing — DrmBackend's resume rebuilds the fd, and
+  // EnsureDrmFbId re-imports on demand. The cached drm_fb_id will be
+  // invalidated by DrmCompositor::OnResume's slot teardown so the next
+  // acquire() re-imports against the new fd.
+  void on_session_paused() noexcept override {}
+  drm::expected<void, std::error_code> on_session_resumed(
+      const drm::Device& /*new_dev*/) override {
+    return {};
+  }
+
+  // Borrowed pointer accessor for compositor-side bookkeeping (identity
+  // tag lookups, slot pipeline accounting).
+  [[nodiscard]] GbmBackingStore* store() const noexcept { return store_; }
+
+ private:
+  GbmBackingStore* store_;
+  EnsureFbIdFn ensure_fb_id_;
+};

--- a/shell/backend/drm_kms_egl/scene_layer_source_vk.cc
+++ b/shell/backend/drm_kms_egl/scene_layer_source_vk.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/drm_kms_egl/scene_layer_source_vk.h"
+
+#include <utility>
+
+drm::expected<std::unique_ptr<VkBackingStoreLayerSource>, std::error_code>
+VkBackingStoreLayerSource::create(
+    const drm::Device& dev,
+    std::uint32_t width,
+    std::uint32_t height,
+    std::uint32_t drm_fourcc,
+    std::uint64_t modifier,
+    drm::span<const drm::scene::ExternalPlaneInfo> planes) {
+  auto inner = drm::scene::ExternalDmaBufSource::create(
+      dev, width, height, drm_fourcc, modifier, planes);
+  if (!inner) {
+    return drm::unexpected(inner.error());
+  }
+  return std::unique_ptr<VkBackingStoreLayerSource>(
+      new VkBackingStoreLayerSource(std::move(*inner)));
+}

--- a/shell/backend/drm_kms_egl/scene_layer_source_vk.h
+++ b/shell/backend/drm_kms_egl/scene_layer_source_vk.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <system_error>
+
+#include <drm-cxx/detail/expected.hpp>
+#include <drm-cxx/scene/buffer_source.hpp>
+#include <drm-cxx/scene/external_dma_buf_source.hpp>
+
+namespace drm {
+class Device;
+}  // namespace drm
+
+// drm::scene::LayerBufferSource adapter for a Flutter Vulkan backing
+// store (kFlutterBackingStoreTypeVulkan) whose VkImage has already been
+// exported to a DMA-BUF by the renderer-side integration.
+//
+// The Vulkan engine path ships dormant in ivi-homescreen today — there
+// is no live BUILD_BACKEND_DRM_KMS_VULKAN backend yet — but the seam is
+// in place so the eventual Impeller-on-Linux integration is a renderer-
+// config flip plus a CreateBackingStore switch arm, not an architectural
+// change.
+//
+// The VkImage→dmabuf export (vkGetMemoryFdKHR via VK_KHR_external_memory_fd,
+// plus a VkExternalMemoryImageCreateInfo on image creation) lives in the
+// caller — this wrapper takes the already-exported (fd, format, modifier,
+// plane layout) tuple. That keeps the wrapper free of Vulkan headers and
+// keeps USE_DRM_SCENE off the BUILD_BACKEND_VULKAN dependency graph.
+//
+// Per the Flutter embedder contract (embedder.h:1780-1783), the engine
+// has already host-synced the VkImage before invoking present_layers,
+// so no per-frame fence import is needed. The wrapper caches one
+// ExternalDmaBufSource per VkImage; on first sight the caller constructs
+// the wrapper with the dmabuf fd (one per VkImage; the wrapper dups it
+// internally via ExternalDmaBufSource), on subsequent frames the same
+// wrapper is reused for the same VkImage.
+class VkBackingStoreLayerSource final : public drm::scene::LayerBufferSource {
+ public:
+  // Construct over a caller-exported dmabuf. The wrapper builds an
+  // ExternalDmaBufSource that owns the duped fd and the resulting KMS
+  // framebuffer.
+  //
+  // The 1..4-plane / LINEAR-or-INVALID modifier restriction is inherited
+  // from ExternalDmaBufSource — see its header for the validation
+  // contract. Tiled modifiers (X_TILED, AFBC, etc.) are out of scope and
+  // would require explicit driver-side negotiation per renderer.
+  [[nodiscard]] static drm::expected<std::unique_ptr<VkBackingStoreLayerSource>,
+                                     std::error_code>
+  create(const drm::Device& dev,
+         std::uint32_t width,
+         std::uint32_t height,
+         std::uint32_t drm_fourcc,
+         std::uint64_t modifier,
+         drm::span<const drm::scene::ExternalPlaneInfo> planes);
+
+  ~VkBackingStoreLayerSource() override = default;
+
+  VkBackingStoreLayerSource(const VkBackingStoreLayerSource&) = delete;
+  VkBackingStoreLayerSource& operator=(const VkBackingStoreLayerSource&) =
+      delete;
+
+  // ── LayerBufferSource — forwarded to inner ExternalDmaBufSource. ────
+  [[nodiscard]] drm::expected<drm::scene::AcquiredBuffer, std::error_code>
+  acquire() override {
+    return inner_->acquire();
+  }
+  void release(drm::scene::AcquiredBuffer acquired) noexcept override {
+    inner_->release(acquired);
+  }
+  [[nodiscard]] drm::scene::BindingModel binding_model()
+      const noexcept override {
+    return inner_->binding_model();
+  }
+  [[nodiscard]] drm::scene::SourceFormat format() const noexcept override {
+    return inner_->format();
+  }
+  void on_session_paused() noexcept override { inner_->on_session_paused(); }
+  drm::expected<void, std::error_code> on_session_resumed(
+      const drm::Device& new_dev) override {
+    return inner_->on_session_resumed(new_dev);
+  }
+
+ private:
+  explicit VkBackingStoreLayerSource(
+      std::unique_ptr<drm::scene::ExternalDmaBufSource> inner)
+      : inner_(std::move(inner)) {}
+
+  std::unique_ptr<drm::scene::ExternalDmaBufSource> inner_;
+};


### PR DESCRIPTION
## Summary

Off-by-default cmake option `USE_DRM_SCENE` plus two new
`drm::scene::LayerBufferSource` adapters for the Flutter backing-store
types the DRM/KMS backend hands out. No call sites yet — `DrmCompositor`
is unchanged and the `USE_DRM_SCENE=OFF` build is byte-for-byte
equivalent to `v2.0`.

- **`cmake/options.cmake`** — new `USE_DRM_SCENE` option, defaults
  `OFF`. Configure rejects `USE_DRM_SCENE=ON` without
  `BUILD_BACKEND_DRM_KMS_EGL=ON` so the flag can't silently no-op on
  a misconfigured build.
- **`cmake/config_common.h.in`** — propagates `USE_DRM_SCENE` as a 0/1
  macro under the same `#ifndef` guard pattern as the
  `BUILD_BACKEND_*` flags.
- **`shell/CMakeLists.txt`** — `scene_layer_source_gl.cc` and
  `scene_layer_source_vk.cc` compile only when `USE_DRM_SCENE=ON`. The
  `OFF` backend stays free of `drm::scene` symbols and headers.
- **`shell/backend/drm_kms_egl/scene_layer_source_gl.{h,cc}`** —
  `GbmBackingStoreLayerSource`: `drm::scene::LayerBufferSource`
  adapter over the `GbmBackingStore` that `DrmCompositor` hands to
  Flutter as a `kFlutterBackingStoreTypeOpenGL` FBO. `acquire()`
  returns the store's cached `drm_fb_id` (importing on first sight via
  an injected `EnsureFbIdFn` callback so the wrapper stays free of the
  EGL/GL machinery `DrmCompositor::EnsureDrmFbId` holds);
  `release()` is a no-op because slot rotation is owned by
  `DrmCompositor`'s `in_flight_slots_` pipeline. `BindingModel` is
  `SceneSubmitsFbId` — the scene writes the cached `fb_id` to the
  plane's `FB_ID` property directly, no driver-side binding.
  `on_session_paused()` is also a no-op; `DrmCompositor::OnResume`'s
  slot teardown invalidates the cached `drm_fb_id` so the next
  `acquire()` re-imports against the new fd.
- **`shell/backend/drm_kms_egl/scene_layer_source_vk.{h,cc}`** —
  `VkBackingStoreLayerSource`: dormant adapter for a Flutter Vulkan
  backing store (`kFlutterBackingStoreTypeVulkan`) whose `VkImage` has
  already been exported to a DMA-BUF by the renderer-side
  integration. Implemented as a thin forwarder over
  `drm::scene::ExternalDmaBufSource`. Ships inactive — there is no
  live DRM Vulkan backend yet — but the seam exists so the eventual
  Impeller-on-Linux integration is a renderer-config flip plus a
  `CreateBackingStore` `switch` arm, not an architectural change. The
  `VK_KHR_external_memory_fd` export lives in the caller (future
  Impeller code), not in this wrapper, so the adapter and
  `USE_DRM_SCENE` stay free of a Vulkan build dep.

## Out of scope (in this PR)

Tracked separately — these are the commits that turn the spike from
"carves a seam" into "uses it":

- **Wire `CreateBackingStore` / `CollectBackingStore`** under
  `USE_DRM_SCENE` to construct/release the `GbmBackingStoreLayerSource`
  per backing store and stash it in `StoreBaton`.
- **Construct + own a `drm::scene::LayerScene`** on
  `DrmCompositor`. Initialize in `InitPlaneAllocator` from
  `backend_->device()` + `crtc_id` + `connector_id` + `mode`.
- **Replace the non-framed `PresentLayers` body** (the
  `framed_=false` branch). Per `FlutterLayer`,
  `LayerScene::find_by_identity_tag(baton)` lookup + `add_layer` on
  miss; `set_dst_rect_if_changed` on hit; `scene_->commit(...)` in
  place of the manual `AtomicRequest`. Inspect `CommitReport.placements` —
  if any backing-store layer is `Composited`, fall through to
  `PresentViaGlFallback` for that frame (the GL composite path is
  materially faster than `CompositeCanvas`'s CPU-readback over uncached
  GBM memory). Framed-mode path stays unchanged.
- **Drop superseded members under `USE_DRM_SCENE`**:
  `plane_registry_`, `allocator_`, `comp_layer_`, `modeset_`,
  `plane_mode_set_`, `primary_zpos_`. `framed_props_` stays.
- **Forward `DrmSession` pause/resume** to
  `scene_->on_session_paused()` / `scene_->on_session_resumed(...)`.
  `DrmSession::TakeDevice` already sets
  `preserve_fd_across_resume = true` so the resume fd matches the
  paused fd in the common case.
- **Re-emit per-frame logging via `CommitReport` fields** rather than
  the manual counters today.
- **Verify the build matrix** (`USE_DRM_SCENE` off + on) and smoke
  against `test/drm_kms_vkms.sh`.

## Drm-cxx submodule notes

Spike was developed against the current `third_party/drm-cxx` pin
`124b0c3` (current `main` after the `v2.0` PR #198 bump). Two recent
drm-cxx additions shape the follow-on `PresentLayers` rewrite:

- **`LayerDesc::identity_tag` + `LayerScene::find_by_identity_tag`**
  (PR #75, commit `c5c9a81`) — opaque `void*` caller-side handle on
  a layer; never dereferenced by the scene. The follow-on rewrite
  sets it to the `StoreBaton*` for backing-store layers and to the
  platform-view identifier for platform-view layers, and uses
  `find_by_identity_tag(tag)` in the per-frame loop. No parallel
  `flat_hash_map<BackingStore*, LayerHandle>` is needed
  embedder-side — the scene already owns the live-layer list.
- **`Layer::set_*_if_changed` setters** (PR #74, commits `ad9c2b0` +
  `5ea92ef`) — conditional setters that compare against the layer's
  current `DisplayParams` field and only mark dirty when the value
  changed. Steady-state `set_dst_rect_if_changed` calls elide the
  per-property dirty-mark when Flutter's layer geometry didn't
  change between frames, so the commit degrades to a pure page-flip.

## Verification

This PR is scaffolding-only — no behavioral change to test. Verifies:

- [x] `USE_DRM_SCENE=OFF` (default) — DRM backend builds clean under
      clang-19 + gcc-14 with no new symbols / no new linker deps;
      identical to `v2.0`.
- [x] `USE_DRM_SCENE=ON` — DRM backend builds clean; both new wrapper
      TUs compile cleanly against drm-cxx tip; no unresolved
      references; no warnings; clang-tidy + clang-format clean.
- [x] `USE_DRM_SCENE=ON` + `BUILD_BACKEND_DRM_KMS_EGL=OFF` — configure
      rejects with a clear `FATAL_ERROR` message.

The runtime smoke tests (`compositor_integration.sh` and
`drm_kms_vkms.sh` with `USE_DRM_SCENE=ON` on i915 / amdgpu / vkms)
land with the follow-on PR that wires the wrappers into the present
path. There is nothing to smoke-test in this PR yet — the wrappers
exist but are never instantiated.
