### PR TITLE
[drm_kms_egl] wire LayerScene through the non-framed DrmCompositor present path

### DIFF
--- a/scripts/build_pi.sh
+++ b/scripts/build_pi.sh
@@ -39,6 +39,11 @@
 #                                   (engine is dlopen'd at runtime — not linked at build)
 #     --plugins-dir <path>          default: ../ivi-homescreen-plugins/plugins
 #     --no-plugins                  build homescreen only
+#     --with-scene                  drm-kms-egl only: enable the plane
+#                                   compositor + drm-cxx LayerScene present
+#                                   path (BUILD_COMPOSITOR + USE_DRM_SCENE).
+#                                   Default off = direct DRM/KMS + GBM, no
+#                                   compositor.
 #     --jobs <N>                    default: nproc
 #     --clean                       wipe build dir before configure
 #     --prepare-only                fetch/extract toolchain, sysroot, engine, then exit
@@ -146,6 +151,7 @@ ENGINE_URL=""
 # actual CMake entry; the repo root has no CMakeLists.txt.
 PLUGINS_DIR="${REPO_DIR%/*}/ivi-homescreen-plugins/plugins"
 NO_PLUGINS=0
+WITH_SCENE=0
 JOBS="$(nproc 2>/dev/null || echo 4)"
 CLEAN=0
 PREPARE_ONLY=0
@@ -236,6 +242,7 @@ while [[ $# -gt 0 ]]; do
         --engine-url)         ENGINE_URL="$2"; shift 2 ;;
         --plugins-dir)        PLUGINS_DIR="$2"; shift 2 ;;
         --no-plugins)         NO_PLUGINS=1; shift ;;
+        --with-scene)         WITH_SCENE=1; shift ;;
         --jobs)               JOBS="$2"; shift 2 ;;
         --clean)              CLEAN=1; shift ;;
         --prepare-only)       PREPARE_ONLY=1; shift ;;
@@ -922,7 +929,13 @@ phase4_build() {
                 -DBUILD_BACKEND_WAYLAND_EGL=OFF
                 -DBUILD_BACKEND_WAYLAND_VULKAN=OFF
                 -DBUILD_BACKEND_DRM_KMS_EGL=ON
-                -DBUILD_BACKEND_SOFTWARE=OFF) ;;
+                -DBUILD_BACKEND_SOFTWARE=OFF)
+            # --with-scene lights up the plane compositor + drm-cxx LayerScene
+            # present path (direct-scanout with GL fallback) instead of the
+            # default direct DRM/KMS + GBM path. Only meaningful for drm-kms-egl.
+            if [[ "$WITH_SCENE" -eq 1 ]]; then
+                cmake_args+=(-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON)
+            fi ;;
         software)
             cmake_args+=(
                 -DBUILD_BACKEND_WAYLAND_EGL=OFF

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -1426,7 +1426,17 @@ void DrmBackend::UnifiedPageFlipHandler(int /*fd*/,
     spdlog::info("[DrmBackend] flip #{} handled (asio monitor)", n);
   }
 #if BUILD_COMPOSITOR
-  if (self->compositor_ && self->compositor_->planes_active()) {
+  // Dispatch the completion to whichever subsystem ARMED this flip, identified
+  // by its pending flag — NOT by planes_active(). planes_active() reflects who
+  // owns scanout in steady state, but when the compositor is active and a frame
+  // falls back to backend_->Present()'s legacy page flip (e.g. a backing-store
+  // layer needs composition), the completion must clear
+  // DrmBackend::flip_pending_. Routing by planes_active() cleared the
+  // compositor's (unset) flag instead, leaving DrmBackend::flip_pending_ stuck
+  // and deadlocking the next WaitForPendingFlip(). At most one flip is in
+  // flight per CRTC, so at most one flag is set; the compositor's pending flag
+  // therefore identifies its own flips.
+  if (self->compositor_ && self->compositor_->IsFlipPending()) {
     self->compositor_->OnFlipComplete();
   } else {
     self->OnLegacyFlipComplete();

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -20,6 +20,7 @@
 #include <poll.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
 #include <chrono>
@@ -39,6 +40,9 @@
 
 #include "backend/drm_kms_egl/driver_probe.h"
 #include "backend/drm_kms_egl/drm_backend.h"
+#if USE_DRM_SCENE
+#include "backend/drm_kms_egl/scene_layer_source_gl.h"
+#endif
 #include "drm-cxx/src/modeset/atomic.hpp"
 #include "libflutter_engine.h"
 #include "logging.h"
@@ -409,6 +413,32 @@ bool DrmCompositor::InitPlaneAllocator() {
         "[DrmCompositor] framed-mode init failed; plane path disabled");
     return false;
   }
+
+#if USE_DRM_SCENE
+  // Construct the LayerScene that drives the non-framed present path
+  // (framed mode keeps its dedicated manual primary-BG + overlay layout
+  // — LayerScene's allocator can't produce that shape on the drivers
+  // that need it). Both paths coexist; the per-frame branch in
+  // PresentLayers picks one based on framed_.
+  if (!framed_) {
+    drm::scene::LayerScene::Config scene_cfg{};
+    scene_cfg.crtc_id = backend_->crtc_id();
+    scene_cfg.connector_id = backend_->connector_id();
+    scene_cfg.mode = backend_->mode();
+    auto scene = drm::scene::LayerScene::create(
+        const_cast<drm::Device&>(backend_->device()), scene_cfg);
+    if (!scene) {
+      spdlog::error("[DrmCompositor] LayerScene::create: {}",
+                    scene.error().message());
+      return false;
+    }
+    scene_ = std::move(*scene);
+    spdlog::info(
+        "[DrmCompositor] LayerScene constructed (crtc={} connector={})",
+        scene_cfg.crtc_id, scene_cfg.connector_id);
+  }
+#endif
+
   return true;
 }
 
@@ -1541,6 +1571,20 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
     return PresentFramed(layers, layer_count);
   }
 
+#if USE_DRM_SCENE
+  // Non-framed path under USE_DRM_SCENE: route every frame through
+  // LayerScene. PresentLayersViaScene owns the fallback decision —
+  // returns true on a successful scene commit, false (after invoking
+  // PresentViaGlFallback itself) when any layer would be Composited
+  // (BS overflow), when the frame contains a platform view (not yet
+  // wired into the scene path), or on commit failure that latches
+  // fallback for the rest of the session. Also returns false on a
+  // skip-frame condition (EACCES / pause race).
+  if (scene_) {
+    return PresentLayersViaScene(layers, layer_count);
+  }
+#endif
+
   // Profile fence post t0 (entry). Same wait/compose/commit/total
   // breakdown as PresentFramed; logs every kProfileWindow frames when
   // IVI_DRM_PROFILE=1.
@@ -2107,6 +2151,299 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
   return true;
 }
 
+#if USE_DRM_SCENE
+// ─── LayerScene-driven non-framed present path ───────────────────────────
+
+bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
+                                          const size_t layer_count) {
+  // Pause / fallback-latched / framed gates have already fired in
+  // PresentLayers before dispatching here. Profile fences mirror the
+  // legacy non-framed path so IVI_DRM_PROFILE output stays comparable.
+  const bool profile = ProfileEnabled();
+  const uint64_t t0 = profile ? NsNow() : 0;
+
+  if (!WaitForPendingFlip()) {
+    return PresentViaGlFallback(layers, layer_count);
+  }
+  const uint64_t t1 = profile ? NsNow() : 0;
+
+  // Pre-scan: any platform-view layer forces the whole frame through
+  // the GL composite path. Platform-view→LayerBufferSource plumbing
+  // (Tier-2 wrappers over ExternalDmaBufSource / GstAppsinkSource) is
+  // not wired in this revision; routing PVs through GL keeps the
+  // current visual behaviour intact while BS layers benefit from the
+  // scene allocator.
+  for (size_t i = 0; i < layer_count; ++i) {
+    const FlutterLayer* fl = layers[i];
+    if (fl && fl->type == kFlutterLayerContentTypePlatformView) {
+      return PresentViaGlFallback(layers, layer_count);
+    }
+  }
+
+  // Walk the FlutterLayer[] in z-order (Flutter's convention: layer 0
+  // is bottom). Sync scene_'s layer set against the current frame's
+  // batons: add new, update dst_rect on existing, remove any scene
+  // layer whose baton didn't appear this frame.
+  struct FrameLayer {
+    const FlutterLayer* flutter;
+    GbmBackingStore* store;
+    StoreBaton* baton;
+  };
+  std::vector<FrameLayer> frame_layers;
+  frame_layers.reserve(layer_count);
+
+  // Track this frame's batons for the stale-layer prune below. Linear
+  // scan; engaged layer count is single-digit in practice.
+  std::vector<StoreBaton*> frame_batons;
+  frame_batons.reserve(layer_count);
+
+  for (size_t i = 0; i < layer_count; ++i) {
+    const FlutterLayer* fl = layers[i];
+    if (!fl || fl->type != kFlutterLayerContentTypeBackingStore ||
+        !fl->backing_store) {
+      continue;
+    }
+    auto* baton = static_cast<StoreBaton*>(fl->backing_store->user_data);
+    if (!baton || !baton->store) {
+      continue;
+    }
+    frame_layers.push_back({fl, baton->store, baton});
+    frame_batons.push_back(baton);
+  }
+
+  // Prune scene layers whose batons are not in this frame's set. The
+  // scene retains layers across commits; without this step, a layer
+  // for a backing store Flutter dropped from its layer tree (without
+  // collecting it yet) would still be acquired by the next commit
+  // with stale dst_rect.
+  for (auto it = scene_layer_batons_.begin();
+       it != scene_layer_batons_.end();) {
+    StoreBaton* baton = *it;
+    const bool still_present =
+        std::find(frame_batons.begin(), frame_batons.end(), baton) !=
+        frame_batons.end();
+    if (!still_present) {
+      if (auto* layer = scene_->find_by_identity_tag(baton)) {
+        scene_->remove_layer(layer->handle());
+      }
+      it = scene_layer_batons_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  // Add new layers; update dst_rect on existing ones. dst_rect is in
+  // CRTC coordinates; the non-framed path has no letterbox so
+  // FlutterLayer.offset is already CRTC-relative.
+  for (auto& fl : frame_layers) {
+    drm::scene::Rect dst_rect{
+        static_cast<int32_t>(fl.flutter->offset.x),
+        static_cast<int32_t>(fl.flutter->offset.y),
+        static_cast<uint32_t>(fl.flutter->size.width),
+        static_cast<uint32_t>(fl.flutter->size.height),
+    };
+    auto* layer = scene_->find_by_identity_tag(fl.baton);
+    if (layer) {
+      layer->set_dst_rect_if_changed(dst_rect);
+      continue;
+    }
+    // First sight: hand the scene_source wrapper to the scene.
+    // CreateBackingStore pre-built it; nullptr would only happen if
+    // the store predated the scene_ construction, which can't happen
+    // on the non-framed path (scene_ is built before any Present).
+    if (!fl.baton->scene_source) {
+      spdlog::warn(
+          "[DrmCompositor] LayerScene: baton lacks scene_source; routing "
+          "frame through GL fallback");
+      return PresentViaGlFallback(layers, layer_count);
+    }
+    drm::scene::LayerDesc desc{};
+    desc.source = std::move(fl.baton->scene_source);
+    desc.display.dst_rect = dst_rect;
+    desc.display.rotation = DRM_MODE_ROTATE_0 | DRM_MODE_REFLECT_Y;
+    desc.content_type = (&fl == &frame_layers.front())
+                            ? drm::planes::ContentType::UI
+                            : drm::planes::ContentType::Generic;
+    desc.identity_tag = fl.baton;
+    auto handle = scene_->add_layer(std::move(desc));
+    if (!handle) {
+      spdlog::warn("[DrmCompositor] LayerScene::add_layer: {}",
+                   handle.error().message());
+      return PresentViaGlFallback(layers, layer_count);
+    }
+    scene_layer_batons_.push_back(fl.baton);
+  }
+
+  // TEST_ONLY probe: if any layer would land in the composition
+  // bucket, route the frame through PresentViaGlFallback. The GL
+  // composite path is materially faster than drm-cxx's CompositeCanvas
+  // over uncached GBM read-back for backing-store layers, and PVs
+  // already short-circuited above.
+  auto test = scene_->test();
+  if (!test) {
+    if (test.error() == std::errc::permission_denied) {
+      if (!paused_.load(std::memory_order_acquire)) {
+        spdlog::warn(
+            "[DrmCompositor] LayerScene::test: master revoked (EACCES); "
+            "skip frame");
+      }
+      return false;
+    }
+    spdlog::warn("[DrmCompositor] LayerScene::test: {}; routing through GL",
+                 test.error().message());
+    return PresentViaGlFallback(layers, layer_count);
+  }
+  for (const auto& p : test->placements) {
+    if (p.placement == drm::scene::LayerPlacement::Composited ||
+        p.placement == drm::scene::LayerPlacement::Unassigned) {
+      if (backend_->cfg_.debug_backend) {
+        spdlog::debug(
+            "[DrmCompositor] LayerScene test: layer {} {}; routing through "
+            "GL fallback",
+            p.handle.id,
+            p.placement == drm::scene::LayerPlacement::Composited
+                ? "composited"
+                : "unassigned");
+      }
+      return PresentViaGlFallback(layers, layer_count);
+    }
+  }
+
+  // All BS layers placed on planes. Sync GPU writes before scanout —
+  // the legacy direct-scanout path uses IN_FENCE_FD when the EGL
+  // native-fence-sync extension is present; the scene path falls back
+  // to a synchronous drain for now. Correctness-equivalent at the
+  // cost of one per-frame stall on Tegra; LayerBufferSource sync
+  // hooks are a follow-on.
+  glFinish();
+
+  if (backend_->cfg_.debug_backend) {
+    backend_->flip_submit_ns_ = LibFlutterEngine->GetCurrentTime();
+  }
+
+  const uint32_t commit_flags =
+      DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
+  const uint64_t t2 = profile ? NsNow() : 0;
+
+  // LayerScene injects ALLOW_MODESET implicitly on its first commit,
+  // so the embedder doesn't manage plane_mode_set_ for this path.
+  const bool was_first_commit_pre = !plane_mode_set_;
+
+  auto report = scene_->commit(commit_flags, backend_);
+  if (!report) {
+    if (report.error() == std::errc::permission_denied) {
+      if (!paused_.load(std::memory_order_acquire)) {
+        spdlog::warn(
+            "[DrmCompositor] LayerScene::commit: master revoked (EACCES); "
+            "skip frame");
+      }
+      return false;
+    }
+    spdlog::warn(
+        "[DrmCompositor] LayerScene::commit failed ({}); latching GL "
+        "fallback for remaining session",
+        report.error().message());
+    fallback_latched_ = true;
+    return PresentViaGlFallback(layers, layer_count);
+  }
+
+  if (was_first_commit_pre) {
+    // First commit landed; LayerScene's implicit ALLOW_MODESET cycle
+    // is blocking, so no PAGE_FLIP_EVENT is in flight. Latch + verify
+    // + kick the initial vsync baton, same as the legacy path.
+    plane_mode_set_ = true;
+    flip_pending_.store(false, std::memory_order_release);
+    VerifyPipeRunning();
+    const intptr_t baton =
+        backend_->vsync_baton_.exchange(0, std::memory_order_acq_rel);
+    if (baton != 0) {
+      if (auto engine =
+              backend_->engine_handle_.load(std::memory_order_acquire)) {
+        backend_->PostOnVsync(engine, baton);
+      }
+    }
+  } else {
+    flip_pending_.store(true, std::memory_order_release);
+  }
+
+  // Rotate every BS pool that participated. Same slot-pipeline
+  // bookkeeping as the legacy path — the scene path does not touch
+  // these data structures, so the existing in_flight_slots_ /
+  // scanning_slots_ release semantics still apply.
+  bool any_rotated = false;
+  std::vector<SlotRef> committed_this_frame;
+  for (const auto& fl : frame_layers) {
+    if (!fl.store || fl.store->pool_size <= 1) {
+      continue;
+    }
+    auto& store = *fl.store;
+    const size_t committed_idx = store.active_idx;
+    store.pool[committed_idx].state = GbmBackingStore::Slot::State::Pending;
+    committed_this_frame.push_back({&store, committed_idx});
+    store.active_idx = (store.active_idx + 1) % store.pool_size;
+    store.pool[store.active_idx].state = GbmBackingStore::Slot::State::Active;
+    glBindFramebuffer(GL_FRAMEBUFFER, store.fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           store.active().color_tex, 0);
+    any_rotated = true;
+  }
+  if (any_rotated) {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  }
+  if (!committed_this_frame.empty()) {
+    std::lock_guard<std::mutex> lock(slot_pipeline_mu_);
+    if (was_first_commit_pre) {
+      for (auto& ref : scanning_slots_) {
+        ref.store->pool[ref.slot_idx].state =
+            GbmBackingStore::Slot::State::Free;
+      }
+      scanning_slots_ = std::move(committed_this_frame);
+    } else {
+      in_flight_slots_.push_back(std::move(committed_this_frame));
+    }
+  }
+
+  if (backend_->cfg_.debug_backend) {
+    spdlog::debug(
+        "[DrmCompositor] LayerScene commit: total={} assigned={} "
+        "composited={} unassigned={} skipped={} props_written={} "
+        "fbs_attached={}",
+        report->layers_total, report->layers_assigned,
+        report->layers_composited, report->layers_unassigned,
+        report->layers_skipped_no_frame, report->properties_written,
+        report->fbs_attached);
+  }
+
+  if (profile && profile_) {
+    const uint64_t t3 = NsNow();
+    const uint64_t wait_ns = t1 - t0;
+    const uint64_t compose_ns = t2 - t1;
+    const uint64_t commit_ns = t3 - t2;
+    const uint64_t total_ns = t3 - t0;
+    profile_->p.account(wait_ns, compose_ns, /*test=*/0, commit_ns, total_ns);
+    if (profile_->p.frames >= kProfileWindow) {
+      const auto& s = profile_->p;
+      const auto ms = [&](uint64_t ns_sum) {
+        return static_cast<double>(ns_sum) /
+               (static_cast<double>(s.frames) * 1e6);
+      };
+      const auto ms_max = [](uint64_t ns) {
+        return static_cast<double>(ns) / 1e6;
+      };
+      spdlog::info(
+          "[DrmCompositor] scene profile (n={}): wait={:.2f}ms (max {:.2f})  "
+          "compose={:.2f}ms (max {:.2f})  commit={:.2f}ms (max {:.2f})  "
+          "total={:.2f}ms (max {:.2f})",
+          s.frames, ms(s.wait_sum_ns), ms_max(s.wait_max_ns),
+          ms(s.compose_sum_ns), ms_max(s.compose_max_ns), ms(s.commit_sum_ns),
+          ms_max(s.commit_max_ns), ms(s.total_sum_ns), ms_max(s.total_max_ns));
+      profile_->p.reset();
+    }
+  }
+  return true;
+}
+#endif  // USE_DRM_SCENE
+
 // ─── Backing store create / collect ──────────────────────────────────────
 
 bool DrmCompositor::CreateBackingStore(const FlutterBackingStoreConfig* config,
@@ -2155,7 +2492,20 @@ bool DrmCompositor::CreateBackingStore(const FlutterBackingStoreConfig* config,
     ++store_pool_misses_;
   }
 
-  auto* baton = new StoreBaton{this, store.get()};
+  auto* baton = new StoreBaton{};
+  baton->owner = this;
+  baton->store = store.get();
+#if USE_DRM_SCENE
+  // Pre-build the LayerBufferSource wrapper for the LayerScene path.
+  // It stays in the baton until the first PresentLayers under
+  // USE_DRM_SCENE moves it into scene_->add_layer(). If the store
+  // retires (CollectBackingStore) before any Present, the wrapper is
+  // freed with the baton.
+  if (scene_) {
+    baton->scene_source = std::make_unique<GbmBackingStoreLayerSource>(
+        store.get(), [this](GbmBackingStore& s) { return EnsureDrmFbId(s); });
+  }
+#endif
 
   out->struct_size = sizeof(FlutterBackingStore);
   out->type = kFlutterBackingStoreTypeOpenGL;
@@ -2188,6 +2538,17 @@ bool DrmCompositor::CollectBackingStore(const FlutterBackingStore* store) {
   if (!baton) {
     return false;
   }
+#if USE_DRM_SCENE
+  // If the store appeared in a Present this generation, the LayerScene
+  // owns a Layer with identity_tag == baton. Drop it before the baton
+  // disappears so the scene doesn't leave a stale layer referring to
+  // memory we're about to free.
+  if (scene_) {
+    if (auto* layer = scene_->find_by_identity_tag(baton)) {
+      scene_->remove_layer(layer->handle());
+    }
+  }
+#endif
   if (const auto it = stores_.find(baton); it != stores_.end()) {
     // Return the store to the pool instead of destroying it. Keeps the
     // GBM BO + EGLImage + GL FBO/tex/RB and (if already imported) the
@@ -2209,6 +2570,15 @@ bool DrmCompositor::CollectBackingStore(const FlutterBackingStore* store) {
 
 void DrmCompositor::SetPaused(const bool paused) {
   paused_.store(paused, std::memory_order_release);
+#if USE_DRM_SCENE
+  // Mirror the pause edge into the scene so its layer sources can
+  // drop fd-bound state before the kernel revokes master. Idempotent
+  // and infallible per the LayerBufferSource::on_session_paused
+  // contract.
+  if (paused && scene_) {
+    scene_->on_session_paused();
+  }
+#endif
   spdlog::info("[DrmCompositor] session {}", paused ? "paused" : "resumed");
 }
 
@@ -2222,6 +2592,21 @@ void DrmCompositor::OnResume() {
   plane_mode_set_ = false;
   paused_.store(false, std::memory_order_release);
   resume_pending_logged_ = false;
+
+#if USE_DRM_SCENE
+  // Rebuild the scene's per-fd kernel state (plane registry, property
+  // caches, GEM/FB handles). DrmSession::TakeDevice opts in to
+  // preserve_fd_across_resume, so backend_->device() wraps the same
+  // fd that the seat originally handed us — the LayerScene's
+  // implementation skips fd-substitution and just re-enumerates.
+  if (scene_) {
+    auto& dev = const_cast<drm::Device&>(backend_->device());
+    if (auto r = scene_->on_session_resumed(dev); !r) {
+      spdlog::error("[DrmCompositor] LayerScene::on_session_resumed: {}",
+                    r.error().message());
+    }
+  }
+#endif
 
   // Drain the BS-slot release pipeline — any flip events that would
   // have freed slots queued before pause never fired. Promote

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -305,8 +305,10 @@ bool DrmCompositor::InitPlaneAllocator() {
   plane_registry_.emplace(std::move(*reg));
 
   const auto available = plane_registry_->for_crtc(backend_->crtc_index());
-  spdlog::info("[DrmCompositor] {} planes available for CRTC {}",
-               available.size(), backend_->crtc_id());
+  spdlog::info(
+      "[DrmCompositor] {} planes available for CRTC {} (crtc_index={})",
+      available.size(), backend_->crtc_id(), backend_->crtc_index());
+  uint32_t primary_id = 0;
   for (const auto* p : available) {
     auto type_str = "?";
     switch (p->type) {
@@ -327,6 +329,14 @@ bool DrmCompositor::InitPlaneAllocator() {
       // mutable it's still the lowest slot, and we want the root Flutter
       // layer on the bottom.
       primary_zpos_ = p->zpos_min.value_or(0);
+      primary_id = static_cast<uint32_t>(p->id);
+      // Provisional: whether the primary's rotation enum advertises
+      // REFLECT_Y. This is only a hint — vc4/amdgpu DC primaries
+      // advertise it but reject it at commit (EINVAL). The non-framed
+      // branch below confirms it with a TEST_ONLY commit
+      // (ProbePrimaryReflectY) before deciding direct-overlay vs scene.
+      primary_supports_reflect_y_ = PlaneSupportsReflectY(
+          backend_->drm_fd(), static_cast<uint32_t>(p->id));
     }
     // Per-plane probe for REFLECT_Y. Direct-scanout in PresentLayers
     // sets rotation=REFLECT_Y so GL-rendered (bottom-up) bits flip to
@@ -415,27 +425,50 @@ bool DrmCompositor::InitPlaneAllocator() {
   }
 
 #if USE_DRM_SCENE
-  // Construct the LayerScene that drives the non-framed present path
-  // (framed mode keeps its dedicated manual primary-BG + overlay layout
-  // — LayerScene's allocator can't produce that shape on the drivers
-  // that need it). Both paths coexist; the per-frame branch in
-  // PresentLayers picks one based on framed_.
-  if (!framed_) {
-    drm::scene::LayerScene::Config scene_cfg{};
-    scene_cfg.crtc_id = backend_->crtc_id();
-    scene_cfg.connector_id = backend_->connector_id();
-    scene_cfg.mode = backend_->mode();
-    auto scene = drm::scene::LayerScene::create(
-        const_cast<drm::Device&>(backend_->device()), scene_cfg);
-    if (!scene) {
-      spdlog::error("[DrmCompositor] LayerScene::create: {}",
-                    scene.error().message());
-      return false;
+  // The LayerScene drives the non-framed present path, but it only pays
+  // off where the bottom-up GL backing store can reach scanout — i.e.
+  // some plane supports REFLECT_Y. On hardware where NO plane does
+  // (amdgpu DC: primary + overlays all advertise ROTATE_0 only), the
+  // scene would set REFLECT_Y on every candidate plane, fail every
+  // atomic TEST with EINVAL, and fall back to a slow CompositeCanvas
+  // read-back. Skip scene construction entirely there: scene_ stays
+  // null and PresentLayers falls through to the legacy GL-composite
+  // path (which gates direct-scanout on any_plane_supports_reflect_y_
+  // and composites with the orientation flip otherwise). Framed mode
+  // keeps its own manual primary-BG + overlay layout.
+  if (!framed_ && any_plane_supports_reflect_y_) {
+    // Confirm the primary's advertised REFLECT_Y with a TEST_ONLY commit
+    // (the enum bitmask false-positives on vc4). If the primary can't
+    // actually take REFLECT_Y but an overlay can, use zero-copy
+    // direct-overlay mode (opaque BG on the primary, BS on a REFLECT_Y
+    // overlay); otherwise drive the scene (direct-scan on the primary).
+    primary_supports_reflect_y_ =
+        ProbePrimaryReflectY(primary_id, primary_supports_reflect_y_);
+    if (!primary_supports_reflect_y_ && InitDirectOverlay()) {
+      direct_overlay_mode_ = true;
+      // Skip LayerScene construction; PresentDirectOverlay drives the
+      // atomic commit manually and never touches scene_.
+    } else {
+      drm::scene::LayerScene::Config scene_cfg{};
+      scene_cfg.crtc_id = backend_->crtc_id();
+      scene_cfg.connector_id = backend_->connector_id();
+      scene_cfg.mode = backend_->mode();
+      auto scene = drm::scene::LayerScene::create(
+          const_cast<drm::Device&>(backend_->device()), scene_cfg);
+      if (!scene) {
+        spdlog::error("[DrmCompositor] LayerScene::create: {}",
+                      scene.error().message());
+        return false;
+      }
+      scene_ = std::move(*scene);
+      spdlog::info(
+          "[DrmCompositor] LayerScene constructed (crtc={} connector={})",
+          scene_cfg.crtc_id, scene_cfg.connector_id);
     }
-    scene_ = std::move(*scene);
+  } else if (!framed_) {
     spdlog::info(
-        "[DrmCompositor] LayerScene constructed (crtc={} connector={})",
-        scene_cfg.crtc_id, scene_cfg.connector_id);
+        "[DrmCompositor] no plane supports REFLECT_Y; using GL-composite "
+        "path (scene direct-scanout needs the flip)");
   }
 #endif
 
@@ -604,7 +637,8 @@ bool DrmCompositor::CreateGbmStore(GbmBackingStore& store,
                                    uint32_t w,
                                    uint32_t h,
                                    const uint32_t format,
-                                   const size_t pool_size) const {
+                                   const size_t pool_size,
+                                   const bool force_scanout) const {
   if (pool_size == 0 || pool_size > GbmBackingStore::kMaxPoolSize) {
     spdlog::error(
         "[DrmCompositor] CreateGbmStore: pool_size={} out of range [1, {}]",
@@ -615,7 +649,7 @@ bool DrmCompositor::CreateGbmStore(GbmBackingStore& store,
   store.height = h;
   store.format = format;
   store.pool_size = pool_size;
-  const uint32_t usage = planes_available_
+  const uint32_t usage = (planes_available_ || force_scanout)
                              ? (GBM_BO_USE_RENDERING | GBM_BO_USE_SCANOUT)
                              : GBM_BO_USE_RENDERING;
 
@@ -1572,6 +1606,14 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
   }
 
 #if USE_DRM_SCENE
+  // Zero-copy direct-overlay path (primary lacks REFLECT_Y): BG on the
+  // primary, the single Flutter BS direct-scanned on a REFLECT_Y
+  // overlay. Owns its own GL-fallback decision for multi-layer / PV
+  // frames, same as the scene path below.
+  if (direct_overlay_mode_) {
+    return PresentDirectOverlay(layers, layer_count);
+  }
+
   // Non-framed path under USE_DRM_SCENE: route every frame through
   // LayerScene. PresentLayersViaScene owns the fallback decision —
   // returns true on a successful scene commit, false (after invoking
@@ -2433,6 +2475,476 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       spdlog::info(
           "[DrmCompositor] scene profile (n={}): wait={:.2f}ms (max {:.2f})  "
           "compose={:.2f}ms (max {:.2f})  commit={:.2f}ms (max {:.2f})  "
+          "total={:.2f}ms (max {:.2f})",
+          s.frames, ms(s.wait_sum_ns), ms_max(s.wait_max_ns),
+          ms(s.compose_sum_ns), ms_max(s.compose_max_ns), ms(s.commit_sum_ns),
+          ms_max(s.commit_max_ns), ms(s.total_sum_ns), ms_max(s.total_max_ns));
+      profile_->p.reset();
+    }
+  }
+  return true;
+}
+
+// ─── Direct-overlay mode (zero-copy scene present) ───────────────────────
+
+bool DrmCompositor::ProbePrimaryReflectY(const uint32_t primary_id,
+                                         const bool enum_hint) {
+  if (primary_id == 0 || !modeset_) {
+    return enum_hint;
+  }
+
+  // Cache the primary + other non-cursor planes' property IDs locally;
+  // the probe disables the others so residual fbcon state can't taint
+  // the TEST result.
+  const int fd = backend_->drm_fd();
+  drm::PropertyStore pp;
+  if (auto r = pp.cache_properties(fd, primary_id, DRM_MODE_OBJECT_PLANE); !r) {
+    spdlog::warn("[DrmCompositor] REFLECT_Y probe: cache primary props: {}",
+                 r.error().message());
+    return enum_hint;
+  }
+  for (const auto* p : plane_registry_->for_crtc(backend_->crtc_index())) {
+    if (p->type == drm::planes::DRMPlaneType::CURSOR || p->id == primary_id) {
+      continue;
+    }
+    (void)pp.cache_properties(fd, p->id, DRM_MODE_OBJECT_PLANE);
+  }
+
+  // The probe needs a real FB on the primary, and it must be the SAME
+  // format the direct path actually scans out: the backing-store format
+  // (bs_format, an alpha format), NOT primary_format (opaque). vc4's
+  // primary accepts XRGB+REFLECT_Y but rejects ARGB+REFLECT_Y, so a BG
+  // (XRGB) probe false-positives. Use a throwaway bs_format FB —
+  // TEST_ONLY validates config only (format/modifier/rotation/rects), so
+  // its pixels need no clear.
+  const uint32_t probe_format = backend_->resolved().bs_format;
+  GbmBackingStore probe_fb{};
+  if (!CreateGbmStore(probe_fb, backend_->mode_width(), backend_->mode_height(),
+                      probe_format, /*pool_size=*/1,
+                      /*force_scanout=*/true) ||
+      !EnsureDrmFbId(probe_fb)) {
+    spdlog::warn("[DrmCompositor] REFLECT_Y probe: test FB create failed");
+    DestroyGbmStore(probe_fb);
+    return enum_hint;
+  }
+
+  const uint32_t crtc_id = backend_->crtc_id();
+  const uint32_t mode_w = backend_->mode_width();
+  const uint32_t mode_h = backend_->mode_height();
+
+  // TEST_ONLY commit: power up the pipe (modeset), bind the probe FB to
+  // the primary at the requested rotation, disable every other non-cursor
+  // plane. Returns true iff the kernel validates the transaction. The
+  // primary's zpos is deliberately NOT written — it's a fixed slot on
+  // these drivers and writing it would EINVAL, masking the REFLECT_Y
+  // result we're actually probing for.
+  auto try_rotation = [&](const uint64_t rotation) -> bool {
+    drm::AtomicRequest req(backend_->device());
+    if (!req.valid()) {
+      return false;
+    }
+    if (auto r = modeset_->attach(req); !r) {
+      return false;
+    }
+    auto set = [&](const uint32_t obj, const char* name,
+                   const uint64_t value) -> bool {
+      auto pid = pp.property_id(obj, name);
+      return pid && req.add_property(obj, *pid, value).has_value();
+    };
+    if (!set(primary_id, "FB_ID", probe_fb.active().drm_fb_id) ||
+        !set(primary_id, "CRTC_ID", crtc_id) || !set(primary_id, "CRTC_X", 0) ||
+        !set(primary_id, "CRTC_Y", 0) || !set(primary_id, "CRTC_W", mode_w) ||
+        !set(primary_id, "CRTC_H", mode_h) || !set(primary_id, "SRC_X", 0) ||
+        !set(primary_id, "SRC_Y", 0) ||
+        !set(primary_id, "SRC_W", static_cast<uint64_t>(mode_w) << 16) ||
+        !set(primary_id, "SRC_H", static_cast<uint64_t>(mode_h) << 16) ||
+        !set(primary_id, "rotation", rotation)) {
+      return false;
+    }
+    for (const auto* p : plane_registry_->for_crtc(backend_->crtc_index())) {
+      if (p->type == drm::planes::DRMPlaneType::CURSOR || p->id == primary_id) {
+        continue;
+      }
+      if (auto fb_pid = pp.property_id(p->id, "FB_ID")) {
+        (void)req.add_property(p->id, *fb_pid, 0);
+      }
+      if (auto crtc_pid = pp.property_id(p->id, "CRTC_ID")) {
+        (void)req.add_property(p->id, *crtc_pid, 0);
+      }
+    }
+    constexpr uint32_t test_flags =
+        DRM_MODE_ATOMIC_TEST_ONLY | DRM_MODE_ATOMIC_ALLOW_MODESET;
+    return req.test(test_flags).has_value();
+  };
+
+  // Isolate REFLECT_Y: if the primary takes the BS format with REFLECT_Y
+  // it's genuinely capable; if it rejects REFLECT_Y but accepts ROTATE_0
+  // with the same FB, REFLECT_Y is the specific culprit → route to an
+  // overlay. If both fail (primary can't scan this format at all) the
+  // probe can't isolate REFLECT_Y, so defer to the enum hint.
+  bool result = enum_hint;
+  const char* verdict = "inconclusive (both ROTATE_0 and REFLECT_Y failed)";
+  if (try_rotation(DRM_MODE_ROTATE_0 | DRM_MODE_REFLECT_Y)) {
+    result = true;
+    verdict = "accepts REFLECT_Y (direct scanout on primary OK)";
+  } else if (try_rotation(DRM_MODE_ROTATE_0)) {
+    result = false;
+    verdict = "rejects REFLECT_Y, accepts ROTATE_0 -> route BS to overlay";
+  }
+  DestroyGbmStore(probe_fb);
+
+  spdlog::info("[DrmCompositor] REFLECT_Y probe: primary {} {} (verdict={})",
+               primary_id, verdict, result);
+  return result;
+}
+
+bool DrmCompositor::InitDirectOverlay() {
+  // Pick the PRIMARY (the opaque-BG target) and the first OVERLAY that
+  // advertises both the backing-store scanout format and REFLECT_Y. The
+  // overlay carries the bottom-up GL-rendered BS and flips it to scanout
+  // order; the primary scans out a mode-sized opaque BG so amdgpu DC's
+  // "primary must cover the CRTC" check is satisfied. Mirrors
+  // InitFramedMode's plane selection, but the overlay format is the BS
+  // (alpha) format and the overlay must also support REFLECT_Y.
+  const uint32_t bg_format = backend_->resolved().primary_format;
+  const uint32_t bs_format = backend_->resolved().bs_format;
+  const uint64_t want_overlay_zpos = primary_zpos_ + 1;
+  const int fd = backend_->drm_fd();
+
+  for (const auto* p : plane_registry_->for_crtc(backend_->crtc_index())) {
+    if (p->type == drm::planes::DRMPlaneType::PRIMARY &&
+        framed_primary_id_ == 0) {
+      framed_primary_id_ = p->id;
+      continue;
+    }
+    if (p->type == drm::planes::DRMPlaneType::OVERLAY &&
+        direct_overlay_id_ == 0) {
+      if (!p->supports_format(bs_format) ||
+          !PlaneSupportsReflectY(fd, static_cast<uint32_t>(p->id))) {
+        continue;
+      }
+      // Clamp the requested zpos to the advertised range; when immutable
+      // we take whatever the overlay reports (the commit still succeeds
+      // as long as primary and overlay don't collide on one zpos).
+      uint64_t zpos = want_overlay_zpos;
+      if (p->zpos_min.has_value() && zpos < *p->zpos_min) {
+        zpos = *p->zpos_min;
+      }
+      if (p->zpos_max.has_value() && zpos > *p->zpos_max) {
+        zpos = *p->zpos_max;
+      }
+      direct_overlay_id_ = p->id;
+      direct_overlay_zpos_ = zpos;
+    }
+  }
+  if (framed_primary_id_ == 0 || direct_overlay_id_ == 0) {
+    spdlog::info(
+        "[DrmCompositor] direct-overlay needs 1 primary + 1 REFLECT_Y overlay "
+        "supporting the BS format on CRTC {} (primary={}, overlay={}); using "
+        "scene path",
+        backend_->crtc_id(), framed_primary_id_, direct_overlay_id_);
+    return false;
+  }
+
+  // Cache property IDs for primary + overlay so PresentDirectOverlay
+  // builds the atomic request without per-frame kernel round-trips.
+  if (auto r = framed_props_.cache_properties(fd, framed_primary_id_,
+                                              DRM_MODE_OBJECT_PLANE);
+      !r) {
+    spdlog::error("[DrmCompositor] direct-overlay cache primary props: {}",
+                  r.error().message());
+    return false;
+  }
+  if (auto r = framed_props_.cache_properties(fd, direct_overlay_id_,
+                                              DRM_MODE_OBJECT_PLANE);
+      !r) {
+    spdlog::error("[DrmCompositor] direct-overlay cache overlay props: {}",
+                  r.error().message());
+    return false;
+  }
+  // Cache the other non-cursor planes we disable each frame so their
+  // FB_ID/CRTC_ID IDs resolve from cache.
+  for (const auto* p : plane_registry_->for_crtc(backend_->crtc_index())) {
+    if (p->type == drm::planes::DRMPlaneType::CURSOR) {
+      continue;
+    }
+    if (p->id == framed_primary_id_ || p->id == direct_overlay_id_) {
+      continue;
+    }
+    (void)framed_props_.cache_properties(fd, p->id, DRM_MODE_OBJECT_PLANE);
+  }
+
+  // Mode-sized opaque BG pinned to the primary for the session. Filled
+  // with black once; the overlay carries all moving pixels. The GL
+  // context is current here (InitPlaneAllocator runs inside
+  // EnsureGlCapsProbed), so the clear is safe. ProbePrimaryReflectY
+  // creates this same store as its TEST FB, so reuse it when valid.
+  if (!bg_store_valid_) {
+    if (!CreateGbmStore(bg_store_, backend_->mode_width(),
+                        backend_->mode_height(), bg_format, /*pool_size=*/1,
+                        /*force_scanout=*/true) ||
+        !EnsureDrmFbId(bg_store_)) {
+      spdlog::error(
+          "[DrmCompositor] direct-overlay BG GBM store create failed");
+      return false;
+    }
+    glBindFramebuffer(GL_FRAMEBUFFER, bg_store_.fbo);
+    glDisable(GL_SCISSOR_TEST);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glFinish();  // commit BG pixels before the first atomic scanout binds it
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    bg_store_valid_ = true;
+  }
+
+  spdlog::info(
+      "[DrmCompositor] direct-overlay mode: primary(BG)={} overlay(BS)={} "
+      "(zpos={}), CRTC {}x{}",
+      framed_primary_id_, direct_overlay_id_, direct_overlay_zpos_,
+      backend_->mode_width(), backend_->mode_height());
+  return true;
+}
+
+bool DrmCompositor::PresentDirectOverlay(const FlutterLayer** layers,
+                                         const size_t count) {
+  const bool profile = ProfileEnabled();
+  const uint64_t t0 = profile ? NsNow() : 0;
+
+  if (!WaitForPendingFlip()) {
+    return PresentViaGlFallback(layers, count);
+  }
+  const uint64_t t1 = profile ? NsNow() : 0;
+
+  // Find the single backing-store layer. Any platform-view layer, or
+  // anything other than exactly one BS layer, forces the GL fallback —
+  // multi-layer / PV direct-overlay is a follow-on.
+  GbmBackingStore* store = nullptr;
+  size_t bs_layers = 0;
+  for (size_t i = 0; i < count; ++i) {
+    const FlutterLayer* fl = layers[i];
+    if (!fl) {
+      continue;
+    }
+    if (fl->type == kFlutterLayerContentTypePlatformView) {
+      return PresentViaGlFallback(layers, count);
+    }
+    if (fl->type == kFlutterLayerContentTypeBackingStore && fl->backing_store) {
+      ++bs_layers;
+      if (auto* baton =
+              static_cast<StoreBaton*>(fl->backing_store->user_data)) {
+        store = baton->store;
+      }
+    }
+  }
+  if (bs_layers != 1 || !store) {
+    return PresentViaGlFallback(layers, count);
+  }
+
+  // KMS framebuffer on the BS BO's active slot. Bail to GL on failure.
+  if (!EnsureDrmFbId(*store) || store->active().drm_fb_id == 0) {
+    return PresentViaGlFallback(layers, count);
+  }
+
+  // Sync Flutter's GPU writes to the BS BO before the kernel scans it.
+  // The scene path uses the same synchronous drain (IN_FENCE_FD on the
+  // overlay is a follow-on).
+  glFinish();
+
+  // ── Build the atomic request ──
+  drm::AtomicRequest req(backend_->device());
+  if (!req.valid()) {
+    spdlog::warn("[DrmCompositor] direct-overlay: AtomicRequest alloc failed");
+    fallback_latched_ = true;
+    return PresentViaGlFallback(layers, count);
+  }
+
+  const uint32_t crtc_id = backend_->crtc_id();
+  const uint32_t mode_w = backend_->mode_width();
+  const uint32_t mode_h = backend_->mode_height();
+  const bool dump = backend_->cfg_.debug_backend && !plane_mode_set_;
+
+  // First commit only: power up the pipe (MODE_ID / ACTIVE / CRTC_ID).
+  if (!plane_mode_set_ && modeset_) {
+    if (auto r = modeset_->attach(req); !r) {
+      spdlog::warn("[DrmCompositor] direct-overlay: modeset attach: {}",
+                   r.error().message());
+      return PresentViaGlFallback(layers, count);
+    }
+  }
+
+  auto set = [&](const uint32_t obj, const char* name,
+                 const uint64_t value) -> bool {
+    auto pid = framed_props_.property_id(obj, name);
+    if (!pid) {
+      spdlog::warn("[DrmCompositor] direct-overlay: property {}.{} missing: {}",
+                   obj, name, pid.error().message());
+      return false;
+    }
+    if (auto r = req.add_property(obj, *pid, value); !r) {
+      spdlog::warn("[DrmCompositor] direct-overlay: add_property {}.{}: {}",
+                   obj, name, r.error().message());
+      return false;
+    }
+    if (dump) {
+      spdlog::debug("[DrmCompositor] direct-overlay prop: obj={} pid={} {}={}",
+                    obj, *pid, name, value);
+    }
+    return true;
+  };
+
+  // Primary: persistent mode-sized opaque BG covering the whole CRTC.
+  if (!set(framed_primary_id_, "FB_ID", bg_store_.active().drm_fb_id) ||
+      !set(framed_primary_id_, "CRTC_ID", crtc_id) ||
+      !set(framed_primary_id_, "CRTC_X", 0) ||
+      !set(framed_primary_id_, "CRTC_Y", 0) ||
+      !set(framed_primary_id_, "CRTC_W", mode_w) ||
+      !set(framed_primary_id_, "CRTC_H", mode_h) ||
+      !set(framed_primary_id_, "SRC_X", 0) ||
+      !set(framed_primary_id_, "SRC_Y", 0) ||
+      !set(framed_primary_id_, "SRC_W", static_cast<uint64_t>(mode_w) << 16) ||
+      !set(framed_primary_id_, "SRC_H", static_cast<uint64_t>(mode_h) << 16)) {
+    return PresentViaGlFallback(layers, count);
+  }
+  if (auto pid = framed_props_.property_id(framed_primary_id_, "zpos")) {
+    if (const auto immut =
+            framed_props_.is_immutable(framed_primary_id_, "zpos");
+        !immut || !*immut) {
+      (void)req.add_property(framed_primary_id_, *pid, primary_zpos_);
+    }
+  }
+
+  // Overlay: the Flutter backing store, direct-scanned over the full
+  // CRTC with REFLECT_Y (the overlay supports it — that's the point).
+  const uint64_t src_w = static_cast<uint64_t>(store->width) << 16;
+  const uint64_t src_h = static_cast<uint64_t>(store->height) << 16;
+  if (!set(direct_overlay_id_, "FB_ID", store->active().drm_fb_id) ||
+      !set(direct_overlay_id_, "CRTC_ID", crtc_id) ||
+      !set(direct_overlay_id_, "CRTC_X", 0) ||
+      !set(direct_overlay_id_, "CRTC_Y", 0) ||
+      !set(direct_overlay_id_, "CRTC_W", mode_w) ||
+      !set(direct_overlay_id_, "CRTC_H", mode_h) ||
+      !set(direct_overlay_id_, "SRC_X", 0) ||
+      !set(direct_overlay_id_, "SRC_Y", 0) ||
+      !set(direct_overlay_id_, "SRC_W", src_w) ||
+      !set(direct_overlay_id_, "SRC_H", src_h) ||
+      !set(direct_overlay_id_, "rotation",
+           DRM_MODE_ROTATE_0 | DRM_MODE_REFLECT_Y)) {
+    return PresentViaGlFallback(layers, count);
+  }
+  if (auto pid = framed_props_.property_id(direct_overlay_id_, "zpos")) {
+    if (const auto immut =
+            framed_props_.is_immutable(direct_overlay_id_, "zpos");
+        !immut || !*immut) {
+      (void)req.add_property(direct_overlay_id_, *pid, direct_overlay_zpos_);
+    }
+  }
+
+  // Disable every other non-cursor plane so the commit doesn't inherit
+  // stale FB/CRTC/zpos from fbcon or a prior session.
+  for (const auto* p : plane_registry_->for_crtc(backend_->crtc_index())) {
+    if (p->type == drm::planes::DRMPlaneType::CURSOR) {
+      continue;
+    }
+    if (p->id == framed_primary_id_ || p->id == direct_overlay_id_) {
+      continue;
+    }
+    if (auto fb_pid = framed_props_.property_id(p->id, "FB_ID")) {
+      (void)req.add_property(p->id, *fb_pid, 0);
+    }
+    if (auto crtc_pid = framed_props_.property_id(p->id, "CRTC_ID")) {
+      (void)req.add_property(p->id, *crtc_pid, 0);
+    }
+  }
+
+  // ── Commit ──
+  if (backend_->cfg_.debug_backend) {
+    backend_->flip_submit_ns_ = LibFlutterEngine->GetCurrentTime();
+  }
+
+  uint32_t commit_flags = 0;
+  const bool was_first_commit_pre = !plane_mode_set_;
+  if (was_first_commit_pre) {
+    commit_flags = DRM_MODE_ATOMIC_ALLOW_MODESET;
+  } else {
+    commit_flags = DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
+  }
+  const uint64_t t2 = profile ? NsNow() : 0;
+
+  if (auto r = req.commit(commit_flags, backend_); !r) {
+    if (r.error() == std::errc::permission_denied) {
+      if (!paused_.load(std::memory_order_acquire)) {
+        spdlog::warn(
+            "[DrmCompositor] direct-overlay commit: master revoked (EACCES); "
+            "skip frame");
+      }
+      return false;
+    }
+    spdlog::warn(
+        "[DrmCompositor] direct-overlay atomic commit failed ({}); latching GL "
+        "fallback for remaining session",
+        r.error().message());
+    fallback_latched_ = true;
+    return PresentViaGlFallback(layers, count);
+  }
+
+  if (was_first_commit_pre) {
+    plane_mode_set_ = true;
+    flip_pending_.store(false, std::memory_order_release);
+    VerifyPipeRunning();
+    const intptr_t baton =
+        backend_->vsync_baton_.exchange(0, std::memory_order_acq_rel);
+    if (baton != 0) {
+      if (auto engine =
+              backend_->engine_handle_.load(std::memory_order_acquire)) {
+        backend_->PostOnVsync(engine, baton);
+      }
+    }
+  } else {
+    flip_pending_.store(true, std::memory_order_release);
+  }
+
+  // Rotate the BS pool slot so Flutter's next render targets a different
+  // BO than the one the kernel is scanning out. Same slot-release
+  // pipeline bookkeeping as the scene path.
+  if (store->pool_size > 1) {
+    const size_t committed_idx = store->active_idx;
+    store->pool[committed_idx].state = GbmBackingStore::Slot::State::Pending;
+    SlotRef committed{store, committed_idx};
+    store->active_idx = (store->active_idx + 1) % store->pool_size;
+    store->pool[store->active_idx].state = GbmBackingStore::Slot::State::Active;
+    glBindFramebuffer(GL_FRAMEBUFFER, store->fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           store->active().color_tex, 0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    std::lock_guard<std::mutex> lock(slot_pipeline_mu_);
+    if (was_first_commit_pre) {
+      for (auto& ref : scanning_slots_) {
+        ref.store->pool[ref.slot_idx].state =
+            GbmBackingStore::Slot::State::Free;
+      }
+      scanning_slots_.assign(1, committed);
+    } else {
+      in_flight_slots_.push_back({committed});
+    }
+  }
+
+  if (profile && profile_) {
+    const uint64_t t3 = NsNow();
+    profile_->p.account(t1 - t0, t2 - t1, /*test=*/0, t3 - t2, t3 - t0);
+    if (profile_->p.frames >= kProfileWindow) {
+      const auto& s = profile_->p;
+      const auto ms = [&](uint64_t ns_sum) {
+        return static_cast<double>(ns_sum) /
+               (static_cast<double>(s.frames) * 1e6);
+      };
+      const auto ms_max = [](uint64_t ns) {
+        return static_cast<double>(ns) / 1e6;
+      };
+      spdlog::info(
+          "[DrmCompositor] direct-overlay profile (n={}): wait={:.2f}ms (max "
+          "{:.2f})  sync={:.2f}ms (max {:.2f})  commit={:.2f}ms (max {:.2f})  "
           "total={:.2f}ms (max {:.2f})",
           s.frames, ms(s.wait_sum_ns), ms_max(s.wait_max_ns),
           ms(s.compose_sum_ns), ms_max(s.compose_max_ns), ms(s.commit_sum_ns),

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -40,11 +40,18 @@
 
 #include <shell/platform/embedder/embedder.h>
 
+#include "config/common.h"
+
+#if USE_DRM_SCENE
+#include <drm-cxx/scene/layer_scene.hpp>
+#endif
+
 #include "backend/wayland_egl/gl_caps.h"
 #include "backend/wayland_egl/gl_compositor.h"
 
 class DrmBackend;
 class ICompositorSurface;
+class GbmBackingStoreLayerSource;
 
 // Default pool sizes used by CreateGbmStore. Flutter backing-stores
 // rotate among N=3 BOs so direct-scanout never binds the BO that's
@@ -161,6 +168,15 @@ class DrmCompositor {
   struct StoreBaton {
     DrmCompositor* owner;
     GbmBackingStore* store;
+#if USE_DRM_SCENE
+    // Borrowed LayerBufferSource adapter — owned by the LayerScene
+    // once add_layer() consumes it; nullptr after that. CreateBackingStore
+    // constructs it; PresentLayers (under USE_DRM_SCENE) moves it into
+    // the scene the first time the store appears in a FlutterLayer.
+    // CollectBackingStore destroys the wrapper if it never reached the
+    // scene (e.g. the store retired before its first Present).
+    std::unique_ptr<GbmBackingStoreLayerSource> scene_source;
+#endif
   };
 
   bool InitEglExtensions();
@@ -237,6 +253,21 @@ class DrmCompositor {
   // rejects that anyway.
   bool PresentFramed(const FlutterLayer** layers, size_t count);
 
+#if USE_DRM_SCENE
+  // Non-framed present path driven by drm::scene::LayerScene. Walks
+  // FlutterLayer[], syncs the scene's layer membership against it via
+  // find_by_identity_tag / add_layer / remove_layer keyed on the
+  // backing-store baton pointer, updates DisplayParams via
+  // set_*_if_changed setters, and runs scene_->commit() in place of
+  // the manual AtomicRequest + Allocator path. CommitReport.placements
+  // is inspected: any layer reported Composited routes the frame
+  // through PresentViaGlFallback instead (the GL composite path is
+  // materially faster than drm-cxx's CompositeCanvas over uncached
+  // GBM read-back). Platform-view layers force the same fallback —
+  // platform-view→scene plumbing is not wired in this revision.
+  bool PresentLayersViaScene(const FlutterLayer** layers, size_t count);
+#endif
+
   DrmBackend* backend_;
 
   // EGL image extensions.
@@ -299,6 +330,27 @@ class DrmCompositor {
   // Owns the MODE_ID / ACTIVE / Connector.CRTC_ID properties + mode
   // blob for atomic modesets. attach()-ed to the first commit.
   std::optional<drm::modeset::Modeset> modeset_;
+
+#if USE_DRM_SCENE
+  // LayerScene-driven non-framed present path. Constructed in
+  // InitPlaneAllocator when !framed_; null in framed mode (the
+  // primary-BG + overlay layout keeps the manual atomic path).
+  // PresentLayers's non-framed branch routes per-frame add_layer /
+  // find_by_identity_tag / commit through this scene; CreateBackingStore
+  // produces matching LayerBufferSource wrappers stashed in StoreBaton
+  // until their first Present add_layer()s them in.
+  std::unique_ptr<drm::scene::LayerScene> scene_;
+
+  // Embedder-side mirror of the scene's live layer set, keyed by
+  // baton pointer (the same pointer set as LayerDesc::identity_tag).
+  // Walked each frame to prune layers whose baton didn't appear in
+  // the current FlutterLayer[] — drm-cxx's scene retains layers
+  // across commits and exposes no iteration API beyond
+  // find_by_identity_tag, so the prune list lives here. Single-digit
+  // capacity in steady state; std::vector + linear scan is faster
+  // than any hashing for that size.
+  std::vector<StoreBaton*> scene_layer_batons_;
+#endif
 
   // Double-buffered composition buffer for layers that overflow HW planes.
   static constexpr int kNumCompBufs = 2;

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -191,11 +191,18 @@ class DrmCompositor {
   bool InitFramedMode();
   void EnsureGlCapsProbed();
   void DestroyGbmStore(GbmBackingStore& store) const;
+  // @p force_scanout requests GBM_BO_USE_SCANOUT even before
+  // planes_available_ is set — needed for stores created during
+  // InitPlaneAllocator (the REFLECT_Y probe / direct-overlay BG), which
+  // must be KMS-importable but run before the caller flips the flag.
+  // Without it gbm may pick a render-only tiled modifier that AddFB2
+  // rejects.
   bool CreateGbmStore(GbmBackingStore& store,
                       uint32_t w,
                       uint32_t h,
                       uint32_t format,
-                      size_t pool_size = 1) const;
+                      size_t pool_size = 1,
+                      bool force_scanout = false) const;
   uint32_t ImportBoAsFb(gbm_bo* bo) const;
   // Lazily import the store's BO as a DRM framebuffer on first direct-
   // scanout use. Returns true when @c store.drm_fb_id is non-zero on
@@ -266,6 +273,35 @@ class DrmCompositor {
   // GBM read-back). Platform-view layers force the same fallback —
   // platform-view→scene plumbing is not wired in this revision.
   bool PresentLayersViaScene(const FlutterLayer** layers, size_t count);
+
+  // Direct-overlay setup: pick the REFLECT_Y-capable overlay for the
+  // backing-store scanout, cache its property IDs plus the primary
+  // plane's (the BG target), and create the mode-sized opaque BG store.
+  // Mirrors InitFramedMode's plane selection but requires the overlay
+  // to advertise both the BS format and REFLECT_Y. Returns false (→
+  // fall back to the scene_ path) if no suitable overlay exists or the
+  // BG store can't be created. See direct_overlay_mode_ / the class
+  // comment for the rationale.
+  bool InitDirectOverlay();
+
+  // Authoritative REFLECT_Y-on-primary probe. The rotation-property enum
+  // bitmask (PlaneSupportsReflectY) is unreliable: vc4 (and amdgpu DC)
+  // primaries advertise REFLECT_Y yet the kernel rejects it at commit
+  // with EINVAL. This runs a one-shot TEST_ONLY atomic commit binding
+  // the opaque BG to the primary with ROTATE_0|REFLECT_Y; if that TEST
+  // fails but the same commit with plain ROTATE_0 passes, REFLECT_Y is
+  // the culprit and the primary genuinely can't do it. Sets up bg_store_
+  // as the probe FB (reused by InitDirectOverlay). Returns the verdict;
+  // on an inconclusive probe (both variants fail) returns @p enum_hint.
+  bool ProbePrimaryReflectY(uint32_t primary_id, bool enum_hint);
+
+  // Direct-overlay present path. Zero-copy analogue of PresentFramed:
+  // pins the opaque BG to the primary (full CRTC) and atomic-commits
+  // the single Flutter backing store directly on the overlay with
+  // REFLECT_Y, no GL composite. Falls back to PresentViaGlFallback for
+  // any frame that isn't exactly one backing-store layer (multi-layer /
+  // platform-view frames are a follow-on).
+  bool PresentDirectOverlay(const FlutterLayer** layers, size_t count);
 #endif
 
   DrmBackend* backend_;
@@ -373,6 +409,23 @@ class DrmCompositor {
   uint64_t framed_overlay_zpos_{0};
   drm::PropertyStore framed_props_;
 
+  // ── Direct-overlay mode (zero-copy scene present) ─────────────────
+  // For non-framed configs on hardware whose PRIMARY plane lacks
+  // REFLECT_Y (amdgpu DC, RPi5 vc4) but whose overlays support it: pin
+  // an opaque BG to the primary (full CRTC coverage, as amdgpu DC
+  // requires) and direct-scan the single Flutter backing store on a
+  // REFLECT_Y-capable overlay so the GL-rendered (bottom-up) bits flip
+  // to scanout order without a copy. Reuses framed_primary_id_ (the BG
+  // target), framed_props_ (cached plane props), and bg_store_ (the
+  // opaque BG) — same plane shape as framed mode, but the overlay
+  // direct-scans the BS instead of carrying a composited buffer.
+  // direct_overlay_mode_ gates PresentDirectOverlay in PresentLayers;
+  // it stays false (and the scene_ path runs) when the primary already
+  // supports REFLECT_Y or no overlay qualifies.
+  bool direct_overlay_mode_{false};
+  uint32_t direct_overlay_id_{0};
+  uint64_t direct_overlay_zpos_{0};
+
   // Atomic-commit flip state. Written by
   // DrmBackend::UnifiedPageFlipHandler → OnFlipComplete on the
   // platform task runner thread (when the kernel reports flip
@@ -420,6 +473,14 @@ class DrmCompositor {
   // where overlays support rotation but primary doesn't can still
   // benefit on the layers where the allocator can use an overlay.
   bool any_plane_supports_reflect_y_{false};
+
+  // Probed once in InitPlaneAllocator: true iff the PRIMARY plane's
+  // rotation bitmask includes REFLECT_Y. When false but
+  // any_plane_supports_reflect_y_ is true, the non-framed path can't
+  // direct-scan the bottom-up BS on the primary (REFLECT_Y write →
+  // EINVAL on amdgpu DC / vc4), so it routes through direct-overlay
+  // mode (BG on primary, BS on a REFLECT_Y overlay) instead.
+  bool primary_supports_reflect_y_{false};
 
   // One-shot diagnostic: log on the first PresentLayers entry after a
   // resume so a stuck Flutter frame pacer is visible. Cleared by

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -83,23 +83,47 @@ int main(const int argc, char** argv) {
 
 #if BUILD_BACKEND_DRM_KMS_EGL
   // Handle --drm-list-modes[=<path>] before the main config parse so the
-  // user doesn't need to supply a bundle path just to inspect modes. Value
-  // is optional; default device is /dev/dri/card1 to match DrmConfig.
+  // user doesn't need to supply a bundle path just to inspect modes.
+  // Device resolution precedence (first match wins):
+  //   1. --drm-list-modes=<path> (explicit attached value)
+  //   2. --drm-list-modes <path> (next positional, unless it starts with -)
+  //   3. --drm-device <path> or --drm-device=<path> anywhere in argv
+  //      (the same flag the launch path consumes)
+  //   4. /dev/dri/card1 (matches the launch-path default)
+  // Step 3 is the fix for `--drm-list-modes --drm-device /dev/dri/cardN`,
+  // which previously silently fell through to /dev/dri/card1 because the
+  // next-positional check at step 2 rejects anything starting with `-`.
+  bool list_modes_requested = false;
+  std::string list_modes_dev;
   for (int i = 1; i < argc; ++i) {
     const std::string_view arg = argv[i];
-    std::string dev;
     if (arg == "--drm-list-modes") {
-      dev = (i + 1 < argc && argv[i + 1][0] != '-') ? argv[i + 1]
-                                                    : "/dev/dri/card1";
-      return PrintDrmModes(dev) == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+      list_modes_requested = true;
+      if (i + 1 < argc && argv[i + 1][0] != '-') {
+        list_modes_dev = argv[i + 1];
+      }
+      continue;
     }
     if (arg.rfind("--drm-list-modes=", 0) == 0) {
-      dev = std::string(arg.substr(std::strlen("--drm-list-modes=")));
-      if (dev.empty()) {
-        dev = "/dev/dri/card1";
-      }
-      return PrintDrmModes(dev) == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+      list_modes_requested = true;
+      list_modes_dev =
+          std::string(arg.substr(std::strlen("--drm-list-modes=")));
+      continue;
     }
+    if (!list_modes_dev.empty()) {
+      continue;
+    }
+    if (arg == "--drm-device" && i + 1 < argc) {
+      list_modes_dev = argv[i + 1];
+    } else if (arg.rfind("--drm-device=", 0) == 0) {
+      list_modes_dev = std::string(arg.substr(std::strlen("--drm-device=")));
+    }
+  }
+  if (list_modes_requested) {
+    if (list_modes_dev.empty()) {
+      list_modes_dev = "/dev/dri/card1";
+    }
+    return PrintDrmModes(list_modes_dev) == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
   }
 #endif
 


### PR DESCRIPTION
## Summary

Lights up `USE_DRM_SCENE` end-to-end on top of the wrapper scaffolding
from PR #199. The OFF build is byte-for-byte identical to `v2.0` (no
`scene_` member, no scene includes, no behavioural change). The ON
build constructs a `drm::scene::LayerScene` in `InitPlaneAllocator`
and routes every non-framed present through it. Framed mode is
unchanged and continues to use the manual primary-BG + overlay path
(LayerScene's allocator can't produce that shape on amdgpu DC).

## Update — primary direct-scanout + per-platform REFLECT_Y gating

Follow-on commits bump drm-cxx to pick up the LayerScene fixes from
jwinarske/drm-cxx#77 and make the scene path actually achieve zero-copy
direct scanout where the hardware allows it, with a clean fallback where
it doesn't. Validated on RPi5 vc4 and amdgpu DC (see Verification).

**drm-cxx#77** — three bugs in the previously-unreached primary-assignment path:
- `Allocator::apply` resolved the CRTC index as the first populated `possible_crtcs` bit instead of the Output's actual CRTC, so on multi-CRTC parts (RPi5 vc4: chosen CRTC at index 2, overlays span `0xe`) it bound a foreign-CRTC plane → EINVAL on every commit.
- writing a fixed-range (`zpos_min == zpos_max`) but non-`IMMUTABLE`-flagged zpos (vc4 primary advertises `[0,0]` without the flag) → EINVAL; now also skipped.
- `remove_layer` left dangling `scene_layer` pointers in the deferred-release ring (`prev_/prev_prev_acquisitions_`) → use-after-free in `release_all` on the next `finalize_frame`.

**Embedder side (this PR):**
- `ProbePrimaryReflectY` — a one-shot `TEST_ONLY` atomic commit that decides per device whether the primary actually accepts `ROTATE_0 | REFLECT_Y` with the backing-store format. The rotation-enum bitmask is unreliable (it false-positives on vc4), so the probe is the authoritative signal.
- `InitDirectOverlay` / `PresentDirectOverlay` — zero-copy direct-overlay path for hardware whose primary can't REFLECT_Y but an overlay can: an opaque background is pinned to the primary (full CRTC coverage) and the backing store is direct-scanned on a REFLECT_Y overlay. Falls back to GL for multi-layer / platform-view frames.
- **Scene gated on REFLECT_Y availability** — when no plane supports REFLECT_Y (amdgpu DC: primary + both overlays advertise ROTATE_0 only), `scene_` is not constructed; the present falls through to the legacy GL-composite path instead of setting REFLECT_Y on every candidate plane, failing every atomic TEST, and dropping to a slow `CompositeCanvas` read-back.

| Platform | Primary REFLECT_Y | Present path | Result |
|---|---|---|---|
| RPi5 vc4 | yes | scene direct-scanout on primary | zero-copy, ~60fps |
| amdgpu DC | no (no plane) | legacy GL-composite (scene skipped) | no EINVAL, right-side-up |
| no-REFLECT_Y primary + REFLECT_Y overlay | n/a | direct-overlay (BG on primary + BS on overlay) | zero-copy |

### `DrmCompositor.h`
- `StoreBaton` grows a `scene_source: std::unique_ptr<GbmBackingStoreLayerSource>`, pre-built in `CreateBackingStore` and consumed by the scene's first `add_layer` for that baton.
- New member `scene_: std::unique_ptr<drm::scene::LayerScene>`.
- New member `scene_layer_batons_: vector<StoreBaton*>` mirroring the scene's live layer set so a per-frame prune can remove layers whose baton fell out of the current `FlutterLayer[]` (drm-cxx's scene exposes no iteration API beyond `find_by_identity_tag`, so the prune list lives embedder-side).
- New private `PresentLayersViaScene(...)` declaration.
- Direct-overlay members (`direct_overlay_mode_`, `direct_overlay_id_`, `direct_overlay_zpos_`, `primary_supports_reflect_y_`) and `InitDirectOverlay` / `ProbePrimaryReflectY` / `PresentDirectOverlay` declarations; `CreateGbmStore` gains a `force_scanout` parameter for stores created before `planes_available_` is set.

### `DrmCompositor.cc`
- `InitPlaneAllocator` constructs the LayerScene after `framed_` detection (skipped in framed mode, and now also skipped when no plane supports REFLECT_Y) from `backend_->device()` + crtc/connector ids + mode. When the primary can't REFLECT_Y but an overlay can, it adopts direct-overlay mode instead.
- `CreateBackingStore` pre-builds the `GbmBackingStoreLayerSource` and stashes it in the baton; `CollectBackingStore` removes the matching scene layer (via `find_by_identity_tag`) before deleting the baton.
- `PresentLayers` dispatches to `PresentDirectOverlay` / `PresentLayersViaScene` under `USE_DRM_SCENE` for the non-framed branch.
- New `PresentLayersViaScene`: walks the `FlutterLayer[]` in z-order, syncs the scene's layer set against this frame's batons (add new, `set_dst_rect_if_changed` on existing, remove stale), runs `scene_->test()` to predict placements, falls through to `PresentViaGlFallback` when any layer would be `Composited` or `Unassigned` (GL composite path is faster than `CompositeCanvas`'s CPU read-back over uncached GBM) or when any FlutterLayer is a platform view (PV→LayerBufferSource plumbing is a follow-on). Otherwise `glFinish`-syncs GPU writes, `scene_->commit`'s with `PAGE_FLIP_EVENT | NONBLOCK`, handles `EACCES` skip-frame and latched fallback, advances first-commit modeset state + `VerifyPipeRunning` + initial vsync baton, and rotates the BS slot pipeline identically to the legacy path. Debug logging emits per-frame `CommitReport` counters plus a separate scene-profile block under `IVI_DRM_PROFILE=1`.
- `SetPaused` mirrors pause edges into `scene_->on_session_paused`.
- `OnResume` calls `scene_->on_session_resumed(backend_->device())` after the existing latch reset; `DrmSession::TakeDevice` already opts in to `preserve_fd_across_resume` so the wrapped `Device`'s fd is the same one across pause/resume cycles.

## Out of scope (deferred)

- **Member cleanup** — `plane_registry_`, `allocator_`, `comp_layer_`, `modeset_`, `plane_mode_set_`, `primary_zpos_` remain because framed-mode reads `plane_registry_` for plane discovery and `primary_zpos_` for overlay zpos placement. Removing them needs framed-mode also migrated to LayerScene — separate PR.
- **Platform-view→LayerBufferSource plumbing** — frames containing a platform view force the GL composite path. PV adapters (Tier-2 wrappers over `ExternalDmaBufSource` / `GstAppsinkSource`) are follow-on work.
- **Explicit fence sync on the scene path** — the legacy direct-scanout path uses `IN_FENCE_FD` when the EGL native-fence-sync extension is present; the scene path falls back to a synchronous `glFinish` before commit. Correctness-equivalent at the cost of one per-frame stall on Tegra; `LayerBufferSource` sync hooks are a follow-on.

## Verification

- [x] `USE_DRM_SCENE=ON` / `OFF` — DRM backend builds clean (clang-tidy + clang-format clean); OFF is identical to `v2.0` (no `scene_` symbols, no `drm::scene` includes).
- [x] **RPi5 vc4** (trixie, kernel 6.12, 1280x1440) — backing store direct-scans on the **primary** with REFLECT_Y: `atomic TEST FAIL: 0`, no `partial-fallback drop`, steady ~60fps (`commit ~0.1ms`, no compositing), 0 `[W]`, right-side-up, no crash over a full run.
- [x] **amdgpu DC** (native x86_64, ICS-homescreen bundle) — no plane supports REFLECT_Y → scene gated off → legacy GL-composite path: 0 EINVAL, 0 `partial-fallback drop`, no crash, right-side-up. Replaces the prior behaviour where the scene set REFLECT_Y unconditionally and fell to a slow `CompositeCanvas` read-back with per-frame EINVAL.
