### PR TITLE
Add DRM/KMS Vulkan backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,16 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
     endif ()
 endif ()
 
+if (BUILD_BACKEND_DRM_KMS_VULKAN)
+    if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN OR
+        BUILD_BACKEND_DRM_KMS_EGL)
+        message(FATAL_ERROR
+                "BUILD_BACKEND_DRM_KMS_VULKAN is mutually exclusive with "
+                "BUILD_BACKEND_WAYLAND_EGL, BUILD_BACKEND_WAYLAND_VULKAN, and "
+                "BUILD_BACKEND_DRM_KMS_EGL")
+    endif ()
+endif ()
+
 # FlutterView's backend type is picked by an #if/#elif chain over the
 # BUILD_BACKEND_* flags; enabling both Wayland EGL and Wayland Vulkan
 # yields a single binary whose renderer is silently determined by
@@ -60,7 +70,8 @@ endif ()
 # incompatible with the GL/Vulkan configs the other backends produce.
 # Reject the combination at configure time.
 if (BUILD_BACKEND_SOFTWARE)
-    if (BUILD_BACKEND_DRM_KMS_EGL OR BUILD_BACKEND_WAYLAND_EGL OR
+    if (BUILD_BACKEND_DRM_KMS_EGL OR BUILD_BACKEND_DRM_KMS_VULKAN OR
+        BUILD_BACKEND_WAYLAND_EGL OR
         BUILD_BACKEND_WAYLAND_VULKAN OR BUILD_BACKEND_HEADLESS_EGL)
         message(FATAL_ERROR
                 "BUILD_BACKEND_SOFTWARE is mutually exclusive with the "
@@ -79,7 +90,7 @@ include(compiler)
 # library (which carries -stdlib=libc++ on clang builds) exists when we
 # add_subdirectory(drm-cxx). Otherwise drm-cxx compiles against libstdc++
 # and link fails with mixed ABI symbols.
-if (BUILD_BACKEND_DRM_KMS_EGL)
+if (BUILD_BACKEND_DRM_KMS_EGL OR BUILD_BACKEND_DRM_KMS_VULKAN)
     include(drm_kms)
 endif ()
 

--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -19,10 +19,6 @@
 
 #include <array>
 
-#include <EGL/egl.h>
-
-#include <waypp/waypp.h>
-
 #ifndef BUILD_BACKEND_WAYLAND_EGL
 #cmakedefine01 BUILD_BACKEND_WAYLAND_EGL
 #endif
@@ -55,6 +51,29 @@
 #endif
 #ifndef BUILD_SOFTWARE_INPUT_LIBINPUT
 #cmakedefine01 BUILD_SOFTWARE_INPUT_LIBINPUT
+#endif
+
+// EGL is needed only by the EGL-based backends. Including <EGL/egl.h> here
+// unconditionally dragged EGL/GL headers into the DRM-Vulkan and software
+// builds, which must stay EGL/GL-free.
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_DRM_KMS_EGL || \
+    BUILD_BACKEND_HEADLESS_EGL
+#define IVI_HAVE_EGL 1
+#include <EGL/egl.h>
+#else
+#define IVI_HAVE_EGL 0
+#endif
+
+// waypp (the Wayland C++ wrapper + generated protocol bindings) is needed
+// only by the Wayland backends (and headless, which links wayland-gen). No
+// shell/ code references waypp:: outside those backends, so the DRM EGL/Vulkan
+// and software builds drop the header — and with it the libwayland-client /
+// libwayland-cursor runtime deps. This condition MUST match the waypp build
+// gate in third_party/CMakeLists.txt: waypp's own sources include this header
+// (via logging.h), so a mismatch breaks waypp's build.
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN || \
+    BUILD_BACKEND_HEADLESS_EGL
+#include <waypp/waypp.h>
 #endif
 
 #cmakedefine01 BUILD_EGL_TRANSPARENCY
@@ -146,6 +165,10 @@ static constexpr char kDltContextIdDescription[] = "Flutter Embedder";
 // Compositor Surface
 constexpr unsigned int kCompSurfExpectedInterfaceVersion = 0x00010000;
 
+// EGL config arrays use EGLint / EGL_* and are consumed only by the EGL
+// backends; guard them with the same condition as the <EGL/egl.h> include so
+// non-EGL builds neither need nor reference the EGL header.
+#if IVI_HAVE_EGL
 static constexpr std::array<EGLint, 5> kEglContextAttribs = {{
     // clang-format off
     EGL_CONTEXT_MAJOR_VERSION, 3,
@@ -200,6 +223,7 @@ static constexpr std::array<EGLint, 13> kEglConfigAttribsFallBack = {{
     EGL_NONE // termination sentinel
     // clang-format on
 }};
+#endif  // IVI_HAVE_EGL
 
 
 // All vkCreate* functions take an optional allocator. For now, we select the

--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -18,6 +18,8 @@
 #define CONFIG_COMMON_H_
 
 #include <array>
+#include <cstdint>  // int32_t in the constants below; was pulled in transitively
+                    // by <EGL/egl.h>/<waypp.h> before those became conditional
 
 #ifndef BUILD_BACKEND_WAYLAND_EGL
 #cmakedefine01 BUILD_BACKEND_WAYLAND_EGL

--- a/cmake/drm_kms.cmake
+++ b/cmake/drm_kms.cmake
@@ -6,7 +6,7 @@
 # are resolved through pkg-config.
 #
 
-if (NOT BUILD_BACKEND_DRM_KMS_EGL)
+if (NOT BUILD_BACKEND_DRM_KMS_EGL AND NOT BUILD_BACKEND_DRM_KMS_VULKAN)
     return()
 endif ()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -106,11 +106,20 @@ option(BUILD_BACKEND_DRM_KMS_VULKAN
         OFF)
 
 # Vendor VK_LAYER_KHRONOS_validation into the Vulkan backend so -d guarantees
-# validation even on images that ship no system layer registry (plan §7). Off
-# by default; flip ON for dev/CI presets. Wiring lands with the backend's
-# device bring-up; the option is declared here so the build graph is stable.
+# validation even on images that ship no system layer registry. Off by default;
+# flip ON for dev/CI presets. The option is declared here so the build graph is
+# stable ahead of the in-process layer wiring.
 option(BUILD_VULKAN_VALIDATION
         "Vendor the Khronos Vulkan validation layer into the Vulkan backend"
+        OFF)
+
+# Standalone zero-copy-capability probe (drm_kms_vulkan_probe). Builds just the
+# probe tool without selecting the DRM/KMS Vulkan backend, so it can be
+# cross-built and run on a target — alongside any backend — to report whether
+# the device can do zero-copy dma-buf scanout. Implied ON when the DRM/KMS
+# Vulkan backend itself is built.
+option(BUILD_DRM_KMS_VULKAN_PROBE
+        "Build the standalone drm_kms_vulkan zero-copy capability probe"
         OFF)
 
 # Drive the non-framed DRM/KMS present path through drm::scene::LayerScene

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -101,6 +101,17 @@ option(BUILD_BACKEND_WAYLAND_LEASED_DRM "Build Wayland Leased DRM backend" OFF)
 option(BUILD_BACKEND_DRM_KMS_EGL
         "Build DRM/KMS EGL backend (mutually exclusive with EGL and Vulkan backends)"
         OFF)
+option(BUILD_BACKEND_DRM_KMS_VULKAN
+        "Build DRM/KMS Vulkan backend (mutually exclusive with the EGL and Wayland backends)"
+        OFF)
+
+# Vendor VK_LAYER_KHRONOS_validation into the Vulkan backend so -d guarantees
+# validation even on images that ship no system layer registry (plan §7). Off
+# by default; flip ON for dev/CI presets. Wiring lands with the backend's
+# device bring-up; the option is declared here so the build graph is stable.
+option(BUILD_VULKAN_VALIDATION
+        "Vendor the Khronos Vulkan validation layer into the Vulkan backend"
+        OFF)
 
 # Drive the non-framed DRM/KMS present path through drm::scene::LayerScene
 # rather than the in-tree PlaneRegistry + Allocator + AtomicRequest pipeline.
@@ -110,9 +121,10 @@ option(BUILD_BACKEND_DRM_KMS_EGL
 option(USE_DRM_SCENE
         "Drive DRM/KMS non-framed present path via drm::scene::LayerScene"
         OFF)
-if (USE_DRM_SCENE AND NOT BUILD_BACKEND_DRM_KMS_EGL)
+if (USE_DRM_SCENE AND NOT (BUILD_BACKEND_DRM_KMS_EGL OR BUILD_BACKEND_DRM_KMS_VULKAN))
     message(FATAL_ERROR
-            "USE_DRM_SCENE=ON requires BUILD_BACKEND_DRM_KMS_EGL=ON")
+            "USE_DRM_SCENE=ON requires BUILD_BACKEND_DRM_KMS_EGL=ON or "
+            "BUILD_BACKEND_DRM_KMS_VULKAN=ON")
 endif ()
 
 #

--- a/scripts/build_pi.sh
+++ b/scripts/build_pi.sh
@@ -39,6 +39,10 @@
 #                                   (engine is dlopen'd at runtime — not linked at build)
 #     --plugins-dir <path>          default: ../ivi-homescreen-plugins/plugins
 #     --no-plugins                  build homescreen only
+#     --with-vk-probe               also build drm_kms_vulkan_probe, the
+#                                   standalone zero-copy capability probe (run
+#                                   it on-target to report dma-buf scanout
+#                                   support); independent of the chosen backend
 #     --with-scene                  drm-kms-egl only: enable the plane
 #                                   compositor + drm-cxx LayerScene present
 #                                   path (BUILD_COMPOSITOR + USE_DRM_SCENE).
@@ -71,7 +75,7 @@
 #                                     device name to confirm.
 #     --device <path>               non-interactive: image to this device (skips the
 #                                     plug-in detection). Still validated for
-#                                     removability + recognised path pattern.
+#                                     removability + recognized path pattern.
 #     --provision                   install homescreen as a systemd service into the
 #                                     imaged SD card. Implied by --image-sd; pass
 #                                     standalone to re-provision an already-imaged
@@ -152,6 +156,7 @@ ENGINE_URL=""
 PLUGINS_DIR="${REPO_DIR%/*}/ivi-homescreen-plugins/plugins"
 NO_PLUGINS=0
 WITH_SCENE=0
+WITH_VK_PROBE=0
 JOBS="$(nproc 2>/dev/null || echo 4)"
 CLEAN=0
 PREPARE_ONLY=0
@@ -243,6 +248,7 @@ while [[ $# -gt 0 ]]; do
         --plugins-dir)        PLUGINS_DIR="$2"; shift 2 ;;
         --no-plugins)         NO_PLUGINS=1; shift ;;
         --with-scene)         WITH_SCENE=1; shift ;;
+        --with-vk-probe)      WITH_VK_PROBE=1; shift ;;
         --jobs)               JOBS="$2"; shift 2 ;;
         --clean)              CLEAN=1; shift ;;
         --prepare-only)       PREPARE_ONLY=1; shift ;;
@@ -278,7 +284,7 @@ case "$SERVICE_BACKEND" in
     *) die "--service-backend must be wayland-egl|wayland-vulkan|drm-kms-egl|software (got: $SERVICE_BACKEND)" ;;
 esac
 [[ -z "$TARGET_DEVICE" || "$TARGET_DEVICE" =~ ^/dev/(sd[a-z]+|mmcblk[0-9]+|nvme[0-9]+n[0-9]+)$ ]] \
-    || die "--device $TARGET_DEVICE: not a recognised path (need /dev/sd*, /dev/mmcblk*, or /dev/nvme*n*)"
+    || die "--device $TARGET_DEVICE: not a recognized path (need /dev/sd*, /dev/mmcblk*, or /dev/nvme*n*)"
 
 # --drm-mode format: WxH@R (e.g. 1920x1080@120). The embedder's parser
 # is the source of truth — this is just a friendly typo guard.
@@ -944,6 +950,11 @@ phase4_build() {
                 -DBUILD_BACKEND_SOFTWARE=ON) ;;
     esac
 
+    # Standalone zero-copy capability probe, independent of the backend above.
+    if [[ "$WITH_VK_PROBE" -eq 1 ]]; then
+        cmake_args+=(-DBUILD_DRM_KMS_VULKAN_PROBE=ON)
+    fi
+
     if [[ "$NO_PLUGINS" -eq 1 ]]; then
         cmake_args+=(-DDISABLE_PLUGINS=ON)
     else
@@ -975,6 +986,9 @@ phase5_report() {
             file "$exe" | sed 's/^/      /'
         else
             echo "    (no homescreen binary produced)"
+        fi
+        if [[ -x "$BUILD_DIR/shell/drm_kms_vulkan_probe" ]]; then
+            echo "    vk-probe : $BUILD_DIR/shell/drm_kms_vulkan_probe"
         fi
     done
     echo "  sysroot       : $XC_SYSROOT"

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -187,6 +187,58 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
     )
 endif ()
 
+if (BUILD_BACKEND_DRM_KMS_VULKAN)
+    # Phase 0 scaffold. The Vulkan render/scanout sources are the new backend
+    # dir; the session / display / seat / driver-probe TUs are shared verbatim
+    # with drm_kms_egl (they sit below the pixel layer and are GL-free).
+    target_sources(${PROJECT_NAME} PRIVATE
+            backend/drm_kms_vulkan/vulkan_drm_backend.cc
+            backend/drm_kms_vulkan/device_caps.cc
+            backend/drm_kms_egl/drm_session.cc
+            backend/drm_kms_egl/driver_probe.cc
+            display/drm_display.cc
+            input/drm_seat.cc
+    )
+    # HW cursor shares drm_kms_egl's drm-cxx-backed cursor (GL-free). Mirror
+    # the EGL backend's libxcursor probe so the optionality matches.
+    pkg_check_modules(XCURSOR xcursor)
+    if (XCURSOR_FOUND)
+        target_sources(${PROJECT_NAME} PRIVATE
+                backend/drm_kms_egl/drm_cursor.cc
+        )
+        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_DRM_CURSOR=1)
+    else ()
+        message(STATUS "libxcursor not found; DRM HW cursor disabled")
+    endif ()
+    # No EGL/GLESv2: the Vulkan backend produces no GL textures, and
+    # flutter_desktop.cc's glDeleteTextures branch is compiled out for it
+    # (same as the Wayland-Vulkan backend). Vulkan is resolved at runtime via
+    # vulkan.hpp's dynamic loader; only the headers are needed at build time.
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+            drm-cxx::drm-cxx
+            PkgConfig::DRM
+            PkgConfig::GBM
+            PkgConfig::LIBINPUT
+            PkgConfig::UDEV
+            vulkan_headers
+    )
+
+    # Standalone exerciser for the §4.1 zero-copy gate. Calls ProbeDeviceCaps()
+    # in isolation so the pass/refuse paths can be validated without bringing up
+    # DrmDisplay/libseat. device_caps.cc has no shell/EGL/Wayland/DRM deps — only
+    # the Vulkan headers + libdl (vulkan.hpp dlopens libvulkan at runtime) — so
+    # the probe links nothing the backend itself wouldn't. Exit code: 0 = gate
+    # passed, 1 = refused (mirrors the backend's exit(EXIT_FAILURE)).
+    add_executable(drm_kms_vulkan_probe
+            backend/drm_kms_vulkan/probe_main.cc
+            backend/drm_kms_vulkan/device_caps.cc
+    )
+    target_link_libraries(drm_kms_vulkan_probe PRIVATE
+            vulkan_headers
+            ${CMAKE_DL_LIBS}
+    )
+endif ()
+
 if (ENABLE_DLT)
     target_sources(${PROJECT_NAME} PRIVATE logging/dlt/dlt.cc logging/dlt/libdlt.cc)
 endif ()
@@ -246,16 +298,15 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
         platform_homescreen
 )
 
-# Propagate wayland-gen's include dirs unconditionally (config/common.h
-# pulls <waypp/waypp.h> regardless of backend for the AGL/XDG client
-# compile defines) but link the static library only on Wayland builds
-# so non-Wayland binaries don't drag in libwayland-client /
-# libwayland-cursor as runtime deps.
-target_include_directories(${PROJECT_NAME} PRIVATE
-        $<TARGET_PROPERTY:wayland-gen,INTERFACE_INCLUDE_DIRECTORIES>
-)
+# config/common.h includes <waypp/waypp.h> only on the Wayland backends, so
+# the wayland-gen protocol-header include dirs and the static library are both
+# needed only there. Non-Wayland binaries (DRM EGL/Vulkan, software) get
+# neither the headers nor the libwayland-client / libwayland-cursor deps.
 if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN OR
     BUILD_BACKEND_HEADLESS_EGL)
+    target_include_directories(${PROJECT_NAME} PRIVATE
+            $<TARGET_PROPERTY:wayland-gen,INTERFACE_INCLUDE_DIRECTORIES>
+    )
     target_link_libraries(${PROJECT_NAME} PRIVATE wayland-gen)
 endif ()
 

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -188,9 +188,9 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
 endif ()
 
 if (BUILD_BACKEND_DRM_KMS_VULKAN)
-    # Phase 0 scaffold. The Vulkan render/scanout sources are the new backend
-    # dir; the session / display / seat / driver-probe TUs are shared verbatim
-    # with drm_kms_egl (they sit below the pixel layer and are GL-free).
+    # The Vulkan render/scanout sources are the new backend dir; the session /
+    # display / seat / driver-probe TUs are shared verbatim with drm_kms_egl
+    # (they sit below the pixel layer and are GL-free).
     target_sources(${PROJECT_NAME} PRIVATE
             backend/drm_kms_vulkan/vulkan_drm_backend.cc
             backend/drm_kms_vulkan/device_caps.cc
@@ -222,21 +222,27 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN)
             PkgConfig::UDEV
             vulkan_headers
     )
+endif ()
 
-    # Standalone exerciser for the §4.1 zero-copy gate. Calls ProbeDeviceCaps()
-    # in isolation so the pass/refuse paths can be validated without bringing up
-    # DrmDisplay/libseat. device_caps.cc has no shell/EGL/Wayland/DRM deps — only
-    # the Vulkan headers + libdl (vulkan.hpp dlopens libvulkan at runtime) — so
-    # the probe links nothing the backend itself wouldn't. Exit code: 0 = gate
-    # passed, 1 = refused (mirrors the backend's exit(EXIT_FAILURE)).
+# Standalone zero-copy-capability probe. Builds with the DRM/KMS Vulkan backend,
+# or on its own via BUILD_DRM_KMS_VULKAN_PROBE so it can be cross-built and run
+# on a target alongside any backend to report whether the device can do
+# zero-copy dma-buf scanout. device_caps.cc has no shell/EGL/Wayland/DRM deps —
+# only the Vulkan headers + libdl (vulkan.hpp dlopens libvulkan at runtime).
+# Exit code: 0 = gate passed, 1 = refused.
+if (BUILD_BACKEND_DRM_KMS_VULKAN OR BUILD_DRM_KMS_VULKAN_PROBE)
     add_executable(drm_kms_vulkan_probe
             backend/drm_kms_vulkan/probe_main.cc
             backend/drm_kms_vulkan/device_caps.cc
     )
-    target_link_libraries(drm_kms_vulkan_probe PRIVATE
-            vulkan_headers
-            ${CMAKE_DL_LIBS}
+    # Use the vendored Vulkan headers directly so the probe is self-contained
+    # and cross-builds without a Vulkan SDK in the target sysroot. Only the
+    # headers are needed at build time; libvulkan is dlopened at runtime.
+    target_include_directories(drm_kms_vulkan_probe PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}
+            ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include
     )
+    target_link_libraries(drm_kms_vulkan_probe PRIVATE ${CMAKE_DL_LIBS})
 endif ()
 
 if (ENABLE_DLT)

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -30,7 +30,7 @@
 #include "wayland/display.h"
 #include "wayland/window.h"
 #endif
-#if BUILD_BACKEND_DRM_KMS_EGL
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
 #include "display/drm_display.h"
 #endif
 
@@ -54,7 +54,7 @@ constexpr int kIdleHeartbeatMs = 1000;
 
 std::shared_ptr<IDisplay> MakeDisplay(
     const std::vector<Configuration::Config>& configs) {
-#if BUILD_BACKEND_DRM_KMS_EGL
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
   // DRM/KMS does not have a compositor-level display concept. The refresh
   // rate and mode are owned by the backend; the DrmDisplay stub answers
   // queries the shell issues (metrics, cursor activation, event loop) with

--- a/shell/backend/backend.h
+++ b/shell/backend/backend.h
@@ -50,6 +50,7 @@ class Backend {
     WaylandVulkan,
     WaylandLeasedDrm,
     DrmKms,
+    DrmKmsVulkan,
   };
 
   Backend() = default;

--- a/shell/backend/drm_kms_egl/scene_layer_source_vk.h
+++ b/shell/backend/drm_kms_egl/scene_layer_source_vk.h
@@ -53,7 +53,7 @@ class Device;
 // idling its raster queue before present_layers, or the exported dma-buf
 // carrying an implicit dma_resv fence KMS auto-waits on — neither is
 // confirmed. This must be resolved by the render-complete hand-off spike
-// before relying on it (drm_kms_vulkan plan §6.2). If explicit sync turns
+// before relying on it. If explicit sync turns
 // out to be required, it belongs on ExternalDmaBufSource's IN_FENCE_FD
 // path, not here — this wrapper stays deliberately sync-agnostic.
 //

--- a/shell/backend/drm_kms_egl/scene_layer_source_vk.h
+++ b/shell/backend/drm_kms_egl/scene_layer_source_vk.h
@@ -44,13 +44,23 @@ class Device;
 // plane layout) tuple. That keeps the wrapper free of Vulkan headers and
 // keeps USE_DRM_SCENE off the BUILD_BACKEND_VULKAN dependency graph.
 //
-// Per the Flutter embedder contract (embedder.h:1780-1783), the engine
-// has already host-synced the VkImage before invoking present_layers,
-// so no per-frame fence import is needed. The wrapper caches one
-// ExternalDmaBufSource per VkImage; on first sight the caller constructs
-// the wrapper with the dmabuf fd (one per VkImage; the wrapper dups it
-// internally via ExternalDmaBufSource), on subsequent frames the same
-// wrapper is reused for the same VkImage.
+// Sync is an OPEN QUESTION, not a solved one. FlutterVulkanImage carries
+// only {image, format} — the embedder exposes no per-backing-store
+// render-complete fence or semaphore, and was empirically shown (issue
+// #208) to rely on shared-queue submission ordering rather than an
+// observable hand-off. Whether the exported dma-buf is safe to scan out
+// at present_layers time therefore depends on either the engine host-
+// idling its raster queue before present_layers, or the exported dma-buf
+// carrying an implicit dma_resv fence KMS auto-waits on — neither is
+// confirmed. This must be resolved by the render-complete hand-off spike
+// before relying on it (drm_kms_vulkan plan §6.2). If explicit sync turns
+// out to be required, it belongs on ExternalDmaBufSource's IN_FENCE_FD
+// path, not here — this wrapper stays deliberately sync-agnostic.
+//
+// The wrapper caches one ExternalDmaBufSource per VkImage; on first sight
+// the caller constructs the wrapper with the dmabuf fd (one per VkImage;
+// the wrapper dups it internally via ExternalDmaBufSource), on subsequent
+// frames the same wrapper is reused for the same VkImage.
 class VkBackingStoreLayerSource final : public drm::scene::LayerBufferSource {
  public:
   // Construct over a caller-exported dmabuf. The wrapper builds an

--- a/shell/backend/drm_kms_vulkan/device_caps.cc
+++ b/shell/backend/drm_kms_vulkan/device_caps.cc
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Use vulkan.hpp's dynamic dispatch loader, matching the Wayland-Vulkan
+// backend. The loader dlopens libvulkan at runtime, so a missing loader (the
+// misconfigured-Yocto / pre-driver-install image the §4.1 gate guards against)
+// surfaces as a catchable failure here rather than an unresolved-symbol link
+// error. This TU owns the single dynamic-dispatcher storage definition for the
+// drm_kms_vulkan backend (Wayland-Vulkan's wayland_vulkan.cc owns the other;
+// the two backends are mutually exclusive, so exactly one is ever linked).
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+#include <vulkan/vulkan.hpp>
+VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+
+#include "device_caps.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace drm_kms_vulkan {
+
+namespace {
+
+const auto& d = vk::detail::defaultDispatchLoaderDynamic;
+
+bool HasExt(const std::vector<VkExtensionProperties>& exts, const char* name) {
+  for (const auto& e : exts) {
+    if (std::strcmp(e.extensionName, name) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool NameLooksLikeSoftware(const char* name) {
+  // llvmpipe reports deviceType == CPU (already rejected), but lavapipe builds
+  // and some odd configs slip through; a name match is a cheap backstop.
+  return std::strstr(name, "llvmpipe") != nullptr ||
+         std::strstr(name, "lavapipe") != nullptr ||
+         std::strstr(name, "SwiftShader") != nullptr;
+}
+
+}  // namespace
+
+DeviceCaps ProbeDeviceCaps(const std::string& display_device,
+                           std::string& refusal_reason) {
+  DeviceCaps caps{};
+
+  // 1. Bootstrap the loader. The no-arg init() resolves vkGetInstanceProcAddr
+  //    + the global-level entry points by dlopening libvulkan.
+  try {
+    VULKAN_HPP_DEFAULT_DISPATCHER.init();
+  } catch (const std::exception& e) {
+    refusal_reason = std::string(
+                         "Vulkan loader not present (libvulkan could not be "
+                         "opened): ") +
+                     e.what();
+    return caps;
+  }
+  if (d.vkCreateInstance == nullptr) {
+    refusal_reason = "Vulkan loader present but vkCreateInstance unresolved";
+    return caps;
+  }
+
+  // 2. Minimal instance. Vulkan 1.1 gives core get_physical_device_properties2
+  //    and queue_family_foreign without instance extensions.
+  VkApplicationInfo app{};
+  app.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+  app.pApplicationName = "ivi-homescreen drm_kms_vulkan probe";
+  app.apiVersion = VK_API_VERSION_1_1;
+  VkInstanceCreateInfo ici{};
+  ici.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+  ici.pApplicationInfo = &app;
+
+  VkInstance instance = VK_NULL_HANDLE;
+  if (d.vkCreateInstance(&ici, nullptr, &instance) != VK_SUCCESS) {
+    refusal_reason = "vkCreateInstance failed";
+    return caps;
+  }
+  VULKAN_HPP_DEFAULT_DISPATCHER.init(vk::Instance(instance));
+
+  // 3. Walk physical devices; the first non-CPU, non-software device that
+  //    exposes the full dma-buf-import extension set wins the gate.
+  uint32_t count = 0;
+  d.vkEnumeratePhysicalDevices(instance, &count, nullptr);
+  std::vector<VkPhysicalDevice> devices(count);
+  if (count > 0) {
+    d.vkEnumeratePhysicalDevices(instance, &count, devices.data());
+  }
+
+  static constexpr const char* kRequired[] = {
+      "VK_EXT_image_drm_format_modifier",
+      "VK_EXT_external_memory_dma_buf",
+      "VK_KHR_external_memory_fd",
+      "VK_EXT_queue_family_foreign",
+  };
+
+  bool found = false;
+  std::string last_miss;
+  for (VkPhysicalDevice pd : devices) {
+    VkPhysicalDeviceProperties props{};
+    d.vkGetPhysicalDeviceProperties(pd, &props);
+
+    if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU ||
+        NameLooksLikeSoftware(props.deviceName)) {
+      last_miss = std::string(props.deviceName) + " is a CPU/software renderer";
+      continue;
+    }
+
+    uint32_t ext_count = 0;
+    d.vkEnumerateDeviceExtensionProperties(pd, nullptr, &ext_count, nullptr);
+    std::vector<VkExtensionProperties> exts(ext_count);
+    if (ext_count > 0) {
+      d.vkEnumerateDeviceExtensionProperties(pd, nullptr, &ext_count,
+                                             exts.data());
+    }
+
+    bool ok = true;
+    for (const char* req : kRequired) {
+      if (!HasExt(exts, req)) {
+        ok = false;
+        last_miss =
+            std::string(props.deviceName) + " missing " + std::string(req);
+        break;
+      }
+    }
+    if (!ok) {
+      continue;
+    }
+
+    // Gate passed for this device — record caps (display openability checked
+    // below decides zero_copy_supported).
+    caps.device_name = props.deviceName;
+    caps.vendor_id = props.vendorID;
+    caps.has_physical_device_drm = HasExt(exts, "VK_EXT_physical_device_drm");
+    caps.has_global_priority = HasExt(exts, "VK_EXT_global_priority") ||
+                               HasExt(exts, "VK_KHR_global_priority");
+    caps.has_timeline_semaphore = props.apiVersion >= VK_API_VERSION_1_2 ||
+                                  HasExt(exts, "VK_KHR_timeline_semaphore");
+
+    uint32_t qf_count = 0;
+    d.vkGetPhysicalDeviceQueueFamilyProperties(pd, &qf_count, nullptr);
+    std::vector<VkQueueFamilyProperties> qfs(qf_count);
+    if (qf_count > 0) {
+      d.vkGetPhysicalDeviceQueueFamilyProperties(pd, &qf_count, qfs.data());
+    }
+    for (const auto& qf : qfs) {
+      if (qf.queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+        caps.graphics_queue_count = qf.queueCount;
+        break;
+      }
+    }
+    found = true;
+    break;
+  }
+
+  d.vkDestroyInstance(instance, nullptr);
+
+  if (!found) {
+    refusal_reason =
+        "no Vulkan physical device exposes the zero-copy dma-buf import "
+        "extension set" +
+        (last_miss.empty() ? std::string()
+                           : std::string(" (") + last_miss + ")");
+    return caps;
+  }
+
+  // 4. The display node must be openable — a render-only GPU with no display
+  //    DRM node cannot scan out. open()+close() is the cheapest probe.
+  const int fd = ::open(display_device.c_str(), O_RDWR | O_CLOEXEC);
+  if (fd < 0) {
+    refusal_reason = "DRM display node '" + display_device +
+                     "' is not openable: " + std::strerror(errno);
+    return caps;
+  }
+  ::close(fd);
+
+  caps.zero_copy_supported = true;
+  return caps;
+}
+
+}  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/device_caps.cc
+++ b/shell/backend/drm_kms_vulkan/device_caps.cc
@@ -16,11 +16,17 @@
 
 // Use vulkan.hpp's dynamic dispatch loader, matching the Wayland-Vulkan
 // backend. The loader dlopens libvulkan at runtime, so a missing loader (the
-// misconfigured-Yocto / pre-driver-install image the §4.1 gate guards against)
+// misconfigured-Yocto / pre-driver-install image the gate guards against)
 // surfaces as a catchable failure here rather than an unresolved-symbol link
 // error. This TU owns the single dynamic-dispatcher storage definition for the
 // drm_kms_vulkan backend (Wayland-Vulkan's wayland_vulkan.cc owns the other;
 // the two backends are mutually exclusive, so exactly one is ever linked).
+//
+// System headers are included before vulkan.hpp so the stat()/sysmacros use in
+// DrmNodeNumber resolves cleanly.
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+
 #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
 #include <vulkan/vulkan.hpp>
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
@@ -64,8 +70,8 @@ DeviceCaps ProbeDeviceCaps(const std::string& display_device,
                            std::string& refusal_reason) {
   DeviceCaps caps{};
 
-  // 1. Bootstrap the loader. The no-arg init() resolves vkGetInstanceProcAddr
-  //    + the global-level entry points by dlopening libvulkan.
+  // Bootstrap the loader. The no-arg init() resolves vkGetInstanceProcAddr +
+  // the global-level entry points by dlopening libvulkan.
   try {
     VULKAN_HPP_DEFAULT_DISPATCHER.init();
   } catch (const std::exception& e) {
@@ -80,8 +86,8 @@ DeviceCaps ProbeDeviceCaps(const std::string& display_device,
     return caps;
   }
 
-  // 2. Minimal instance. Vulkan 1.1 gives core get_physical_device_properties2
-  //    and queue_family_foreign without instance extensions.
+  // Minimal instance. Vulkan 1.1 gives core get_physical_device_properties2 and
+  // queue_family_foreign without instance extensions.
   VkApplicationInfo app{};
   app.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
   app.pApplicationName = "ivi-homescreen drm_kms_vulkan probe";
@@ -97,8 +103,8 @@ DeviceCaps ProbeDeviceCaps(const std::string& display_device,
   }
   VULKAN_HPP_DEFAULT_DISPATCHER.init(vk::Instance(instance));
 
-  // 3. Walk physical devices; the first non-CPU, non-software device that
-  //    exposes the full dma-buf-import extension set wins the gate.
+  // Walk physical devices; the first non-CPU, non-software device that exposes
+  // the full dma-buf-import extension set wins the gate.
   uint32_t count = 0;
   d.vkEnumeratePhysicalDevices(instance, &count, nullptr);
   std::vector<VkPhysicalDevice> devices(count);
@@ -150,11 +156,34 @@ DeviceCaps ProbeDeviceCaps(const std::string& display_device,
     // below decides zero_copy_supported).
     caps.device_name = props.deviceName;
     caps.vendor_id = props.vendorID;
+    caps.device_id = props.deviceID;
+    caps.api_version = props.apiVersion;
+    caps.max_image_2d = props.limits.maxImageDimension2D;
     caps.has_physical_device_drm = HasExt(exts, "VK_EXT_physical_device_drm");
     caps.has_global_priority = HasExt(exts, "VK_EXT_global_priority") ||
                                HasExt(exts, "VK_KHR_global_priority");
-    caps.has_timeline_semaphore = props.apiVersion >= VK_API_VERSION_1_2 ||
-                                  HasExt(exts, "VK_KHR_timeline_semaphore");
+
+    // Query the actual timelineSemaphore feature bit rather than inferring it
+    // from the API version or extension list — Mesa Turnip, for one, exposes
+    // it on a device whose advertised properties would not imply it.
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline{};
+    timeline.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+    VkPhysicalDeviceFeatures2 features2{};
+    features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    features2.pNext = &timeline;
+    d.vkGetPhysicalDeviceFeatures2(pd, &features2);
+    caps.has_timeline_semaphore = timeline.timelineSemaphore == VK_TRUE;
+
+    VkPhysicalDeviceMemoryProperties mem{};
+    d.vkGetPhysicalDeviceMemoryProperties(pd, &mem);
+    for (uint32_t i = 0; i < mem.memoryTypeCount; ++i) {
+      if (mem.memoryTypes[i].propertyFlags &
+          VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) {
+        caps.has_lazy_transient = true;
+        break;
+      }
+    }
 
     uint32_t qf_count = 0;
     d.vkGetPhysicalDeviceQueueFamilyProperties(pd, &qf_count, nullptr);
@@ -168,6 +197,16 @@ DeviceCaps ProbeDeviceCaps(const std::string& display_device,
         break;
       }
     }
+    for (const auto& qf : qfs) {
+      const bool transfer = (qf.queueFlags & VK_QUEUE_TRANSFER_BIT) != 0;
+      const bool graphics = (qf.queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0;
+      const bool compute = (qf.queueFlags & VK_QUEUE_COMPUTE_BIT) != 0;
+      if (transfer && !graphics && !compute) {
+        caps.has_dedicated_transfer_queue = true;
+        break;
+      }
+    }
+
     found = true;
     break;
   }
@@ -183,8 +222,8 @@ DeviceCaps ProbeDeviceCaps(const std::string& display_device,
     return caps;
   }
 
-  // 4. The display node must be openable — a render-only GPU with no display
-  //    DRM node cannot scan out. open()+close() is the cheapest probe.
+  // The display node must be openable — a render-only GPU with no display DRM
+  // node cannot scan out. open()+close() is the cheapest probe.
   const int fd = ::open(display_device.c_str(), O_RDWR | O_CLOEXEC);
   if (fd < 0) {
     refusal_reason = "DRM display node '" + display_device +
@@ -195,6 +234,20 @@ DeviceCaps ProbeDeviceCaps(const std::string& display_device,
 
   caps.zero_copy_supported = true;
   return caps;
+}
+
+bool DrmNodeNumber(const std::string& path,
+                   unsigned& major_out,
+                   unsigned& minor_out) {
+  struct stat st{};
+  if (::stat(path.c_str(), &st) != 0) {
+    return false;
+  }
+  // vulkan.hpp #undefs the major()/minor() macros (they clash with version
+  // field names), so call the underlying glibc functions directly.
+  major_out = gnu_dev_major(st.st_rdev);
+  minor_out = gnu_dev_minor(st.st_rdev);
+  return true;
 }
 
 }  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/device_caps.h
+++ b/shell/backend/drm_kms_vulkan/device_caps.h
@@ -21,35 +21,53 @@
 
 namespace drm_kms_vulkan {
 
-// Capability probe result for the zero-copy scanout gate. Only the fields
-// Phase 0 needs are populated today; later phases extend this with the
-// scanout memory-type index, negotiated modifier, and per-plane layout
-// (drm_kms_vulkan plan §4). The struct stays free of Vulkan headers so it can
-// be included widely.
+// Capability summary for the DRM/KMS Vulkan scanout backend, filled at device
+// bring-up and logged. Everything platform-specific reduces to this struct so
+// nothing platform-specific is hardcoded. The struct stays free of Vulkan
+// headers so it can be included widely.
 struct DeviceCaps {
-  // Zero-copy gate (plan §4.1): true only when a non-CPU, non-llvmpipe
-  // physical device exposes the dma-buf-import extension set AND the DRM
-  // display node is openable.
+  // Zero-copy gate: true only when a non-CPU, non-software-rasterizer device
+  // exposes the dma-buf import extension set AND a DRM display node is
+  // openable. When false the backend refuses at init with a clear diagnostic
+  // instead of failing later inside framebuffer import.
   bool zero_copy_supported = false;
 
   bool has_physical_device_drm = false;  // false on Adreno & Mali blobs
-  bool has_timeline_semaphore = false;   // false on Adreno -> binary sem floor
-  bool has_global_priority = false;      // gate HIGH/REALTIME homescreen queue
-  uint32_t vendor_id = 0;                // fallback match when DRM node absent
-  uint32_t graphics_queue_count = 0;     // >1 -> async composition blit allowed
+  bool has_timeline_semaphore = false;   // false on Adreno
+  bool has_global_priority = false;      // gate a high-priority queue
+  bool has_lazy_transient = false;       // transient attachments in tile mem
+  bool has_dedicated_transfer_queue =
+      false;               // offload copies off the gfx queue
+  uint32_t vendor_id = 0;  // fallback match when no DRM node
+  uint32_t device_id = 0;
+  uint32_t api_version = 0;
+  uint32_t graphics_queue_count = 0;  // >1 allows an async composition queue
+  uint32_t max_image_2d = 0;          // clamp surface size (4096 on vc4)
   std::string device_name;
   std::string driver_name;
 };
 
-// Probe the local Vulkan + DRM stack for the zero-copy scanout gate (plan
-// §4.1). On success returns caps with @c zero_copy_supported == true. On any
-// failure returns @c zero_copy_supported == false and writes a human-readable
-// cause into @p refusal_reason — the diagnostic the backend logs before it
-// refuses, instead of crashing deep in @c drmModeAddFB2WithModifiers.
+// Probe the local Vulkan + DRM stack for the zero-copy scanout gate. On
+// success returns caps with @c zero_copy_supported == true. On any failure
+// returns @c zero_copy_supported == false and writes a human-readable cause
+// into @p refusal_reason.
+//
+// This is the lightweight check used by the drm_kms_vulkan_probe tool: it
+// creates a throwaway instance and no logical device. The backend itself does
+// a fuller bring-up (logical device + queues) rather than calling this.
 //
 // @p display_device is the DRM node intended for scanout (e.g. /dev/dri/card0);
 // it must be openable for the gate to pass.
 DeviceCaps ProbeDeviceCaps(const std::string& display_device,
                            std::string& refusal_reason);
+
+// Resolve the (major, minor) device numbers of a DRM node path so the backend
+// can match a Vulkan physical device's DRM node against the scanout device.
+// Returns false (leaving the outputs untouched) when the path cannot be
+// stat'd. Lives here so the stat/sysmacros includes stay out of the backend
+// translation unit, which pulls in spdlog.
+bool DrmNodeNumber(const std::string& path,
+                   unsigned& major_out,
+                   unsigned& minor_out);
 
 }  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/device_caps.h
+++ b/shell/backend/drm_kms_vulkan/device_caps.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace drm_kms_vulkan {
+
+// Capability probe result for the zero-copy scanout gate. Only the fields
+// Phase 0 needs are populated today; later phases extend this with the
+// scanout memory-type index, negotiated modifier, and per-plane layout
+// (drm_kms_vulkan plan §4). The struct stays free of Vulkan headers so it can
+// be included widely.
+struct DeviceCaps {
+  // Zero-copy gate (plan §4.1): true only when a non-CPU, non-llvmpipe
+  // physical device exposes the dma-buf-import extension set AND the DRM
+  // display node is openable.
+  bool zero_copy_supported = false;
+
+  bool has_physical_device_drm = false;  // false on Adreno & Mali blobs
+  bool has_timeline_semaphore = false;   // false on Adreno -> binary sem floor
+  bool has_global_priority = false;      // gate HIGH/REALTIME homescreen queue
+  uint32_t vendor_id = 0;                // fallback match when DRM node absent
+  uint32_t graphics_queue_count = 0;     // >1 -> async composition blit allowed
+  std::string device_name;
+  std::string driver_name;
+};
+
+// Probe the local Vulkan + DRM stack for the zero-copy scanout gate (plan
+// §4.1). On success returns caps with @c zero_copy_supported == true. On any
+// failure returns @c zero_copy_supported == false and writes a human-readable
+// cause into @p refusal_reason — the diagnostic the backend logs before it
+// refuses, instead of crashing deep in @c drmModeAddFB2WithModifiers.
+//
+// @p display_device is the DRM node intended for scanout (e.g. /dev/dri/card0);
+// it must be openable for the gate to pass.
+DeviceCaps ProbeDeviceCaps(const std::string& display_device,
+                           std::string& refusal_reason);
+
+}  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/probe_main.cc
+++ b/shell/backend/drm_kms_vulkan/probe_main.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Standalone exerciser for the drm_kms_vulkan §4.1 zero-copy gate.
+// Standalone exerciser for the drm_kms_vulkan zero-copy gate.
 //
 // VulkanDrmBackend::Create() runs ProbeDeviceCaps() and refuses (logs +
 // returns nullptr -> FlutterView exit(EXIT_FAILURE)) when the gate fails. The
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
       drm_kms_vulkan::ProbeDeviceCaps(dev, refusal);
 
   if (caps.zero_copy_supported) {
-    std::printf("§4.1 GATE: PASS  (display_node=%s)\n", dev);
+    std::printf("ZERO-COPY GATE: PASS  (display_node=%s)\n", dev);
     std::printf("  device         = %s\n", caps.device_name.c_str());
     std::printf("  vendor_id      = 0x%04x\n", caps.vendor_id);
     std::printf("  phys_dev_drm   = %s\n",
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  std::printf("§4.1 GATE: REFUSE  (display_node=%s)\n", dev);
+  std::printf("ZERO-COPY GATE: REFUSE  (display_node=%s)\n", dev);
   std::printf("  reason = %s\n", refusal.c_str());
   return 1;
 }

--- a/shell/backend/drm_kms_vulkan/probe_main.cc
+++ b/shell/backend/drm_kms_vulkan/probe_main.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standalone exerciser for the drm_kms_vulkan §4.1 zero-copy gate.
+//
+// VulkanDrmBackend::Create() runs ProbeDeviceCaps() and refuses (logs +
+// returns nullptr -> FlutterView exit(EXIT_FAILURE)) when the gate fails. The
+// full backend can't easily be run for that check because DrmDisplay opens a
+// libseat session first. This driver calls the same ProbeDeviceCaps() in
+// isolation so the pass and refuse paths can be observed without bringing up
+// libseat / DRM master.
+//
+// Exit code mirrors the backend's contract: 0 = gate passed, 1 = refused
+// (the same outcome that drives FlutterView's exit(EXIT_FAILURE)).
+//
+// Usage:   drm_kms_vulkan_probe [/dev/dri/cardN]      (default /dev/dri/card0)
+// Refuse:  VK_ICD_FILENAMES=<lavapipe icd.json> drm_kms_vulkan_probe   (CPU
+// dev)
+//          drm_kms_vulkan_probe /dev/dri/does-not-exist                (no
+//          node)
+
+#include <cstdio>
+#include <string>
+
+#include "device_caps.h"
+
+int main(int argc, char** argv) {
+  const char* dev = argc > 1 ? argv[1] : "/dev/dri/card0";
+
+  std::string refusal;
+  const drm_kms_vulkan::DeviceCaps caps =
+      drm_kms_vulkan::ProbeDeviceCaps(dev, refusal);
+
+  if (caps.zero_copy_supported) {
+    std::printf("§4.1 GATE: PASS  (display_node=%s)\n", dev);
+    std::printf("  device         = %s\n", caps.device_name.c_str());
+    std::printf("  vendor_id      = 0x%04x\n", caps.vendor_id);
+    std::printf("  phys_dev_drm   = %s\n",
+                caps.has_physical_device_drm ? "yes" : "no");
+    std::printf("  timeline_sem   = %s\n",
+                caps.has_timeline_semaphore ? "yes" : "no");
+    std::printf("  global_priority= %s\n",
+                caps.has_global_priority ? "yes" : "no");
+    std::printf("  graphics_queues= %u\n", caps.graphics_queue_count);
+    return 0;
+  }
+
+  std::printf("§4.1 GATE: REFUSE  (display_node=%s)\n", dev);
+  std::printf("  reason = %s\n", refusal.c_str());
+  return 1;
+}

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -14,65 +14,493 @@
  * limitations under the License.
  */
 
+// vulkan.hpp's dynamic dispatcher is used here too; the single storage
+// definition lives in device_caps.cc (linked alongside this TU).
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+#include <vulkan/vulkan.hpp>
+
 #include "vulkan_drm_backend.h"
 
-#include "device_caps.h"
+#include <array>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+#include "backend/drm_kms_vulkan/device_caps.h"
 #include "logging.h"
 
-VulkanDrmBackend::VulkanDrmBackend(uint32_t width,
-                                   uint32_t height,
+namespace {
+
+const auto& d = vk::detail::defaultDispatchLoaderDynamic;
+
+// Device extensions required for zero-copy dma-buf scanout and explicit
+// synchronization. The dependencies of VK_EXT_image_drm_format_modifier
+// (bind_memory2, get_memory_requirements2, sampler_ycbcr_conversion,
+// get_physical_device_properties2) are all core in Vulkan 1.1, which the
+// instance targets, so only the non-core extensions are listed here.
+constexpr std::array<const char*, 7> kRequiredDeviceExtensions = {
+    VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+    VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
+    VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME,
+    VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME,
+    VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+    VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME,
+    VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME,
+};
+
+bool HasExt(const std::vector<VkExtensionProperties>& exts, const char* name) {
+  for (const auto& e : exts) {
+    if (std::strcmp(e.extensionName, name) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool LooksLikeSoftware(const char* name) {
+  return std::strstr(name, "llvmpipe") != nullptr ||
+         std::strstr(name, "lavapipe") != nullptr ||
+         std::strstr(name, "SwiftShader") != nullptr;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL
+DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+                   VkDebugUtilsMessageTypeFlagsEXT /*types*/,
+                   const VkDebugUtilsMessengerCallbackDataEXT* data,
+                   void* /*user_data*/) {
+  const char* msg = data && data->pMessage ? data->pMessage : "";
+  if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
+    spdlog::error("[vulkan] {}", msg);
+  } else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+    spdlog::warn("[vulkan] {}", msg);
+  } else {
+    spdlog::debug("[vulkan] {}", msg);
+  }
+  return VK_FALSE;
+}
+
+// Matches FlutterVulkanInstanceProcAddressCallback: the instance handle is an
+// opaque void* (FlutterVulkanInstanceHandle), cast back to VkInstance here.
+void* GetInstanceProcAddressCallback(void* /*user_data*/,
+                                     void* instance,
+                                     const char* procname) {
+  return reinterpret_cast<void*>(
+      d.vkGetInstanceProcAddr(static_cast<VkInstance>(instance), procname));
+}
+
+}  // namespace
+
+VulkanDrmBackend::VulkanDrmBackend(std::string drm_device,
+                                   bool enable_validation,
                                    homescreen::DrmSession* session)
-    : width_(width), height_(height), session_(session) {}
+    : drm_device_(std::move(drm_device)),
+      enable_validation_(enable_validation),
+      session_(session) {}
+
+VulkanDrmBackend::~VulkanDrmBackend() {
+  Teardown();
+}
 
 std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
     const std::string& drm_device,
     bool enable_validation,
     homescreen::DrmSession* session) {
-  (void)session;
+  auto backend = std::shared_ptr<VulkanDrmBackend>(
+      new VulkanDrmBackend(drm_device, enable_validation, session));
 
-  if (enable_validation) {
-    // Validation vendoring + the -d-driven in-process VK_LAYER_PATH setup land
-    // in a later phase (plan §7). Note the request so a debug run that expects
-    // validation isn't silently unvalidated.
-    spdlog::info(
-        "[VulkanDrmBackend] validation requested (-d); vendored layer wiring "
-        "is not implemented yet (drm_kms_vulkan plan §7)");
-  }
-
-  // §4.1 zero-copy gate. On failure this is the clear diagnostic the contract
-  // promises instead of a crash deep in drmModeAddFB2WithModifiers.
   std::string refusal;
-  const drm_kms_vulkan::DeviceCaps caps =
-      drm_kms_vulkan::ProbeDeviceCaps(drm_device, refusal);
-  if (!caps.zero_copy_supported) {
-    spdlog::critical(
-        "[VulkanDrmBackend] zero-copy scanout unsupported on this system; "
-        "refusing to start: {}",
-        refusal);
+  if (!backend->BringUp(refusal)) {
+    spdlog::critical("[VulkanDrmBackend] init failed; refusing to start: {}",
+                     refusal);
     return nullptr;
   }
 
-  spdlog::info(
-      "[VulkanDrmBackend] zero-copy gate passed: device='{}' vendor=0x{:04x} "
-      "drm_node={} timeline_sem={} global_priority={} gfx_queues={}",
-      caps.device_name, caps.vendor_id, caps.has_physical_device_drm,
-      caps.has_timeline_semaphore, caps.has_global_priority,
-      caps.graphics_queue_count);
-
-  // Phase 0: the gate is the only implemented step. The device bring-up,
-  // negotiated-modifier backing store, LayerScene compositor, explicit sync,
-  // and session/vsync reuse are Phases 1-6. Refuse rather than hand back a
-  // backend that cannot present a frame.
+  // Bring-up succeeded; the device and queues exist and the capabilities are
+  // logged. The render and present path is not wired yet, so refuse rather
+  // than hand back a backend that cannot present a frame.
   spdlog::critical(
-      "[VulkanDrmBackend] backend is a Phase 0 scaffold — the Vulkan "
-      "render/scanout path is not implemented yet; refusing to start. "
-      "Use BUILD_BACKEND_DRM_KMS_EGL for a working DRM/KMS backend.");
+      "[VulkanDrmBackend] device and queues created; the Vulkan render and "
+      "present path is not implemented yet. Refusing to start. Use "
+      "BUILD_BACKEND_DRM_KMS_EGL for a working DRM/KMS backend.");
   return nullptr;
 }
 
-// ── Backend interface stubs
-// ─────────────────────────────────────────────────── Unreachable while
-// Create() refuses; present for the vtable and call sites.
+bool VulkanDrmBackend::BringUp(std::string& refusal_reason) {
+  try {
+    VULKAN_HPP_DEFAULT_DISPATCHER.init();
+  } catch (const std::exception& e) {
+    refusal_reason = std::string(
+                         "Vulkan loader not present (libvulkan could not be "
+                         "opened): ") +
+                     e.what();
+    return false;
+  }
+  if (d.vkCreateInstance == nullptr) {
+    refusal_reason = "Vulkan loader present but vkCreateInstance unresolved";
+    return false;
+  }
+
+  if (!CreateInstance(refusal_reason)) {
+    return false;
+  }
+  SetupDebugMessenger();
+  if (!SelectPhysicalDevice(refusal_reason)) {
+    return false;
+  }
+  if (!CreateLogicalDevice(refusal_reason)) {
+    return false;
+  }
+  PopulateCaps();
+
+  spdlog::info(
+      "[VulkanDrmBackend] device='{}' driver='{}' vendor=0x{:04x} "
+      "device=0x{:04x} api={}.{}.{}",
+      caps_.device_name, caps_.driver_name, caps_.vendor_id, caps_.device_id,
+      VK_VERSION_MAJOR(caps_.api_version), VK_VERSION_MINOR(caps_.api_version),
+      VK_VERSION_PATCH(caps_.api_version));
+  spdlog::info(
+      "[VulkanDrmBackend] caps: drm_node={} timeline_sem={} global_priority={} "
+      "lazy_transient={} dedicated_transfer={} gfx_queues={} max_image_2d={}",
+      caps_.has_physical_device_drm, caps_.has_timeline_semaphore,
+      caps_.has_global_priority, caps_.has_lazy_transient,
+      caps_.has_dedicated_transfer_queue, caps_.graphics_queue_count,
+      caps_.max_image_2d);
+  spdlog::info(
+      "[VulkanDrmBackend] graphics queue family {} created; scanout node '{}'",
+      graphics_queue_family_, drm_device_);
+  return true;
+}
+
+bool VulkanDrmBackend::CreateInstance(std::string& refusal_reason) {
+  VkApplicationInfo app{};
+  app.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+  app.pApplicationName = "ivi-homescreen";
+  app.apiVersion = VK_API_VERSION_1_1;
+
+  if (enable_validation_) {
+    uint32_t layer_count = 0;
+    d.vkEnumerateInstanceLayerProperties(&layer_count, nullptr);
+    std::vector<VkLayerProperties> layers(layer_count);
+    if (layer_count > 0) {
+      d.vkEnumerateInstanceLayerProperties(&layer_count, layers.data());
+    }
+    constexpr const char* kValidation = "VK_LAYER_KHRONOS_validation";
+    for (const auto& l : layers) {
+      if (std::strcmp(l.layerName, kValidation) == 0) {
+        enabled_instance_layers_.push_back(kValidation);
+        enabled_instance_extensions_.push_back(
+            VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+        break;
+      }
+    }
+    if (enabled_instance_layers_.empty()) {
+      spdlog::warn(
+          "[VulkanDrmBackend] validation requested (-d) but "
+          "VK_LAYER_KHRONOS_validation is not enumerable; continuing without "
+          "validation");
+    }
+  }
+
+  VkInstanceCreateInfo info{};
+  info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+  info.pApplicationInfo = &app;
+  info.enabledLayerCount =
+      static_cast<uint32_t>(enabled_instance_layers_.size());
+  info.ppEnabledLayerNames = enabled_instance_layers_.data();
+  info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_instance_extensions_.size());
+  info.ppEnabledExtensionNames = enabled_instance_extensions_.data();
+
+  if (d.vkCreateInstance(&info, nullptr, &instance_) != VK_SUCCESS) {
+    refusal_reason = "vkCreateInstance failed";
+    return false;
+  }
+  VULKAN_HPP_DEFAULT_DISPATCHER.init(vk::Instance(instance_));
+  return true;
+}
+
+void VulkanDrmBackend::SetupDebugMessenger() {
+  if (enabled_instance_layers_.empty() ||
+      d.vkCreateDebugUtilsMessengerEXT == nullptr) {
+    return;
+  }
+  VkDebugUtilsMessengerCreateInfoEXT info{};
+  info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+  info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                         VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+  info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+                     VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                     VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+  info.pfnUserCallback = DebugUtilsCallback;
+  d.vkCreateDebugUtilsMessengerEXT(instance_, &info, nullptr,
+                                   &debug_messenger_);
+}
+
+bool VulkanDrmBackend::SelectPhysicalDevice(std::string& refusal_reason) {
+  uint32_t count = 0;
+  d.vkEnumeratePhysicalDevices(instance_, &count, nullptr);
+  std::vector<VkPhysicalDevice> devices(count);
+  if (count > 0) {
+    d.vkEnumeratePhysicalDevices(instance_, &count, devices.data());
+  }
+
+  unsigned disp_major = 0;
+  unsigned disp_minor = 0;
+  drm_kms_vulkan::DrmNodeNumber(drm_device_, disp_major, disp_minor);
+
+  uint64_t best_score = 0;
+  std::string last_miss;
+  for (VkPhysicalDevice pd : devices) {
+    VkPhysicalDeviceProperties props{};
+    d.vkGetPhysicalDeviceProperties(pd, &props);
+
+    if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU ||
+        LooksLikeSoftware(props.deviceName)) {
+      last_miss = std::string(props.deviceName) + " is a CPU/software renderer";
+      continue;
+    }
+
+    uint32_t ext_count = 0;
+    d.vkEnumerateDeviceExtensionProperties(pd, nullptr, &ext_count, nullptr);
+    std::vector<VkExtensionProperties> exts(ext_count);
+    if (ext_count > 0) {
+      d.vkEnumerateDeviceExtensionProperties(pd, nullptr, &ext_count,
+                                             exts.data());
+    }
+    bool has_all = true;
+    for (const char* req : kRequiredDeviceExtensions) {
+      if (!HasExt(exts, req)) {
+        has_all = false;
+        last_miss = std::string(props.deviceName) + " missing " + req;
+        break;
+      }
+    }
+    if (!has_all) {
+      continue;
+    }
+
+    uint32_t qf_count = 0;
+    d.vkGetPhysicalDeviceQueueFamilyProperties(pd, &qf_count, nullptr);
+    std::vector<VkQueueFamilyProperties> qfs(qf_count);
+    if (qf_count > 0) {
+      d.vkGetPhysicalDeviceQueueFamilyProperties(pd, &qf_count, qfs.data());
+    }
+    uint32_t gfx_family = UINT32_MAX;
+    for (uint32_t i = 0; i < qfs.size(); ++i) {
+      if (qfs[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+        gfx_family = i;
+        break;
+      }
+    }
+    if (gfx_family == UINT32_MAX) {
+      last_miss = std::string(props.deviceName) + " has no graphics queue";
+      continue;
+    }
+
+    // A DRM-node match against the scanout device dominates (render on the GPU
+    // that drives the display); then prefer discrete GPUs; then a larger max
+    // image dimension.
+    uint64_t score = 1;
+    if (HasExt(exts, VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME) &&
+        (disp_major != 0 || disp_minor != 0)) {
+      VkPhysicalDeviceDrmPropertiesEXT drm{};
+      drm.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT;
+      VkPhysicalDeviceProperties2 p2{};
+      p2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+      p2.pNext = &drm;
+      d.vkGetPhysicalDeviceProperties2(pd, &p2);
+      const bool primary_match =
+          drm.hasPrimary &&
+          static_cast<unsigned>(drm.primaryMajor) == disp_major &&
+          static_cast<unsigned>(drm.primaryMinor) == disp_minor;
+      const bool render_match =
+          drm.hasRender &&
+          static_cast<unsigned>(drm.renderMajor) == disp_major &&
+          static_cast<unsigned>(drm.renderMinor) == disp_minor;
+      if (primary_match || render_match) {
+        score += 1ULL << 40;
+      }
+    }
+    if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+      score += 1ULL << 30;
+    }
+    score += props.limits.maxImageDimension2D;
+
+    if (score > best_score) {
+      best_score = score;
+      physical_device_ = pd;
+      graphics_queue_family_ = gfx_family;
+      enabled_device_extensions_.assign(kRequiredDeviceExtensions.begin(),
+                                        kRequiredDeviceExtensions.end());
+    }
+  }
+
+  if (physical_device_ == VK_NULL_HANDLE) {
+    refusal_reason =
+        "no Vulkan physical device supports zero-copy dma-buf scanout" +
+        (last_miss.empty() ? std::string()
+                           : std::string(" (") + last_miss + ")");
+    return false;
+  }
+  return true;
+}
+
+bool VulkanDrmBackend::CreateLogicalDevice(std::string& refusal_reason) {
+  // Query which optional sync features the selected device offers so the
+  // feature chain only enables what is present.
+  VkPhysicalDeviceTimelineSemaphoreFeatures timeline_supported{};
+  timeline_supported.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+  VkPhysicalDeviceSynchronization2Features sync2_supported{};
+  sync2_supported.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
+  sync2_supported.pNext = &timeline_supported;
+  VkPhysicalDeviceFeatures2 features2{};
+  features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+  features2.pNext = &sync2_supported;
+  d.vkGetPhysicalDeviceFeatures2(physical_device_, &features2);
+
+  if (sync2_supported.synchronization2 != VK_TRUE) {
+    refusal_reason = "selected device does not support synchronization2";
+    return false;
+  }
+
+  VkPhysicalDeviceSynchronization2Features sync2_enable{};
+  sync2_enable.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
+  sync2_enable.synchronization2 = VK_TRUE;
+  VkPhysicalDeviceTimelineSemaphoreFeatures timeline_enable{};
+  timeline_enable.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+  timeline_enable.timelineSemaphore = VK_TRUE;
+  if (timeline_supported.timelineSemaphore == VK_TRUE) {
+    sync2_enable.pNext = &timeline_enable;
+  }
+
+  const float priority = 1.0f;
+  VkDeviceQueueCreateInfo queue_info{};
+  queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  queue_info.queueFamilyIndex = graphics_queue_family_;
+  queue_info.queueCount = 1;
+  queue_info.pQueuePriorities = &priority;
+
+  VkPhysicalDeviceFeatures device_features{};
+  VkDeviceCreateInfo device_info{};
+  device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  device_info.pNext = &sync2_enable;
+  device_info.queueCreateInfoCount = 1;
+  device_info.pQueueCreateInfos = &queue_info;
+  device_info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_device_extensions_.size());
+  device_info.ppEnabledExtensionNames = enabled_device_extensions_.data();
+  device_info.pEnabledFeatures = &device_features;
+
+  if (d.vkCreateDevice(physical_device_, &device_info, nullptr, &device_) !=
+      VK_SUCCESS) {
+    refusal_reason = "vkCreateDevice failed";
+    return false;
+  }
+  VULKAN_HPP_DEFAULT_DISPATCHER.init(vk::Device(device_));
+  d.vkGetDeviceQueue(device_, graphics_queue_family_, 0, &graphics_queue_);
+  return true;
+}
+
+void VulkanDrmBackend::PopulateCaps() {
+  VkPhysicalDeviceProperties props{};
+  d.vkGetPhysicalDeviceProperties(physical_device_, &props);
+  caps_.device_name = props.deviceName;
+  caps_.vendor_id = props.vendorID;
+  caps_.device_id = props.deviceID;
+  caps_.api_version = props.apiVersion;
+  caps_.max_image_2d = props.limits.maxImageDimension2D;
+
+  uint32_t ext_count = 0;
+  d.vkEnumerateDeviceExtensionProperties(physical_device_, nullptr, &ext_count,
+                                         nullptr);
+  std::vector<VkExtensionProperties> exts(ext_count);
+  if (ext_count > 0) {
+    d.vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
+                                           &ext_count, exts.data());
+  }
+  caps_.has_physical_device_drm =
+      HasExt(exts, VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME);
+  caps_.has_global_priority = HasExt(exts, "VK_EXT_global_priority") ||
+                              HasExt(exts, "VK_KHR_global_priority");
+
+  // Query the actual timelineSemaphore feature bit rather than inferring it
+  // from the API version or extension list — Mesa Turnip, for one, exposes it
+  // on a device whose advertised properties would not imply it.
+  VkPhysicalDeviceTimelineSemaphoreFeatures timeline{};
+  timeline.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+  VkPhysicalDeviceFeatures2 timeline_features2{};
+  timeline_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+  timeline_features2.pNext = &timeline;
+  d.vkGetPhysicalDeviceFeatures2(physical_device_, &timeline_features2);
+  caps_.has_timeline_semaphore = timeline.timelineSemaphore == VK_TRUE;
+
+  VkPhysicalDeviceDriverProperties driver{};
+  driver.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
+  VkPhysicalDeviceProperties2 p2{};
+  p2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+  p2.pNext = &driver;
+  d.vkGetPhysicalDeviceProperties2(physical_device_, &p2);
+  caps_.driver_name = driver.driverName;
+
+  VkPhysicalDeviceMemoryProperties mem{};
+  d.vkGetPhysicalDeviceMemoryProperties(physical_device_, &mem);
+  for (uint32_t i = 0; i < mem.memoryTypeCount; ++i) {
+    if (mem.memoryTypes[i].propertyFlags &
+        VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) {
+      caps_.has_lazy_transient = true;
+      break;
+    }
+  }
+
+  uint32_t qf_count = 0;
+  d.vkGetPhysicalDeviceQueueFamilyProperties(physical_device_, &qf_count,
+                                             nullptr);
+  std::vector<VkQueueFamilyProperties> qfs(qf_count);
+  if (qf_count > 0) {
+    d.vkGetPhysicalDeviceQueueFamilyProperties(physical_device_, &qf_count,
+                                               qfs.data());
+  }
+  if (graphics_queue_family_ < qfs.size()) {
+    caps_.graphics_queue_count = qfs[graphics_queue_family_].queueCount;
+  }
+  for (const auto& qf : qfs) {
+    const bool transfer = (qf.queueFlags & VK_QUEUE_TRANSFER_BIT) != 0;
+    const bool graphics = (qf.queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0;
+    const bool compute = (qf.queueFlags & VK_QUEUE_COMPUTE_BIT) != 0;
+    if (transfer && !graphics && !compute) {
+      caps_.has_dedicated_transfer_queue = true;
+      break;
+    }
+  }
+
+  caps_.zero_copy_supported = true;
+}
+
+void VulkanDrmBackend::Teardown() {
+  if (device_ != VK_NULL_HANDLE) {
+    d.vkDestroyDevice(device_, nullptr);
+    device_ = VK_NULL_HANDLE;
+  }
+  if (debug_messenger_ != VK_NULL_HANDLE &&
+      d.vkDestroyDebugUtilsMessengerEXT != nullptr) {
+    d.vkDestroyDebugUtilsMessengerEXT(instance_, debug_messenger_, nullptr);
+    debug_messenger_ = VK_NULL_HANDLE;
+  }
+  if (instance_ != VK_NULL_HANDLE) {
+    d.vkDestroyInstance(instance_, nullptr);
+    instance_ = VK_NULL_HANDLE;
+  }
+}
+
+// ── Backend interface
+// ───────────────────────────────────────────────────────── Present/scanout is
+// not wired yet; never reached while Create() refuses, but required for the
+// vtable and the FlutterView call sites.
 
 void VulkanDrmBackend::Resize(size_t /*index*/,
                               Engine* /*flutter_engine*/,
@@ -96,6 +524,21 @@ FlutterRendererConfig VulkanDrmBackend::GetRenderConfig() {
   FlutterRendererConfig config{};
   config.type = kVulkan;
   config.vulkan.struct_size = sizeof(FlutterVulkanRendererConfig);
+  config.vulkan.version = VK_MAKE_VERSION(1, 1, 0);
+  config.vulkan.instance = instance_;
+  config.vulkan.physical_device = physical_device_;
+  config.vulkan.device = device_;
+  config.vulkan.queue_family_index = graphics_queue_family_;
+  config.vulkan.queue = graphics_queue_;
+  config.vulkan.enabled_instance_extension_count =
+      enabled_instance_extensions_.size();
+  config.vulkan.enabled_instance_extensions =
+      enabled_instance_extensions_.data();
+  config.vulkan.enabled_device_extension_count =
+      enabled_device_extensions_.size();
+  config.vulkan.enabled_device_extensions = enabled_device_extensions_.data();
+  config.vulkan.get_instance_proc_address_callback =
+      GetInstanceProcAddressCallback;
   return config;
 }
 

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vulkan_drm_backend.h"
+
+#include "device_caps.h"
+#include "logging.h"
+
+VulkanDrmBackend::VulkanDrmBackend(uint32_t width,
+                                   uint32_t height,
+                                   homescreen::DrmSession* session)
+    : width_(width), height_(height), session_(session) {}
+
+std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
+    const std::string& drm_device,
+    bool enable_validation,
+    homescreen::DrmSession* session) {
+  (void)session;
+
+  if (enable_validation) {
+    // Validation vendoring + the -d-driven in-process VK_LAYER_PATH setup land
+    // in a later phase (plan §7). Note the request so a debug run that expects
+    // validation isn't silently unvalidated.
+    spdlog::info(
+        "[VulkanDrmBackend] validation requested (-d); vendored layer wiring "
+        "is not implemented yet (drm_kms_vulkan plan §7)");
+  }
+
+  // §4.1 zero-copy gate. On failure this is the clear diagnostic the contract
+  // promises instead of a crash deep in drmModeAddFB2WithModifiers.
+  std::string refusal;
+  const drm_kms_vulkan::DeviceCaps caps =
+      drm_kms_vulkan::ProbeDeviceCaps(drm_device, refusal);
+  if (!caps.zero_copy_supported) {
+    spdlog::critical(
+        "[VulkanDrmBackend] zero-copy scanout unsupported on this system; "
+        "refusing to start: {}",
+        refusal);
+    return nullptr;
+  }
+
+  spdlog::info(
+      "[VulkanDrmBackend] zero-copy gate passed: device='{}' vendor=0x{:04x} "
+      "drm_node={} timeline_sem={} global_priority={} gfx_queues={}",
+      caps.device_name, caps.vendor_id, caps.has_physical_device_drm,
+      caps.has_timeline_semaphore, caps.has_global_priority,
+      caps.graphics_queue_count);
+
+  // Phase 0: the gate is the only implemented step. The device bring-up,
+  // negotiated-modifier backing store, LayerScene compositor, explicit sync,
+  // and session/vsync reuse are Phases 1-6. Refuse rather than hand back a
+  // backend that cannot present a frame.
+  spdlog::critical(
+      "[VulkanDrmBackend] backend is a Phase 0 scaffold — the Vulkan "
+      "render/scanout path is not implemented yet; refusing to start. "
+      "Use BUILD_BACKEND_DRM_KMS_EGL for a working DRM/KMS backend.");
+  return nullptr;
+}
+
+// ── Backend interface stubs
+// ─────────────────────────────────────────────────── Unreachable while
+// Create() refuses; present for the vtable and call sites.
+
+void VulkanDrmBackend::Resize(size_t /*index*/,
+                              Engine* /*flutter_engine*/,
+                              int32_t /*width*/,
+                              int32_t /*height*/) {}
+
+void VulkanDrmBackend::CreateSurface(size_t /*index*/,
+                                     struct wl_surface* /*surface*/,
+                                     int32_t /*width*/,
+                                     int32_t /*height*/) {}
+
+bool VulkanDrmBackend::TextureMakeCurrent() {
+  return false;
+}
+
+bool VulkanDrmBackend::TextureClearCurrent() {
+  return false;
+}
+
+FlutterRendererConfig VulkanDrmBackend::GetRenderConfig() {
+  FlutterRendererConfig config{};
+  config.type = kVulkan;
+  config.vulkan.struct_size = sizeof(FlutterVulkanRendererConfig);
+  return config;
+}
+
+FlutterCompositor VulkanDrmBackend::GetCompositorConfig() {
+  FlutterCompositor compositor{};
+  compositor.struct_size = sizeof(FlutterCompositor);
+  return compositor;
+}

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -19,27 +19,30 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
+
+#include <vulkan/vulkan.h>
 
 #include "backend/backend.h"
+#include "backend/drm_kms_vulkan/device_caps.h"
 
 namespace homescreen {
 class DrmSession;
 }  // namespace homescreen
 
-// Phase 0 scaffold for the DRM/KMS Vulkan scanout backend (drm_kms_vulkan
-// plan). The backend drives Flutter's Vulkan renderer and scans the result
-// out on hardware KMS planes via zero-copy dma-buf import, reusing the
-// session / modeset / vsync stack from drm_kms_egl below the pixel layer.
+// DRM/KMS scanout backend that drives the Flutter Vulkan renderer and presents
+// on hardware KMS planes via zero-copy dma-buf import, reusing the session /
+// modeset / vsync stack from drm_kms_egl below the pixel layer.
 //
-// Today only the scaffold exists: Create() runs the §4.1 zero-copy gate and
-// then refuses (returns nullptr) in every case — either because the gate
-// failed (and logs the precise cause) or because the render/scanout pipeline
-// is not implemented yet (Phases 1-6). The class implements the Backend
-// interface so the FlutterView wiring, the Backend::Type enumerator, and the
-// build graph are all in place ahead of the pixel path.
+// Create() brings up the Vulkan instance, selects a physical device that can do
+// zero-copy dma-buf scanout (render-node-aware when the device exposes a DRM
+// node, vendor/name fallback otherwise), creates the logical device and
+// queues, and logs the resolved capabilities. The render and present path is
+// not implemented yet, so the backend currently refuses after bring-up rather
+// than handing back a backend that cannot present a frame.
 class VulkanDrmBackend final : public Backend {
  public:
-  // Probe the §4.1 gate and (for now) refuse. Returns nullptr on every path:
+  // Bring up the device and (for now) refuse. Returns nullptr on every path:
   // the caller treats null as a hard init failure and aborts, exactly as the
   // drm_kms_egl backend does on DrmBackend::Create returning null. @p session
   // may be null when no libseat session is available.
@@ -48,11 +51,14 @@ class VulkanDrmBackend final : public Backend {
       bool enable_validation,
       homescreen::DrmSession* session);
 
-  ~VulkanDrmBackend() override = default;
+  ~VulkanDrmBackend() override;
+
+  VulkanDrmBackend(const VulkanDrmBackend&) = delete;
+  VulkanDrmBackend& operator=(const VulkanDrmBackend&) = delete;
 
   // ── Backend interface ──────────────────────────────────────────────────────
-  // Stubs until the render/scanout path lands; never reached while Create()
-  // refuses, but required for the vtable and the FlutterView call sites.
+  // Present/scanout is not wired yet; these satisfy the vtable and the
+  // FlutterView call sites.
   void Resize(size_t index,
               Engine* flutter_engine,
               int32_t width,
@@ -66,17 +72,44 @@ class VulkanDrmBackend final : public Backend {
   FlutterRendererConfig GetRenderConfig() override;
   FlutterCompositor GetCompositorConfig() override;
 
-  // Resolved framebuffer dimensions, queried by FlutterView for the display
-  // metrics event (the DRM path has no WaylandWindow to source them).
   [[nodiscard]] uint32_t width() const { return width_; }
   [[nodiscard]] uint32_t height() const { return height_; }
+  [[nodiscard]] const drm_kms_vulkan::DeviceCaps& caps() const { return caps_; }
 
  private:
-  VulkanDrmBackend(uint32_t width,
-                   uint32_t height,
+  VulkanDrmBackend(std::string drm_device,
+                   bool enable_validation,
                    homescreen::DrmSession* session);
+
+  // Bring-up steps. Each logs and returns false on failure; refusal_reason
+  // carries the cause for gate failures.
+  bool BringUp(std::string& refusal_reason);
+  bool CreateInstance(std::string& refusal_reason);
+  void SetupDebugMessenger();
+  bool SelectPhysicalDevice(std::string& refusal_reason);
+  bool CreateLogicalDevice(std::string& refusal_reason);
+  void PopulateCaps();
+  void Teardown();
+
+  std::string drm_device_;
+  bool enable_validation_ = false;
+  // Reused by the session/vsync glue in a later change; held now so Create()'s
+  // signature and the FlutterView wiring are stable.
+  [[maybe_unused]] homescreen::DrmSession* session_ = nullptr;  // not owned
 
   uint32_t width_ = 0;
   uint32_t height_ = 0;
-  homescreen::DrmSession* session_ = nullptr;  // not owned
+
+  VkInstance instance_ = VK_NULL_HANDLE;
+  VkDebugUtilsMessengerEXT debug_messenger_ = VK_NULL_HANDLE;
+  VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;
+  VkDevice device_ = VK_NULL_HANDLE;
+  uint32_t graphics_queue_family_ = UINT32_MAX;
+  VkQueue graphics_queue_ = VK_NULL_HANDLE;
+
+  std::vector<const char*> enabled_instance_extensions_;
+  std::vector<const char*> enabled_instance_layers_;
+  std::vector<const char*> enabled_device_extensions_;
+
+  drm_kms_vulkan::DeviceCaps caps_;
 };

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "backend/backend.h"
+
+namespace homescreen {
+class DrmSession;
+}  // namespace homescreen
+
+// Phase 0 scaffold for the DRM/KMS Vulkan scanout backend (drm_kms_vulkan
+// plan). The backend drives Flutter's Vulkan renderer and scans the result
+// out on hardware KMS planes via zero-copy dma-buf import, reusing the
+// session / modeset / vsync stack from drm_kms_egl below the pixel layer.
+//
+// Today only the scaffold exists: Create() runs the §4.1 zero-copy gate and
+// then refuses (returns nullptr) in every case — either because the gate
+// failed (and logs the precise cause) or because the render/scanout pipeline
+// is not implemented yet (Phases 1-6). The class implements the Backend
+// interface so the FlutterView wiring, the Backend::Type enumerator, and the
+// build graph are all in place ahead of the pixel path.
+class VulkanDrmBackend final : public Backend {
+ public:
+  // Probe the §4.1 gate and (for now) refuse. Returns nullptr on every path:
+  // the caller treats null as a hard init failure and aborts, exactly as the
+  // drm_kms_egl backend does on DrmBackend::Create returning null. @p session
+  // may be null when no libseat session is available.
+  static std::shared_ptr<VulkanDrmBackend> Create(
+      const std::string& drm_device,
+      bool enable_validation,
+      homescreen::DrmSession* session);
+
+  ~VulkanDrmBackend() override = default;
+
+  // ── Backend interface ──────────────────────────────────────────────────────
+  // Stubs until the render/scanout path lands; never reached while Create()
+  // refuses, but required for the vtable and the FlutterView call sites.
+  void Resize(size_t index,
+              Engine* flutter_engine,
+              int32_t width,
+              int32_t height) override;
+  void CreateSurface(size_t index,
+                     struct wl_surface* surface,
+                     int32_t width,
+                     int32_t height) override;
+  bool TextureMakeCurrent() override;
+  bool TextureClearCurrent() override;
+  FlutterRendererConfig GetRenderConfig() override;
+  FlutterCompositor GetCompositorConfig() override;
+
+  // Resolved framebuffer dimensions, queried by FlutterView for the display
+  // metrics event (the DRM path has no WaylandWindow to source them).
+  [[nodiscard]] uint32_t width() const { return width_; }
+  [[nodiscard]] uint32_t height() const { return height_; }
+
+ private:
+  VulkanDrmBackend(uint32_t width,
+                   uint32_t height,
+                   homescreen::DrmSession* session);
+
+  uint32_t width_ = 0;
+  uint32_t height_ = 0;
+  homescreen::DrmSession* session_ = nullptr;  // not owned
+};

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -32,6 +32,11 @@
 #if BUILD_BACKEND_DRM_KMS_EGL
 #include "backend/drm_kms_egl/drm_backend.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
+#elif BUILD_BACKEND_DRM_KMS_VULKAN
+// The Vulkan DRM backend reuses the DRM engine-state path but not the EGL
+// backend header (which pulls in EGL/GL). Only the engine-state type is
+// needed here.
+#include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #endif
 
 // WaylandWindow's complete type is required for the m_egl_window->

--- a/shell/platform/homescreen/CMakeLists.txt
+++ b/shell/platform/homescreen/CMakeLists.txt
@@ -16,6 +16,11 @@ target_include_directories(platform_homescreen PUBLIC
         ${CMAKE_SOURCE_DIR}/shell
         client_wrapper/include
         public
+        # config/common.h is generated at ${PROJECT_BINARY_DIR}/config/common.h
+        # and pulled in via logging.h / backend.h. Add the binary root directly
+        # rather than relying on wayland-gen's exported include dirs (which are
+        # only present on Wayland/Headless builds).
+        ${CMAKE_BINARY_DIR}
         ${CMAKE_BINARY_DIR}/shell
 )
 
@@ -34,18 +39,15 @@ target_link_libraries(platform_homescreen PUBLIC
         tomlplusplus::tomlplusplus
 )
 
-# config/common.h includes <waypp/waypp.h> unconditionally for the
-# ENABLE_AGL_SHELL_CLIENT / ENABLE_XDG_CLIENT compile defines,
-# regardless of backend. Propagate wayland-gen's INTERFACE include
-# dirs without linking the library so non-Wayland builds get the
-# headers but not the libwayland-client / libwayland-cursor
-# runtime deps (the static library archive carries every protocol
-# binding's wl_proxy_* references).
-target_include_directories(platform_homescreen PUBLIC
-        $<TARGET_PROPERTY:wayland-gen,INTERFACE_INCLUDE_DIRECTORIES>
-)
+# config/common.h includes <waypp/waypp.h> only on the Wayland backends, so
+# the wayland-gen protocol-header include dirs and the static library are both
+# scoped to those builds. Non-Wayland backends get neither the headers nor the
+# libwayland-client / libwayland-cursor runtime deps.
 if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN OR
     BUILD_BACKEND_HEADLESS_EGL)
+    target_include_directories(platform_homescreen PUBLIC
+            $<TARGET_PROPERTY:wayland-gen,INTERFACE_INCLUDE_DIRECTORIES>
+    )
     target_link_libraries(platform_homescreen PUBLIC wayland-gen)
 endif ()
 

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -27,6 +27,9 @@
 #elif BUILD_BACKEND_DRM_KMS_EGL
 #include "backend/drm_kms_egl/drm_backend.h"
 #include "display/drm_display.h"
+#elif BUILD_BACKEND_DRM_KMS_VULKAN
+#include "backend/drm_kms_vulkan/vulkan_drm_backend.h"
+#include "display/drm_display.h"
 #elif BUILD_BACKEND_SOFTWARE
 #include "backend/software/sink_factory.h"
 #include "backend/software/software_backend.h"
@@ -218,6 +221,27 @@ FlutterView::FlutterView(Configuration::Config config,
       drm_display->SetCursor(drm_backend->drm_cursor());
     }
   }
+#elif BUILD_BACKEND_DRM_KMS_VULKAN
+  {
+    // Shares DrmDisplay (libseat session, refresh rate, cursor) with the EGL
+    // DRM backend; only the renderer differs. App::MakeDisplay always builds a
+    // DrmDisplay in a DRM build, so the cast failing is programmer error.
+    auto* drm_display = dynamic_cast<DrmDisplay*>(m_display.get());
+    assert(drm_display != nullptr);
+    m_backend = VulkanDrmBackend::Create(
+        m_config.view.drm_device.value_or("/dev/dri/card1"),
+        m_config.debug_backend.value_or(false), drm_display->session());
+
+    // Create returns nullptr on any init failure or refusal (the Phase 0
+    // scaffold always refuses). Continuing would dereference a null backend in
+    // Engine::Run and SEGV; fail-fast with the same exit path the EGL DRM
+    // backend uses.
+    if (!m_backend) {
+      spdlog::critical(
+          "[FlutterView] DRM Vulkan backend init failed; aborting");
+      exit(EXIT_FAILURE);
+    }
+  }
 #elif BUILD_BACKEND_WAYLAND_EGL
   {
     auto* wl = dynamic_cast<Display*>(display.get());
@@ -262,7 +286,8 @@ FlutterView::FlutterView(Configuration::Config config,
                m_config.view.width.value_or(kDefaultViewWidth),
                m_config.view.height.value_or(kDefaultViewWidth));
 
-#if !BUILD_BACKEND_DRM_KMS_EGL && !BUILD_BACKEND_SOFTWARE
+#if !BUILD_BACKEND_DRM_KMS_EGL && !BUILD_BACKEND_DRM_KMS_VULKAN && \
+    !BUILD_BACKEND_SOFTWARE
   auto* wl = dynamic_cast<Display*>(display.get());
   m_wayland_window = std::make_shared<WaylandWindow>(
       m_index, std::dynamic_pointer_cast<Display>(display),
@@ -373,7 +398,8 @@ FlutterView::~FlutterView() {
   }
 }
 
-#if !BUILD_BACKEND_DRM_KMS_EGL && !BUILD_BACKEND_SOFTWARE
+#if !BUILD_BACKEND_DRM_KMS_EGL && !BUILD_BACKEND_DRM_KMS_VULKAN && \
+    !BUILD_BACKEND_SOFTWARE
 Display* FlutterView::GetDisplay() const {
   return dynamic_cast<Display*>(m_display.get());
 }
@@ -426,7 +452,7 @@ void FlutterView::Initialize() {
   display.single_display = true;
   display.refresh_rate =
       m_display->GetRefreshRate(static_cast<uint32_t>(m_index));
-#if BUILD_BACKEND_DRM_KMS_EGL
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
   // DrmDisplay is constructed from the config-level width/height in app.cc,
   // which may still hold the TOML-specified size even when `-f` cleared those
   // values for the backend. Query the backend for the resolved FB size so
@@ -458,7 +484,7 @@ void FlutterView::Initialize() {
   // update view
   m_state->view = m_state->view_wrapper->view = this;
 
-#if BUILD_BACKEND_DRM_KMS_EGL
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
   // On the DRM path there is no WaylandWindow to trigger the initial
   // window-metrics event. Without it Flutter never learns the viewport
   // size and never schedules a frame. Send it explicitly now that the

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -61,6 +61,8 @@ class PlatformChannel;
 class HeadlessBackend;
 #elif BUILD_BACKEND_DRM_KMS_EGL
 class DrmBackend;
+#elif BUILD_BACKEND_DRM_KMS_VULKAN
+class VulkanDrmBackend;
 #elif BUILD_BACKEND_SOFTWARE
 class SoftwareBackend;
 #elif BUILD_BACKEND_WAYLAND_EGL
@@ -70,8 +72,9 @@ class WaylandVulkanBackend;
 #else
 #error \
     "no Flutter backend selected: define one of BUILD_BACKEND_HEADLESS_EGL, " \
-    "BUILD_BACKEND_DRM_KMS_EGL, BUILD_BACKEND_SOFTWARE, " \
-    "BUILD_BACKEND_WAYLAND_EGL, BUILD_BACKEND_WAYLAND_VULKAN"
+    "BUILD_BACKEND_DRM_KMS_EGL, BUILD_BACKEND_DRM_KMS_VULKAN, " \
+    "BUILD_BACKEND_SOFTWARE, BUILD_BACKEND_WAYLAND_EGL, " \
+    "BUILD_BACKEND_WAYLAND_VULKAN"
 #endif
 #ifdef ENABLE_PLUGIN_COMP_SURF
 class CompositorSurface;
@@ -146,7 +149,7 @@ class FlutterView {
    * @relation
    * internal
    */
-#if !BUILD_BACKEND_DRM_KMS_EGL
+#if !BUILD_BACKEND_DRM_KMS_EGL && !BUILD_BACKEND_DRM_KMS_VULKAN
   [[nodiscard]] Display* GetDisplay() const;
 #endif
 
@@ -259,6 +262,8 @@ class FlutterView {
   std::shared_ptr<HeadlessBackend> m_backend;
 #elif BUILD_BACKEND_DRM_KMS_EGL
   std::shared_ptr<DrmBackend> m_backend{};
+#elif BUILD_BACKEND_DRM_KMS_VULKAN
+  std::shared_ptr<VulkanDrmBackend> m_backend{};
 #elif BUILD_BACKEND_SOFTWARE
   std::shared_ptr<SoftwareBackend> m_backend;
 #elif BUILD_BACKEND_WAYLAND_EGL

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -58,35 +58,43 @@ target_include_directories(vulkan_headers INTERFACE Vulkan-Headers/include/vulka
 add_subdirectory(flutter)
 
 #
-# waypp
+# waypp — the Wayland C++ wrapper. Only the Wayland backends (and headless,
+# which links wayland-gen) consume it; config/common.h includes <waypp/waypp.h>
+# under the same condition. Building it for the DRM EGL/Vulkan and software
+# backends would drag Wayland headers + libwayland into builds that must stay
+# Wayland-free, so gate the whole subproject.
 #
-if (BUILD_BACKEND_WAYLAND_EGL)
-    set(ENABLE_EGL ON)
-else ()
-    set(ENABLE_EGL OFF)
-endif ()
-set(LOGGING_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/shell;${CMAKE_BINARY_DIR})
-add_subdirectory(waypp)
-
-# waypp is a git submodule we keep pristine, so apply the "system library"
-# treatment from here rather than editing it: mark its interface include dirs
-# SYSTEM so its headers are -isystem for consumers, and silence GCC's benign
-# -Wpsabi std::pair ABI note (seat/pointer.h get_xy()) that -isystem does not
-# suppress, emitted while compiling waypp's own sources.
-foreach (_tgt waypp wayland-gen)
-    if (TARGET ${_tgt})
-        get_target_property(_waypp_inc ${_tgt} INTERFACE_INCLUDE_DIRECTORIES)
-        if (_waypp_inc)
-            set_target_properties(${_tgt} PROPERTIES
-                    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_waypp_inc}")
-        endif ()
+if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN OR
+    BUILD_BACKEND_HEADLESS_EGL)
+    if (BUILD_BACKEND_WAYLAND_EGL)
+        set(ENABLE_EGL ON)
+    else ()
+        set(ENABLE_EGL OFF)
     endif ()
-endforeach ()
-if (TARGET waypp)
-    # Silence waypp's own-source diagnostics (the -Wpsabi std::pair note, and
-    # -Wunused-parameter on EGL stubs when ENABLE_EGL is off) — pristine vendor.
-    target_compile_options(waypp PRIVATE
-            $<$<CXX_COMPILER_ID:GNU,Clang>:-w>)
+    set(LOGGING_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/shell;${CMAKE_BINARY_DIR})
+    add_subdirectory(waypp)
+
+    # waypp is a git submodule we keep pristine, so apply the "system library"
+    # treatment from here rather than editing it: mark its interface include
+    # dirs SYSTEM so its headers are -isystem for consumers, and silence GCC's
+    # benign -Wpsabi std::pair ABI note (seat/pointer.h get_xy()) that -isystem
+    # does not suppress, emitted while compiling waypp's own sources.
+    foreach (_tgt waypp wayland-gen)
+        if (TARGET ${_tgt})
+            get_target_property(_waypp_inc ${_tgt} INTERFACE_INCLUDE_DIRECTORIES)
+            if (_waypp_inc)
+                set_target_properties(${_tgt} PROPERTIES
+                        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_waypp_inc}")
+            endif ()
+        endif ()
+    endforeach ()
+    if (TARGET waypp)
+        # Silence waypp's own-source diagnostics (the -Wpsabi std::pair note,
+        # and -Wunused-parameter on EGL stubs when ENABLE_EGL is off) — pristine
+        # vendor.
+        target_compile_options(waypp PRIVATE
+                $<$<CXX_COMPILER_ID:GNU,Clang>:-w>)
+    endif ()
 endif ()
 
 #


### PR DESCRIPTION
## Summary

Adds a `BUILD_BACKEND_DRM_KMS_VULKAN` backend that drives the Flutter Vulkan
renderer for hardware KMS scanout, alongside the existing DRM/KMS EGL backend.

At init the backend probes for zero-copy dma-buf scanout: a non-CPU Vulkan
device exposing `VK_EXT_image_drm_format_modifier`,
`VK_EXT_external_memory_dma_buf`, `VK_KHR_external_memory_fd` and
`VK_EXT_queue_family_foreign`, plus an openable DRM display node. When those do
not hold it refuses at init with a clear diagnostic instead of failing later
inside framebuffer import. Vulkan is resolved at runtime through vulkan.hpp's
dynamic dispatcher, so the binary links no EGL, GL, Wayland or Vulkan loader
library. The DRM session, display, seat and cursor code is shared with the EGL
backend. The backend probes and refuses cleanly; it does not present frames yet.

## EGL / Wayland decoupling

To keep this and the software build free of EGL and Wayland, the shared config
header and the waypp subproject are scoped to the backends that use them:

- `config/common.h` includes `<EGL/egl.h>` and the EGL config arrays only for
  the EGL backends, and `<waypp/waypp.h>` only for the Wayland and headless
  backends.
- waypp is built only for those backends.
- `platform_homescreen` takes the generated-config include directory directly
  rather than inheriting it from `wayland-gen`.

What the EGL, software and Wayland builds link is unchanged.

## Also

- `Backend::Type::DrmKmsVulkan` enumerator, wired through the backend-selection
  sites and the build
- `BUILD_VULKAN_VALIDATION` option
- `drm_kms_vulkan_probe` tool that reports the capability-gate result
  (exit 0 pass, 1 refuse)
- corrected sync note in `scene_layer_source_vk.h`: the embedder exposes no
  per-image render-complete fence, so producer/consumer synchronization is an
  open question rather than a settled one

## Testing

- All six backends build clean (clang / Ninja): DRM-Vulkan, DRM-EGL,
  Wayland-Vulkan, Wayland-EGL, Headless-EGL, Software.
- Link audited: DRM-Vulkan and Software pull no EGL/GL/Vulkan/Wayland/waypp;
  DRM-EGL keeps EGL; Wayland and headless keep waypp/wayland-gen.
- `drm_kms_vulkan_probe` on amdgpu: gate passes (exit 0); refuses with a
  diagnostic on a software-only ICD and on a missing DRM node (exit 1).
- Full binary on amdgpu with DRM master: acquires the libseat session, gate
  passes, refuses cleanly, exits with a failure status, releases master and
  restores the VT keyboard mode.
