### PR TITLE
[drm_kms_vulkan] present Flutter Vulkan frames via zero-copy KMS scanout

### DIFF
--- a/scripts/build_pi.sh
+++ b/scripts/build_pi.sh
@@ -22,15 +22,18 @@
 #     --pios <bookworm|trixie>      PiOS release (default: bookworm)
 #     --target <pi4|pi5|piz2|generic>   -mcpu tuning (default: generic)
 #                                         piz2 = Pi Zero 2 W (Cortex-A53)
-#     --backend <wayland-egl|wayland-vulkan|drm-kms-egl|software|all>
+#     --backend <wayland-egl|wayland-vulkan|drm-kms-egl|drm-kms-vulkan|software|all>
 #                                   default: all
 #                                     wayland-egl    GLES2 on Wayland
 #                                     wayland-vulkan Vulkan on Wayland
 #                                     drm-kms-egl    direct DRM/KMS + GBM + GLES2 (no compositor)
+#                                     drm-kms-vulkan Flutter Vulkan renderer scanned out zero-copy
+#                                                    on KMS planes via dma-buf import (compositor)
 #                                     software       CPU rasterizer → DRM dumb buffer / fbdev
 #                                     all            build every backend in its own build dir
 #                                                    (drm-kms-egl is skipped on bookworm —
-#                                                     libdisplay-info 0.1.1 < drm-cxx's 0.2.0)
+#                                                     libdisplay-info 0.1.1 < drm-cxx's 0.2.0;
+#                                                     drm-kms-vulkan is build-only via --backend)
 #     --flutter-engine <path>       dir with lib/libflutter_engine.so + data/icudtl.dat
 #                                     (bypasses auto-fetch)
 #     --flutter-runtime <debug|debug-unopt|profile|release>   default: release
@@ -293,8 +296,9 @@ esac
 
 case "$PIOS" in bookworm|trixie) ;; *) die "--pios must be bookworm|trixie (got: $PIOS)" ;; esac
 case "$TARGET" in pi4|pi5|piz2|generic) ;; *) die "--target must be pi4|pi5|piz2|generic (got: $TARGET)" ;; esac
-case "$BACKEND" in wayland-egl|wayland-vulkan|drm-kms-egl|software|all) ;;
-    *) die "--backend must be wayland-egl|wayland-vulkan|drm-kms-egl|software|all (got: $BACKEND)" ;;
+case "$BACKEND" in
+    wayland-egl|wayland-vulkan|drm-kms-egl|drm-kms-vulkan|software|all) ;;
+    *) die "--backend must be wayland-egl|wayland-vulkan|drm-kms-egl|drm-kms-vulkan|software|all (got: $BACKEND)" ;;
 esac
 
 # Resolve which backends to actually build. drm-kms-egl needs libdisplay-info
@@ -311,9 +315,10 @@ if [[ "$BACKEND" == "all" ]]; then
     fi
 else
     BUILD_BACKENDS=("$BACKEND")
-    if [[ "$BACKEND" == "drm-kms-egl" && "$PIOS" == "bookworm" \
-          && "$WITH_LOCAL_DISPLAY_INFO" -eq 0 ]]; then
-        die "drm-kms-egl on bookworm needs libdisplay-info >= 0.2.0 (ships 0.1.1); pass --with-local-display-info to cross-build it"
+    # Both DRM backends pull in drm-cxx, which needs libdisplay-info >= 0.2.0.
+    if [[ ("$BACKEND" == "drm-kms-egl" || "$BACKEND" == "drm-kms-vulkan") \
+          && "$PIOS" == "bookworm" && "$WITH_LOCAL_DISPLAY_INFO" -eq 0 ]]; then
+        die "$BACKEND on bookworm needs libdisplay-info >= 0.2.0 (ships 0.1.1); pass --with-local-display-info to cross-build it"
     fi
 fi
 case "$FLUTTER_RUNTIME" in debug|debug-unopt|profile|release) ;;
@@ -577,13 +582,16 @@ sysroot_pkg_list() {
                 : ;;  # EGL/GLES + wayland (for waypp) come from the shared list
             wayland-vulkan)
                 pkgs+=(libvulkan-dev mesa-vulkan-drivers) ;;
-            drm-kms-egl)
+            drm-kms-egl|drm-kms-vulkan)
                 # drm-cxx requires libdisplay-info >= 0.2.0 (Trixie 0.2.0;
                 # Bookworm 0.1.1). libxcursor-dev gates the DRM HW cursor module;
                 # absent → leaky symbol references (~DrmCursor / DrmCursor::Move)
                 # break the link. libseat-dev is required by drm-cxx's
                 # drm::session::Seat (DRM_CXX_SESSION=ON in cmake/drm_kms.cmake);
                 # used by shell/backend/drm_kms_egl/drm_session.cc unconditionally.
+                # drm-kms-vulkan shares the same DRM/GBM/seat deps; its Vulkan
+                # entry points are dlopen'd at runtime (vulkan.hpp dynamic
+                # dispatch), so no libvulkan-dev is needed to link.
                 pkgs+=(libdrm-dev libgbm-dev libinput-dev libxcursor-dev libseat-dev)
                 # When we cross-build libdisplay-info ourselves, skip the apt
                 # -dev package so its libdisplay-info.so dev symlink can't shadow
@@ -915,6 +923,7 @@ phase4_build() {
         -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/.xc-toolchain.cmake"
         -DCMAKE_BUILD_TYPE=Release
         -DBUILD_BACKEND_HEADLESS_EGL=OFF
+        -DBUILD_BACKEND_DRM_KMS_VULKAN=OFF
     )
     # Exactly one backend is enabled; the rest are forced OFF.
     case "$be" in
@@ -942,6 +951,19 @@ phase4_build() {
             if [[ "$WITH_SCENE" -eq 1 ]]; then
                 cmake_args+=(-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON)
             fi ;;
+        drm-kms-vulkan)
+            # Flutter Vulkan renderer scanned out zero-copy on KMS planes via
+            # dma-buf import + drm-cxx LayerScene. Requires the compositor (the
+            # engine presents through CreateBackingStore/PresentLayers); the
+            # scene path is linked unconditionally in this backend, so
+            # USE_DRM_SCENE stays off (it gates only the drm-kms-egl GL scene).
+            cmake_args+=(
+                -DBUILD_BACKEND_WAYLAND_EGL=OFF
+                -DBUILD_BACKEND_WAYLAND_VULKAN=OFF
+                -DBUILD_BACKEND_DRM_KMS_EGL=OFF
+                -DBUILD_BACKEND_DRM_KMS_VULKAN=ON
+                -DBUILD_BACKEND_SOFTWARE=OFF
+                -DBUILD_COMPOSITOR=ON) ;;
         software)
             cmake_args+=(
                 -DBUILD_BACKEND_WAYLAND_EGL=OFF
@@ -1398,6 +1420,12 @@ libjpeg62-turbo libxml2 libglib2.0-0t64"
                 drm-kms-egl)
                     deps_backend="libdrm2 libgbm1 libinput10 libdisplay-info2 \
 libxcursor1 dmz-cursor-theme libegl1 libgles2"
+                    ;;
+                drm-kms-vulkan)
+                    # Same DRM/GBM/cursor stack as drm-kms-egl, but the Vulkan
+                    # loader + an ICD (V3DV on Pi) replace EGL/GLES at runtime.
+                    deps_backend="libdrm2 libgbm1 libinput10 libdisplay-info2 \
+libxcursor1 dmz-cursor-theme libvulkan1 mesa-vulkan-drivers"
                     ;;
                 software)
                     deps_backend="libdrm2 libinput10"

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -194,6 +194,9 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN)
     target_sources(${PROJECT_NAME} PRIVATE
             backend/drm_kms_vulkan/vulkan_drm_backend.cc
             backend/drm_kms_vulkan/device_caps.cc
+            backend/drm_kms_vulkan/vulkan_backing_store.cc
+            backend/drm_kms_vulkan/drm_scanout_target.cc
+            backend/drm_kms_egl/scene_layer_source_vk.cc
             backend/drm_kms_egl/drm_session.cc
             backend/drm_kms_egl/driver_probe.cc
             display/drm_display.cc
@@ -213,7 +216,8 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN)
     # No EGL/GLESv2: the Vulkan backend produces no GL textures, and
     # flutter_desktop.cc's glDeleteTextures branch is compiled out for it
     # (same as the Wayland-Vulkan backend). Vulkan is resolved at runtime via
-    # vulkan.hpp's dynamic loader; only the headers are needed at build time.
+    # vulkan.hpp's dynamic loader; only the vendored headers (vulkan_headers)
+    # are needed at build time — never a Vulkan SDK in the system/sysroot.
     target_link_libraries(${PROJECT_NAME} PRIVATE
             drm-cxx::drm-cxx
             PkgConfig::DRM

--- a/shell/backend/drm_kms_vulkan/README.md
+++ b/shell/backend/drm_kms_vulkan/README.md
@@ -1,0 +1,173 @@
+# drm_kms_vulkan backend
+
+Drives the Flutter **Vulkan** renderer and presents the result on hardware
+KMS planes via **zero-copy dma-buf import**, using the drm-cxx scene
+abstraction. The session / modeset / seat / input stack is shared with the
+`drm_kms_egl` backend (those translation units sit below the pixel layer and
+are GL-free); only the renderer and the present path differ.
+
+Enable with `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON`. **`-DBUILD_COMPOSITOR=ON` is
+required** — the engine only reaches the present path through the Flutter
+compositor's `CreateBackingStore` / `PresentLayers` callbacks.
+
+## How it works
+
+1. **Device bring-up.** Creates a Vulkan 1.1 instance and selects a physical
+   device that can do zero-copy dma-buf scanout: render-node-aware when the
+   device exposes a DRM node, vendor/name fallback otherwise (this is what
+   picks the real GPU over a software ICD such as llvmpipe). The device is
+   gated on **Vulkan 1.1** (the Flutter engine's Skia backend requires a 1.1
+   device — a 1.0 device is rejected here so the backend refuses with a clear
+   reason instead of the engine fatally aborting), a fixed set of extensions,
+   and `timelineSemaphore`; if any are missing the backend refuses cleanly
+   rather than handing back a backend that cannot present. Required device
+   extensions:
+   `VK_KHR_external_memory_fd`, `VK_EXT_external_memory_dma_buf`,
+   `VK_EXT_image_drm_format_modifier`, `VK_EXT_queue_family_foreign`,
+   `VK_KHR_external_semaphore_fd`, `VK_KHR_external_fence_fd`,
+   `VK_KHR_synchronization2`.
+
+2. **Scanout target.** Opens the KMS device read-only, finds a connected
+   connector + its CRTC + primary plane, picks a mode (connector-preferred by
+   default; see `--drm-mode`), and reads that plane's `IN_FORMATS` modifiers.
+   `NegotiateModifiers` intersects the modifiers the GPU can export for the
+   color format with those the plane can scan out.
+
+3. **Backing stores.** Each Flutter backing store is a device-local `VkImage`
+   allocated with an explicit DRM format modifier (`VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT`)
+   and exported as a dma-buf. The image is handed to the engine already in
+   `COLOR_ATTACHMENT_OPTIMAL`, which is the layout the Flutter Vulkan renderer
+   expects on entry and leaves it in after rendering. `FlutterVulkanImage`
+   only carries `{image, format}`, so all backing-store images use the
+   vendored Vulkan headers and a single consistent dispatch.
+
+4. **Present.** `avoid_backing_store_cache` is on, so the engine cycles through
+   a small **ring of scanout buffers** (rendering into a free buffer while KMS
+   scans another). A single persistent drm-cxx `LayerScene` layer presents
+   whichever ring slot is ready; the framebuffer is imported once per slot and
+   reused. Before each commit a barrier flushes the renderer's color writes
+   (`COLOR_ATTACHMENT_OPTIMAL` → `GENERAL`) so the scanout engine sees the
+   frame. Commits are **vsync-paced**: the first is a blocking modeset, the
+   rest are non-blocking page flips drained against the DRM fd, giving
+   tear-free triple-buffered present.
+
+   The Vulkan renderer config also supplies `get_next_image` / `present_image`
+   callbacks. They are never invoked on the compositor path, but the embedder
+   rejects a Vulkan renderer config that leaves them null, so they are stubs.
+
+## Hardware support
+
+Zero-copy scanout requires a buffer that **both** the render GPU and the
+display controller can use directly. What matters is whether the **display**
+can address the render GPU's exported (MMU-mapped, possibly scattered) buffer —
+either because it is the same device, or because the display has its own
+address translation.
+
+| Platform | Render → display | Result |
+| --- | --- | --- |
+| amdgpu (and unified-memory GPUs) | one device, unified memory + IOMMU | **Works** — validated, renders correctly, tear-free |
+| Raspberry Pi 5 | `v3d` (V3D 7.x) → `vc4-drm`, display can address V3D buffers | **Works** — validated, renders correctly, tear-free at 3840×2160 |
+| Raspberry Pi 4 | `v3d` (V3D 4.2) → `vc4-drm`, **no display IOMMU** | **Fails** — `AddFB` EINVAL (see below) |
+| Arduino Uno Q | Turnip Adreno 702 via virtio/gfxstream → `msm_dpu` | **Fails** — device exposes Vulkan 1.0 (engine needs 1.1); virtualized GPU |
+| NanoPC-T6 (rk3588) | Mali-G610 (blob, Vulkan 1.3) → `rockchip-drm` (vop2) | **Refuses** — vop2 rejects the LINEAR import at any resolution; its planes want AFBC, which the LINEAR-only source can't produce |
+
+### Unified-memory GPUs (render device == scanout device)
+
+On GPUs where one device both renders and scans out (e.g. **amdgpu**), the
+exported modifier image is directly scannable. This is the simplest path.
+
+### Split render/display SoCs
+
+These have a separate render GPU and display controller (e.g. the Pi's `v3d` +
+`vc4-drm`). The render GPU has its own MMU and backs `VkImage` allocations with
+ordinary **shmem (scattered) pages**. Whether that buffer can be scanned out
+depends on the **display** side:
+
+- **Pi 5 (works).** The VideoCore VII display path can address the
+  V3D-allocated buffer, so importing the V3D-exported dma-buf as a `vc4`
+  framebuffer succeeds and it presents at 4K.
+- **Pi 4 (fails).** The `vc4` display HVS has **no IOMMU**; it DMAs the
+  framebuffer by physical address and can only scan **physically contiguous
+  (CMA)** memory. Registering the scattered V3D buffer as a `vc4` framebuffer
+  (`drmModeAddFB2WithModifiers`) returns **EINVAL**. This is independent of
+  resolution (confirmed at 3840×2160 and 1920×1080) and of the format/modifier
+  (`vc4` advertises `LINEAR` `XRGB8888` and it is negotiated correctly) — the
+  buffer's physical layout simply is not scannable.
+- **NanoPC-T6 / rk3588 (refuses).** A second failure mode, independent of
+  contiguity: the `rockchip-drm` vop2 display *has* an IOMMU, but its planes
+  want a tiled/compressed **AFBC** modifier and reject the `LINEAR` import at
+  any resolution. The render GPU (Mali-G610 blob) and the source only offer
+  `LINEAR`, so there is no common scanout modifier. The display advertising an
+  IOMMU is necessary but not sufficient — it must also accept a modifier the
+  render GPU can export. The backend refuses cleanly here.
+
+**On the Pi 4, the `cma=` boot setting does not fix this.** CMA *size* governs
+how much contiguous memory `vc4` can allocate for its **own** buffers; it has no
+effect on where V3D allocates a `VkImage`. V3D never uses CMA (it has an MMU),
+so its buffers are non-contiguous regardless of CMA capacity — the mismatch is
+the allocation **source/layout**, not the CMA **size**.
+
+Making the export-based path work on a no-display-IOMMU SoC like the Pi 4 would
+require inverting the buffer ownership: allocate the scanout buffer from a
+**contiguous source** the display can scan (a GBM BO with `GBM_BO_USE_SCANOUT`,
+or the kernel CMA dma-buf heap `/dev/dma_heap/linux,cma`) and **import** it into
+the Vulkan driver via `VK_EXT_external_memory_dma_buf`, rendering into the
+imported buffer. That is an import-based allocator, not implemented here and not
+a boot-config change. For such SoCs the GL backend (`drm_kms_egl`, which uses
+GBM scanout buffers) is the working path today.
+
+### Vulkan version and virtualized GPUs
+
+Independent of scanout, the device must expose **Vulkan 1.1** (the engine's
+Skia backend requires it). Some stacks expose only 1.0 and are rejected at the
+gate. The confirmed example is the **Arduino Uno Q**, whose Adreno 702 is
+driven by a **virtio-gpu / gfxstream** Turnip (the board runs Linux over a
+Qualcomm hypervisor): it reports Vulkan 1.0, so the backend refuses before the
+engine starts. The scanout side there is otherwise fine — the `msm_dpu` display
+has an SMMU and advertises `LINEAR`, so a native ≥1.1 Adreno/Turnip would be
+expected to work.
+
+## Running
+
+The backend needs **DRM master** on the scanout device.
+
+- `--drm-device <node>` — the KMS device with the connectors (the display
+  controller, e.g. `card1` for vc4 on a Pi, not the render-only `v3d` node).
+- `--drm-mode <W>x<H>[@<R>]` — select the scanout mode (`R` = integer refresh
+  Hz; omitted = any). Unset uses the connector's preferred mode.
+
+Session / DRM master:
+
+- With a libseat seat (logind) the backend uses it automatically
+  (`[DrmDisplay] libseat session active`).
+- Without a usable seat (e.g. a plain SSH login or a console login with no
+  logind seat), libseat's in-process builtin backend cannot grab the VT. Force
+  the legacy direct-master path by setting **`LIBSEAT_BACKEND=seatd`** with no
+  seatd daemon running: libseat fails to open the seat, `DrmSession::Open()`
+  returns null, and the backend falls back to a direct `/dev/dri` open +
+  `drmSetMaster`. Run from an active VT or as root.
+
+Example (Pi, forcing the fallback and a specific mode):
+
+```sh
+LIBSEAT_BACKEND=seatd LD_LIBRARY_PATH=<bundle>/lib \
+    homescreen --drm-device /dev/dri/card1 --drm-mode 1920x1080@60 -b <bundle>
+```
+
+The Vulkan loader and an ICD must be present at runtime (`libvulkan1` +
+`mesa-vulkan-drivers` for V3DV on the Pi; the headers are vendored, so the
+loader is dlopen'd, never linked).
+
+## Cross-compiling for the Raspberry Pi
+
+`scripts/build_pi.sh` builds the backend for aarch64:
+
+```sh
+scripts/build_pi.sh --backend drm-kms-vulkan --pios trixie --target generic
+```
+
+It reuses the `drm-kms-egl` sysroot/toolchain (same DRM/GBM/seat deps; the
+Vulkan entry points are dlopen'd, so no link-time `libvulkan`). A JIT (debug)
+bundle works for testing: `flutter build bundle --debug` produces an
+architecture-independent `kernel_blob.bin` that runs on the target's matching
+debug engine.

--- a/shell/backend/drm_kms_vulkan/drm_scanout_target.cc
+++ b/shell/backend/drm_kms_vulkan/drm_scanout_target.cc
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "drm_scanout_target.h"
+
+#include <drm_fourcc.h>
+#include <drm_mode.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+#include "logging.h"
+
+namespace drm_kms_vulkan {
+
+namespace {
+
+// First value of a named property on a KMS object, or UINT64_MAX.
+uint64_t PropValue(int fd, uint32_t obj, uint32_t type, const char* name) {
+  drmModeObjectProperties* props = drmModeObjectGetProperties(fd, obj, type);
+  if (!props) {
+    return UINT64_MAX;
+  }
+  uint64_t v = UINT64_MAX;
+  for (uint32_t i = 0; i < props->count_props && v == UINT64_MAX; ++i) {
+    drmModePropertyRes* p = drmModeGetProperty(fd, props->props[i]);
+    if (p) {
+      if (std::strcmp(p->name, name) == 0) {
+        v = props->prop_values[i];
+      }
+      drmModeFreeProperty(p);
+    }
+  }
+  drmModeFreeObjectProperties(props);
+  return v;
+}
+
+void ReadPlaneModifiers(int fd,
+                        uint32_t plane_id,
+                        uint32_t fourcc,
+                        std::vector<uint64_t>& out) {
+  uint64_t blob_id =
+      PropValue(fd, plane_id, DRM_MODE_OBJECT_PLANE, "IN_FORMATS");
+  if (blob_id == UINT64_MAX) {
+    return;
+  }
+  drmModePropertyBlobRes* blob =
+      drmModeGetPropertyBlob(fd, static_cast<uint32_t>(blob_id));
+  if (!blob) {
+    return;
+  }
+  const auto* hdr = static_cast<const drm_format_modifier_blob*>(blob->data);
+  const auto* base = static_cast<const uint8_t*>(blob->data);
+  const auto* fmts =
+      reinterpret_cast<const uint32_t*>(base + hdr->formats_offset);
+  const auto* mods = reinterpret_cast<const drm_format_modifier*>(
+      base + hdr->modifiers_offset);
+  for (uint32_t i = 0; i < hdr->count_formats; ++i) {
+    if (fmts[i] != fourcc) {
+      continue;
+    }
+    for (uint32_t j = 0; j < hdr->count_modifiers; ++j) {
+      if (i < mods[j].offset || i >= mods[j].offset + 64) {
+        continue;
+      }
+      if (mods[j].formats & (1ULL << (i - mods[j].offset))) {
+        out.push_back(mods[j].modifier);
+      }
+    }
+  }
+  drmModeFreePropertyBlob(blob);
+}
+
+}  // namespace
+
+bool DiscoverScanoutTarget(const std::string& drm_device,
+                           uint32_t fourcc,
+                           const std::string& mode_spec,
+                           ScanoutTarget& out,
+                           std::string& err) {
+  const int fd = ::open(drm_device.c_str(), O_RDWR | O_CLOEXEC);
+  if (fd < 0) {
+    err = "open('" + drm_device + "'): " + std::strerror(errno);
+    return false;
+  }
+  drmSetClientCap(fd, DRM_CLIENT_CAP_ATOMIC, 1);
+  drmSetClientCap(fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+
+  drmModeRes* res = drmModeGetResources(fd);
+  if (!res) {
+    err = "drmModeGetResources failed";
+    ::close(fd);
+    return false;
+  }
+
+  drmModeConnector* conn = nullptr;
+  for (int i = 0; i < res->count_connectors && !conn; ++i) {
+    drmModeConnector* c = drmModeGetConnector(fd, res->connectors[i]);
+    if (c && c->connection == DRM_MODE_CONNECTED && c->count_modes > 0) {
+      conn = c;
+    } else if (c) {
+      drmModeFreeConnector(c);
+    }
+  }
+  if (!conn) {
+    err = "no connected connector with a mode";
+    drmModeFreeResources(res);
+    ::close(fd);
+    return false;
+  }
+  out.connector_id = conn->connector_id;
+  // Default to the connector's preferred mode (index 0). A mode_spec of
+  // "<W>x<H>" or "<W>x<H>@<R>" selects the first matching mode instead (R =
+  // integer vrefresh Hz; omitted = any refresh).
+  int chosen = 0;
+  if (!mode_spec.empty()) {
+    unsigned long want_w = 0;
+    unsigned long want_h = 0;
+    unsigned long want_r = 0;
+    char* p = nullptr;
+    want_w = std::strtoul(mode_spec.c_str(), &p, 10);
+    if (p != nullptr && *p == 'x') {
+      want_h = std::strtoul(p + 1, &p, 10);
+    }
+    if (p != nullptr && *p == '@') {
+      want_r = std::strtoul(p + 1, &p, 10);
+    }
+    int match = -1;
+    if (want_w != 0 && want_h != 0) {
+      for (int i = 0; i < conn->count_modes; ++i) {
+        const drmModeModeInfo& m = conn->modes[i];
+        if (m.hdisplay == want_w && m.vdisplay == want_h &&
+            (want_r == 0 || m.vrefresh == want_r)) {
+          match = i;
+          break;
+        }
+      }
+    }
+    if (match >= 0) {
+      chosen = match;
+    } else {
+      spdlog::warn(
+          "[drm_scanout] --drm-mode '{}' not found on connector; using "
+          "preferred mode {}x{}",
+          mode_spec, conn->modes[0].hdisplay, conn->modes[0].vdisplay);
+    }
+  }
+  out.mode = conn->modes[chosen];
+  out.mode_width = conn->modes[chosen].hdisplay;
+  out.mode_height = conn->modes[chosen].vdisplay;
+
+  drmModeEncoder* enc = drmModeGetEncoder(fd, conn->encoder_id);
+  if (enc && enc->crtc_id) {
+    out.crtc_id = enc->crtc_id;
+  } else if (res->count_crtcs > 0) {
+    out.crtc_id = res->crtcs[0];
+  }
+  if (enc) {
+    drmModeFreeEncoder(enc);
+  }
+  drmModeFreeConnector(conn);
+  if (!out.crtc_id) {
+    err = "no CRTC for connector";
+    drmModeFreeResources(res);
+    ::close(fd);
+    return false;
+  }
+
+  int crtc_index = -1;
+  for (int i = 0; i < res->count_crtcs; ++i) {
+    if (res->crtcs[i] == out.crtc_id) {
+      crtc_index = i;
+      break;
+    }
+  }
+  drmModeFreeResources(res);
+  if (crtc_index < 0) {
+    err = "CRTC not found in resources";
+    ::close(fd);
+    return false;
+  }
+
+  drmModePlaneRes* pres = drmModeGetPlaneResources(fd);
+  if (!pres) {
+    err = "drmModeGetPlaneResources failed";
+    ::close(fd);
+    return false;
+  }
+  for (uint32_t i = 0; i < pres->count_planes; ++i) {
+    drmModePlane* pl = drmModeGetPlane(fd, pres->planes[i]);
+    if (!pl) {
+      continue;
+    }
+    const bool usable = (pl->possible_crtcs & (1u << crtc_index)) != 0;
+    drmModeFreePlane(pl);
+    if (usable && PropValue(fd, pres->planes[i], DRM_MODE_OBJECT_PLANE,
+                            "type") == DRM_PLANE_TYPE_PRIMARY) {
+      out.primary_plane_id = pres->planes[i];
+      break;
+    }
+  }
+  drmModeFreePlaneResources(pres);
+  if (!out.primary_plane_id) {
+    err = "no primary plane for CRTC";
+    ::close(fd);
+    return false;
+  }
+
+  ReadPlaneModifiers(fd, out.primary_plane_id, fourcc, out.plane_modifiers);
+  ::close(fd);
+  return true;
+}
+
+}  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/drm_scanout_target.h
+++ b/shell/backend/drm_kms_vulkan/drm_scanout_target.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <xf86drmMode.h>
+
+namespace drm_kms_vulkan {
+
+// The KMS scanout target the compositor presents to: a connected connector, its
+// CRTC and preferred mode, and the CRTC's primary plane plus the modifiers that
+// plane advertises (IN_FORMATS) for a chosen fourcc — the set the backing-store
+// modifier negotiation intersects against.
+struct ScanoutTarget {
+  uint32_t connector_id = 0;
+  uint32_t crtc_id = 0;
+  uint32_t primary_plane_id = 0;
+  uint32_t mode_width = 0;
+  uint32_t mode_height = 0;
+  drmModeModeInfo mode{};  // full mode for the LayerScene modeset
+  std::vector<uint64_t> plane_modifiers;  // for the queried fourcc
+};
+
+// Open @p drm_device read-only, find a connected connector + its CRTC + a mode
+// + the CRTC's primary plane, and read that plane's IN_FORMATS modifiers for
+// @p fourcc. @p mode_spec selects the mode: empty picks the connector's
+// preferred mode; "<W>x<H>" or "<W>x<H>@<R>" (R = integer vrefresh Hz) picks
+// the first matching mode, falling back to preferred with a warning if none
+// matches. Returns false (with @p err set) if no usable display is found. Does
+// NOT take DRM master — it only reads KMS state, so it is safe to call before
+// the modeset path acquires the device.
+bool DiscoverScanoutTarget(const std::string& drm_device,
+                           uint32_t fourcc,
+                           const std::string& mode_spec,
+                           ScanoutTarget& out,
+                           std::string& err);
+
+}  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/vulkan_backing_store.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_backing_store.cc
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+#include <vulkan/vulkan.hpp>
+
+#include "vulkan_backing_store.h"
+
+#include <drm_fourcc.h>
+#include <unistd.h>
+
+#include <array>
+#include <set>
+
+namespace drm_kms_vulkan {
+
+namespace {
+
+// The dynamic dispatcher; storage is defined in device_caps.cc. It is init'd to
+// the instance and device by the backend before any backing store is created,
+// so the device-level modifier/external-memory entry points are resolved here.
+const auto& d = vk::detail::defaultDispatchLoaderDynamic;
+
+uint32_t PickMemoryType(VkPhysicalDevice phys,
+                        uint32_t type_bits,
+                        VkMemoryPropertyFlags want) {
+  VkPhysicalDeviceMemoryProperties mp{};
+  d.vkGetPhysicalDeviceMemoryProperties(phys, &mp);
+  for (uint32_t i = 0; i < mp.memoryTypeCount; ++i) {
+    if ((type_bits & (1u << i)) &&
+        (mp.memoryTypes[i].propertyFlags & want) == want) {
+      return i;
+    }
+  }
+  return UINT32_MAX;
+}
+
+// Plane count the driver uses for @p modifier with @p vk_format.
+uint32_t PlaneCountForModifier(VkPhysicalDevice phys,
+                               VkFormat vk_format,
+                               uint64_t modifier) {
+  VkDrmFormatModifierPropertiesListEXT list{};
+  list.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+  VkFormatProperties2 fp{};
+  fp.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+  fp.pNext = &list;
+  d.vkGetPhysicalDeviceFormatProperties2(phys, vk_format, &fp);
+  std::vector<VkDrmFormatModifierPropertiesEXT> mods(
+      list.drmFormatModifierCount);
+  list.pDrmFormatModifierProperties = mods.data();
+  d.vkGetPhysicalDeviceFormatProperties2(phys, vk_format, &fp);
+  for (const auto& m : mods) {
+    if (m.drmFormatModifier == modifier) {
+      return m.drmFormatModifierPlaneCount;
+    }
+  }
+  return 0;
+}
+
+}  // namespace
+
+std::vector<uint64_t> NegotiateModifiers(
+    VkPhysicalDevice physical_device,
+    VkFormat vk_format,
+    const std::vector<uint64_t>& plane_modifiers) {
+  // Modifiers the ICD can export for this format as a transfer/color target.
+  VkDrmFormatModifierPropertiesListEXT list{};
+  list.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+  VkFormatProperties2 fp{};
+  fp.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+  fp.pNext = &list;
+  d.vkGetPhysicalDeviceFormatProperties2(physical_device, vk_format, &fp);
+  std::vector<VkDrmFormatModifierPropertiesEXT> mods(
+      list.drmFormatModifierCount);
+  list.pDrmFormatModifierProperties = mods.data();
+  d.vkGetPhysicalDeviceFormatProperties2(physical_device, vk_format, &fp);
+
+  const VkFormatFeatureFlags need = VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
+  std::set<uint64_t> exportable;
+  for (const auto& m : mods) {
+    if ((m.drmFormatModifierTilingFeatures & need) == need) {
+      exportable.insert(m.drmFormatModifier);
+    }
+  }
+
+  const std::set<uint64_t> plane(plane_modifiers.begin(),
+                                 plane_modifiers.end());
+  std::vector<uint64_t> tiled;
+  bool has_linear = false;
+  for (uint64_t m : exportable) {
+    if (!plane.count(m)) {
+      continue;
+    }
+    if (m == DRM_FORMAT_MOD_LINEAR) {
+      has_linear = true;
+    } else {
+      tiled.push_back(m);
+    }
+  }
+  // Tiled first (the driver prefers a compressed/tiled layout), LINEAR last.
+  if (has_linear) {
+    tiled.push_back(DRM_FORMAT_MOD_LINEAR);
+  }
+  return tiled;
+}
+
+std::unique_ptr<VulkanBackingStore> VulkanBackingStore::Create(
+    VkPhysicalDevice physical_device,
+    VkDevice device,
+    uint32_t width,
+    uint32_t height,
+    VkFormat vk_format,
+    uint32_t drm_fourcc,
+    const std::vector<uint64_t>& allowed_modifiers,
+    std::string& err) {
+  if (allowed_modifiers.empty()) {
+    err = "no allowed modifiers (empty negotiation result)";
+    return nullptr;
+  }
+
+  std::unique_ptr<VulkanBackingStore> store(
+      new VulkanBackingStore(device, width, height));
+  store->vk_format_ = vk_format;
+  store->drm_fourcc_ = drm_fourcc;
+
+  // Exported image constrained to the negotiated modifier set; the driver picks
+  // one, read back below.
+  VkImageDrmFormatModifierListCreateInfoEXT mod_list{};
+  mod_list.sType =
+      VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT;
+  mod_list.drmFormatModifierCount =
+      static_cast<uint32_t>(allowed_modifiers.size());
+  mod_list.pDrmFormatModifiers = allowed_modifiers.data();
+  VkExternalMemoryImageCreateInfo ext{};
+  ext.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+  ext.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+  ext.pNext = &mod_list;
+
+  VkImageCreateInfo ic{};
+  ic.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  ic.pNext = &ext;
+  ic.imageType = VK_IMAGE_TYPE_2D;
+  ic.format = vk_format;
+  ic.extent = {width, height, 1};
+  ic.mipLevels = 1;
+  ic.arrayLayers = 1;
+  ic.samples = VK_SAMPLE_COUNT_1_BIT;
+  ic.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
+  ic.usage =
+      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+  ic.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  if (d.vkCreateImage(device, &ic, nullptr, &store->image_) != VK_SUCCESS) {
+    err = "vkCreateImage with modifier list failed";
+    return nullptr;
+  }
+
+  VkImageDrmFormatModifierPropertiesEXT mp{};
+  mp.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT;
+  if (d.vkGetImageDrmFormatModifierPropertiesEXT(device, store->image_, &mp) !=
+      VK_SUCCESS) {
+    err = "vkGetImageDrmFormatModifierPropertiesEXT failed";
+    return nullptr;
+  }
+  store->modifier_ = mp.drmFormatModifier;
+
+  const uint32_t plane_count =
+      PlaneCountForModifier(physical_device, vk_format, store->modifier_);
+  if (plane_count < 1 || plane_count > 4) {
+    err = "unexpected plane count for chosen modifier";
+    return nullptr;
+  }
+
+  VkMemoryRequirements req{};
+  d.vkGetImageMemoryRequirements(device, store->image_, &req);
+  const uint32_t mt = PickMemoryType(physical_device, req.memoryTypeBits,
+                                     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+  if (mt == UINT32_MAX) {
+    err = "no DEVICE_LOCAL memory type for scanout image";
+    return nullptr;
+  }
+  VkExportMemoryAllocateInfo emai{};
+  emai.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
+  emai.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+  VkMemoryAllocateInfo mai{};
+  mai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  mai.pNext = &emai;
+  mai.allocationSize = req.size;
+  mai.memoryTypeIndex = mt;
+  if (d.vkAllocateMemory(device, &mai, nullptr, &store->memory_) !=
+      VK_SUCCESS) {
+    err = "vkAllocateMemory (exported) failed";
+    return nullptr;
+  }
+  if (d.vkBindImageMemory(device, store->image_, store->memory_, 0) !=
+      VK_SUCCESS) {
+    err = "vkBindImageMemory failed";
+    return nullptr;
+  }
+
+  static constexpr std::array<VkImageAspectFlagBits, 4> kMemPlane = {
+      VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT,
+      VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT,
+      VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT,
+      VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT,
+  };
+  store->planes_.resize(plane_count);
+  for (uint32_t i = 0; i < plane_count; ++i) {
+    VkImageSubresource sub{};
+    sub.aspectMask = kMemPlane[i];
+    VkSubresourceLayout sl{};
+    d.vkGetImageSubresourceLayout(device, store->image_, &sub, &sl);
+    store->planes_[i] = {sl.offset, sl.rowPitch};
+  }
+
+  VkMemoryGetFdInfoKHR gfi{};
+  gfi.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+  gfi.memory = store->memory_;
+  gfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+  if (d.vkGetMemoryFdKHR(device, &gfi, &store->dma_buf_fd_) != VK_SUCCESS) {
+    err = "vkGetMemoryFdKHR failed";
+    return nullptr;
+  }
+
+  VkImageViewCreateInfo vci{};
+  vci.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+  vci.image = store->image_;
+  vci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+  vci.format = vk_format;
+  vci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+  if (d.vkCreateImageView(device, &vci, nullptr, &store->view_) != VK_SUCCESS) {
+    err = "vkCreateImageView failed";
+    return nullptr;
+  }
+
+  store->flutter_image_.struct_size = sizeof(FlutterVulkanImage);
+  store->flutter_image_.image = reinterpret_cast<uint64_t>(store->image_);
+  store->flutter_image_.format = static_cast<uint32_t>(vk_format);
+  return store;
+}
+
+VulkanBackingStore::VulkanBackingStore(VkDevice device,
+                                       uint32_t width,
+                                       uint32_t height)
+    : device_(device), width_(width), height_(height) {}
+
+VulkanBackingStore::~VulkanBackingStore() {
+  if (view_ != VK_NULL_HANDLE) {
+    d.vkDestroyImageView(device_, view_, nullptr);
+  }
+  if (image_ != VK_NULL_HANDLE) {
+    d.vkDestroyImage(device_, image_, nullptr);
+  }
+  if (memory_ != VK_NULL_HANDLE) {
+    d.vkFreeMemory(device_, memory_, nullptr);
+  }
+  if (dma_buf_fd_ >= 0) {
+    ::close(dma_buf_fd_);
+  }
+}
+
+}  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/vulkan_backing_store.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_backing_store.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <vulkan/vulkan.h>
+
+#include <shell/platform/embedder/embedder.h>
+
+namespace drm_kms_vulkan {
+
+// Per-memory-plane layout of an exported modifier image, used to import it as a
+// KMS framebuffer (drmModeAddFB2WithModifiers) without a copy.
+struct PlaneLayout {
+  uint64_t offset = 0;
+  uint64_t pitch = 0;
+};
+
+// Intersect the modifiers a Vulkan ICD can EXPORT for @p vk_format (as a
+// transfer/color target) with @p plane_modifiers (a scanout plane's IN_FORMATS
+// for the matching fourcc). Returns the common set ordered tiled-first with
+// DRM_FORMAT_MOD_LINEAR last, so the driver prefers a compressed/tiled layout
+// and only falls back to linear. Empty if there is no overlap.
+std::vector<uint64_t> NegotiateModifiers(
+    VkPhysicalDevice physical_device,
+    VkFormat vk_format,
+    const std::vector<uint64_t>& plane_modifiers);
+
+// A device-local VkImage allocated with an explicit DRM format modifier and
+// exported as a dma-buf, ready for zero-copy KMS scanout. The driver chooses a
+// modifier from the negotiated set; the chosen modifier and per-plane layout
+// are read back for the framebuffer import. Owns the image, memory, view, and
+// the exported dma-buf fd; all are released in the destructor.
+class VulkanBackingStore {
+ public:
+  // Create the exported modifier image. @p allowed_modifiers is the negotiated
+  // set from NegotiateModifiers (must be non-empty). On failure returns nullptr
+  // and sets @p err.
+  static std::unique_ptr<VulkanBackingStore> Create(
+      VkPhysicalDevice physical_device,
+      VkDevice device,
+      uint32_t width,
+      uint32_t height,
+      VkFormat vk_format,
+      uint32_t drm_fourcc,
+      const std::vector<uint64_t>& allowed_modifiers,
+      std::string& err);
+
+  ~VulkanBackingStore();
+
+  VulkanBackingStore(const VulkanBackingStore&) = delete;
+  VulkanBackingStore& operator=(const VulkanBackingStore&) = delete;
+
+  [[nodiscard]] VkImage image() const { return image_; }
+  [[nodiscard]] VkImageView view() const { return view_; }
+  [[nodiscard]] uint32_t width() const { return width_; }
+  [[nodiscard]] uint32_t height() const { return height_; }
+  [[nodiscard]] VkFormat vk_format() const { return vk_format_; }
+  [[nodiscard]] uint32_t drm_fourcc() const { return drm_fourcc_; }
+  [[nodiscard]] uint64_t modifier() const { return modifier_; }
+  [[nodiscard]] const std::vector<PlaneLayout>& planes() const {
+    return planes_;
+  }
+  // Borrowed; the store owns it and closes it on destruction.
+  [[nodiscard]] int dma_buf_fd() const { return dma_buf_fd_; }
+
+  // Address-stable FlutterVulkanImage for the renderer config / backing store.
+  [[nodiscard]] const FlutterVulkanImage* flutter_image() const {
+    return &flutter_image_;
+  }
+
+ private:
+  VulkanBackingStore(VkDevice device, uint32_t width, uint32_t height);
+
+  VkDevice device_ = VK_NULL_HANDLE;  // not owned
+  uint32_t width_ = 0;
+  uint32_t height_ = 0;
+  VkFormat vk_format_ = VK_FORMAT_UNDEFINED;
+  uint32_t drm_fourcc_ = 0;
+  uint64_t modifier_ = 0;
+
+  VkImage image_ = VK_NULL_HANDLE;
+  VkDeviceMemory memory_ = VK_NULL_HANDLE;
+  VkImageView view_ = VK_NULL_HANDLE;
+  int dma_buf_fd_ = -1;
+  std::vector<PlaneLayout> planes_;
+
+  FlutterVulkanImage flutter_image_{};
+};
+
+}  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -21,12 +21,32 @@
 
 #include "vulkan_drm_backend.h"
 
+#include <drm_fourcc.h>
+
 #include <array>
+#include <cerrno>
 #include <cstring>
+#include <optional>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include <xf86drm.h>
+
+#include <ctime>
+
+#include <poll.h>
+
+#include <drm-cxx/core/device.hpp>
+#include <drm-cxx/scene/external_dma_buf_source.hpp>
+#include <drm-cxx/scene/layer_desc.hpp>
+#include <drm-cxx/scene/layer_handle.hpp>
+#include <drm-cxx/scene/layer_scene.hpp>
+
+#include "backend/drm_kms_egl/scene_layer_source_vk.h"
 #include "backend/drm_kms_vulkan/device_caps.h"
+#include "backend/drm_kms_vulkan/drm_scanout_target.h"
+#include "backend/drm_kms_vulkan/vulkan_backing_store.h"
 #include "logging.h"
 
 namespace {
@@ -88,41 +108,190 @@ void* GetInstanceProcAddressCallback(void* /*user_data*/,
       d.vkGetInstanceProcAddr(static_cast<VkInstance>(instance), procname));
 }
 
+// Build a whole-color-aspect image-memory barrier.
+VkImageMemoryBarrier ColorBarrier(VkImage image,
+                                  VkImageLayout old_layout,
+                                  VkImageLayout new_layout,
+                                  VkAccessFlags src_access,
+                                  VkAccessFlags dst_access) {
+  VkImageMemoryBarrier b{};
+  b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  b.oldLayout = old_layout;
+  b.newLayout = new_layout;
+  b.srcAccessMask = src_access;
+  b.dstAccessMask = dst_access;
+  b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  b.image = image;
+  b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+  return b;
+}
+
+// Record and submit one image-memory barrier on `queue`, blocking on `fence`
+// until the GPU has executed it. Used to walk a backing-store image between the
+// layout the Flutter Vulkan renderer leaves it in (COLOR_ATTACHMENT_OPTIMAL)
+// and a flushed layout whose writes are visible to the KMS scanout engine.
+void SubmitImageBarrier(VkDevice device,
+                        VkCommandPool pool,
+                        VkFence fence,
+                        VkQueue queue,
+                        const VkImageMemoryBarrier& barrier,
+                        VkPipelineStageFlags src_stage,
+                        VkPipelineStageFlags dst_stage) {
+  VkCommandBufferAllocateInfo cbai{};
+  cbai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+  cbai.commandPool = pool;
+  cbai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+  cbai.commandBufferCount = 1;
+  VkCommandBuffer cmd = VK_NULL_HANDLE;
+  if (d.vkAllocateCommandBuffers(device, &cbai, &cmd) != VK_SUCCESS) {
+    return;
+  }
+  VkCommandBufferBeginInfo bi{};
+  bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+  bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+  d.vkBeginCommandBuffer(cmd, &bi);
+  d.vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr,
+                         1, &barrier);
+  d.vkEndCommandBuffer(cmd);
+
+  VkSubmitInfo si{};
+  si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+  si.commandBufferCount = 1;
+  si.pCommandBuffers = &cmd;
+  d.vkResetFences(device, 1, &fence);
+  d.vkQueueSubmit(queue, 1, &si, fence);
+  d.vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+  d.vkFreeCommandBuffers(device, pool, 1, &cmd);
+}
+
+// One layer, many buffers: a LayerBufferSource that owns a ring of
+// ExternalDmaBufSource framebuffers (one per scanout buffer) and presents
+// whichever slot the backend marks ready for the current frame. This lets the
+// engine render into a free buffer while KMS scans another — the basis for
+// tear-free, vsync-paced double/triple buffering on a single plane.
+class VkScanoutRing final : public drm::scene::LayerBufferSource {
+ public:
+  // Import `store`'s dma-buf as a KMS framebuffer and append it as a ring slot.
+  // Returns the new slot index, or nullopt if the framebuffer import failed.
+  std::optional<size_t> AddSlot(const drm::Device& dev,
+                                const drm_kms_vulkan::VulkanBackingStore& store,
+                                uint32_t fourcc) {
+    std::vector<drm::scene::ExternalPlaneInfo> planes;
+    for (const auto& pl : store.planes()) {
+      drm::scene::ExternalPlaneInfo info{};
+      info.fd = store.dma_buf_fd();
+      info.offset = static_cast<uint32_t>(pl.offset);
+      info.pitch = static_cast<uint32_t>(pl.pitch);
+      planes.push_back(info);
+    }
+    auto src = drm::scene::ExternalDmaBufSource::create(
+        dev, store.width(), store.height(), fourcc, DRM_FORMAT_MOD_LINEAR,
+        planes);
+    if (!src) {
+      spdlog::error(
+          "[VulkanDrmBackend] framebuffer import ({}x{} fourcc=0x{:08x} "
+          "mod=0x{:016x} planes={} offset={} pitch={}): {}",
+          store.width(), store.height(), fourcc, DRM_FORMAT_MOD_LINEAR,
+          planes.size(), planes.empty() ? 0u : planes[0].offset,
+          planes.empty() ? 0u : planes[0].pitch, src.error().message());
+      return std::nullopt;
+    }
+    slots_.push_back(std::move(src.value()));
+    return slots_.size() - 1;
+  }
+
+  void SetReady(size_t slot) noexcept { ready_ = slot; }
+  [[nodiscard]] size_t slot_count() const noexcept { return slots_.size(); }
+
+  // ── LayerBufferSource — forwarded to the ready slot. ──────────────────────
+  [[nodiscard]] drm::expected<drm::scene::AcquiredBuffer, std::error_code>
+  acquire() override {
+    last_acquired_ = ready_;
+    return slots_[ready_]->acquire();
+  }
+  void release(drm::scene::AcquiredBuffer acquired) noexcept override {
+    slots_[last_acquired_]->release(acquired);
+  }
+  [[nodiscard]] drm::scene::BindingModel binding_model()
+      const noexcept override {
+    return drm::scene::BindingModel::SceneSubmitsFbId;
+  }
+  [[nodiscard]] drm::scene::SourceFormat format() const noexcept override {
+    return slots_.empty() ? drm::scene::SourceFormat{}
+                          : slots_[ready_]->format();
+  }
+  void on_session_paused() noexcept override {
+    for (auto& s : slots_) {
+      s->on_session_paused();
+    }
+  }
+  drm::expected<void, std::error_code> on_session_resumed(
+      const drm::Device& new_dev) override {
+    for (auto& s : slots_) {
+      auto r = s->on_session_resumed(new_dev);
+      if (!r) {
+        return r;
+      }
+    }
+    return {};
+  }
+
+ private:
+  std::vector<std::unique_ptr<drm::scene::ExternalDmaBufSource>> slots_;
+  size_t ready_ = 0;
+  size_t last_acquired_ = 0;
+};
+
+// Block until one queued page-flip event drains from the DRM fd, pacing the
+// caller to vblank. Bounded by a timeout so a missed event degrades to a
+// dropped frame instead of a hang.
+void WaitForFlip(int drm_fd, drmEventContext& evctx) {
+  struct pollfd pfd{drm_fd, POLLIN, 0};
+  if (::poll(&pfd, 1, 100) > 0 && (pfd.revents & POLLIN) != 0) {
+    drmHandleEvent(drm_fd, &evctx);
+  }
+}
+
 }  // namespace
 
 VulkanDrmBackend::VulkanDrmBackend(std::string drm_device,
                                    bool enable_validation,
-                                   homescreen::DrmSession* session)
+                                   homescreen::DrmSession* session,
+                                   std::string mode_spec)
     : drm_device_(std::move(drm_device)),
+      mode_spec_(std::move(mode_spec)),
       enable_validation_(enable_validation),
       session_(session) {}
 
 VulkanDrmBackend::~VulkanDrmBackend() {
+  // Drop master + scene + backing stores while the Vulkan device is still
+  // alive (the stores free Vulkan resources in their destructors).
+  compositor_.reset();
   Teardown();
 }
 
 std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
     const std::string& drm_device,
     bool enable_validation,
-    homescreen::DrmSession* session) {
+    homescreen::DrmSession* session,
+    const std::string& mode_spec) {
   auto backend = std::shared_ptr<VulkanDrmBackend>(
-      new VulkanDrmBackend(drm_device, enable_validation, session));
+      new VulkanDrmBackend(drm_device, enable_validation, session, mode_spec));
 
-  std::string refusal;
-  if (!backend->BringUp(refusal)) {
+  std::string err;
+  if (!backend->BringUp(err)) {
     spdlog::critical("[VulkanDrmBackend] init failed; refusing to start: {}",
-                     refusal);
+                     err);
     return nullptr;
   }
-
-  // Bring-up succeeded; the device and queues exist and the capabilities are
-  // logged. The render and present path is not wired yet, so refuse rather
-  // than hand back a backend that cannot present a frame.
-  spdlog::critical(
-      "[VulkanDrmBackend] device and queues created; the Vulkan render and "
-      "present path is not implemented yet. Refusing to start. Use "
-      "BUILD_BACKEND_DRM_KMS_EGL for a working DRM/KMS backend.");
-  return nullptr;
+  if (!backend->SetupCompositor(err)) {
+    spdlog::critical(
+        "[VulkanDrmBackend] compositor setup failed; refusing to start: {}",
+        err);
+    return nullptr;
+  }
+  return backend;
 }
 
 bool VulkanDrmBackend::BringUp(std::string& refusal_reason) {
@@ -168,6 +337,422 @@ bool VulkanDrmBackend::BringUp(std::string& refusal_reason) {
   spdlog::info(
       "[VulkanDrmBackend] graphics queue family {} created; scanout node '{}'",
       graphics_queue_family_, drm_device_);
+
+  return true;
+}
+
+// ── Compositor (present path)
+// ─────────────────────────────────────────────────
+
+struct VulkanDrmBackend::CompositorState {
+  explicit CompositorState(drm::Device d) : device(std::move(d)) {}
+  ~CompositorState() {
+    // Drain the in-flight flip so KMS is not mid-page-flip on a buffer we are
+    // about to free, then idle the GPU before releasing any Vulkan resources.
+    if (flip_pending) {
+      WaitForFlip(device.fd(), evctx);
+    }
+    if (vk_device != VK_NULL_HANDLE) {
+      d.vkDeviceWaitIdle(vk_device);
+    }
+    // Order matters: drop the scene (and the ring source's framebuffers) before
+    // freeing the images/dma-bufs the framebuffers reference.
+    scene.reset();
+    ring_owner.reset();
+    slots.clear();
+    if (barrier_fence != VK_NULL_HANDLE) {
+      d.vkDestroyFence(vk_device, barrier_fence, nullptr);
+    }
+    if (barrier_pool != VK_NULL_HANDLE) {
+      d.vkDestroyCommandPool(vk_device, barrier_pool, nullptr);
+    }
+    if (have_master) {
+      drmDropMaster(device.fd());
+    }
+  }
+
+  drm::Device device;
+  std::unique_ptr<drm::scene::LayerScene> scene;
+  bool have_master = false;
+  uint32_t fourcc = 0;
+  uint32_t width = 0;
+  uint32_t height = 0;
+
+  // Ring of scanout buffers. The engine cycles through them
+  // (avoid_backing_store_cache), rendering into a free slot while KMS scans
+  // another; a single persistent layer presents whichever slot is ready.
+  static constexpr size_t kMaxRing = 6;
+  struct Slot {
+    std::unique_ptr<drm_kms_vulkan::VulkanBackingStore> store;
+    bool engine_owned = false;  // handed to the engine, not yet collected
+  };
+  std::vector<Slot> slots;
+  std::unordered_map<const void*, size_t> key_to_slot;
+  std::unique_ptr<VkScanoutRing>
+      ring_owner;                 // until moved into the scene layer
+  VkScanoutRing* ring = nullptr;  // stable; owned by the scene layer
+  std::optional<drm::scene::LayerHandle> layer;
+
+  // Vsync pacing. The first commit is a blocking modeset; subsequent commits
+  // are non-blocking page flips drained against this event context.
+  bool first_commit = true;
+  bool flip_pending = false;
+  int scanning_slot = -1;  // slot the CRTC is currently scanning
+  int pending_slot = -1;   // slot in the in-flight non-blocking flip
+  drmEventContext evctx{};
+
+  // Scanout hand-off: drives each backing-store image's layout/cache between
+  // the renderer and the KMS scanout engine.
+  VkDevice vk_device = VK_NULL_HANDLE;
+  VkCommandPool barrier_pool = VK_NULL_HANDLE;
+  VkFence barrier_fence = VK_NULL_HANDLE;
+  uint64_t frame = 0;
+};
+
+bool VulkanDrmBackend::SetupCompositor(std::string& err) {
+  drm_kms_vulkan::ScanoutTarget target;
+  if (!drm_kms_vulkan::DiscoverScanoutTarget(drm_device_, DRM_FORMAT_XRGB8888,
+                                             mode_spec_, target, err)) {
+    return false;
+  }
+  const std::vector<uint64_t> allowed = drm_kms_vulkan::NegotiateModifiers(
+      physical_device_, VK_FORMAT_B8G8R8A8_UNORM, target.plane_modifiers);
+  if (allowed.empty()) {
+    err = "no modifier common to the GPU and the scanout plane";
+    return false;
+  }
+  spdlog::info(
+      "[VulkanDrmBackend] scanout target: connector {} crtc {} plane {} mode "
+      "{}x{}; {} modifier(s) negotiated",
+      target.connector_id, target.crtc_id, target.primary_plane_id,
+      target.mode_width, target.mode_height, allowed.size());
+  {
+    std::string adv;
+    for (auto m : target.plane_modifiers) {
+      adv += fmt::format(" 0x{:016x}", m);
+    }
+    std::string neg;
+    for (auto m : allowed) {
+      neg += fmt::format(" 0x{:016x}", m);
+    }
+    spdlog::info("[VulkanDrmBackend] plane modifiers advertised:{}", adv);
+    spdlog::info("[VulkanDrmBackend] modifiers negotiated:{}", neg);
+  }
+
+  auto dev_exp = drm::Device::open(drm_device_);
+  if (!dev_exp) {
+    err = "drm::Device::open: " + dev_exp.error().message();
+    return false;
+  }
+  auto state = std::make_unique<CompositorState>(std::move(dev_exp.value()));
+  (void)state->device.enable_atomic();
+  (void)state->device.enable_universal_planes();
+  state->fourcc = DRM_FORMAT_XRGB8888;
+  state->width = target.mode_width;
+  state->height = target.mode_height;
+
+  drm::scene::LayerScene::Config scfg{};
+  scfg.crtc_id = target.crtc_id;
+  scfg.connector_id = target.connector_id;
+  scfg.mode = target.mode;
+  auto scene_exp = drm::scene::LayerScene::create(state->device, scfg);
+  if (!scene_exp) {
+    err = "LayerScene::create: " + scene_exp.error().message();
+    return false;
+  }
+  state->scene = std::move(scene_exp.value());
+
+  // Probe the scanout path once: allocate a mode-sized backing store and try to
+  // import it as a KMS framebuffer. On hardware whose display cannot address
+  // the render GPU's exported buffer (e.g. a split render/display SoC with no
+  // display IOMMU — RPi4 vc4), this fails here, so refuse cleanly now instead
+  // of letting every per-frame CreateBackingStore fail into a black screen. The
+  // probe image and its framebuffer are released immediately (ring before
+  // store, so the framebuffer is gone before the memory it references).
+  {
+    std::string probe_err;
+    auto probe = drm_kms_vulkan::VulkanBackingStore::Create(
+        physical_device_, device_, state->width, state->height,
+        VK_FORMAT_B8G8R8A8_UNORM, state->fourcc, {DRM_FORMAT_MOD_LINEAR},
+        probe_err);
+    if (!probe) {
+      err = "scanout buffer allocation failed: " + probe_err;
+      return false;
+    }
+    VkScanoutRing probe_ring;
+    if (!probe_ring.AddSlot(state->device, *probe, state->fourcc)) {
+      err =
+          "this GPU/display combination cannot zero-copy scan out the Vulkan "
+          "renderer's buffers (KMS framebuffer import failed) — use the GL "
+          "backend (drm_kms_egl) on this hardware";
+      return false;
+    }
+  }
+
+  // Command pool + fence for the per-frame scanout hand-off barriers.
+  state->vk_device = device_;
+  VkCommandPoolCreateInfo pci{};
+  pci.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+  pci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+  pci.queueFamilyIndex = graphics_queue_family_;
+  if (d.vkCreateCommandPool(device_, &pci, nullptr, &state->barrier_pool) !=
+      VK_SUCCESS) {
+    err = "vkCreateCommandPool for scanout hand-off failed";
+    return false;
+  }
+  VkFenceCreateInfo fci{};
+  fci.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+  if (d.vkCreateFence(device_, &fci, nullptr, &state->barrier_fence) !=
+      VK_SUCCESS) {
+    err = "vkCreateFence for scanout hand-off failed";
+    return false;
+  }
+
+  // Page-flip event draining for vsync pacing. A no-op handler is enough — the
+  // event arriving is the signal; we carry no per-flip state through it.
+  state->evctx.version = 2;
+  state->evctx.page_flip_handler =
+      [](int /*fd*/, unsigned int /*sequence*/, unsigned int /*tv_sec*/,
+         unsigned int /*tv_usec*/, void* /*user_data*/) {};
+
+  if (drmSetMaster(state->device.fd()) != 0) {
+    err = std::string("drmSetMaster: ") + std::strerror(errno) +
+          " (run from a free VT / stop the active compositor)";
+    return false;
+  }
+  state->have_master = true;
+
+  width_ = state->width;
+  height_ = state->height;
+  compositor_ = std::move(state);
+  spdlog::info(
+      "[VulkanDrmBackend] compositor ready: {}x{}, DRM master acquired", width_,
+      height_);
+  return true;
+}
+
+FlutterVulkanImage VulkanDrmBackend::GetNextImageCb(
+    void* /*user_data*/,
+    const FlutterFrameInfo* /*frame_info*/) {
+  // Unreachable on the compositor path; present a well-formed but empty image
+  // so the embedder's renderer-config validation is satisfied.
+  FlutterVulkanImage img{};
+  img.struct_size = sizeof(FlutterVulkanImage);
+  img.image = 0;  // FlutterVulkanImageHandle is an opaque uint64, not a pointer
+  img.format = VK_FORMAT_B8G8R8A8_UNORM;
+  return img;
+}
+
+bool VulkanDrmBackend::PresentImageCb(void* /*user_data*/,
+                                      const FlutterVulkanImage* /*image*/) {
+  return true;
+}
+
+bool VulkanDrmBackend::CreateBackingStoreCb(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* out,
+    void* user_data) {
+  return static_cast<VulkanDrmBackend*>(user_data)->CreateBackingStoreImpl(
+      config, out);
+}
+
+bool VulkanDrmBackend::CollectBackingStoreCb(const FlutterBackingStore* store,
+                                             void* user_data) {
+  return static_cast<VulkanDrmBackend*>(user_data)->CollectBackingStoreImpl(
+      store);
+}
+
+bool VulkanDrmBackend::PresentLayersCb(const FlutterLayer** layers,
+                                       size_t count,
+                                       void* user_data) {
+  return static_cast<VulkanDrmBackend*>(user_data)->PresentLayersImpl(layers,
+                                                                      count);
+}
+
+bool VulkanDrmBackend::CreateBackingStoreImpl(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* out) {
+  if (!compositor_) {
+    return false;
+  }
+  CompositorState& c = *compositor_;
+  const auto w = static_cast<uint32_t>(config->size.width);
+  const auto h = static_cast<uint32_t>(config->size.height);
+
+  // Reuse a ring slot that the engine has released and the scanout engine is no
+  // longer scanning or about to scan; otherwise grow the ring.
+  int slot = -1;
+  for (size_t i = 0; i < c.slots.size(); ++i) {
+    const auto& s = c.slots[i];
+    if (!s.engine_owned && static_cast<int>(i) != c.scanning_slot &&
+        static_cast<int>(i) != c.pending_slot && s.store->width() == w &&
+        s.store->height() == h) {
+      slot = static_cast<int>(i);
+      break;
+    }
+  }
+
+  if (slot < 0) {
+    if (c.slots.size() >= CompositorState::kMaxRing) {
+      spdlog::error(
+          "[VulkanDrmBackend] scanout ring exhausted ({} buffers); dropping "
+          "frame",
+          c.slots.size());
+      return false;
+    }
+    std::string err;
+    // LINEAR is the modifier ExternalDmaBufSource accepts today; tiled is a
+    // follow-on once that wrapper learns multi-plane tiled modifiers.
+    auto store = drm_kms_vulkan::VulkanBackingStore::Create(
+        physical_device_, device_, w, h, VK_FORMAT_B8G8R8A8_UNORM, c.fourcc,
+        {DRM_FORMAT_MOD_LINEAR}, err);
+    if (!store) {
+      spdlog::error("[VulkanDrmBackend] CreateBackingStore({}x{}): {}", w, h,
+                    err);
+      return false;
+    }
+    if (c.ring == nullptr) {
+      c.ring_owner = std::make_unique<VkScanoutRing>();
+      c.ring = c.ring_owner.get();
+    }
+    auto idx = c.ring->AddSlot(c.device, *store, c.fourcc);
+    if (!idx) {
+      spdlog::error("[VulkanDrmBackend] scanout framebuffer import failed");
+      return false;
+    }
+    slot = static_cast<int>(*idx);
+    c.key_to_slot[store.get()] = static_cast<size_t>(slot);
+    c.slots.push_back({std::move(store), false});
+    spdlog::info("[VulkanDrmBackend] scanout ring grew to {} buffer(s) ({}x{})",
+                 c.slots.size(), w, h);
+  }
+
+  CompositorState::Slot& s = c.slots[static_cast<size_t>(slot)];
+  s.engine_owned = true;
+  // Hand the engine an image in the layout it renders into. UNDEFINED as the
+  // old layout discards the slot's prior contents — the engine fully repaints
+  // each frame (avoid_backing_store_cache), so nothing is lost.
+  SubmitImageBarrier(device_, c.barrier_pool, c.barrier_fence, graphics_queue_,
+                     ColorBarrier(s.store->image(), VK_IMAGE_LAYOUT_UNDEFINED,
+                                  VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, 0,
+                                  VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT),
+                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                     VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+
+  const void* key = s.store.get();
+  out->struct_size = sizeof(FlutterBackingStore);
+  out->type = kFlutterBackingStoreTypeVulkan;
+  out->user_data = const_cast<void*>(key);
+  out->vulkan.struct_size = sizeof(FlutterVulkanBackingStore);
+  out->vulkan.image = s.store->flutter_image();
+  out->vulkan.user_data = const_cast<void*>(key);
+  out->vulkan.destruction_callback = [](void*) {};
+  return true;
+}
+
+bool VulkanDrmBackend::CollectBackingStoreImpl(
+    const FlutterBackingStore* store) {
+  if (!compositor_) {
+    return false;
+  }
+  // Return the slot to the free pool; its image/framebuffer stay alive for
+  // reuse and are released with the whole ring at teardown.
+  auto it = compositor_->key_to_slot.find(store->user_data);
+  if (it != compositor_->key_to_slot.end()) {
+    compositor_->slots[it->second].engine_owned = false;
+  }
+  return true;
+}
+
+bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
+                                         size_t count) {
+  if (!compositor_ || !compositor_->scene) {
+    return false;
+  }
+  CompositorState& c = *compositor_;
+  const FlutterLayer* bs_layer = nullptr;
+  for (size_t i = 0; i < count; ++i) {
+    if (layers[i]->type == kFlutterLayerContentTypeBackingStore) {
+      bs_layer = layers[i];
+      break;
+    }
+  }
+  if (bs_layer == nullptr) {
+    return false;
+  }
+  const auto it = c.key_to_slot.find(bs_layer->backing_store->user_data);
+  if (it == c.key_to_slot.end()) {
+    return false;
+  }
+  const size_t slot = it->second;
+  drm_kms_vulkan::VulkanBackingStore* store = c.slots[slot].store.get();
+
+  // Flush the renderer's color writes so the scanout engine sees this frame.
+  // The embedder host-syncs all layers before present_layers, so the render is
+  // already retired; this barrier only makes the writes visible to KMS.
+  SubmitImageBarrier(
+      device_, c.barrier_pool, c.barrier_fence, graphics_queue_,
+      ColorBarrier(store->image(), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                   VK_IMAGE_LAYOUT_GENERAL,
+                   VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                   VK_ACCESS_MEMORY_READ_BIT),
+      VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+      VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+
+  // Pace to vblank: drain the previous non-blocking flip before queueing the
+  // next. The drained flip's slot becomes the one being scanned; the slot it
+  // replaced returns to the free pool.
+  if (c.flip_pending) {
+    WaitForFlip(c.device.fd(), c.evctx);
+    c.flip_pending = false;
+    c.scanning_slot = c.pending_slot;
+    c.pending_slot = -1;
+  }
+
+  // Create the single presenting layer once the ring has a slot; thereafter the
+  // ring source rotates which slot's framebuffer the layer scans out.
+  if (!c.layer) {
+    if (c.ring == nullptr) {
+      return false;
+    }
+    drm::scene::LayerDesc desc;
+    desc.source = std::move(c.ring_owner);
+    desc.display.dst_rect = {0, 0, c.width, c.height};
+    auto layer = c.scene->add_layer(std::move(desc));
+    if (!layer) {
+      spdlog::error("[VulkanDrmBackend] add_layer: {}",
+                    layer.error().message());
+      return false;
+    }
+    c.layer = layer.value();
+  }
+
+  c.ring->SetReady(slot);
+  // First commit is a blocking modeset (the scene adds ALLOW_MODESET, which
+  // cannot be non-blocking); subsequent frames are non-blocking page flips we
+  // pace against.
+  const uint32_t flags =
+      c.first_commit ? 0U
+                     : (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK);
+  auto report = c.scene->commit(flags);
+  if (!report) {
+    spdlog::error("[VulkanDrmBackend] commit: {}", report.error().message());
+    return false;
+  }
+  if (c.first_commit) {
+    c.first_commit = false;
+    c.scanning_slot = static_cast<int>(slot);
+  } else {
+    c.pending_slot = static_cast<int>(slot);
+    c.flip_pending = true;
+  }
+
+  const uint64_t n = c.frame++;
+  if (n < 3 || n % 120 == 0) {
+    spdlog::info(
+        "[VulkanDrmBackend] presented frame {} slot {} ({}x{}); ring={}", n,
+        slot, store->width(), store->height(), c.slots.size());
+  }
   return true;
 }
 
@@ -257,6 +842,18 @@ bool VulkanDrmBackend::SelectPhysicalDevice(std::string& refusal_reason) {
     if (props.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU ||
         LooksLikeSoftware(props.deviceName)) {
       last_miss = std::string(props.deviceName) + " is a CPU/software renderer";
+      continue;
+    }
+
+    // The Flutter engine's Skia backend requires a Vulkan 1.1 device. Reject a
+    // 1.0 device here (e.g. some virtio/gfxstream Turnip stacks expose only
+    // 1.0) so the backend refuses with a clear reason instead of the engine
+    // fatally aborting during renderer init.
+    if (props.apiVersion < VK_API_VERSION_1_1) {
+      last_miss = std::string(props.deviceName) + " exposes Vulkan " +
+                  std::to_string(VK_VERSION_MAJOR(props.apiVersion)) + "." +
+                  std::to_string(VK_VERSION_MINOR(props.apiVersion)) +
+                  " (the Flutter Vulkan renderer requires 1.1)";
       continue;
     }
 
@@ -497,10 +1094,10 @@ void VulkanDrmBackend::Teardown() {
   }
 }
 
-// ── Backend interface
-// ───────────────────────────────────────────────────────── Present/scanout is
-// not wired yet; never reached while Create() refuses, but required for the
-// vtable and the FlutterView call sites.
+// ── Backend interface ──────────────────────────────────────────────────────
+// The Flutter Vulkan renderer drives a fixed-size scanout target, so resize is
+// driven by the discovered mode rather than these call sites; they satisfy the
+// vtable and the FlutterView wiring.
 
 void VulkanDrmBackend::Resize(size_t /*index*/,
                               Engine* /*flutter_engine*/,
@@ -539,11 +1136,21 @@ FlutterRendererConfig VulkanDrmBackend::GetRenderConfig() {
   config.vulkan.enabled_device_extensions = enabled_device_extensions_.data();
   config.vulkan.get_instance_proc_address_callback =
       GetInstanceProcAddressCallback;
+  config.vulkan.get_next_image_callback = GetNextImageCb;
+  config.vulkan.present_image_callback = PresentImageCb;
   return config;
 }
 
 FlutterCompositor VulkanDrmBackend::GetCompositorConfig() {
   FlutterCompositor compositor{};
   compositor.struct_size = sizeof(FlutterCompositor);
+  compositor.user_data = this;
+  compositor.create_backing_store_callback = CreateBackingStoreCb;
+  compositor.collect_backing_store_callback = CollectBackingStoreCb;
+  compositor.present_layers_callback = PresentLayersCb;
+  // Force a fresh backing store each frame so the engine cycles through the
+  // scanout ring (rendering into a free buffer while KMS scans another) rather
+  // than reusing one buffer — the basis for tear-free, vsync-paced present.
+  compositor.avoid_backing_store_cache = true;
   return compositor;
 }

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -36,20 +36,23 @@ class DrmSession;
 //
 // Create() brings up the Vulkan instance, selects a physical device that can do
 // zero-copy dma-buf scanout (render-node-aware when the device exposes a DRM
-// node, vendor/name fallback otherwise), creates the logical device and
-// queues, and logs the resolved capabilities. The render and present path is
-// not implemented yet, so the backend currently refuses after bring-up rather
-// than handing back a backend that cannot present a frame.
+// node, vendor/name fallback otherwise), creates the logical device and queues,
+// then opens the DRM device, takes master, discovers the scanout target, and
+// builds the LayerScene the present path commits onto. The Flutter compositor
+// callbacks back each backing store with an exported modifier VkImage and scan
+// it out zero-copy on the primary plane.
 class VulkanDrmBackend final : public Backend {
  public:
-  // Bring up the device and (for now) refuse. Returns nullptr on every path:
-  // the caller treats null as a hard init failure and aborts, exactly as the
+  // Bring up the device and the present path. Returns nullptr on failure: the
+  // caller treats null as a hard init failure and aborts, exactly as the
   // drm_kms_egl backend does on DrmBackend::Create returning null. @p session
-  // may be null when no libseat session is available.
+  // may be null when no libseat session is available. @p mode_spec selects the
+  // scanout mode ("<W>x<H>[@<R>]"); empty uses the connector's preferred mode.
   static std::shared_ptr<VulkanDrmBackend> Create(
       const std::string& drm_device,
       bool enable_validation,
-      homescreen::DrmSession* session);
+      homescreen::DrmSession* session,
+      const std::string& mode_spec);
 
   ~VulkanDrmBackend() override;
 
@@ -57,8 +60,9 @@ class VulkanDrmBackend final : public Backend {
   VulkanDrmBackend& operator=(const VulkanDrmBackend&) = delete;
 
   // ── Backend interface ──────────────────────────────────────────────────────
-  // Present/scanout is not wired yet; these satisfy the vtable and the
-  // FlutterView call sites.
+  // Present runs through the Flutter compositor callbacks
+  // (GetCompositorConfig), so these size/surface/texture entry points are no-op
+  // stubs that satisfy the vtable and the FlutterView call sites.
   void Resize(size_t index,
               Engine* flutter_engine,
               int32_t width,
@@ -79,7 +83,8 @@ class VulkanDrmBackend final : public Backend {
  private:
   VulkanDrmBackend(std::string drm_device,
                    bool enable_validation,
-                   homescreen::DrmSession* session);
+                   homescreen::DrmSession* session,
+                   std::string mode_spec);
 
   // Bring-up steps. Each logs and returns false on failure; refusal_reason
   // carries the cause for gate failures.
@@ -91,7 +96,36 @@ class VulkanDrmBackend final : public Backend {
   void PopulateCaps();
   void Teardown();
 
+  // Open the DRM device, take master, build the LayerScene for the discovered
+  // scanout target, and cache the negotiated modifier set. On success the
+  // backend can present and Create() returns it instead of refusing.
+  bool SetupCompositor(std::string& err);
+
+  // Root-surface renderer callbacks. The compositor path renders into backing
+  // stores and presents via present_layers, so these are never invoked at
+  // runtime, but the embedder rejects a Vulkan renderer config that leaves them
+  // null.
+  static FlutterVulkanImage GetNextImageCb(void* user_data,
+                                           const FlutterFrameInfo* frame_info);
+  static bool PresentImageCb(void* user_data, const FlutterVulkanImage* image);
+
+  // Flutter compositor callbacks (user_data == this) and their implementations.
+  static bool CreateBackingStoreCb(const FlutterBackingStoreConfig* config,
+                                   FlutterBackingStore* out,
+                                   void* user_data);
+  static bool CollectBackingStoreCb(const FlutterBackingStore* store,
+                                    void* user_data);
+  static bool PresentLayersCb(const FlutterLayer** layers,
+                              size_t count,
+                              void* user_data);
+  bool CreateBackingStoreImpl(const FlutterBackingStoreConfig* config,
+                              FlutterBackingStore* out);
+  bool CollectBackingStoreImpl(const FlutterBackingStore* store);
+  bool PresentLayersImpl(const FlutterLayer** layers, size_t count);
+
   std::string drm_device_;
+  // Scanout mode selector ("<W>x<H>[@<R>]"); empty = connector preferred mode.
+  std::string mode_spec_;
   bool enable_validation_ = false;
   // Reused by the session/vsync glue in a later change; held now so Create()'s
   // signature and the FlutterView wiring are stable.
@@ -112,4 +146,10 @@ class VulkanDrmBackend final : public Backend {
   std::vector<const char*> enabled_device_extensions_;
 
   drm_kms_vulkan::DeviceCaps caps_;
+
+  // DRM device + LayerScene + backing-store registry. Held behind a pimpl so
+  // the drm-cxx scene/device headers stay out of this header (it is included by
+  // FlutterView and other GL-free translation units).
+  struct CompositorState;
+  std::unique_ptr<CompositorState> compositor_;
 };

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -232,12 +232,17 @@ FlutterView::FlutterView(Configuration::Config config,
     // DrmDisplay in a DRM build, so the cast failing is programmer error.
     auto* drm_display = dynamic_cast<DrmDisplay*>(m_display.get());
     assert(drm_display != nullptr);
+    const std::string drm_mode =
+        (m_config.view.drm_mode.has_value() && !m_config.view.drm_mode->empty())
+            ? *m_config.view.drm_mode
+            : std::string{};
     m_backend = VulkanDrmBackend::Create(
         m_config.view.drm_device.value_or("/dev/dri/card1"),
-        m_config.debug_backend.value_or(false), drm_display->session());
+        m_config.debug_backend.value_or(false), drm_display->session(),
+        drm_mode);
 
-    // Create returns nullptr on any init failure or refusal (the Phase 0
-    // scaffold always refuses). Continuing would dereference a null backend in
+    // Create returns nullptr on any init failure (unsupported device, no
+    // zero-copy scanout path). Continuing would dereference a null backend in
     // Engine::Run and SEGV; fail-fast with the same exit path the EGL DRM
     // backend uses.
     if (!m_backend) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -49,8 +49,14 @@ target_compile_options(tomlplusplus_tomlplusplus INTERFACE
 #
 # Vulkan-Headers
 #
+# Expose the top-level include dir (not include/vulkan) so the canonical
+# <vulkan/vulkan.h> / <vulkan/vulkan.hpp> includes every consumer uses resolve
+# from the vendored tree. Pointing at include/vulkan only satisfied bare
+# <vulkan.h> (which nothing uses) and let <vulkan/...> silently fall back to the
+# system Vulkan SDK on desktop hosts — a source of API/ABI skew, and a hard
+# failure when cross-compiling against a sysroot with no Vulkan headers.
 add_library(vulkan_headers INTERFACE)
-target_include_directories(vulkan_headers INTERFACE Vulkan-Headers/include/vulkan)
+target_include_directories(vulkan_headers INTERFACE Vulkan-Headers/include)
 
 #
 # Flutter Common library


### PR DESCRIPTION
## Summary

Adds the **`drm_kms_vulkan`** backend: it drives the Flutter Vulkan renderer and scans its output out on hardware KMS planes with **no copy**, via dma-buf import through the drm-cxx `LayerScene`. The session / modeset / seat / input stack is shared with `drm_kms_egl` below the pixel layer; only the renderer and present path differ. Requires `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON -DBUILD_COMPOSITOR=ON`.

## Present path

- Each Flutter backing store is a device-local `VkImage` allocated with an explicit DRM format modifier and exported as a dma-buf; the engine renders into it and the exported buffer is imported as a KMS framebuffer.
- A reusable **ring of scanout buffers** (`avoid_backing_store_cache`): the engine renders into a free buffer while KMS scans another. One persistent `LayerScene` layer presents whichever slot is ready.
- **Vsync-paced**: first commit is a blocking modeset, subsequent frames are non-blocking page flips drained off the DRM fd — triple-buffered, tear-free.
- A layout/cache barrier flushes the renderer's color writes (`COLOR_ATTACHMENT_OPTIMAL` → `GENERAL`) before each commit so the scanout engine sees the frame.

## Robustness / selection

- `--drm-mode <W>x<H>[@<R>]` selects the scanout mode (default: connector preferred).
- Gated on **Vulkan 1.1** (the engine's Skia backend requires it — a 1.0 device is rejected with a clear reason instead of a fatal engine abort), the dma-buf/sync extensions, and `timelineSemaphore`.
- `SetupCompositor` **probes the scanout import once** and refuses cleanly when the display cannot scan out the render GPU's buffer, rather than failing every per-frame backing-store creation into a black screen.
- `vulkan_headers` now exposes the vendored `Vulkan-Headers` top-level include so `<vulkan/vulkan.h>` resolves from the vendored tree everywhere (no system Vulkan SDK fallback — fixes cross-compiles and avoids API skew).
- `build_pi.sh` gains a `drm-kms-vulkan` backend for aarch64 cross-builds.

## Testing

| Platform | Result |
| --- | --- |
| amdgpu (unified memory) | renders correctly, tear-free |
| Raspberry Pi 5 (V3D 7.x → vc4) | renders correctly, tear-free @ 3840×2160 |
| Raspberry Pi 4 (vc4, no display IOMMU) | refuses cleanly — `AddFB` EINVAL |
| NanoPC-T6 / rk3588 (Mali-G610 → vop2) | refuses cleanly — vop2 wants AFBC, rejects LINEAR |
| Arduino Uno Q (Adreno via virtio/gfxstream) | refuses cleanly — exposes Vulkan 1.0 |

Zero-copy needs a buffer the **display** can address — unified memory, or a display IOMMU that also accepts a modifier the render GPU can export. Where that doesn't hold, the backend refuses and the GL backend (`drm_kms_egl`) is the path. See `shell/backend/drm_kms_vulkan/README.md`.
