### PR TITLE
[drm_kms_egl] gate REFLECT_Y off on rockchip (VOP IOMMU fault) + build-matrix docs

### DIFF
--- a/shell/backend/drm_kms_egl/README.md
+++ b/shell/backend/drm_kms_egl/README.md
@@ -211,6 +211,34 @@ GL fallback runs and `drm_compositor.cc` is excluded.
 Output binary: `cmake-build-debug-clang/shell/homescreen` (the name is
 `EXE_OUTPUT_NAME` from `cmake/options.cmake:204` — default "homescreen").
 
+### Build matrix (compositor / scene)
+
+Two CMake options select the present path. They are independent of the
+runtime `--drm-compositor auto|planes|gl` flag (which only picks among
+what was compiled in):
+
+| Config | CMake flags | Present path compiled in |
+|--------|-------------|--------------------------|
+| **C1** | `-DBUILD_COMPOSITOR=OFF` | Legacy GL only — `eglSwapBuffers` + `drmModePageFlip`. `drm_compositor.cc` is excluded. |
+| **C2** | `-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=OFF` | Atomic plane allocator + GL composite. The drm-cxx `LayerScene` zero-copy path is excluded. |
+| **C3** | `-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON` | Full path: `LayerScene` direct-scanout when the primary supports `REFLECT_Y`, GL composite otherwise. **Recommended / canonical.** |
+
+`USE_DRM_SCENE=ON` requires `BUILD_COMPOSITOR=ON` (it has no effect
+otherwise). Any code reachable from the unconditional `BUILD_COMPOSITOR`
+API (e.g. `DrmCompositor::ReserveCursorPlane`) must compile in **all**
+three configs — C2 in particular (compositor without scene) is an easy
+one to break, so the build matrix is exercised on both x86_64 and
+aarch64.
+
+The aarch64 cross-build helper maps these as: `scripts/build_pi.sh`
+default → **C1**; `scripts/build_pi.sh --with-scene` → **C3**.
+
+Per-driver note: on **rockchip** (rk3588 VOP2) the primary advertises
+`REFLECT_Y` and passes a `TEST_ONLY` atomic commit with it, but a live
+reflected scanout faults the display IOMMU; C3 therefore force-selects
+the GL-composite sub-path on that driver (zero-copy direct-scanout is
+not usable there). vc4 and amdgpu are unaffected.
+
 ### Optional features detected at configure time
 
 - **libxcursor** missing → `HAVE_DRM_CURSOR` undefined, `drm_cursor.cc`

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -356,6 +356,22 @@ bool DrmCompositor::InitPlaneAllocator() {
   }
   spdlog::info("[DrmCompositor] primary plane zpos = {}", primary_zpos_);
 
+  // rockchip VOP2 advertises REFLECT_Y on its planes and even passes a
+  // TEST_ONLY atomic commit with it, but an actual reflected scanout
+  // faults the display IOMMU into a storm (rk_iommu "stall request timed
+  // out" + vop2 POST_BUF_EMPTY), wedging the pipe — a green/black screen.
+  // The TEST_ONLY probe can't catch this (it only validates state, not a
+  // live scanout), so blocklist the driver: direct-scanout needs
+  // REFLECT_Y to flip GL's bottom-up buffer, so with it gone the
+  // compositor uses the GL-composite path (Y-flip baked into the shader,
+  // scanned un-reflected) which the VOP scans cleanly.
+  if (backend_->resolved().driver_name == "rockchip") {
+    any_plane_supports_reflect_y_ = false;
+    spdlog::info(
+        "[DrmCompositor] rockchip: REFLECT_Y scanout faults the VOP IOMMU; "
+        "forcing GL composite");
+  }
+
   // Universal diagnostic kill-switch: force GL composite even when
   // REFLECT_Y is available. Useful for bisecting visual artifacts that
   // appear on the direct-scanout path.


### PR DESCRIPTION
## Summary

On **rockchip** (rk3588 VOP2) the primary plane advertises `REFLECT_Y` and even passes a `TEST_ONLY` atomic commit with it — but a *live* reflected scanout accesses unmapped addresses, triggering an `rk_iommu` stall-request-timeout + `vop2 POST_BUF_EMPTY` storm that wedges the pipe (green/black screen). The `TEST_ONLY` probe can't detect this (it validates state, not a live scanout).

Direct-scanout requires `REFLECT_Y` to flip GL's bottom-up buffer for top-down scanout, so the fix gates `REFLECT_Y` off when `driver_name == "rockchip"`. With it gone, the compositor falls to the GL-composite path (Y-flip baked into the shader, scanned un-reflected), which the VOP scans cleanly. Zero-copy direct-scanout is not usable on this hardware.

Second commit documents the `BUILD_COMPOSITOR` / `USE_DRM_SCENE` build matrix (C1/C2/C3) in the backend README, including the per-driver rockchip note.

## Hardware validation (no regressions)

Bounded HW × build-config matrix run on four boards:

| | amdgpu | rk3588 | RPi4 / vc4 | Uno Q / msm |
|---|---|---|---|---|
| **C1** (no-comp) | renders | renders | renders | — * |
| **C2** (comp, no-scene) | renders | renders | renders | — * |
| **C3** (comp+scene) | renders (framed) | **gate → GL composite, renders** | renders (direct-scanout) | renders (direct-scanout) |

- **rk3588 A/B:** without the gate, C3 faults the IOMMU (2505 faults, green); with it, 0 faults, steady flips. Gate fires only on rockchip.
- **gate inert on amdgpu and vc4** (`rockchip gate fired: 0`, behavior unchanged).
- **cursor reservation** confirmed firing on both 2-plane boards (vc4 + msm/Uno Q plane 41) with no flicker.
- Compile matrix (C1/C2/C3 × x86_64 + aarch64) all green.

\* Uno Q C1/C2 skipped (unrelated build-dir Wayland-protocol fragility); their code is covered by the RPi4 (same aarch64/trixie) runs + compile matrix.

Tegra/nvidia-drm (Jetson) not covered here — to be validated separately after merge.

## Notes

Builds in all three configs on both x86_64 and aarch64; the rockchip gate is driver-scoped so other drivers are unaffected.
