### PR TITLE
[drm_kms_egl] reserve cursor overlay from scene allocator + modifier-aware front-buffer import

### DIFF
--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -385,6 +385,15 @@ std::unique_ptr<DrmBackend> DrmBackend::Create(
   backend->cursor_ = homescreen::DrmCursor::Create(
       *backend->drm_dev_, backend->crtc_id_, backend->connector_id_,
       backend->mode_, backend->fb_w_, backend->fb_h_);
+#if BUILD_COMPOSITOR
+  // On a CRTC with no dedicated cursor plane the cursor takes an
+  // overlay; reserve it so the scene allocator's disable-unused pass
+  // doesn't toggle it off every commit (flicker on pointer motion).
+  // plane_id()==0 (legacy cursor path) is a no-op in the compositor.
+  if (backend->cursor_ && backend->compositor_) {
+    backend->compositor_->ReserveCursorPlane(backend->cursor_->plane_id());
+  }
+#endif
 #endif
 #if HAVE_DRM_CAPTURE
   backend->capture_ = homescreen::DrmCapture::Create();

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -17,6 +17,7 @@
 #include "backend/drm_kms_egl/drm_backend.h"
 #include "logging/logging.h"
 
+#include <drm_fourcc.h>
 #include <fcntl.h>
 #include <linux/vt.h>
 #include <poll.h>
@@ -1150,13 +1151,54 @@ bool DrmBackend::InitEgl() {
 uint32_t DrmBackend::AddFb(gbm_bo* bo) const {
   const uint32_t width = gbm_bo_get_width(bo);
   const uint32_t height = gbm_bo_get_height(bo);
-  const uint32_t stride = gbm_bo_get_stride(bo);
-  const uint32_t handle = gbm_bo_get_handle(bo).u32;
+  const uint32_t format = gbm_bo_get_format(bo);
+  const uint64_t modifier = gbm_bo_get_modifier(bo);
+  const int plane_count = gbm_bo_get_plane_count(bo);
+
+  // The gbm_surface is created with_modifiers, so on tiled/compressed
+  // allocators (e.g. the Mali blob's AFBC on rk3588) the front buffer
+  // carries a non-linear modifier. The legacy drmModeAddFB is
+  // modifier-blind and tells KMS the buffer is linear — the display
+  // controller then scans tiled data as linear and underflows
+  // (rockchip VOP2 POST_BUF_EMPTY → green/black field). Propagate the
+  // real modifier via drmModeAddFB2WithModifiers, mirroring
+  // DrmCompositor::ImportBoAsFb.
+  uint32_t handles[4] = {};
+  uint32_t pitches[4] = {};
+  uint32_t offsets[4] = {};
+  uint64_t modifiers[4] = {};
+  for (int i = 0; i < plane_count && i < 4; ++i) {
+    handles[i] = gbm_bo_get_handle_for_plane(bo, i).u32;
+    pitches[i] = gbm_bo_get_stride_for_plane(bo, i);
+    offsets[i] = gbm_bo_get_offset(bo, i);
+    modifiers[i] = modifier;
+  }
+
   uint32_t fb_id = 0;
-  if (drmModeAddFB(drm_dev_->fd(), width, height, 24, 32, stride, handle,
-                   &fb_id) != 0) {
-    spdlog::error("[DrmBackend] drmModeAddFB: {}", std::strerror(errno));
+  const bool use_modifiers = (modifier != DRM_FORMAT_MOD_INVALID) &&
+                             (modifier != DRM_FORMAT_MOD_LINEAR);
+  if (use_modifiers) {
+    if (drmModeAddFB2WithModifiers(drm_dev_->fd(), width, height, format,
+                                   handles, pitches, offsets, modifiers, &fb_id,
+                                   DRM_MODE_FB_MODIFIERS) != 0) {
+      spdlog::error(
+          "[DrmBackend] drmModeAddFB2WithModifiers({}x{}, fmt=0x{:08x}, "
+          "mod=0x{:016x}, planes={}): {}",
+          width, height, format, modifier, plane_count, std::strerror(errno));
+      return 0;
+    }
+  } else if (drmModeAddFB2(drm_dev_->fd(), width, height, format, handles,
+                           pitches, offsets, &fb_id, 0) != 0) {
+    spdlog::error("[DrmBackend] drmModeAddFB2({}x{}, fmt=0x{:08x}, linear): {}",
+                  width, height, format, std::strerror(errno));
     return 0;
+  }
+  if (cfg_.debug_backend) {
+    spdlog::debug(
+        "[DrmBackend] AddFb fb_id={} {}x{} fmt=0x{:08x} mod=0x{:016x} "
+        "planes={} ({})",
+        fb_id, width, height, format, modifier, plane_count,
+        use_modifiers ? "modifier-aware" : "linear");
   }
   return fb_id;
 }

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -461,6 +461,7 @@ bool DrmCompositor::InitPlaneAllocator() {
         return false;
       }
       scene_ = std::move(*scene);
+      ApplyCursorReservation();
       spdlog::info(
           "[DrmCompositor] LayerScene constructed (crtc={} connector={})",
           scene_cfg.crtc_id, scene_cfg.connector_id);
@@ -3079,6 +3080,27 @@ bool DrmCompositor::CollectBackingStore(const FlutterBackingStore* store) {
 }
 
 // ─── Session pause / resume ──────────────────────────────────────────────
+
+void DrmCompositor::ReserveCursorPlane(const uint32_t plane_id) {
+  cursor_reserved_plane_ = plane_id;
+  // Apply immediately in case the scene already exists (cursor wired
+  // after the first present); otherwise the scene-build path applies it.
+  ApplyCursorReservation();
+}
+
+void DrmCompositor::ApplyCursorReservation() {
+#if USE_DRM_SCENE
+  if (!scene_ || cursor_reserved_plane_ == 0) {
+    return;
+  }
+  const uint32_t planes[] = {cursor_reserved_plane_};
+  scene_->set_external_reserved_planes(drm::span<const uint32_t>(planes, 1));
+  spdlog::info(
+      "[DrmCompositor] reserved cursor plane {} from scene allocator "
+      "(disable-unused pass will leave it alone)",
+      cursor_reserved_plane_);
+#endif
+}
 
 void DrmCompositor::SetPaused(const bool paused) {
   paused_.store(paused, std::memory_order_release);

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -148,6 +148,16 @@ class DrmCompositor {
   void SetPaused(bool paused);
   void OnResume();
 
+  // Tell the compositor which DRM plane an externally-managed cursor
+  // (drm::cursor::Renderer) is armed on, so the scene allocator never
+  // disables it. On a CRTC with no dedicated cursor plane the cursor
+  // takes an overlay this scene would otherwise treat as unused;
+  // without the reservation the disable-unused pass turns it off every
+  // commit, fighting the cursor's own commits (flicker on motion).
+  // Stored and (re)applied to the LayerScene whenever it is built.
+  // plane_id == 0 (legacy cursor path / no cursor) is a no-op.
+  void ReserveCursorPlane(uint32_t plane_id);
+
   // Per-flip-complete work for the atomic plane path. Called by
   // DrmBackend::UnifiedPageFlipHandler on the platform task runner
   // thread when planes_active() returns true. Just clears
@@ -376,6 +386,17 @@ class DrmCompositor {
   // produces matching LayerBufferSource wrappers stashed in StoreBaton
   // until their first Present add_layer()s them in.
   std::unique_ptr<drm::scene::LayerScene> scene_;
+
+  // DRM plane id of an externally-managed cursor to reserve from the
+  // scene allocator's disable-unused pass. Set by ReserveCursorPlane()
+  // (from DrmBackend, once the cursor exists); applied to scene_ each
+  // time the scene is built. 0 = none / legacy cursor path.
+  uint32_t cursor_reserved_plane_{0};
+
+  // Push cursor_reserved_plane_ into the live scene (if any). No-op
+  // when there's no scene or no cursor plane. Idempotent; called both
+  // when the reservation is set and whenever the scene is (re)built.
+  void ApplyCursorReservation();
 
   // Embedder-side mirror of the scene's live layer set, keyed by
   // baton pointer (the same pointer set as LayerDesc::identity_tag).

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -387,17 +387,6 @@ class DrmCompositor {
   // until their first Present add_layer()s them in.
   std::unique_ptr<drm::scene::LayerScene> scene_;
 
-  // DRM plane id of an externally-managed cursor to reserve from the
-  // scene allocator's disable-unused pass. Set by ReserveCursorPlane()
-  // (from DrmBackend, once the cursor exists); applied to scene_ each
-  // time the scene is built. 0 = none / legacy cursor path.
-  uint32_t cursor_reserved_plane_{0};
-
-  // Push cursor_reserved_plane_ into the live scene (if any). No-op
-  // when there's no scene or no cursor plane. Idempotent; called both
-  // when the reservation is set and whenever the scene is (re)built.
-  void ApplyCursorReservation();
-
   // Embedder-side mirror of the scene's live layer set, keyed by
   // baton pointer (the same pointer set as LayerDesc::identity_tag).
   // Walked each frame to prune layers whose baton didn't appear in
@@ -408,6 +397,16 @@ class DrmCompositor {
   // than any hashing for that size.
   std::vector<StoreBaton*> scene_layer_batons_;
 #endif
+
+  // DRM plane id of an externally-managed cursor to reserve from the
+  // scene allocator's disable-unused pass. Set by ReserveCursorPlane()
+  // (from DrmBackend, once the cursor exists); applied to scene_ each
+  // time the scene is built. 0 = none / legacy cursor path. Declared
+  // unconditionally (ReserveCursorPlane is part of the BUILD_COMPOSITOR
+  // API regardless of USE_DRM_SCENE); ApplyCursorReservation's body is
+  // a no-op when USE_DRM_SCENE is off (no scene to reserve from).
+  uint32_t cursor_reserved_plane_{0};
+  void ApplyCursorReservation();
 
   // Double-buffered composition buffer for layers that overflow HW planes.
   static constexpr int kNumCompBufs = 2;

--- a/shell/backend/drm_kms_egl/drm_cursor.cc
+++ b/shell/backend/drm_kms_egl/drm_cursor.cc
@@ -193,6 +193,10 @@ std::unique_ptr<DrmCursor> DrmCursor::Create(drm::Device& dev,
 DrmCursor::DrmCursor(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
 DrmCursor::~DrmCursor() = default;
 
+uint32_t DrmCursor::plane_id() const {
+  return impl_->renderer.plane_id();
+}
+
 void DrmCursor::Move(const int fb_x, const int fb_y) {
   const int crtc_x = fb_x + impl_->letterbox_x;
   const int crtc_y = fb_y + impl_->letterbox_y;

--- a/shell/backend/drm_kms_egl/drm_cursor.h
+++ b/shell/backend/drm_kms_egl/drm_cursor.h
@@ -86,6 +86,13 @@ class DrmCursor {
   // sprite stalls.
   void Move(int fb_x, int fb_y);
 
+  // The DRM plane id the cursor is scanned out on (0 on the legacy
+  // drmModeSetCursor path, which has no addressable plane). On a CRTC
+  // with no dedicated cursor plane the renderer takes an overlay; the
+  // compositor must reserve that plane so its scene allocator doesn't
+  // disable it every commit. Fixed for the cursor's lifetime.
+  [[nodiscard]] uint32_t plane_id() const;
+
  private:
   struct Impl;
   std::unique_ptr<Impl> impl_;


### PR DESCRIPTION
## Summary

Two DRM/KMS (`drm_kms_egl`) fixes:

1. **Reserve the cursor's overlay from the scene allocator.** On a CRTC with no dedicated cursor plane the HW cursor takes an overlay; the scene allocator's disable-unused pass then toggles it off every commit, fighting the cursor's own commits — visible as cursor/primary flicker on pointer motion. Plumbs the cursor's plane id into `LayerScene::set_external_reserved_planes` via `DrmCompositor::ReserveCursorPlane`. Inert on hardware with a dedicated cursor plane (plane id 0 / reservation no-ops).

2. **Import the gbm front buffer modifier-aware.** `DrmBackend::AddFb` used the legacy modifier-blind `drmModeAddFB` on a `gbm_surface` created `with_modifiers`; a non-linear front-buffer modifier would be dropped and KMS would scan it as linear. Now uses `drmModeAddFB2WithModifiers` (mirroring `DrmCompositor::ImportBoAsFb`), falling back to `AddFB2` for linear/invalid.

## Dependency

Commit 1 bumps the `drm-cxx` submodule to pick up `set_external_reserved_planes` (jwinarske/drm-cxx#78). **Merge the drm-cxx PR first.**

## Validation (real hardware)

| HW | Driver | Result |
|----|--------|--------|
| amdgpu | amdgpu | renders, 0 EINVAL, clean exit; dedicated cursor plane → reservation inert (no regression) |
| RPi4 | vc4 | fullscreen direct-scanout: reservation fires (`reserved cursor plane`), renders, 0 EINVAL |
| Arduino Uno Q | msm | 2-plane CRTC, cursor takes overlay → flicker on motion fixed (confirmed) |
| NanoPC-T6 | rockchip (rk3588) | dedicated cursor plane → reservation inert; cursor on/off identical (no regression) |

The modifier-aware `AddFb` change is correctness hardening surfaced during rk3588 bring-up; it is **not** the fix for the separate, pre-existing rk3588 direct-scanout issue (that buffer is linear-modifier).
