### PR TITLE
EGL swap-interval pacing, swap profiling, and ordered shutdown teardown

### DIFF
--- a/shell/backend/backend.h
+++ b/shell/backend/backend.h
@@ -167,6 +167,20 @@ class Backend {
    */
   virtual void StopVsyncMonitor() {}
 
+  /**
+   * @brief Release the backend's GPU / windowing-system resources (render
+   * surface, native window, GL contexts, display connection).
+   *
+   * Called from @c FlutterView::~FlutterView @e after the engine has been
+   * stopped and all its threads joined, but while the window/display members
+   * are still alive. Tearing these down before the rasterizer thread is
+   * joined races that thread on the GL context (driver heap corruption);
+   * tearing them down after the window member is destroyed is a use-after-free
+   * on the native surface. This hook is the one safe point between the two.
+   * Must be idempotent. Default is a no-op.
+   */
+  virtual void ReleaseRenderSurfaces() {}
+
 #if BUILD_COMPOSITOR
   /**
    * @brief Register a platform-view compositor surface.

--- a/shell/backend/drm_kms_egl/scene_layer_source_vk.cc
+++ b/shell/backend/drm_kms_egl/scene_layer_source_vk.cc
@@ -29,7 +29,7 @@ VkBackingStoreLayerSource::create(
   auto inner = drm::scene::ExternalDmaBufSource::create(
       dev, width, height, drm_fourcc, modifier, planes);
   if (!inner) {
-    return drm::unexpected(inner.error());
+    return drm::unexpected<std::error_code>(inner.error());
   }
   return std::unique_ptr<VkBackingStoreLayerSource>(
       new VkBackingStoreLayerSource(std::move(*inner)));

--- a/shell/backend/headless/osmesa.cc
+++ b/shell/backend/headless/osmesa.cc
@@ -51,7 +51,23 @@ OSMesaHeadless::OSMesaHeadless(const int32_t initial_width,
 }
 
 OSMesaHeadless::~OSMesaHeadless() {
-  OSMesaDestroyContext(m_context);
+  // The original only destroyed m_context, leaking the resource and texture
+  // contexts and the malloc'd framebuffer. OSMesa contexts have no external
+  // surface binding (unlike the EGL/Wayland backend), so they can be destroyed
+  // directly; free the backing buffer last.
+  if (m_texture_context != nullptr) {
+    OSMesaDestroyContext(m_texture_context);
+    m_texture_context = nullptr;
+  }
+  if (m_resource_context != nullptr) {
+    OSMesaDestroyContext(m_resource_context);
+    m_resource_context = nullptr;
+  }
+  if (m_context != nullptr) {
+    OSMesaDestroyContext(m_context);
+    m_context = nullptr;
+  }
+  free_buffer();
 }
 
 bool OSMesaHeadless::MakeCurrent() const {

--- a/shell/backend/wayland_egl/egl.cc
+++ b/shell/backend/wayland_egl/egl.cc
@@ -179,6 +179,23 @@ Egl::Egl(void* native_display, const int buffer_size, const bool debug)
 }
 
 Egl::~Egl() {
+  // Unbind and destroy the contexts before terminating the display. The
+  // window-backed surface + wl_egl_window are released earlier (by
+  // WaylandEglBackend::StopVsyncMonitor, while the wl_surface is still alive);
+  // here we own the three contexts and the display connection.
+  eglMakeCurrent(m_dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  if (m_texture_context != EGL_NO_CONTEXT) {
+    eglDestroyContext(m_dpy, m_texture_context);
+    m_texture_context = EGL_NO_CONTEXT;
+  }
+  if (m_resource_context != EGL_NO_CONTEXT) {
+    eglDestroyContext(m_dpy, m_resource_context);
+    m_resource_context = EGL_NO_CONTEXT;
+  }
+  if (m_context != EGL_NO_CONTEXT) {
+    eglDestroyContext(m_dpy, m_context);
+    m_context = EGL_NO_CONTEXT;
+  }
   eglTerminate(m_dpy);
   eglReleaseThread();
 }

--- a/shell/backend/wayland_egl/egl.cc
+++ b/shell/backend/wayland_egl/egl.cc
@@ -179,10 +179,23 @@ Egl::Egl(void* native_display, const int buffer_size, const bool debug)
 }
 
 Egl::~Egl() {
-  // Unbind and destroy the contexts before terminating the display. The
-  // window-backed surface + wl_egl_window are released earlier (by
-  // WaylandEglBackend::StopVsyncMonitor, while the wl_surface is still alive);
-  // here we own the three contexts and the display connection.
+  // Idempotent: ReleaseContexts() normally already ran from the controlled
+  // shutdown path (WaylandEglBackend::ReleaseRenderSurfaces, after the engine
+  // was stopped and its threads joined). This is the fallback for any Egl
+  // owner that doesn't drive that path.
+  ReleaseContexts();
+}
+
+void Egl::ReleaseContexts() {
+  if (m_dpy == EGL_NO_DISPLAY) {
+    return;  // already torn down
+  }
+  // Unbind and destroy the contexts before terminating the display. Callers
+  // must guarantee no other thread (notably the Flutter rasterizer) still has
+  // a context current — destroying a context that is live on another thread
+  // corrupts the driver's heap (observed as a SIGSEGV inside Mesa's
+  // st_destroy_context on amdgpu). The window-backed surface + wl_egl_window
+  // are released first, while the wl_surface is still alive.
   eglMakeCurrent(m_dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
   if (m_texture_context != EGL_NO_CONTEXT) {
     eglDestroyContext(m_dpy, m_texture_context);
@@ -198,6 +211,7 @@ Egl::~Egl() {
   }
   eglTerminate(m_dpy);
   eglReleaseThread();
+  m_dpy = EGL_NO_DISPLAY;
 }
 
 bool Egl::MakeCurrent() const {

--- a/shell/backend/wayland_egl/egl.h
+++ b/shell/backend/wayland_egl/egl.h
@@ -152,6 +152,15 @@ class Egl {
  protected:
   EGLSurface m_egl_surface{};
 
+  /**
+   * @brief Unbind and destroy the three EGL contexts and terminate the
+   * display. Idempotent: safe to call more than once and a no-op once the
+   * display has been terminated. Must run only after every thread that could
+   * have a context current (notably the Flutter rasterizer) has been joined.
+   * @relation wayland
+   */
+  void ReleaseContexts();
+
  private:
   EGLConfig m_config{};
   EGLContext m_texture_context{};

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -693,6 +693,25 @@ void WaylandEglBackend::CreateSurface(size_t /* index */,
   m_wl_surface.store(surface, std::memory_order_release);
   m_egl_window = wl_egl_window_create(surface, width, height);
   m_egl_surface = create_egl_surface(m_egl_window, nullptr);
+
+  // Frame pacing is owned by the wp_presentation_feedback ->
+  // FlutterEngineOnVsync path whenever it is active, so make eglSwapBuffers
+  // non-blocking (swap interval 0) and avoid double-throttling the rasterizer
+  // inside the swap. When that path is disabled (IVI_WL_VSYNC=0, or no
+  // compatible presentation clock) the engine falls back to its wall-clock
+  // scheduler and the swap interval is the only throttle, so keep the EGL
+  // default of 1 there. Mirrors GetVsyncCallback()'s condition exactly so the
+  // two never disagree.
+  const EGLint swap_interval = GetVsyncCallback() != nullptr ? 0 : 1;
+  MakeCurrent();
+  if (eglSwapInterval(GetDisplay(), swap_interval) != EGL_TRUE) {
+    spdlog::warn("[WaylandEglBackend] eglSwapInterval({}) failed",
+                 swap_interval);
+  } else {
+    SPDLOG_DEBUG("[WaylandEglBackend] eglSwapInterval set to {}",
+                 swap_interval);
+  }
+  ClearCurrent();
 }
 
 #if 0  // TODO

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -690,13 +690,21 @@ void WaylandEglBackend::StopVsyncMonitor() {
         sw.blocked, 100.0 * sw.blocked / static_cast<double>(sw.samples));
   }
 
-  // Tear down the window-backed EGL surface + wl_egl_window here, not in a
-  // destructor. StopVsyncMonitor is called from FlutterView::~FlutterView
-  // while every member is still alive; the backend's own destructor runs
-  // *after* m_wayland_window (declared later, destroyed first), by which
-  // point the wl_surface the EGL surface / WSI reference is already freed —
-  // tearing them down there is a use-after-free (and leaving them for the
-  // base eglTerminate is what crashed on exit). Idempotent via the guards.
+  // NB: GPU / WSI resources (EGL surface, wl_egl_window, GL contexts,
+  // EGLDisplay) are NOT torn down here. StopVsyncMonitor runs before the
+  // engine is stopped, so the rasterizer thread may still be live and have a
+  // context current; destroying them now races that thread. They are released
+  // from ReleaseRenderSurfaces(), which FlutterView::~FlutterView calls after
+  // the engine has been stopped and joined.
+}
+
+void WaylandEglBackend::ReleaseRenderSurfaces() {
+  // Called from FlutterView::~FlutterView after Engine::Shutdown() has joined
+  // every engine thread (so no rasterizer thread holds a context current) but
+  // while m_wayland_window (the wl_surface) and m_display (the wl_display) are
+  // still alive (so the EGL surface / WSI objects and the EGLDisplay are still
+  // valid). This is the only safe point to release them. Idempotent via the
+  // guards below plus Egl::ReleaseContexts().
 #if BUILD_COMPOSITOR
   // The scratch blit FBO needs a current context; delete it before the
   // surface goes away.
@@ -716,6 +724,10 @@ void WaylandEglBackend::StopVsyncMonitor() {
     wl_egl_window_destroy(m_egl_window);
     m_egl_window = nullptr;
   }
+  // Destroy the GL contexts and terminate the display now, while no engine
+  // thread is alive. (Egl::~Egl would otherwise run at member-destruction
+  // time, after m_display has freed the wl_display the EGLDisplay wraps.)
+  ReleaseContexts();
 }
 
 void WaylandEglBackend::RecordSwapDuration(const uint64_t swap_ns) {

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -130,40 +130,55 @@ FlutterRendererConfig WaylandEglBackend::GetRenderConfig() {
     // THIS commit. No-op when wp_presentation isn't usable.
     b->RequestPresentationFeedback();
 
-    // Full swap if FlutterPresentInfo is invalid
-    if (info->struct_size != sizeof(FlutterPresentInfo)) {
-      return b->SwapBuffers();
-    }
+    static const bool profile_enabled =
+        std::getenv("IVI_WL_PROFILE") != nullptr;
 
-    // Existing-damage storage is held by value in m_existing_damage_map;
-    // populate_existing_damage rewrites the entry in place on every call,
-    // so no per-frame free is required here.
-
-    if (b->GetSetDamageRegion()) {
-      // Set the buffer damage as the damage region.
-      auto buffer_rects = b->RectToInts(info->buffer_damage.damage[0]);
-      b->GetSetDamageRegion()(b->GetDisplay(), b->m_egl_surface,
-                              buffer_rects.data(), 1);
-    }
-
-    if (info->frame_damage.damage) {
-      // Add frame damage to damage history
-      b->m_damage_history.push_back(info->frame_damage.damage[0]);
-      if (b->m_damage_history.size() > kMaxHistorySize) {
-        b->m_damage_history.pop_front();
+    // Decide the swap mechanism (and do the cheap damage bookkeeping) BEFORE
+    // timing, so the measured interval reflects only the swap-call block time
+    // — the quantity the swap-interval setting moves — not RectToInts / damage
+    // map work.
+    bool use_damage_swap = false;
+    std::array<EGLint, 4> frame_rects{};
+    if (info->struct_size == sizeof(FlutterPresentInfo)) {
+      // Existing-damage storage is held by value in m_existing_damage_map;
+      // populate_existing_damage rewrites the entry in place on every call,
+      // so no per-frame free is required here.
+      if (b->GetSetDamageRegion()) {
+        // Set the buffer damage as the damage region.
+        auto buffer_rects = b->RectToInts(info->buffer_damage.damage[0]);
+        b->GetSetDamageRegion()(b->GetDisplay(), b->m_egl_surface,
+                                buffer_rects.data(), 1);
       }
-
-      if (b->GetSwapBuffersWithDamage()) {
-        // Swap buffers with frame damage.
-        const auto frame_rects = b->RectToInts(info->frame_damage.damage[0]);
-        return b->GetSwapBuffersWithDamage()(
-            b->GetDisplay(), b->m_egl_surface,
-            const_cast<int*>(frame_rects.data()), 1);
+      if (info->frame_damage.damage) {
+        // Add frame damage to damage history
+        b->m_damage_history.push_back(info->frame_damage.damage[0]);
+        if (b->m_damage_history.size() > kMaxHistorySize) {
+          b->m_damage_history.pop_front();
+        }
+        if (b->GetSwapBuffersWithDamage()) {
+          frame_rects = b->RectToInts(info->frame_damage.damage[0]);
+          use_damage_swap = true;
+        }
       }
     }
-    // If the required extensions for partial repaint were not
-    // provided, do full repaint.
-    return b->SwapBuffers();
+
+    const uint64_t t0 =
+        profile_enabled ? LibFlutterEngine->GetCurrentTime() : 0;
+    bool result;
+    if (use_damage_swap) {
+      // Swap buffers with frame damage.
+      result = b->GetSwapBuffersWithDamage()(
+          b->GetDisplay(), b->m_egl_surface,
+          const_cast<int*>(frame_rects.data()), 1);
+    } else {
+      // Full repaint: invalid present info, no frame damage, or the
+      // partial-repaint extension wasn't provided.
+      result = b->SwapBuffers();
+    }
+    if (profile_enabled) {
+      b->RecordSwapDuration(LibFlutterEngine->GetCurrentTime() - t0);
+    }
+    return result;
   };
 
   config.open_gl.populate_existing_damage =
@@ -663,6 +678,42 @@ void WaylandEglBackend::StopVsyncMonitor() {
           s.bucket_idle * inv);
     }
   }
+
+  // Session-aggregate eglSwapBuffers self-time (IVI_WL_PROFILE=1). This is the
+  // metric the swap-interval setting moves: lower mean / fewer blocked swaps
+  // means the rasterizer spent less time stalled in the swap.
+  if (const auto& sw = swap_session_; sw.samples > 0) {
+    spdlog::info(
+        "[WaylandEglBackend] swap session: n={} mean={}us max={}us "
+        "blocked(>2ms)={} ({:.1f}%)",
+        sw.samples, (sw.sum_ns / sw.samples) / 1000, sw.max_ns / 1000,
+        sw.blocked, 100.0 * sw.blocked / static_cast<double>(sw.samples));
+  }
+}
+
+void WaylandEglBackend::RecordSwapDuration(const uint64_t swap_ns) {
+  const auto accumulate = [swap_ns](SwapProfile& p) {
+    p.sum_ns += swap_ns;
+    if (swap_ns > p.max_ns) {
+      p.max_ns = swap_ns;
+    }
+    if (swap_ns > kSwapBlockedNs) {
+      ++p.blocked;
+    }
+    ++p.samples;
+  };
+  accumulate(swap_profile_);
+  accumulate(swap_session_);
+
+  // Flush a window every 60 swaps, mirroring the frame-interval profiler.
+  if (auto& w = swap_profile_; w.samples >= 60) {
+    spdlog::info(
+        "[WaylandEglBackend] swap profile (n={}): mean={}us max={}us "
+        "blocked(>2ms)={} ({:.1f}%)",
+        w.samples, (w.sum_ns / w.samples) / 1000, w.max_ns / 1000, w.blocked,
+        100.0 * w.blocked / static_cast<double>(w.samples));
+    w = SwapProfile{};
+  }
 }
 
 void WaylandEglBackend::Resize(size_t /* index */,
@@ -702,7 +753,19 @@ void WaylandEglBackend::CreateSurface(size_t /* index */,
   // scheduler and the swap interval is the only throttle, so keep the EGL
   // default of 1 there. Mirrors GetVsyncCallback()'s condition exactly so the
   // two never disagree.
-  const EGLint swap_interval = GetVsyncCallback() != nullptr ? 0 : 1;
+  EGLint swap_interval = GetVsyncCallback() != nullptr ? 0 : 1;
+  // IVI_WL_SWAP_INTERVAL=auto|0|1 forces the interval independent of the vsync
+  // path, so it can be A/B'd (0 vs 1 with vsync held on) when measuring the
+  // rasterizer swap-block time. "auto" (default) keeps the vsync-coupled value.
+  if (const char* env = std::getenv("IVI_WL_SWAP_INTERVAL")) {
+    if (std::string_view(env) == "0") {
+      swap_interval = 0;
+    } else if (std::string_view(env) == "1") {
+      swap_interval = 1;
+    }
+    spdlog::info("[WaylandEglBackend] IVI_WL_SWAP_INTERVAL={} -> interval {}",
+                 env, swap_interval);
+  }
   MakeCurrent();
   if (eglSwapInterval(GetDisplay(), swap_interval) != EGL_TRUE) {
     spdlog::warn("[WaylandEglBackend] eglSwapInterval({}) failed",

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -689,6 +689,33 @@ void WaylandEglBackend::StopVsyncMonitor() {
         sw.samples, (sw.sum_ns / sw.samples) / 1000, sw.max_ns / 1000,
         sw.blocked, 100.0 * sw.blocked / static_cast<double>(sw.samples));
   }
+
+  // Tear down the window-backed EGL surface + wl_egl_window here, not in a
+  // destructor. StopVsyncMonitor is called from FlutterView::~FlutterView
+  // while every member is still alive; the backend's own destructor runs
+  // *after* m_wayland_window (declared later, destroyed first), by which
+  // point the wl_surface the EGL surface / WSI reference is already freed —
+  // tearing them down there is a use-after-free (and leaving them for the
+  // base eglTerminate is what crashed on exit). Idempotent via the guards.
+#if BUILD_COMPOSITOR
+  // The scratch blit FBO needs a current context; delete it before the
+  // surface goes away.
+  if (m_texture_blit_fbo_) {
+    MakeCurrent();
+    glDeleteFramebuffers(1, &m_texture_blit_fbo_);
+    m_texture_blit_fbo_ = 0;
+  }
+#endif
+  // eglDestroySurface must not run on a bound surface — unbind first.
+  ClearCurrent();
+  if (m_egl_surface != EGL_NO_SURFACE) {
+    eglDestroySurface(GetDisplay(), m_egl_surface);
+    m_egl_surface = EGL_NO_SURFACE;
+  }
+  if (m_egl_window != nullptr) {
+    wl_egl_window_destroy(m_egl_window);
+    m_egl_window = nullptr;
+  }
 }
 
 void WaylandEglBackend::RecordSwapDuration(const uint64_t swap_ns) {
@@ -1258,15 +1285,6 @@ void WaylandEglBackend::ResizeCompositorSurface(
   }
   if (surface) {
     surface->OnResize(width, height);
-  }
-}
-
-WaylandEglBackend::~WaylandEglBackend() {
-  // Pools flush themselves; the scratch blit FBO needs explicit cleanup
-  // while the EGL context from the base class is still current.
-  if (m_texture_blit_fbo_) {
-    glDeleteFramebuffers(1, &m_texture_blit_fbo_);
-    m_texture_blit_fbo_ = 0;
   }
 }
 

--- a/shell/backend/wayland_egl/wayland_egl.h
+++ b/shell/backend/wayland_egl/wayland_egl.h
@@ -70,10 +70,6 @@ class WaylandEglBackend : public Egl, public Backend {
                     bool debug_backend,
                     int buffer_size = kEglBufferSize);
 
-#if BUILD_COMPOSITOR
-  ~WaylandEglBackend() override;
-#endif
-
   /**
    * @brief Resize Flutter engine Window size
    * @param[in] index No use

--- a/shell/backend/wayland_egl/wayland_egl.h
+++ b/shell/backend/wayland_egl/wayland_egl.h
@@ -161,6 +161,13 @@ class WaylandEglBackend : public Egl, public Backend {
    */
   void StopVsyncMonitor() override;
 
+  /**
+   * @brief Release the EGL surface, wl_egl_window and GL contexts. Called
+   * from @c FlutterView::~FlutterView after the engine has been stopped and
+   * joined, while the wl_surface / wl_display are still alive.
+   */
+  void ReleaseRenderSurfaces() override;
+
   void UpdateSize(int _width, int _height) {
     m_initial_width = static_cast<uint32_t>(_width);
     m_initial_height = static_cast<uint32_t>(_height);

--- a/shell/backend/wayland_egl/wayland_egl.h
+++ b/shell/backend/wayland_egl/wayland_egl.h
@@ -357,6 +357,26 @@ class WaylandEglBackend : public Egl, public Backend {
   // without having to sum the per-window windows.
   FrameProfile session_totals_{};
 
+  // eglSwapBuffers self-time profile (IVI_WL_PROFILE=1). This is the metric
+  // that the swap-interval change moves: with interval 1 the swap blocks the
+  // rasterizer on the compositor throttle, with interval 0 it returns
+  // promptly. Accumulated and flushed entirely on the rasterizer thread
+  // (present_with_info), so it is kept separate from profile_ — which is
+  // written on Display's event_thread_ — to avoid a cross-thread data race.
+  struct SwapProfile {
+    uint64_t sum_ns{0};
+    uint64_t max_ns{0};
+    uint32_t samples{0};
+    uint32_t blocked{0};  // swaps slower than kSwapBlockedNs (≈ blocked)
+  };
+  static constexpr uint64_t kSwapBlockedNs = 2'000'000;  // 2ms
+  SwapProfile swap_profile_{};
+  SwapProfile swap_session_{};
+
+  // Record one eglSwapBuffers duration and flush a window every 60 swaps.
+  // Rasterizer-thread only. No-op unless IVI_WL_PROFILE is set.
+  void RecordSwapDuration(uint64_t swap_ns);
+
   // Mirrors DrmBackend::VsyncTrampoline. Flutter calls this with the
   // FlutterDesktopEngineState* as user_data plus an opaque baton; we
   // recover the backend instance and forward to SetVsyncBaton.

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -259,13 +259,9 @@ Engine::Engine(FlutterView* view,
 }
 
 Engine::~Engine() {
-  if (m_running) {
-    LibFlutterEngine->Deinitialize(m_flutter_engine);
-    LibFlutterEngine->Shutdown(m_flutter_engine);
-    if (m_aot_data) {
-      LibFlutterEngine->CollectAOTData(m_aot_data);
-    }
-  }
+  // Stop the engine (idempotent) as a fallback for owners that don't drive
+  // the explicit shutdown sequence in FlutterView::~FlutterView.
+  Shutdown();
   // Free engine_state explicitly here — after Deinitialize/Shutdown have
   // joined all engine threads and drained final callbacks (so user_data
   // dereferences in OnFlutterPlatformMessage hit live state), but before
@@ -283,11 +279,23 @@ FlutterEngineResult Engine::RunTask() {
   return kSuccess;
 }
 
-FlutterEngineResult Engine::Shutdown() const {
-  if (!m_flutter_engine) {
-    return kSuccess;
+void Engine::Shutdown() {
+  if (!m_running) {
+    return;  // never started, or already stopped — idempotent
   }
-  return LibFlutterEngine->Shutdown(m_flutter_engine);
+  m_running = false;
+  // Deinitialize stops new frame work; Shutdown joins the platform, UI and
+  // rasterizer threads. After this returns nothing in the engine touches the
+  // backend (no more VsyncTrampoline / PresentLayers), so the caller may
+  // safely release the GL contexts and render surfaces those threads used.
+  if (m_flutter_engine) {
+    LibFlutterEngine->Deinitialize(m_flutter_engine);
+    LibFlutterEngine->Shutdown(m_flutter_engine);
+  }
+  if (m_aot_data) {
+    LibFlutterEngine->CollectAOTData(m_aot_data);
+    m_aot_data = nullptr;
+  }
 }
 
 bool Engine::IsRunning() const {

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -108,13 +108,17 @@ class Engine {
   [[nodiscard]] double GetPixelRatio() const { return m_prev_pixel_ratio; };
 
   /**
-   * @brief Shutsdown Flutter Engine Instance
-   * @return FlutterEngineResult
-   * @retval The result of shutting down the engine
+   * @brief Stop the Flutter engine and join all of its threads.
+   *
+   * This is the explicit shutdown point of control: after it returns no
+   * engine thread (platform, UI, rasterizer) is alive, so it is safe to tear
+   * down the resources those threads touch (GL contexts, render surfaces).
+   * Idempotent — a no-op if the engine was never started or is already
+   * stopped. ~Engine() calls it as a fallback.
    * @relation
    * flutter
    */
-  [[nodiscard]] FlutterEngineResult Shutdown() const;
+  void Shutdown();
 
   /**
    * @brief Check if engine is running
@@ -387,7 +391,11 @@ class Engine {
   FlutterTaskRunnerDescription m_platform_task_runner_description{};
   FlutterCustomTaskRunners m_custom_task_runners{};
 
-  FlutterEngineAOTData m_aot_data;
+  // Zero-initialized: only assigned for AOT runs (RunsAOTCompiledDartCode()).
+  // On a JIT/debug run LoadAotData() never runs, so this must be null —
+  // otherwise the `if (m_aot_data)` guard in Shutdown() reads garbage and
+  // CollectAOTData() corrupts the heap.
+  FlutterEngineAOTData m_aot_data{};
 
   // Owned by Engine so it survives FlutterEngineDeinitialize. See
   // TakeEngineState() above. ~Engine resets this between Shutdown and

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -337,15 +337,38 @@ FlutterView::~FlutterView() {
     m_state->engine_state->messenger->SetEngine(nullptr);
   }
 
-  // Tear down any backend-owned vsync/event-loop monitor before
-  // m_flutter_engine destructs. DRM's monitor is an asio async_wait on
-  // the drm fd living on the engine's platform task runner; if it's
-  // still outstanding when Engine::~Engine resets the runner,
-  // TaskRunner::~TaskRunner blocks forever joining a worker parked in
-  // epoll_wait waiting for an event that will never arrive. The default
-  // virtual is a no-op for backends without a monitor.
+  // Ordered shutdown. The three steps below must run in this order; relying
+  // on member-destruction order instead races the engine's rasterizer thread
+  // against GL/WSI teardown (SIGSEGV) or strands GPU resources behind a
+  // freed wl_surface.
+  //
+  // 1. Stop the backend's vsync/event-loop monitor while the engine and its
+  //    platform task runner are still alive. DRM's monitor is an asio
+  //    async_wait on the drm fd living on that runner; if it's still
+  //    outstanding when the runner is destroyed, TaskRunner::~TaskRunner
+  //    blocks forever joining a worker parked in epoll_wait. This does NOT
+  //    touch GL/WSI resources. No-op for backends without a monitor.
   if (m_backend) {
     m_backend->StopVsyncMonitor();
+  }
+
+  // 2. Point of control: stop the engine and join the platform, UI and
+  //    rasterizer threads. Until this returns the rasterizer can still call
+  //    into the backend (VsyncTrampoline / PresentLayers) and hold a GL
+  //    context current. Doing this explicitly here — rather than leaving it
+  //    to m_flutter_engine's destruction further down — guarantees no engine
+  //    thread is alive for step 3.
+  if (m_flutter_engine) {
+    m_flutter_engine->Shutdown();
+  }
+
+  // 3. Now that no engine thread is alive, release the backend's GL contexts
+  //    and render surfaces, while m_wayland_window (wl_surface) and m_display
+  //    (wl_display) are still alive — both are destroyed later, in member
+  //    order — so the EGL surface / EGLDisplay are still valid. No-op for
+  //    backends that don't hold such resources.
+  if (m_backend) {
+    m_backend->ReleaseRenderSurfaces();
   }
 }
 


### PR DESCRIPTION
## Summary

EGL backend follow-ups from the performance audit (`docs/reports/performance.md`, item P4), the measurement tooling that quantifies it, and a sweep of backend shutdown teardown that fixes resource-release gaps and a shutdown crash.

### EGL swap interval (`9f87674b`)
When the `wp_presentation_feedback` → `FlutterEngineOnVsync` path drives frame pacing, the EGL default swap interval of 1 makes `eglSwapBuffers` additionally block the rasterizer on the compositor throttle. The backend now sets the interval from that condition: **0 when the presentation-feedback path is active** (pacing is owned solely by it), **1 when it is not** (`IVI_WL_VSYNC=0` or no compatible presentation clock — the wall-clock scheduler runs and the swap is the only throttle). The condition mirrors `GetVsyncCallback()` exactly so the two never disagree.

### Measurement tooling (`7e6daa7a`)
- `IVI_WL_PROFILE` records **`eglSwapBuffers` self-time** (mean/max + % of swaps blocking >2 ms) — the quantity the swap interval moves. Held on a rasterizer-thread-only struct, separate from the event-thread frame profiler, to avoid a data race.
- `IVI_WL_SWAP_INTERVAL=auto|0|1` forces the interval independent of the vsync path so 0 vs 1 can be A/B'd with everything else held constant.

### Ordered shutdown teardown (`9d88b944`, `c6d1880e`, `df920297`)
`FlutterView::~FlutterView` relied on member-destruction order to tear down the engine and the backend's GL/WSI resources. That left the EGL surface / `wl_egl_window` / GL contexts referencing a `wl_surface` already freed by the time `eglTerminate` ran (SIGSEGV on exit), and races the engine's rasterizer thread — which can hold a context current and call back into the backend until the engine is actually stopped — against context destruction (SIGSEGV in Mesa's `st_destroy_context` on amdgpu, ~2/5 SIGTERM runs).

The destructor now drives an explicit, ordered sequence:
1. `StopVsyncMonitor()` — stop the backend's vsync/event-loop monitor while the platform task runner is still alive (no GL/WSI work here).
2. `Engine::Shutdown()` — join the platform, UI and rasterizer threads; after this no engine thread touches the backend. `Shutdown()` is non-const and idempotent (guarded by `m_running`); `~Engine()` calls it as a fallback.
3. `ReleaseRenderSurfaces()` — new `Backend` hook that destroys the `EGLSurface`, `wl_egl_window`, GL contexts and `EGLDisplay` while the `wl_surface` / `wl_display` are still alive. `Egl::ReleaseContexts()` is extracted from `~Egl` and made idempotent via an `EGL_NO_DISPLAY` guard.

`Engine::m_aot_data` is zero-initialized: on JIT runs `LoadAotData()` never assigns it, so the guarded `CollectAOTData()` in shutdown read an uninitialized pointer and corrupted the heap.

The headless/OSMesa backend (`c6d1880e`) destroys all three OSMesa contexts and frees the framebuffer (was leaking the resource/texture contexts and the malloc'd buffer); OSMesa contexts have no external surface binding, so there is no teardown-ordering constraint there.

The **software backend needs no change**: the DRM-dumb and fbdev sinks already restore the CRTC, free buffers, munmap and close their fds in their destructors, and file/memory/none hold no persistent OS resources.

Also folds in a small DRM `scene_layer_source_vk.cc` build fix (`drm::unexpected<std::error_code>`).

## Validation

x86_64 Fedora, GNOME/mutter Wayland, AMD radeonsi, Mesa 25.3.6 (mutter exposes `wp_presentation clock_id=1`, so `auto` engages interval 0).

**Shutdown** — clean SIGTERM exit, 0 SIGSEGV: Wayland-EGL COMPOSITOR=OFF 16/16, COMPOSITOR=ON 11/11; Wayland-Vulkan smoke clean. Builds clean across all backends (Wayland-EGL comp on/off, Wayland-Vulkan, DRM-KMS-EGL comp on/off, headless). clang-tidy (clang-21) + clang-format clean on all changed files.

**Swap-interval benefit** — A/B with `IVI_WL_PROFILE=1`, COMPOSITOR=OFF build, ~20 s per run, `eglSwapBuffers` self-time on the rasterizer thread:

| run | `SWAP_INTERVAL` | n | mean | max | swaps blocking >2 ms |
|---|---|---|---|---|---|
| 1 | `1` | 999 | 5185 µs | 9941 µs | 642 (64.3 %) |
| 1 | `0` | 3591 | 66 µs | 7805 µs | 3 (0.1 %) |
| 2 | `1` | 919 | 7754 µs | 23065 µs | 830 (90.3 %) |
| 2 | `0` | 1427 | 86 µs | 6184 µs | 3 (0.2 %) |

At interval 1 the mean swap blocks ~5–8 ms and most swaps stall >2 ms on the compositor throttle; at interval 0 the swap returns in ~70–90 µs and essentially nothing blocks — ~60–90× less time inside `eglSwapBuffers`, with the rasterizer no longer parked in the swap.

The swap profiler lives in the `present_with_info` path of the COMPOSITOR=OFF build; the compositor build emits no `swap session:` line.

## Known issue

The headless/OSMesa backend hangs on SIGTERM — a pre-existing Wayland event-thread join deadlock, independent of this PR (reproduces with these changes reverted). Tracked in #203.
