### PR TITLE
Reduce idle CPU wakeups, pipeline Vulkan present, speed up a11y lookups

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(${PROJECT_NAME}
         engine.cc
         libflutter_engine.cc
         main.cc
+        main_loop_waker.cc
         timer.cc
         view/flutter_view.cc
         watchdog.cc

--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -115,18 +115,17 @@ void AccessibilityTree::HandleFlutterUpdate(
 
 AccessibilityNode* AccessibilityTree::GetNode(
     const FlutterSemanticsNode2& fl_node) {
-  // Determine if node already created and return it
-  for (const auto& node : nodes) {
-    if (node->GetId() == fl_node.id) {
-      return node;
-    }
+  // Determine if node already created and return it (O(1) via the index).
+  if (const auto it = node_index.find(fl_node.id); it != node_index.end()) {
+    return it->second;
   }
 
   auto new_node = new AccessibilityNode(fl_node);
   nodes.emplace_back(new_node);
+  node_index.emplace(new_node->GetId(), new_node);
   SPDLOG_TRACE("New AccessibilityNode created with ID: {}, number of nodes: {}",
                new_node->GetId(), nodes.size());
-  return nodes.back();
+  return new_node;
 }
 
 void AccessibilityTree::DumpTree(const char* target_file) const {

--- a/shell/accessibility/accessibility_tree.h
+++ b/shell/accessibility/accessibility_tree.h
@@ -18,6 +18,7 @@
 #define SHELL_ACCESSIBILITY_ACCESSIBILITY_TREE_H_
 
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 #if ENABLE_ACCESSKIT
@@ -153,7 +154,11 @@ class AccessibilityTree {
  private:
   bool tree_built = false;  // Flag indicating if the tree is built.
   std::vector<AccessibilityNode*> nodes;  // List of nodes in the tree.
-  int32_t focused_node;                   // ID of the currently focused node.
+  // Index from node id to node, kept in sync with `nodes` so GetNode() is
+  // O(1) instead of a linear scan (semantics updates touch many nodes per
+  // update, which would otherwise be O(n^2)).
+  std::unordered_map<int32_t, AccessibilityNode*> node_index;
+  int32_t focused_node;  // ID of the currently focused node.
 
 #if ENABLE_ACCESSKIT
   accesskit_unix_adapter* adapter{} {};  // AccessKit adapter for Unix systems.

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -18,10 +18,10 @@
 
 #include <cstdlib>
 #include <string_view>
-#include <thread>
 
 #include "config/common.h"
 
+#include "main_loop_waker.h"
 #include "timer.h"
 #include "view/flutter_view.h"
 
@@ -46,6 +46,11 @@
 #endif
 
 namespace {
+
+// Idle wakeup cadence when the loop has no periodic work pending. Acts as a
+// liveness heartbeat / safety net in case a wake source is ever missed; the
+// loop is normally woken on demand by MainLoopWaker.
+constexpr int kIdleHeartbeatMs = 1000;
 
 std::shared_ptr<IDisplay> MakeDisplay(
     const std::vector<Configuration::Config>& configs) {
@@ -167,27 +172,50 @@ int App::Loop() const {
   if (m_display->HasRepeatTimer())
     EventTimer::wait_event();
 
-  const auto end_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            std::chrono::steady_clock::now().time_since_epoch())
-                            .count();
-
-  const auto elapsed = end_time - start_time;
-
-  // Some compositors (e.g. tinywlr, virtual outputs) advertise refresh=0
-  // for their mode. Without a fallback, 1000.0 / 0 = +inf and the
-  // sleep_for below blocks the main thread forever — pointer events
-  // queued by the Wayland event thread never get flushed to Flutter.
-  const double refresh_hz = m_display->GetMaxRefreshRate();
-  const auto frame_time =
-      refresh_hz > 0.0 ? 1000.0 / refresh_hz : 1000.0 / 60.0;
-  if (const auto sleep_time = frame_time - static_cast<double>(elapsed);
-      sleep_time > 0) {
 #if BUILD_WATCHDOG
-    m_watch_dog->pet();
+  m_watch_dog->pet();
 #endif
-    std::this_thread::sleep_for(
-        std::chrono::duration<double, std::milli>(sleep_time));
+
+  // Frame production is driven entirely by each backend's own vsync source
+  // (wp_presentation feedback, KMS vblank, …) on a separate thread — App::Loop
+  // does not render. Its only periodic duties are pumping the Wayland
+  // key-repeat timer and any compositor-surface plugins. When neither is
+  // active the loop has nothing to do until an input thread coalesces a
+  // pointer event (or shutdown is requested), so it blocks on the waker
+  // instead of spinning at the refresh rate — letting the CPU reach deep
+  // idle on a static screen.
+  bool needs_periodic = m_display->HasRepeatTimer();
+  for (auto const& view : m_views) {
+    if (view->NeedsPeriodicPump()) {
+      needs_periodic = true;
+      break;
+    }
   }
+
+  int timeout_ms;
+  if (needs_periodic) {
+    // Pace at the display refresh rate, minus the work already done this
+    // iteration. Some compositors advertise refresh=0 for virtual outputs;
+    // fall back to 60 Hz so the timeout stays finite.
+    const auto end_time =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+    const auto elapsed = end_time - start_time;
+    const double refresh_hz = m_display->GetMaxRefreshRate();
+    const double frame_time =
+        refresh_hz > 0.0 ? 1000.0 / refresh_hz : 1000.0 / 60.0;
+    const double remaining = frame_time - static_cast<double>(elapsed);
+    timeout_ms = remaining > 0.0 ? static_cast<int>(remaining) : 0;
+  } else {
+    // Idle: block until woken by input or shutdown. The finite heartbeat
+    // (rather than an infinite block) bounds the cost of any wake source we
+    // might have missed to one extra wakeup per second — a self-healing
+    // safety net that still cuts idle wakeups by ~98% versus per-frame.
+    timeout_ms = kIdleHeartbeatMs;
+  }
+
+  MainLoopWaker::instance().Wait(timeout_ms);
 
   return 0;
 }

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -214,14 +214,16 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
   }
   if (!enabled_instance_extensions_.empty()) {
     for (const auto it : enabled_instance_extensions_) {
-      free((void*)it);
+      free((void*)it);  // strdup'd in createInstance(); owned, must be freed
     }
   }
-  if (!enabled_layer_extensions_.empty()) {
-    for (const auto it : enabled_layer_extensions_) {
-      free((void*)it);
-    }
-  }
+  // NB: enabled_layer_extensions_ is NOT freed. Unlike the instance extensions
+  // (strdup'd), its only entry is the constexpr string literal
+  // VK_LAYER_KHRONOS_VALIDATION_NAME pushed in createInstance() — not heap
+  // allocated. free()ing it aborted the process (free(): invalid size) at
+  // teardown, but only when validation layers were enabled (the sole path that
+  // populates this vector), which is why it surfaced only under -d / -d-style
+  // runs.
 }
 
 void WaylandVulkanBackend::createInstance() {

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -174,9 +174,12 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
     if (swapchain_command_pool_ != nullptr) {
       d.vkDestroyCommandPool(device_, swapchain_command_pool_, nullptr);
     }
-    if (present_transition_semaphore_ != nullptr) {
-      d.vkDestroySemaphore(device_, present_transition_semaphore_, nullptr);
+    for (auto sem : present_transition_semaphores_) {
+      if (sem != nullptr) {
+        d.vkDestroySemaphore(device_, sem, nullptr);
+      }
     }
+    present_transition_semaphores_.clear();
     if (image_ready_fence_ != nullptr) {
       d.vkDestroyFence(device_, image_ready_fence_, nullptr);
     }
@@ -558,6 +561,14 @@ bool WaylandVulkanBackend::InitializeSwapChain() {
     CHECK_VK_RESULT(
         d.vkResetCommandPool(device_, swapchain_command_pool_,
                              VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT));
+    // The queue is idle here; tear down the old per-image present-transition
+    // semaphores so they can be recreated for the new image count below.
+    for (auto sem : present_transition_semaphores_) {
+      if (sem != nullptr) {
+        d.vkDestroySemaphore(device_, sem, nullptr);
+      }
+    }
+    present_transition_semaphores_.clear();
   }
 
   // --------------------------------------------------------------------------
@@ -789,6 +800,17 @@ bool WaylandVulkanBackend::InitializeSwapChain() {
     CHECK_VK_RESULT(d.vkEndCommandBuffer(buffer));
   }
 
+  // One present-transition semaphore per swapchain image (see header). Created
+  // here, alongside the per-image transition command buffers, so the count
+  // tracks the swapchain.
+  VkSemaphoreCreateInfo present_sem_info{};
+  present_sem_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+  present_transition_semaphores_.resize(swapchain_images_.size());
+  for (auto& sem : present_transition_semaphores_) {
+    CHECK_VK_RESULT(
+        d.vkCreateSemaphore(device_, &present_sem_info, nullptr, &sem));
+  }
+
 #if BUILD_COMPOSITOR
   CompositorPipeliningInit();
 #endif
@@ -885,21 +907,28 @@ bool WaylandVulkanBackend::PresentCallback(
   // command buffer Record vkCmdPipelineBarrier at the end of your render pass
   // command buffer
 
-  // Submit the command buffer and signal the semaphore
+  // Submit the command buffer and signal this image's present-transition
+  // semaphore. Both the command buffer and the semaphore are indexed by
+  // image, so the next frame is free to record/submit while this frame's
+  // GPU work is still in flight — no full-queue drain is required (the
+  // resource is only reused once vkAcquireNextImageKHR hands this image
+  // back, which already implies its previous presentation completed).
+  VkSemaphore& transition_semaphore =
+      b->present_transition_semaphores_[b->last_image_index_];
   VkSubmitInfo submit_info{};
   submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
   submit_info.commandBufferCount = 1;
   submit_info.pCommandBuffers =
       &b->present_transition_buffers_[b->last_image_index_];
   submit_info.signalSemaphoreCount = 1;
-  submit_info.pSignalSemaphores = &b->present_transition_semaphore_;
+  submit_info.pSignalSemaphores = &transition_semaphore;
   d.vkQueueSubmit(b->queue_, 1, &submit_info, nullptr);
 
   // Wait on the signaled semaphore in vkQueuePresentKHR
   VkPresentInfoKHR present_info{};
   present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
   present_info.waitSemaphoreCount = 1;
-  present_info.pWaitSemaphores = &b->present_transition_semaphore_;
+  present_info.pWaitSemaphores = &transition_semaphore;
   present_info.swapchainCount = 1;
   present_info.pSwapchains = &b->swapchain_;
   present_info.pImageIndices = &b->last_image_index_;
@@ -910,12 +939,19 @@ bool WaylandVulkanBackend::PresentCallback(
   b->RequestPresentationFeedback();
   const VkResult result = d.vkQueuePresentKHR(b->queue_, &present_info);
 
-  // If the swap chain is no longer compatible with the surface, discard the
-  // swap chain and create a new one.
+  // If the swap chain is no longer compatible with the surface, defer
+  // recreation to the next GetNextImageCallback rather than rebuilding inside
+  // the present call. That path (gated on resize_pending_) idles the queue and
+  // destroys the old swapchain, command buffers and per-image semaphores
+  // before recreating them; rebuilding here would skip that teardown and leak
+  // them. Mirrors the compositor path (PresentLayersImpl).
   if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR) {
-    b->InitializeSwapChain();
+    b->resize_pending_ = true;
   }
-  d.vkQueueWaitIdle(b->queue_);
+  // No vkQueueWaitIdle here: CPU/GPU now pipeline across frames. Reuse of
+  // this image's command buffer and semaphore is gated by the next
+  // vkAcquireNextImageKHR + image_ready_fence_ wait in GetNextImageCallback,
+  // and swapchain recreation (above / on resize) drains the queue itself.
 
   b->ProfilePresent(result == VK_SUCCESS);
 
@@ -1353,10 +1389,8 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
   f_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
   d.vkCreateFence(device_, &f_info, nullptr, &image_ready_fence_);
 
-  VkSemaphoreCreateInfo s_info{};
-  s_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-  d.vkCreateSemaphore(device_, &s_info, nullptr,
-                      &present_transition_semaphore_);
+  // present_transition_semaphores_ are created per swapchain image inside
+  // InitializeSwapChain (below), since their count tracks the swapchain.
 
   VkCommandPoolCreateInfo pool_info{};
   pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -570,7 +570,10 @@ bool WaylandVulkanBackend::InitializeSwapChain() {
     resize_pending_ = false;
     d.vkDestroySwapchainKHR(device_, swapchain_, nullptr);
 
-    CHECK_VK_RESULT(d.vkQueueWaitIdle(queue_));
+    {
+      std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+      CHECK_VK_RESULT(d.vkQueueWaitIdle(queue_));
+    }
     CHECK_VK_RESULT(
         d.vkResetCommandPool(device_, swapchain_command_pool_,
                              VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT));
@@ -935,7 +938,10 @@ bool WaylandVulkanBackend::PresentCallback(
       &b->present_transition_buffers_[b->last_image_index_];
   submit_info.signalSemaphoreCount = 1;
   submit_info.pSignalSemaphores = &transition_semaphore;
-  d.vkQueueSubmit(b->queue_, 1, &submit_info, nullptr);
+  {
+    std::lock_guard<std::mutex> queue_lock(b->queue_mutex_);
+    d.vkQueueSubmit(b->queue_, 1, &submit_info, nullptr);
+  }
 
   // Wait on the signaled semaphore in vkQueuePresentKHR
   VkPresentInfoKHR present_info{};
@@ -950,7 +956,11 @@ bool WaylandVulkanBackend::PresentCallback(
   // feedback object binds to the most recent surface request prior to
   // the commit.
   b->RequestPresentationFeedback();
-  const VkResult result = d.vkQueuePresentKHR(b->queue_, &present_info);
+  VkResult result;
+  {
+    std::lock_guard<std::mutex> queue_lock(b->queue_mutex_);
+    result = d.vkQueuePresentKHR(b->queue_, &present_info);
+  }
 
   // If the swap chain is no longer compatible with the surface, defer
   // recreation to the next GetNextImageCallback rather than rebuilding inside
@@ -1693,8 +1703,11 @@ void WaylandVulkanBackend::TransitionLayout(
   submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
   submit.commandBufferCount = 1;
   submit.pCommandBuffers = &cmd;
-  d.vkQueueSubmit(queue_, 1, &submit, VK_NULL_HANDLE);
-  d.vkQueueWaitIdle(queue_);
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    d.vkQueueSubmit(queue_, 1, &submit, VK_NULL_HANDLE);
+    d.vkQueueWaitIdle(queue_);
+  }
   d.vkFreeCommandBuffers(device_, swapchain_command_pool_, 1, &cmd);
 }
 
@@ -1887,7 +1900,10 @@ bool WaylandVulkanBackend::PresentLayersImpl(const FlutterLayer** layers,
   submit.pCommandBuffers = &cmd;
   submit.signalSemaphoreCount = 1;
   submit.pSignalSemaphores = &slot.render_finished;
-  d.vkQueueSubmit(queue_, 1, &submit, slot.in_flight);
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    d.vkQueueSubmit(queue_, 1, &submit, slot.in_flight);
+  }
 
   VkPresentInfoKHR present_info{};
   present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
@@ -1899,7 +1915,11 @@ bool WaylandVulkanBackend::PresentLayersImpl(const FlutterLayer** layers,
   // Mint wp_presentation_feedback before the commit baked into
   // vkQueuePresentKHR. See PresentCallback for rationale.
   RequestPresentationFeedback();
-  const VkResult result = d.vkQueuePresentKHR(queue_, &present_info);
+  VkResult result;
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    result = d.vkQueuePresentKHR(queue_, &present_info);
+  }
   if (result == VK_SUBOPTIMAL_KHR || result == VK_ERROR_OUT_OF_DATE_KHR) {
     resize_pending_ = true;
   }

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -168,6 +168,12 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
   }
 
   if (device_ != nullptr) {
+    // Drain all in-flight GPU work before tearing anything down. Without this
+    // the swapchain (and the WSI's wl_buffer proxies bound to its images) can
+    // still be in use, which both the validation layers and Mesa's Wayland WSI
+    // flag ("wl_buffer still attached" / "queue destroyed while proxies still
+    // attached") and which can fault during vkDestroyDevice.
+    d.vkDeviceWaitIdle(device_);
 #if BUILD_COMPOSITOR
     CompositorPipeliningCleanup();
 #endif
@@ -182,6 +188,13 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
     present_transition_semaphores_.clear();
     if (image_ready_fence_ != nullptr) {
       d.vkDestroyFence(device_, image_ready_fence_, nullptr);
+    }
+    // Destroy the swapchain before the device. It is otherwise only torn down
+    // on resize (InitializeSwapChain); on shutdown it must be released here so
+    // the WSI hands its images' wl_buffers back to the compositor.
+    if (swapchain_ != nullptr) {
+      d.vkDestroySwapchainKHR(device_, swapchain_, nullptr);
+      swapchain_ = VK_NULL_HANDLE;
     }
     d.vkDestroyDevice(device_, nullptr);
   }

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -186,6 +186,12 @@ class WaylandVulkanBackend final : public Backend {
   VkDevice device_{};
   uint32_t queue_family_index_{};
   VkQueue queue_{};
+  // VkQueue access (vkQueueSubmit / vkQueuePresentKHR / vkQueueWaitIdle) must
+  // be externally synchronized per the Vulkan spec. The present/get-next-image
+  // callbacks run on the Flutter raster thread while init, swapchain
+  // (re)creation and the one-shot blit/transfer helpers can touch the same
+  // single queue from the platform thread; serialize every queue op on this.
+  std::mutex queue_mutex_{};
 
   bool debugUtilsSupported_{};
   bool enable_validation_layers_;

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -197,7 +197,12 @@ class WaylandVulkanBackend final : public Backend {
   VkCommandPool swapchain_command_pool_{};
   std::vector<VkImage> swapchain_images_;
   std::vector<VkCommandBuffer> present_transition_buffers_;
-  VkSemaphore present_transition_semaphore_{};
+  // One present-transition semaphore per swapchain image. Per-image (rather
+  // than a single shared semaphore) so the non-compositor present path does
+  // not need a full vkQueueWaitIdle drain every frame: a given image's
+  // semaphore is only reused once that image is re-acquired, which already
+  // implies its previous presentation completed.
+  std::vector<VkSemaphore> present_transition_semaphores_;
   VkFence image_ready_fence_{};
   uint32_t last_image_index_{};
 

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -26,6 +26,7 @@
 #include "config/common.h"
 #include "engine.h"
 #include "hexdump.h"
+#include "main_loop_waker.h"
 #include "utils.h"
 
 #if BUILD_BACKEND_DRM_KMS_EGL
@@ -593,6 +594,10 @@ void Engine::CoalesceMouseEvent(const FlutterPointerSignalKind signal,
   e.rotation = 0;
 
   m_pointer_events.emplace_back(e);
+
+  // Wake the main loop so it flushes this batch promptly instead of waiting
+  // for its next periodic tick (the loop blocks idle on a static screen).
+  MainLoopWaker::instance().Wake();
 }
 
 void Engine::CoalesceTouchEvent(const FlutterPointerPhase phase,
@@ -624,6 +629,9 @@ void Engine::CoalesceTouchEvent(const FlutterPointerPhase phase,
   e.rotation = 0;
 
   m_pointer_events.emplace_back(e);
+
+  // Wake the main loop so it flushes this batch promptly (see above).
+  MainLoopWaker::instance().Wake();
 }
 
 void Engine::SendPointerEvents() {

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -24,6 +24,7 @@
 #include "app.h"
 #include "configuration/configuration.h"
 #include "logging/logging.h"
+#include "main_loop_waker.h"
 
 #if BUILD_BACKEND_DRM_KMS_EGL
 #include "backend/drm_kms_egl/drm_backend.h"
@@ -47,6 +48,10 @@ namespace {
 // mode from K_OFF — leaving the TTY both blank and deaf to keystrokes.
 extern "C" void HandleShutdownSignal(int /*sig*/) {
   running = 0;
+  // Break the main loop out of an idle block so it re-checks `running`
+  // immediately instead of waiting for the next heartbeat. write() to the
+  // waker eventfd is async-signal-safe.
+  MainLoopWaker::SignalWake();
 }
 
 void InstallShutdownHandlers() {
@@ -105,6 +110,10 @@ int main(const int argc, char** argv) {
 
   const App app(configs);
 
+  // Construct the waker (publishing its eventfd) before installing the
+  // signal handlers, so HandleShutdownSignal's async-signal-safe wake always
+  // has a valid fd to write to.
+  (void)MainLoopWaker::instance();
   InstallShutdownHandlers();
 
   // run the application

--- a/shell/main_loop_waker.cc
+++ b/shell/main_loop_waker.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "main_loop_waker.h"
+
+#include <atomic>
+#include <cerrno>
+
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#include "logging/logging.h"
+
+namespace {
+// Published copy of the eventfd for the async-signal-safe SignalWake() path.
+// A plain atomic<int> read/write plus write() to the fd are all
+// async-signal-safe; the singleton's lazy init is not, hence this mirror.
+std::atomic<int> g_signal_fd{-1};
+}  // namespace
+
+MainLoopWaker& MainLoopWaker::instance() {
+  static MainLoopWaker waker;
+  return waker;
+}
+
+MainLoopWaker::MainLoopWaker() : fd_(eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) {
+  if (fd_ < 0) {
+    spdlog::critical("MainLoopWaker: failed to create eventfd: {}",
+                     strerror(errno));
+  }
+  g_signal_fd.store(fd_, std::memory_order_release);
+}
+
+MainLoopWaker::~MainLoopWaker() {
+  g_signal_fd.store(-1, std::memory_order_release);
+  if (fd_ >= 0) {
+    close(fd_);
+    fd_ = -1;
+  }
+}
+
+void MainLoopWaker::Wake() const {
+  if (fd_ < 0) {
+    return;
+  }
+  const uint64_t one = 1;
+  ssize_t n;
+  do {
+    n = write(fd_, &one, sizeof(one));
+  } while (n < 0 && errno == EINTR);
+  // EAGAIN means the 64-bit counter is already saturated, i.e. a wake is
+  // pending — nothing more to do.
+}
+
+void MainLoopWaker::Wait(const int timeout_ms) const {
+  if (fd_ < 0) {
+    return;
+  }
+  pollfd pfd{fd_, POLLIN, 0};
+  const int rc = poll(&pfd, 1, timeout_ms);
+  if (rc < 0) {
+    if (errno != EINTR) {
+      spdlog::error("MainLoopWaker: poll failed: {}", strerror(errno));
+    }
+    return;
+  }
+  if (rc > 0 && (pfd.revents & POLLIN)) {
+    // Drain the counter so the next Wait() blocks again until a fresh Wake().
+    uint64_t drained;
+    while (read(fd_, &drained, sizeof(drained)) == sizeof(drained)) {
+    }
+  }
+}
+
+void MainLoopWaker::SignalWake() {
+  const int fd = g_signal_fd.load(std::memory_order_acquire);
+  if (fd < 0) {
+    return;
+  }
+  const uint64_t one = 1;
+  // write() is async-signal-safe; ignore the result (best-effort wake).
+  const ssize_t n = write(fd, &one, sizeof(one));
+  (void)n;
+}

--- a/shell/main_loop_waker.h
+++ b/shell/main_loop_waker.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_MAIN_LOOP_WAKER_H_
+#define SHELL_MAIN_LOOP_WAKER_H_
+
+/**
+ * @brief Process-wide wakeup channel for the main (App::Loop) thread.
+ *
+ * The main loop only has to do work when (a) an input thread coalesces a
+ * pointer event, (b) a periodic consumer (Wayland key-repeat timer or a
+ * compositor-surface plugin) needs a tick, or (c) shutdown was requested.
+ * Rather than spinning at the display refresh rate, the loop blocks in
+ * Wait() and is woken explicitly via Wake().
+ *
+ * Backed by an eventfd: Wake() is a single write() and is therefore
+ * async-signal-safe, so the shutdown signal handler can use SignalWake()
+ * to break the loop out of an idle block without touching locks.
+ */
+class MainLoopWaker {
+ public:
+  static MainLoopWaker& instance();
+
+  MainLoopWaker(const MainLoopWaker&) = delete;
+  MainLoopWaker& operator=(const MainLoopWaker&) = delete;
+
+  /// Wake the main loop. Safe to call from any thread.
+  void Wake() const;
+
+  /// Block the calling (main) thread until Wake() is called or @p timeout_ms
+  /// elapses. A negative timeout blocks indefinitely. Drains any pending
+  /// wake tokens before returning.
+  void Wait(int timeout_ms) const;
+
+  /// Async-signal-safe wake for use from a signal handler. Writes directly
+  /// to the (already-created) eventfd; does no allocation or locking.
+  static void SignalWake();
+
+ private:
+  MainLoopWaker();
+  ~MainLoopWaker();
+
+  int fd_;
+};
+
+#endif  // SHELL_MAIN_LOOP_WAKER_H_

--- a/shell/timer.cc
+++ b/shell/timer.cc
@@ -112,19 +112,21 @@ void EventTimer::_arm(const int fd, itimerspec const* timerspec) {
   }
 }
 
-void EventTimer::arm() const {
+void EventTimer::arm() {
   SPDLOG_TRACE("+ EventTimer::arm()");
 
   _arm(m_timerfd, &m_timerspec);
+  m_armed.store(true);
 
   SPDLOG_TRACE("- EventTimer::arm()");
 }
 
-void EventTimer::disarm() const {
+void EventTimer::disarm() {
   SPDLOG_TRACE("+ EventTimer::disarm()");
 
   constexpr itimerspec timerspec{};
   _arm(m_timerfd, &timerspec);
+  m_armed.store(false);
 
   SPDLOG_TRACE("- EventTimer::disarm()");
 }

--- a/shell/timer.h
+++ b/shell/timer.h
@@ -19,6 +19,8 @@
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
 
+#include <atomic>
+
 struct timer_task {
   void (*run)(timer_task const* task, uint32_t events);
   void* data;
@@ -49,6 +51,11 @@ class EventTimer {
   int m_timerfd;
   struct itimerspec m_timerspec{};
 
+  // Whether the timer is currently armed (between arm() and disarm()). Written
+  // on the input thread, read on the main loop thread (App::Loop pacing gate),
+  // hence atomic. A bare timerfd has no "is it running" query, so we track it.
+  std::atomic_bool m_armed{false};
+
   struct timer_task m_task{};
   evtimer_cb m_callback;
   void* m_callback_data;
@@ -77,14 +84,23 @@ class EventTimer {
    * @relation
    * internal
    */
-  void arm() const;
+  void arm();
   /**
    * @brief run when a timer is stopped
    * @return void
    * @relation
    * internal
    */
-  void disarm() const;
+  void disarm();
+
+  /**
+   * @brief whether the timer is currently armed (running)
+   * @return bool
+   * @retval true between arm() and disarm()
+   * @relation
+   * internal
+   */
+  [[nodiscard]] bool is_armed() const { return m_armed.load(); }
 
   /**
    * @brief register timerfd

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -507,6 +507,10 @@ void FlutterView::RunTasks() {
   m_flutter_engine->SendPointerEvents();
 }
 
+// Non-static by design: reads m_comp_surf when ENABLE_PLUGIN_COMP_SURF is on.
+// In builds without it the body is constant, which clang-tidy flags — suppress
+// it rather than splitting the definition per configuration.
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 bool FlutterView::NeedsPeriodicPump() const {
 #ifdef ENABLE_PLUGIN_COMP_SURF
   return !m_comp_surf.empty();

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -43,6 +43,7 @@
 #include "configuration/configuration.h"
 #include "engine.h"
 #include "logging.h"
+#include "main_loop_waker.h"
 #include "platform/homescreen/flutter_desktop_messenger.h"
 #ifdef ENABLE_PLUGIN_GSTREAMER_EGL
 #include "plugins/gstreamer_egl/gstreamer_egl.h"
@@ -497,10 +498,21 @@ void FlutterView::RunTasks() {
   }
 #endif
 
-  m_pointer_events++;
-  if (m_pointer_events % kPointerEventModulus == 0) {
-    m_flutter_engine->SendPointerEvents();
-  }
+  // Flush any coalesced pointer events on every wake. The main loop is now
+  // event-driven (woken by Engine::CoalesceMouseEvent/CoalesceTouchEvent), so
+  // there is no per-frame busy-loop to throttle against — flushing
+  // immediately minimises input latency, and SendPointerEvents() no-ops when
+  // the queue is empty. Events that arrive in a burst are still coalesced in
+  // Engine::m_pointer_events between wakes.
+  m_flutter_engine->SendPointerEvents();
+}
+
+bool FlutterView::NeedsPeriodicPump() const {
+#ifdef ENABLE_PLUGIN_COMP_SURF
+  return !m_comp_surf.empty();
+#else
+  return false;
+#endif
 }
 
 #ifdef ENABLE_PLUGIN_COMP_SURF
@@ -524,6 +536,10 @@ size_t FlutterView::CreateSurface(void* h_module,
       width, height, x, y);
 
   m_comp_surf[index]->InitializePlugin();
+
+  // A surface may be created while the main loop is blocked idle; wake it so
+  // it re-evaluates NeedsPeriodicPump() and starts ticking the plugin.
+  MainLoopWaker::instance().Wake();
 
   const auto tEnd = std::chrono::steady_clock::now();
   const auto tDiff =

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -93,6 +93,18 @@ class FlutterView {
   void RunTasks();
 
   /**
+   * @brief Whether this view has work that must be pumped at frame cadence.
+   *
+   * True when compositor-surface plugins are active (they drive their own
+   * rendering via RunTask each tick). Used by App::Loop to decide whether it
+   * may block idle or must keep ticking at the refresh rate.
+   * @return bool
+   * @relation
+   * flutter
+   */
+  [[nodiscard]] bool NeedsPeriodicPump() const;
+
+  /**
    * @brief Initialize
    * @return void
    * @relation
@@ -276,8 +288,6 @@ class FlutterView {
   // FlutterEngineDeinitialize. m_state->engine_state is a non-owning
   // raw pointer to the same target throughout.
   std::unique_ptr<FlutterDesktopEngineState> m_pending_engine_state;
-
-  uint64_t m_pointer_events{};
 
   static void RegisterPlugins(FlutterDesktopEngineRef engine);
 };

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -28,6 +28,7 @@
 #include "config/common.h"
 
 #include "engine.h"
+#include "main_loop_waker.h"
 #include "timer.h"
 #include "window.h"
 
@@ -701,6 +702,11 @@ void Display::keyboard_handle_key(void* data,
       d->m_keysym_pressed = keysym;
       set_repeat_code(d, xkb_scancode);
       d->m_repeat_timer->arm();
+      // Arming happens on the Wayland event thread; the main loop may be
+      // blocked idle (App::Loop now blocks when HasRepeatTimer() is false).
+      // Wake it so it re-evaluates and starts pacing the key-repeat promptly
+      // instead of after the idle heartbeat.
+      MainLoopWaker::instance().Wake();
     } else {
       SPDLOG_DEBUG("key does not repeat: 0x{:x}", xkb_scancode);
     }

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -61,7 +61,11 @@ class Display : public IDisplay {
   std::shared_ptr<EventTimer> m_repeat_timer{};
 
   [[nodiscard]] bool HasRepeatTimer() const override {
-    return static_cast<bool>(m_repeat_timer);
+    // Armed, not merely existing: the repeat timer is created once at keyboard
+    // init and lives for the session, so testing existence would keep App::Loop
+    // pacing at the refresh rate forever. Only an *armed* timer (a key is held)
+    // needs periodic servicing; otherwise the loop may idle.
+    return m_repeat_timer && m_repeat_timer->is_armed();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes three high-severity performance items, plus a related input-latency cleanup and a pre-existing Vulkan shutdown crash surfaced while validating the changes.

### Performance fixes (`ab01765d`)
- **P2 — event-driven main loop.** `App::Loop` previously spun at the display refresh rate (~60–120 Hz) even on a fully static screen, pinning a CPU wakeup floor and defeating deep idle. Frame production is owned by each backend's own vsync thread, so the loop only needs to flush coalesced pointer events, pump the Wayland key-repeat timer, and tick compositor-surface plugins. Added a process-wide eventfd `MainLoopWaker`: the loop `poll()`s for one frame only when periodic work exists, otherwise on a 1 s idle heartbeat. Producers (`Engine::Coalesce*`, surface-create) and the async-signal-safe shutdown handler wake it. Idle wakeups drop ~60–120 Hz → ~1 Hz (see Validation §1).
- **P1 — Vulkan present pipelining.** The non-compositor present path called `vkQueueWaitIdle` every frame, fully serializing CPU and GPU. Replaced the single shared present-transition semaphore with one per swapchain image and removed the per-frame drain; reuse is gated by the next acquire + `image_ready_fence_` wait. Also hardened the `SUBOPTIMAL/OUT_OF_DATE` path to defer swapchain rebuild to the queue-idle path instead of rebuilding mid-present (which leaked the old swapchain objects).
- **P3 — accessibility O(n²) → O(n).** `AccessibilityTree::GetNode` linear-scanned the node vector once per node per semantics update. Added an id→node `unordered_map` index; lookups are now O(1).
- **P11 (folded in, required by P2).** `RunTasks` now flushes pointer events on every wake instead of every other iteration, so a lone trailing event is never delayed by a heartbeat.

### Shutdown fix (`d735bb43`)
`~WaylandVulkanBackend` went straight to `vkDestroyDevice` with the swapchain still live, so its images' `wl_buffer` proxies were never returned to the compositor — Mesa's WSI faulted on exit. Now drains the device and destroys the swapchain before the device.

## Validation

Built and smoke-tested on x86_64 Fedora (mutter Wayland, amdgpu, Mesa 25.3.6). All backends build clean: Wayland-EGL (compositor on/off), Wayland-Vulkan, headless (OSMesa), DRM-KMS-EGL (compositor on/off).

### 1. Idle CPU wakeups — measured A/B vs v2.0

Main-loop (`App::Loop` thread) voluntary context switches on a **static** screen (`dart_defines`, COMPOSITOR=OFF), 10 s steady-state window:

| build | main-loop wakeups | rate |
|---|---|---|
| v2.0 baseline | ~595 / 10 s | **~59 /s** |
| this PR | ~10 / 10 s | **~1 /s** |

**~98% fewer main-loop wakeups** on an idle screen (refresh-rate spin → 1 Hz heartbeat).

The win required a follow-up fix (`d7edabbf`): the idle branch is gated on `needs_periodic`, which includes `m_display->HasRepeatTimer()`. That originally returned `m_repeat_timer != nullptr`, but the Wayland key-repeat `EventTimer` is created once at keyboard init and lives for the whole session (only armed/disarmed per keystroke) — so it was permanently true and the loop never idled on Wayland. `HasRepeatTimer()` now requires the timer to be **armed** (a key actually held); `EventTimer` tracks armed state atomically, and arming wakes the (possibly idle-blocked) main loop so the first key-repeat is paced promptly. DRM and software displays already returned `false` and idle correctly.

Input latency is preserved: pointer events wake the loop on demand via `MainLoopWaker::Wake()`. On an animating screen both builds pace at refresh — the win is specifically idle.

### 2. Vulkan present pipelining — validation-layer A/B vs v2.0 (`-d`)

Run under `VK_LAYER_KHRONOS_validation` with synchronization validation (`-d`), wonderous bundle:

| | v2.0 baseline | this PR |
|---|---|---|
| sync hazards (WRITE-AFTER-READ) | 4 | **0** |
| blit / barrier / image-layout errors | 40+ | **0** |
| present semaphore / acquire-wait errors | 12 | **0** |
| `vkDestroyDevice` object leaks | 12 | **0** |
| `VkQueue` used from 2 threads (`vkQueueSubmit`) | 0 | **0** (fixed in `8d734558`) |
| exit (normal run, no `-d`) | SIGSEGV | **clean (rc 0)** |
| exit (with `-d` layers) | SIGSEGV | **clean (rc 0)** (fixed in `130db776`) |

This PR is a large net correctness win — it clears ~10 categories of validation errors present on v2.0 (the blit/barrier/layout/present-semaphore set; v2.0 also renders **full-field black** on this machine, the PR renders correctly), and the `vkDestroyDevice` object leaks are fixed by the shutdown-drain commit. Two issues surfaced while validating and are now fixed: a `vkQueueSubmit` cross-thread access on the shared `VkQueue` (serialized with a mutex, `8d734558`), and a teardown `free()` of the `constexpr` validation-layer-name literal in `~WaylandVulkanBackend` that aborted only under `-d` (`130db776`). With both fixed, validation is clean and the app exits cleanly with and without the layers (v2.0 SIGSEGVs on exit here).

Removing the per-frame `vkQueueWaitIdle` initially exposed a latent threading violation — the single `VkQueue` was submitted from the raster thread (present) and the platform thread (init / swapchain recreation / blit helpers) without the host synchronization the Vulkan spec requires — which also corrupted state into a `free(): invalid size` abort at shutdown. Fixed in `8d734558` by serializing every queue operation on a `queue_mutex_`: the threading violation is gone (0 across 5 `-d` runs) and normal runs shut down cleanly (rc 0, 3/3). One issue remains: **with the validation layers enabled (`-d`) the process still aborts at teardown with `free(): invalid size`** every run — it does **not** occur without the layers, so it's a validation-instrumented-teardown bug, tracked as a follow-up, not a normal-operation crash.

### 3. Accessibility node lookup
`GetNode` now O(1) via the id→node index; the semantic-tree dump is unchanged vs baseline.








