### PR TITLE
[drm_kms_egl] fix cold-start stall: deliver the parked first vsync baton

### DIFF
--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -1267,10 +1267,11 @@ void DrmBackend::PostOnVsync(FLUTTER_API_SYMBOL(FlutterEngine) engine,
   }
   auto* runner = platform_task_runner_.load(std::memory_order_acquire);
   if (runner == nullptr || runner->GetStrandContext() == nullptr) {
-    // Plumbing not in place yet — drop. Happens between vsync_callback
-    // firing during engine bring-up and FlutterView::SetPlatformTaskRunner
-    // landing. The kick latch ensures Flutter still gets a baton from
-    // the next-frame path once the runner is wired.
+    // Runner not wired yet (the engine's first vsync request raced
+    // SetPlatformTaskRunner during bring-up). Callers leave the baton
+    // parked in vsync_baton_ in this case rather than exchanging it out,
+    // so SetPlatformTaskRunner's kick latch delivers it once the runner
+    // is wired (#210).
     return;
   }
   const uint64_t now = LibFlutterEngine->GetCurrentTime();
@@ -1308,9 +1309,20 @@ void DrmBackend::SetVsyncBaton(FLUTTER_API_SYMBOL(FlutterEngine) engine,
     return;
   }
 
-  // Exchange to take the baton back. The asio handler may have raced
-  // us and already consumed it; exchange returning 0 means it's
-  // already on its way.
+  // Idle pipeline — kick the baton inline. Only pull it out of
+  // vsync_baton_ if the platform task runner is actually wired and can
+  // deliver it; otherwise leave it parked so SetPlatformTaskRunner's kick
+  // latch delivers it once wired. At cold start the engine's first vsync
+  // request can land before SetPlatformTaskRunner; exchanging the baton
+  // out only to drop it in PostOnVsync stranded Flutter's first frame
+  // (#210) — frame 1 was never produced (black screen + only the HW
+  // cursor). Gating here (rather than exchange-then-restore) keeps the
+  // hand-off to the kick latch race-free: the baton is taken exactly once,
+  // by whichever of this path / the latch first sees the runner wired.
+  auto* runner = platform_task_runner_.load(std::memory_order_acquire);
+  if (runner == nullptr || runner->GetStrandContext() == nullptr) {
+    return;  // parked in vsync_baton_; SetPlatformTaskRunner drains it
+  }
   if (const intptr_t mine = vsync_baton_.exchange(0, std::memory_order_acq_rel);
       mine != 0) {
     PostOnVsync(engine, mine);
@@ -1469,6 +1481,26 @@ void DrmBackend::UnifiedPageFlipHandler(int /*fd*/,
 void DrmBackend::SetPlatformTaskRunner(TaskRunner* runner) {
   platform_task_runner_.store(runner, std::memory_order_release);
   StartFlipMonitor();
+
+  // Kick latch (#210). The engine may have requested its first vsync
+  // before this runner was wired (cold-start race between Engine::Run and
+  // this call). In that case SetVsyncBaton left the baton parked in
+  // vsync_baton_ rather than dropping it. Deliver it now so Flutter
+  // renders frame 1. Storing the runner above (release) before this drain
+  // (acq_rel exchange) makes the hand-off exact: SetVsyncBaton either saw
+  // the runner wired and took the baton itself, or saw it unwired and
+  // parked the baton — in which case its release-store of the baton
+  // happens-before this exchange, so we observe and deliver it here. Without
+  // this latch the first baton is never answered and the app hangs on a
+  // black screen (only the HW cursor visible) until restart.
+  if (auto* engine = engine_handle_.load(std::memory_order_acquire);
+      engine != nullptr) {
+    if (const intptr_t baton =
+            vsync_baton_.exchange(0, std::memory_order_acq_rel);
+        baton != 0) {
+      PostOnVsync(engine, baton);
+    }
+  }
 }
 
 void DrmBackend::StartFlipMonitor() {


### PR DESCRIPTION
## Summary

Fixes the intermittent DRM cold-start stall (#210): on ~30–40% of cold starts the
screen comes up black with only the hardware cursor and the app never renders;
a restart clears it.

## Root cause

`FlutterView` runs the engine (`flutter_view.cc:405`) **before** wiring the
platform task runner (`SetPlatformTaskRunner`, `flutter_view.cc:419`). If the
engine's first vsync request lands in that window:

1. `SetVsyncBaton` sees the pipeline idle (`flip_in_flight == false`) and takes
   the inline-kick branch: `vsync_baton_.exchange(0)` pulls the baton out, then
   `PostOnVsync` is called.
2. `PostOnVsync` finds `platform_task_runner_ == nullptr` and **drops the
   baton** — and it was already exchanged out of `vsync_baton_`, so it's lost.
3. `SetPlatformTaskRunner` then wires the runner and arms the flip monitor but
   does **nothing** to recover the dropped baton (the "kick latch" its own
   comment referenced never existed).

Flutter waits forever for the first `OnVsync`, never schedules frame 1, so the
rasterizer never calls `CreateBackingStore`/`PresentLayers` and the compositor's
lazy init never runs — black screen (the cursor shows because it's on its own
atomic-cursor plane). Confirmed live with temporary instrumentation:

```
first SetVsyncBaton: baton=547474122864 flip_in_flight=false runner_wired=false
PostOnVsync DROP: platform runner not wired (runner=0x0), baton=547474122864 LOST
flip monitor armed on fd=5      (~210 µs too late)
```

## Fix

- **`SetVsyncBaton`** — only take the baton out of `vsync_baton_` and kick it
  when the platform task runner is wired and can deliver it; otherwise leave it
  *parked* in `vsync_baton_` for the kick latch. (Gating before the exchange,
  rather than exchange-then-restore, keeps the hand-off to the latch race-free —
  the transient empty state of exchange-then-restore can race the latch and
  strand the baton.)
- **`SetPlatformTaskRunner`** — add the kick latch: after storing the runner and
  starting the flip monitor, deliver any parked baton. The runner store
  (release) before the baton `exchange` (acq-rel) makes the hand-off deliver the
  first baton exactly once, by whichever path first observes the runner wired.
- **`PostOnVsync`** — drop-path comment updated (callers now park instead of
  stranding).

## Verification

- **RPi4 vc4** (Trixie, 1920x1080@60): a 20-iteration cold-start loop now
  presents **20/20** (`present=20 stall=0`), each rendering via the scene
  direct-scanout path. Baseline was ~30–40% stalls, so 0/20 puts the odds of a
  fluke at ~0.08%.
- **amdgpu DC**: unaffected — still presents (gated to the GL-composite path),
  no crash.
- clang-tidy / clang-format clean on the change.

Closes #210.
