### PR TITLE
[drm_kms_egl] make the scene path's first atomic commit blocking

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2363,13 +2363,23 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     backend_->flip_submit_ns_ = LibFlutterEngine->GetCurrentTime();
   }
 
-  const uint32_t commit_flags =
-      DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
-  const uint64_t t2 = profile ? NsNow() : 0;
-
   // LayerScene injects ALLOW_MODESET implicitly on its first commit,
   // so the embedder doesn't manage plane_mode_set_ for this path.
   const bool was_first_commit_pre = !plane_mode_set_;
+
+  // Two-phase flags, mirroring the legacy direct-scanout path: the
+  // first commit is a blocking ALLOW_MODESET with NO PAGE_FLIP_EVENT.
+  // The kernel doesn't deliver a flip event across a modeset on most
+  // drivers (the commit returning is our signal), and combining the
+  // ALLOW_MODESET that LayerScene ORs in for first_commit_ with
+  // NONBLOCK makes rockchip's atomic path return EBUSY against the
+  // modeset's still-pending flip — wedging the CRTC. Steady state:
+  // NONBLOCK + PAGE_FLIP_EVENT for vsync-locked flips.
+  const uint32_t commit_flags =
+      was_first_commit_pre
+          ? DRM_MODE_ATOMIC_ALLOW_MODESET
+          : (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK);
+  const uint64_t t2 = profile ? NsNow() : 0;
 
   auto report = scene_->commit(commit_flags, backend_);
   if (!report) {


### PR DESCRIPTION
## Summary

The scene/direct-scanout present path sent `DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK` on **every** commit, including the first. `LayerScene` ORs `ALLOW_MODESET` into its `first_commit_`, so the first commit became a **NONBLOCK modeset requesting a flip event**.

On rockchip's atomic path that returns `EBUSY` against the modeset's still-pending flip, wedging the CRTC. The present then latches the GL fallback, whose legacy `drmModePageFlip` also `EBUSY`s on the wedged CRTC — so nothing ever presents (black screen).

## Fix

Mirror the **legacy** direct-scanout path's two-phase flags:
- **First commit:** blocking `ALLOW_MODESET`, no `PAGE_FLIP_EVENT` (the kernel doesn't deliver a flip event across a modeset on most drivers; the commit returning is the completion signal).
- **Steady state:** `NONBLOCK | PAGE_FLIP_EVENT`.

This also matches the path's own post-commit logic, which already assumed the first commit was blocking ("ALLOW_MODESET cycle is blocking, so no PAGE_FLIP_EVENT is in flight"). General correctness fix — not rockchip-specific.

## Validation

On rk3588 (NanoPC-T6, rockchip-drm, mainline): before — first scene commit `EBUSY` → GL fallback → `drmModePageFlip EBUSY` flood → no present. After — scene commit succeeds, no fallback, no page-flip EBUSY, stays on zero-copy direct-scanout.

Note: this removes the CRTC-wedge; separate rk3588 scene-path issues (frame-content sync, idle vsync spin) remain under investigation and are not addressed here.
