### PR TITLE
[drm_kms_egl] stage HW cursor into compositor commit + bound WaitForPendingFlip

### DIFF
--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -383,16 +383,46 @@ std::unique_ptr<DrmBackend> DrmBackend::Create(
   // sprite. Independent of the compositor: cursor commits run on
   // their own AtomicRequests on the seat dispatch thread.
 #if HAVE_DRM_CURSOR
-  backend->cursor_ = homescreen::DrmCursor::Create(
-      *backend->drm_dev_, backend->crtc_id_, backend->connector_id_,
-      backend->mode_, backend->fb_w_, backend->fb_h_);
+  if (backend->cfg_.disable_cursor) {
+    spdlog::info("[DrmBackend] HW cursor disabled (--disable-cursor)");
+  } else {
+    backend->cursor_ = homescreen::DrmCursor::Create(
+        *backend->drm_dev_, backend->crtc_id_, backend->connector_id_,
+        backend->mode_, backend->fb_w_, backend->fb_h_);
+  }
 #if BUILD_COMPOSITOR
-  // On a CRTC with no dedicated cursor plane the cursor takes an
-  // overlay; reserve it so the scene allocator's disable-unused pass
-  // doesn't toggle it off every commit (flicker on pointer motion).
-  // plane_id()==0 (legacy cursor path) is a no-op in the compositor.
+  // Decide whether to stage the cursor into the compositor's own atomic commit
+  // or let it self-commit. Staging is only a win on nvidia-drm, where a
+  // separate cursor commit on the CRTC starves the compositor's
+  // PAGE_FLIP_EVENT (the cursor's blocking commit swallows the pending flip's
+  // completion, freezing content on pointer motion). Everywhere else staging
+  // couples cursor motion to Flutter frame production, so the cursor stalls
+  // while the UI is idle — the self-committing cursor is smoother. kAuto (the
+  // default) therefore stages only on nvidia-drm; yes/no force the choice.
+  const bool stage_cursor =
+      backend->cfg_.stage_cursor == drm_config::TriState::kYes ||
+      (backend->cfg_.stage_cursor == drm_config::TriState::kAuto &&
+       backend->resolved_->driver_name == "nvidia-drm");
+  // Either way, reserve the cursor's plane so the scene allocator's
+  // disable-unused pass doesn't toggle it off every commit (flicker on
+  // motion). plane_id()==0 (legacy cursor path) is a no-op in the
+  // compositor.
   if (backend->cursor_ && backend->compositor_) {
+    if (stage_cursor) {
+      backend->cursor_->SetStagedMode(true);
+      backend->compositor_->SetCursor(backend->cursor_.get());
+    }
     backend->compositor_->ReserveCursorPlane(backend->cursor_->plane_id());
+  }
+#else
+  // No compositor to stage into: a self-committing cursor on nvidia-drm
+  // starves the legacy page flip on pointer motion. Drop the cursor on
+  // that driver (other drivers keep the self-commit path).
+  if (backend->cursor_ && backend->resolved_->driver_name == "nvidia-drm") {
+    spdlog::warn(
+        "[DrmBackend] nvidia-drm without compositor: HW cursor disabled (no "
+        "atomic commit to stage into)");
+    backend->cursor_.reset();
   }
 #endif
 #endif

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -1662,8 +1662,23 @@ bool DrmBackend::WaitForPendingFlip() const {
   // it. Short sleep so a 60 Hz frame's ~16ms window has plenty of
   // resolution but we don't burn the rasterizer CPU.
   using namespace std::chrono_literals;
+  // Bounded wait. On nvidia-drm a flip's PAGE_FLIP_EVENT can go
+  // undelivered, and at teardown the asio monitor that would drain it
+  // is already gone — an unbounded loop then spins forever in
+  // hrtimer_nanosleep, hanging Present and (fatally) ~DrmBackend so the
+  // process never exits on SIGTERM. Cap the wait and proceed; a healthy
+  // 60Hz flip clears in ~16ms so this never fires in normal operation.
+  // Same budget as StopVsyncMonitor's drain.
+  constexpr auto kFlipWaitTimeout = 100ms;
+  const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
   while (flip_pending_.load(std::memory_order_acquire)) {
     if (!drm_dev_) {
+      return true;
+    }
+    if (std::chrono::steady_clock::now() >= deadline) {
+      spdlog::warn(
+          "[DrmBackend] WaitForPendingFlip: no flip completion after 100ms; "
+          "proceeding (PAGE_FLIP_EVENT likely lost)");
       return true;
     }
     std::this_thread::sleep_for(500us);

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -80,6 +80,22 @@ struct DrmConfig {
   std::optional<uint32_t> height;
   bool debug_backend{false};
 
+  // Skip HW cursor creation entirely (the global --disable-cursor /
+  // disable_cursor config). Pointer events still reach Flutter; there is
+  // just no DRM cursor sprite. Equivalent to the IVI_DRM_CURSOR=0 env.
+  bool disable_cursor{false};
+
+  // Stage the HW cursor into the compositor's atomic commit instead of
+  // letting it self-commit (DrmCursor staged mode). kAuto (the default)
+  // resolves per driver in DrmBackend::Create: enabled only on nvidia-drm,
+  // where a separate cursor commit on the CRTC starves the compositor's
+  // PAGE_FLIP_EVENT (content freezes on pointer motion). Everywhere else the
+  // self-committing cursor is used — staging it instead couples cursor motion
+  // to Flutter frame production, so the cursor stalls whenever the UI is idle.
+  // kYes forces staging, kNo forces self-commit. No effect without a
+  // compositor.
+  drm_config::TriState stage_cursor{drm_config::TriState::kAuto};
+
   // Unset = pick the highest-ranking connected connector (internal panels
   // preferred, then cable-out). Set = pick the connector whose name
   // (e.g. "eDP-1", "HDMI-A-1") matches; init fails if no such connector

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -925,6 +925,12 @@ bool DrmCompositor::WaitForPendingFlip() const {
   // UnifiedPageFlipHandler → OnFlipComplete. We just wait for it.
   // Short sleep keeps the rasterizer responsive without burning CPU.
   using namespace std::chrono_literals;
+  // Bounded wait — see DrmBackend::WaitForPendingFlip. On nvidia-drm a
+  // flip event can be lost; without a cap the destructor's wait spins
+  // forever and the process never exits on SIGTERM. A healthy 60Hz flip
+  // clears in ~16ms so the cap never fires in normal operation.
+  constexpr auto kFlipWaitTimeout = 100ms;
+  const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
   while (flip_pending_.load(std::memory_order_acquire)) {
     // Session went inactive between submitting the flip and the
     // kernel firing PAGE_FLIP_EVENT — the event will never come.

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -40,6 +40,7 @@
 
 #include "backend/drm_kms_egl/driver_probe.h"
 #include "backend/drm_kms_egl/drm_backend.h"
+#include "backend/drm_kms_egl/drm_cursor.h"
 #if USE_DRM_SCENE
 #include "backend/drm_kms_egl/scene_layer_source_gl.h"
 #endif
@@ -939,6 +940,12 @@ bool DrmCompositor::WaitForPendingFlip() const {
     if (paused_.load(std::memory_order_acquire)) {
       return false;
     }
+    if (std::chrono::steady_clock::now() >= deadline) {
+      spdlog::warn(
+          "[DrmCompositor] WaitForPendingFlip: no flip completion after "
+          "100ms; proceeding (PAGE_FLIP_EVENT likely lost)");
+      return true;
+    }
     std::this_thread::sleep_for(500us);
   }
   return true;
@@ -1025,6 +1032,42 @@ bool DrmCompositor::PresentViaGlFallback(const FlutterLayer** layers,
 
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   return backend_->Present();
+}
+
+// ─── Cursor staging + shared commit settle ──────────────────────────────
+
+bool DrmCompositor::StageCursorInto(drm::AtomicRequest& req) {
+  bool needs_modeset = false;
+  if (cursor_ != nullptr) {
+    (void)cursor_->Stage(req, &needs_modeset);
+  }
+  return needs_modeset;
+}
+
+void DrmCompositor::SettleAtomicCommit(const bool blocking) {
+  if (blocking) {
+    // A blocking commit (initial modeset or a cursor first-enable) lands
+    // synchronously with no PAGE_FLIP_EVENT. The genuine first modeset
+    // also latches plane_mode_set_ and verifies the pipe. Either way the
+    // baton Flutter requested while we built this frame must be returned
+    // inline (the asio flip path won't fire). PostOnVsync marshals via
+    // the platform task runner (we're on the rasterizer thread).
+    if (!plane_mode_set_) {
+      plane_mode_set_ = true;
+      VerifyPipeRunning();
+    }
+    flip_pending_.store(false, std::memory_order_release);
+    const intptr_t baton =
+        backend_->vsync_baton_.exchange(0, std::memory_order_acq_rel);
+    if (baton != 0) {
+      if (auto engine =
+              backend_->engine_handle_.load(std::memory_order_acquire)) {
+        backend_->PostOnVsync(engine, baton);
+      }
+    }
+  } else {
+    flip_pending_.store(true, std::memory_order_release);
+  }
 }
 
 // ─── Framed-mode present (primary BG + overlay content) ─────────────────
@@ -1359,12 +1402,16 @@ bool DrmCompositor::PresentFramed(const FlutterLayer** layers,
     backend_->flip_submit_ns_ = LibFlutterEngine->GetCurrentTime();
   }
 
-  uint32_t commit_flags = 0;
-  if (!plane_mode_set_) {
-    commit_flags = DRM_MODE_ATOMIC_ALLOW_MODESET;
-  } else {
-    commit_flags = DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
-  }
+  // Stage the HW cursor into this commit so it rides the same atomic flip
+  // instead of issuing its own (a separate cursor commit on this CRTC
+  // starves the compositor's PAGE_FLIP_EVENT on nvidia-drm). The cursor's
+  // first plane-enable needs ALLOW_MODESET, which can't be NONBLOCK on
+  // most drivers, so fold it into a blocking commit for that one frame —
+  // exactly how the initial modeset is handled.
+  const bool blocking = !plane_mode_set_ || StageCursorInto(req);
+  const uint32_t commit_flags =
+      blocking ? DRM_MODE_ATOMIC_ALLOW_MODESET
+               : (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK);
 
   // Profile fence post: end of compose / req build, just before the
   // optional TEST_ONLY probe + the real commit.
@@ -1416,28 +1463,7 @@ bool DrmCompositor::PresentFramed(const FlutterLayer** layers,
     return PresentViaGlFallback(layers, count);
   }
 
-  if (!plane_mode_set_) {
-    plane_mode_set_ = true;
-    flip_pending_.store(false, std::memory_order_release);
-    VerifyPipeRunning();
-
-    // First-commit drain: ALLOW_MODESET commits are blocking with no
-    // PAGE_FLIP_EVENT, so the baton Flutter requested while we were
-    // building this frame would otherwise sit in vsync_baton_
-    // unfired. PostOnVsync marshals via the platform task runner
-    // (we're on the rasterizer thread here; OnVsync must be on the
-    // FlutterEngineRun thread).
-    const intptr_t baton =
-        backend_->vsync_baton_.exchange(0, std::memory_order_acq_rel);
-    if (baton != 0) {
-      if (auto engine =
-              backend_->engine_handle_.load(std::memory_order_acquire)) {
-        backend_->PostOnVsync(engine, baton);
-      }
-    }
-  } else {
-    flip_pending_.store(true, std::memory_order_release);
-  }
+  SettleAtomicCommit(blocking);
   comp_idx_ ^= 1;
 
   if (profile && profile_) {
@@ -2004,6 +2030,9 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
     backend_->flip_submit_ns_ = LibFlutterEngine->GetCurrentTime();
   }
 
+  // Stage the HW cursor into this commit (rides the same flip; see
+  // StageCursorInto). Its first plane-enable forces a blocking frame.
+  //
   // Two-phase flags:
   //   First frame: blocking + ALLOW_MODESET, no PAGE_FLIP_EVENT. The
   //     kernel won't deliver a flip-event on a modeset transition on
@@ -2011,13 +2040,13 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
   //   Steady state: NONBLOCK + PAGE_FLIP_EVENT for vsync-locked flips.
   //     ALLOW_MODESET is not combined with NONBLOCK unless the driver
   //     has opted in via --drm-allow-nonblock-modeset.
-  uint32_t commit_flags = 0;
   const bool was_first_commit_pre = !plane_mode_set_;
-  if (was_first_commit_pre) {
-    commit_flags = DRM_MODE_ATOMIC_ALLOW_MODESET;
-  } else {
-    commit_flags = DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
-  }
+  // `blocking` also covers a cursor first-enable; `was_first_commit_pre`
+  // stays "initial modeset" for the slot-pipeline bookkeeping below.
+  const bool blocking = was_first_commit_pre || StageCursorInto(req);
+  const uint32_t commit_flags =
+      blocking ? DRM_MODE_ATOMIC_ALLOW_MODESET
+               : (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK);
 
   // Profile fence post: end of allocator + compose + req build, just
   // before the kernel-side commit.
@@ -2053,33 +2082,7 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
     return PresentViaGlFallback(layers, layer_count);
   }
 
-  if (!plane_mode_set_) {
-    // First commit landed — kernel is scanning out our composition BO.
-    // The blocking commit returned only after the modeset completed,
-    // so there's no page-flip event in flight.
-    plane_mode_set_ = true;
-    flip_pending_.store(false, std::memory_order_release);
-
-    // Readback + vblank probe to catch the "commit reported success but
-    // the pipe isn't actually running" case before Flutter stalls on the
-    // next flip wait. Costs one readback and ~2 refresh periods of sleep,
-    // once at startup.
-    VerifyPipeRunning();
-
-    // Deliver the initial vsync baton now so Flutter can schedule the
-    // next frame. Normal PAGE_FLIP_EVENT deliveries take over from here.
-    // PostOnVsync marshals via the platform task runner.
-    const intptr_t baton =
-        backend_->vsync_baton_.exchange(0, std::memory_order_acq_rel);
-    if (baton != 0) {
-      if (auto engine =
-              backend_->engine_handle_.load(std::memory_order_acquire)) {
-        backend_->PostOnVsync(engine, baton);
-      }
-    }
-  } else {
-    flip_pending_.store(true, std::memory_order_release);
-  }
+  SettleAtomicCommit(blocking);
   // Only advance the comp-buffer double-buffer index if we actually
   // wrote to it this frame. Direct-scanout frames don't touch comp,
   // so the next frame can keep using the same comp_idx_ if it needs
@@ -2439,6 +2442,17 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     }
   } else {
     flip_pending_.store(true, std::memory_order_release);
+  }
+
+  // LayerScene owns its commit and can't accept a staged cursor plane, so
+  // (in staged mode) self-commit the cursor here to keep it visible. The
+  // scene already reserves the cursor's plane (set_external_reserved_planes
+  // via ApplyCursorReservation). TODO: a LayerScene API that takes the
+  // cursor plane in its own commit would avoid this separate commit (which
+  // reintroduces the flip contention on nvidia-drm in fullscreen scene
+  // mode). No-op when no cursor is staged.
+  if (cursor_ != nullptr) {
+    cursor_->CommitPending();
   }
 
   // Rotate every BS pool that participated. Same slot-pipeline
@@ -2895,13 +2909,15 @@ bool DrmCompositor::PresentDirectOverlay(const FlutterLayer** layers,
     backend_->flip_submit_ns_ = LibFlutterEngine->GetCurrentTime();
   }
 
-  uint32_t commit_flags = 0;
+  // Stage the HW cursor into this commit (rides the same flip; see
+  // StageCursorInto); its first plane-enable forces a blocking frame.
   const bool was_first_commit_pre = !plane_mode_set_;
-  if (was_first_commit_pre) {
-    commit_flags = DRM_MODE_ATOMIC_ALLOW_MODESET;
-  } else {
-    commit_flags = DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
-  }
+  // `blocking` also covers a cursor first-enable; `was_first_commit_pre`
+  // stays "initial modeset" for the slot-pipeline bookkeeping below.
+  const bool blocking = was_first_commit_pre || StageCursorInto(req);
+  const uint32_t commit_flags =
+      blocking ? DRM_MODE_ATOMIC_ALLOW_MODESET
+               : (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK);
   const uint64_t t2 = profile ? NsNow() : 0;
 
   if (auto r = req.commit(commit_flags, backend_); !r) {
@@ -2921,21 +2937,7 @@ bool DrmCompositor::PresentDirectOverlay(const FlutterLayer** layers,
     return PresentViaGlFallback(layers, count);
   }
 
-  if (was_first_commit_pre) {
-    plane_mode_set_ = true;
-    flip_pending_.store(false, std::memory_order_release);
-    VerifyPipeRunning();
-    const intptr_t baton =
-        backend_->vsync_baton_.exchange(0, std::memory_order_acq_rel);
-    if (baton != 0) {
-      if (auto engine =
-              backend_->engine_handle_.load(std::memory_order_acquire)) {
-        backend_->PostOnVsync(engine, baton);
-      }
-    }
-  } else {
-    flip_pending_.store(true, std::memory_order_release);
-  }
+  SettleAtomicCommit(blocking);
 
   // Rotate the BS pool slot so Flutter's next render targets a different
   // BO than the one the kernel is scanning out. Same slot-release

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -51,6 +51,9 @@
 
 class DrmBackend;
 class ICompositorSurface;
+namespace homescreen {
+class DrmCursor;
+}  // namespace homescreen
 class GbmBackingStoreLayerSource;
 
 // Default pool sizes used by CreateGbmStore. Flutter backing-stores
@@ -158,6 +161,14 @@ class DrmCompositor {
   // plane_id == 0 (legacy cursor path / no cursor) is a no-op.
   void ReserveCursorPlane(uint32_t plane_id);
 
+  // Give the compositor the HW cursor so it can stage the cursor plane
+  // into its own atomic commit (DrmCursor::Stage) instead of letting the
+  // cursor self-commit. Used on drivers (nvidia-drm) where a separate
+  // cursor commit starves the compositor's PAGE_FLIP_EVENT. nullptr (the
+  // default) keeps the self-committing path. The pointer is owned by
+  // DrmBackend and outlives the compositor.
+  void SetCursor(homescreen::DrmCursor* cursor) { cursor_ = cursor; }
+
   // Per-flip-complete work for the atomic plane path. Called by
   // DrmBackend::UnifiedPageFlipHandler on the platform task runner
   // thread when planes_active() returns true. Just clears
@@ -254,6 +265,20 @@ class DrmCompositor {
   // running" case that otherwise surfaces only as a stalled PresentLayers
   // down the line.
   void VerifyPipeRunning() const;
+
+  // Stage the HW cursor plane into `req` so the cursor rides this atomic
+  // commit instead of self-committing (see DrmCompositor::SetCursor /
+  // DrmCursor::Stage). Returns true when the cursor's first plane-enable
+  // needs DRM_MODE_ATOMIC_ALLOW_MODESET this frame (caller must then
+  // commit blocking). No-op returning false when no cursor is staged.
+  bool StageCursorInto(drm::AtomicRequest& req);
+
+  // Shared post-commit settle for the atomic plane paths. A blocking
+  // commit (the initial modeset, or a cursor first-enable) produces no
+  // PAGE_FLIP_EVENT: clear flip_pending_ and return the vsync baton
+  // inline; the genuine first modeset also latches plane_mode_set_ and
+  // verifies the pipe. A steady-state nonblock flip arms flip_pending_.
+  void SettleAtomicCommit(bool blocking);
 
   // GL fallback: composites all layers into FBO 0 and calls
   // DrmBackend::Present(). Used when the plane allocator isn't
@@ -407,6 +432,10 @@ class DrmCompositor {
   // a no-op when USE_DRM_SCENE is off (no scene to reserve from).
   uint32_t cursor_reserved_plane_{0};
   void ApplyCursorReservation();
+
+  // Externally-owned HW cursor staged into each atomic commit (see
+  // SetCursor). null = self-committing cursor path (the default).
+  homescreen::DrmCursor* cursor_{nullptr};
 
   // Double-buffered composition buffer for layers that overflow HW planes.
   static constexpr int kNumCompBufs = 2;

--- a/shell/backend/drm_kms_egl/drm_cursor.cc
+++ b/shell/backend/drm_kms_egl/drm_cursor.cc
@@ -20,6 +20,7 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
+#include <atomic>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -109,9 +110,25 @@ struct DrmCursor::Impl {
   int letterbox_x{0};
   int letterbox_y{0};
 
+  // Staged mode: the compositor drives the cursor plane via Stage()
+  // instead of the cursor self-committing. desired_pos packs fb_x:fb_y
+  // (set by the seat thread in SetPosition, read by the raster thread in
+  // Stage); have_pos gates the first stage so the plane stays off until
+  // the pointer first moves.
+  bool staged{false};
+  std::atomic<uint64_t> desired_pos{0};
+  std::atomic<bool> have_pos{false};
+
   Impl(drm::cursor::Renderer r, int lx, int ly)
       : renderer(std::move(r)), letterbox_x(lx), letterbox_y(ly) {}
 };
+
+namespace {
+constexpr uint64_t PackPos(const int fb_x, const int fb_y) {
+  return (static_cast<uint64_t>(static_cast<uint32_t>(fb_x)) << 32) |
+         static_cast<uint32_t>(fb_y);
+}
+}  // namespace
 
 std::unique_ptr<DrmCursor> DrmCursor::Create(drm::Device& dev,
                                              const uint32_t crtc_id,
@@ -204,6 +221,52 @@ void DrmCursor::Move(const int fb_x, const int fb_y) {
     spdlog::warn("[DrmCursor] move_to({}, {}): {}", crtc_x, crtc_y,
                  r.error().message());
   }
+}
+
+void DrmCursor::SetStagedMode(const bool enabled) {
+  impl_->staged = enabled;
+}
+
+void DrmCursor::SetPosition(const int fb_x, const int fb_y) {
+  if (!impl_->staged) {
+    Move(fb_x, fb_y);  // legacy self-commit path (non-staging drivers)
+    return;
+  }
+  impl_->desired_pos.store(PackPos(fb_x, fb_y), std::memory_order_release);
+  impl_->have_pos.store(true, std::memory_order_release);
+}
+
+bool DrmCursor::Stage(drm::AtomicRequest& req, bool* const needs_modeset) {
+  if (needs_modeset != nullptr) {
+    *needs_modeset = false;
+  }
+  if (!impl_->have_pos.load(std::memory_order_acquire)) {
+    return false;  // no pointer motion yet — keep the cursor plane off
+  }
+  const uint64_t packed = impl_->desired_pos.load(std::memory_order_acquire);
+  const int fb_x = static_cast<int32_t>(packed >> 32);
+  const int fb_y = static_cast<int32_t>(packed & 0xffffffffU);
+  const int crtc_x = fb_x + impl_->letterbox_x;
+  const int crtc_y = fb_y + impl_->letterbox_y;
+  bool first = false;
+  if (auto r = impl_->renderer.stage(req, crtc_x, crtc_y, first); !r) {
+    spdlog::warn("[DrmCursor] stage({}, {}): {}", crtc_x, crtc_y,
+                 r.error().message());
+    return false;
+  }
+  if (needs_modeset != nullptr) {
+    *needs_modeset = first;
+  }
+  return true;
+}
+
+void DrmCursor::CommitPending() {
+  if (!impl_->staged || !impl_->have_pos.load(std::memory_order_acquire)) {
+    return;
+  }
+  const uint64_t packed = impl_->desired_pos.load(std::memory_order_acquire);
+  Move(static_cast<int32_t>(packed >> 32),
+       static_cast<int32_t>(packed & 0xffffffffU));
 }
 
 }  // namespace homescreen

--- a/shell/backend/drm_kms_egl/drm_cursor.h
+++ b/shell/backend/drm_kms_egl/drm_cursor.h
@@ -23,7 +23,8 @@
 
 namespace drm {
 class Device;
-}
+class AtomicRequest;
+}  // namespace drm
 
 namespace homescreen {
 
@@ -85,6 +86,39 @@ class DrmCursor {
   // ignored — the pointer remains usable in Flutter even if the
   // sprite stalls.
   void Move(int fb_x, int fb_y);
+
+  // Enable staged mode. In staged mode the cursor plane is driven by the
+  // compositor via Stage() instead of self-committing — used on drivers
+  // (nvidia-drm) where a separate cursor commit on the CRTC starves the
+  // compositor's PAGE_FLIP_EVENT. Must be set before the first
+  // SetPosition. The compositor must also be handed this cursor via
+  // DrmCompositor::SetCursor.
+  void SetStagedMode(bool enabled);
+
+  // Record the desired pointer position in framebuffer coordinates. In
+  // staged mode this only stores the position (an atomic, no DRM commit)
+  // for the compositor's next Stage() to apply; otherwise it forwards to
+  // Move(). Safe to call from the seat dispatch thread.
+  void SetPosition(int fb_x, int fb_y);
+
+  // Write the cursor plane state (FB_ID, CRTC, position) into the
+  // compositor's AtomicRequest so the cursor rides the same atomic flip.
+  // Returns false when there is no pending position yet (cursor not shown)
+  // or staging fails. On success, *needs_modeset (when non-null) reports
+  // whether the plane's first enable requires DRM_MODE_ATOMIC_ALLOW_MODESET
+  // — the caller must then commit that frame blocking. Drives the
+  // non-thread-safe drm-cxx Renderer, so call only from the raster
+  // (compositor commit) thread.
+  [[nodiscard]] bool Stage(drm::AtomicRequest& req, bool* needs_modeset);
+
+  // Self-commit the recorded position. Used by present paths that own
+  // their commit and can't accept a staged plane (the USE_DRM_SCENE
+  // LayerScene path) so the cursor stays visible in staged mode. No-op
+  // outside staged mode or before the first SetPosition. Raster-thread
+  // only. NOTE: this is a separate cursor commit on the CRTC and so
+  // reintroduces the flip contention on nvidia-drm — a proper fix needs
+  // LayerScene to accept the cursor plane in its own commit.
+  void CommitPending();
 
   // The DRM plane id the cursor is scanned out on (0 on the legacy
   // drmModeSetCursor path, which has no addressable plane). On a CRTC

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -125,6 +125,10 @@ void Configuration::get_parameters(toml::table* tbl, Config& instance) {
     instance.view.drm_async_flip =
         tbl->at_path("view.drm_async_flip").as_string()->value_or("");
   }
+  if (tbl->at_path("view.drm_stage_cursor").is_string()) {
+    instance.view.drm_stage_cursor =
+        tbl->at_path("view.drm_stage_cursor").as_string()->value_or("");
+  }
 
   if (tbl->at_path("window_activation_area.x").is_integer()) {
     instance.view.activation_area_x =
@@ -240,6 +244,9 @@ void Configuration::get_cli_override(const std::string& bundle_path,
   }
   if (cli.view.drm_async_flip.has_value()) {
     instance.view.drm_async_flip = cli.view.drm_async_flip.value();
+  }
+  if (cli.view.drm_stage_cursor.has_value()) {
+    instance.view.drm_stage_cursor = cli.view.drm_stage_cursor.value();
   }
 }
 
@@ -401,6 +408,9 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
             cxxopts::value<std::string>())(
             "drm-async-flip",
             "Use DRM_MODE_PAGE_FLIP_ASYNC on flip-only commits: auto|yes|no",
+            cxxopts::value<std::string>())(
+            "drm-stage-cursor",
+            "Stage the HW cursor into the compositor commit: auto|yes|no",
             cxxopts::value<std::string>());
 
     const auto result = allocated->parse(argc, argv);
@@ -549,6 +559,8 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
                 config.view.drm_explicit_sync);
     pick_string("drm-async-flip", "HOMESCREEN_DRM_ASYNC_FLIP",
                 config.view.drm_async_flip);
+    pick_string("drm-stage-cursor", "HOMESCREEN_DRM_STAGE_CURSOR",
+                config.view.drm_stage_cursor);
 
     config.view.vm_args.reserve(result.unmatched().size());
     for (const auto& option : result.unmatched()) {

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -62,6 +62,8 @@ class Configuration {
       //   drm_overlay_planes        : "auto" | "yes" | "no"
       //   drm_explicit_sync         : "auto" | "yes" | "no"
       //   drm_async_flip            : "auto" | "yes" | "no"
+      //   drm_stage_cursor          : "auto" | "yes" | "no"
+      //                               (auto = stage only on nvidia-drm)
       // FlutterView parses these into the DrmConfig enum fields. Anything
       // unrecognized is treated as "auto" with a warning.
       std::optional<std::string> drm_connector;
@@ -73,6 +75,7 @@ class Configuration {
       std::optional<std::string> drm_overlay_planes;
       std::optional<std::string> drm_explicit_sync;
       std::optional<std::string> drm_async_flip;
+      std::optional<std::string> drm_stage_cursor;
     } view;
   };
 

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -365,7 +365,10 @@ void DrmSeat::FlushCursorMotion() {
   }
   cursor_motion_pending_ = false;
   if (auto* c = cursor_.load(std::memory_order_acquire); c != nullptr) {
-    c->Move(static_cast<int>(pointer_x_), static_cast<int>(pointer_y_));
+    // SetPosition records the position for the compositor to stage (staged
+    // mode) or self-commits via Move (legacy). Either way, no DRM commit
+    // here in staged mode — the compositor owns the cursor plane.
+    c->SetPosition(static_cast<int>(pointer_x_), static_cast<int>(pointer_y_));
   }
 }
 

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -164,6 +164,7 @@ FlutterView::FlutterView(Configuration::Config config,
         fullscreen ? std::optional<uint32_t>{} : m_config.view.height,
         m_config.debug_backend.value_or(false),
     };
+    cfg.disable_cursor = m_config.disable_cursor.value_or(false);
     // Treat empty TOML/env/CLI string as "unset" — operator-friendly:
     // `drm_connector = ""` in TOML shouldn't force a strict empty-name
     // match against zero connectors.
@@ -183,6 +184,9 @@ FlutterView::FlutterView(Configuration::Config config,
     cfg.overlay_planes = parse_tri(m_config.view.drm_overlay_planes);
     cfg.explicit_sync = parse_tri(m_config.view.drm_explicit_sync);
     cfg.async_flip = parse_tri(m_config.view.drm_async_flip);
+    // kAuto (default) resolves per driver in DrmBackend::Create — staging is
+    // enabled only on nvidia-drm; yes/no force the choice.
+    cfg.stage_cursor = parse_tri(m_config.view.drm_stage_cursor);
 
     // DrmDisplay (constructed by App::MakeDisplay, before us) owns the
     // process-wide libseat session. Pull the raw pointer — may be null


### PR DESCRIPTION
## Summary

Two independent `drm_kms_egl` fixes around the HW cursor and shutdown:

1. **Bound `WaitForPendingFlip`** (`DrmBackend` + `DrmCompositor`). On nvidia-drm a flip's `PAGE_FLIP_EVENT` can go undelivered; at teardown the asio monitor that would drain it is already gone, so `flip_pending_` never clears and the destructors spin forever (process needs `kill -9`). Cap each wait at 100ms — never hit by a healthy ~16ms 60Hz flip — then warn and proceed so the app exits on SIGTERM.

2. **Stage the HW cursor into the compositor commit.** A separate cursor commit on the CRTC starves the compositor's `PAGE_FLIP_EVENT` on nvidia-drm (content freezes on pointer motion). The cursor can instead record its position and let the compositor stage the cursor plane into its own atomic commit, across all three present paths (framed, plane allocator, direct overlay).

   Controlled by `drm_stage_cursor` (TOML/CLI/env: `auto|yes|no`). **`auto` (default) stages only on nvidia-drm** — the one driver where the self-committing cursor breaks the flip. On every other driver, staging would couple cursor motion to Flutter frame production, so the cursor stalls whenever the UI is idle and no frame commits; `auto` keeps the smoother self-committing cursor there. `yes`/`no` force the choice.

   Also wires `--disable-cursor` into the DRM backend (`DrmConfig` had no `disable_cursor` field), matching `IVI_DRM_CURSOR=0`.

## Testing

- **amdgpu** (`auto` → self-commit): cursor tracks smoothly on an idle UI; content responsive. Earlier `auto`-stages-everywhere behavior was janky/froze on idle content — fixed by the nvidia-drm-only default.
- **nvidia-drm** (staged): cursor tracks smoothly, content holds ~60Hz under motion, clean exit (per the original change).

Built with `BUILD_BACKEND_DRM_KMS_EGL=ON BUILD_COMPOSITOR=ON USE_DRM_SCENE=ON`.
