### PR TITLE
[drm_kms_vulkan] add a self-committing HW cursor

### DIFF
--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -43,6 +43,7 @@
 #include <drm-cxx/scene/layer_handle.hpp>
 #include <drm-cxx/scene/layer_scene.hpp>
 
+#include "backend/drm_kms_egl/drm_cursor.h"
 #include "backend/drm_kms_egl/scene_layer_source_vk.h"
 #include "backend/drm_kms_vulkan/device_caps.h"
 #include "backend/drm_kms_vulkan/drm_scanout_target.h"
@@ -265,6 +266,9 @@ VulkanDrmBackend::VulkanDrmBackend(std::string drm_device,
       session_(session) {}
 
 VulkanDrmBackend::~VulkanDrmBackend() {
+  // Tear the cursor down first: it commits on compositor_'s DRM device, so it
+  // must not outlive it.
+  cursor_.reset();
   // Drop master + scene + backing stores while the Vulkan device is still
   // alive (the stores free Vulkan resources in their destructors).
   compositor_.reset();
@@ -528,6 +532,21 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
   spdlog::info(
       "[VulkanDrmBackend] compositor ready: {}x{}, DRM master acquired", width_,
       height_);
+
+#if HAVE_DRM_CURSOR
+  // Self-committing HW cursor on the scanout CRTC's cursor plane. It commits on
+  // its own (driven by seat pointer motion), NOT staged into the per-frame
+  // scanout commit, so it stays responsive while the UI is idle. Failure is
+  // non-fatal — the shell runs without an on-screen sprite. Built on
+  // compositor_'s DRM device (master held above), so it lives in cursor_ and is
+  // torn down before compositor_.
+  cursor_ = homescreen::DrmCursor::Create(compositor_->device, target.crtc_id,
+                                          target.connector_id, target.mode,
+                                          width_, height_);
+  if (!cursor_) {
+    spdlog::info("[VulkanDrmBackend] no HW cursor (disabled or unavailable)");
+  }
+#endif
   return true;
 }
 

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -28,6 +28,7 @@
 
 namespace homescreen {
 class DrmSession;
+class DrmCursor;
 }  // namespace homescreen
 
 // DRM/KMS scanout backend that drives the Flutter Vulkan renderer and presents
@@ -79,6 +80,13 @@ class VulkanDrmBackend final : public Backend {
   [[nodiscard]] uint32_t width() const { return width_; }
   [[nodiscard]] uint32_t height() const { return height_; }
   [[nodiscard]] const drm_kms_vulkan::DeviceCaps& caps() const { return caps_; }
+
+  // The self-committing DRM HW cursor (null when xcursor/drm-cxx-cursor is
+  // unavailable or --disable-cursor). FlutterView forwards it to the seat via
+  // DrmDisplay::SetCursor so pointer motion drives the on-screen sprite.
+  [[nodiscard]] homescreen::DrmCursor* drm_cursor() const {
+    return cursor_.get();
+  }
 
  private:
   VulkanDrmBackend(std::string drm_device,
@@ -152,4 +160,9 @@ class VulkanDrmBackend final : public Backend {
   // FlutterView and other GL-free translation units).
   struct CompositorState;
   std::unique_ptr<CompositorState> compositor_;
+
+  // Self-committing HW cursor on the scanout CRTC's cursor plane. Created in
+  // SetupCompositor against compositor_'s DRM device; destroyed before
+  // compositor_ so it never outlives that device.
+  std::unique_ptr<homescreen::DrmCursor> cursor_;
 };

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -236,7 +236,7 @@ FlutterView::FlutterView(Configuration::Config config,
         (m_config.view.drm_mode.has_value() && !m_config.view.drm_mode->empty())
             ? *m_config.view.drm_mode
             : std::string{};
-    m_backend = VulkanDrmBackend::Create(
+    auto vk_backend = VulkanDrmBackend::Create(
         m_config.view.drm_device.value_or("/dev/dri/card1"),
         m_config.debug_backend.value_or(false), drm_display->session(),
         drm_mode);
@@ -245,11 +245,22 @@ FlutterView::FlutterView(Configuration::Config config,
     // zero-copy scanout path). Continuing would dereference a null backend in
     // Engine::Run and SEGV; fail-fast with the same exit path the EGL DRM
     // backend uses.
-    if (!m_backend) {
+    if (!vk_backend) {
       spdlog::critical(
           "[FlutterView] DRM Vulkan backend init failed; aborting");
       exit(EXIT_FAILURE);
     }
+
+    // Wire the self-committing HW cursor (if Create opened one) to the seat
+    // dispatch thread, and clamp the pointer to the resolved scanout size. The
+    // cursor commits on its own (not staged into the per-frame scanout commit),
+    // so it stays responsive while the UI is idle. The pointer stays valid for
+    // the FlutterView's lifetime (both members, destroyed in declaration
+    // order).
+    drm_display->SetViewportSize(static_cast<int32_t>(vk_backend->width()),
+                                 static_cast<int32_t>(vk_backend->height()));
+    drm_display->SetCursor(vk_backend->drm_cursor());
+    m_backend = vk_backend;
   }
 #elif BUILD_BACKEND_WAYLAND_EGL
   {


### PR DESCRIPTION
## Summary

Adds a hardware cursor to the `drm_kms_vulkan` backend (#218). It previously presented the UI with no on-screen cursor — pointer events reached Flutter, but there was no DRM sprite.

Reuses `drm_kms_egl`'s `DrmCursor` (the drm-cxx cursor renderer on the CRTC's cursor plane):

- `SetupCompositor` creates the cursor on the scanout CRTC against the compositor's DRM device (master already held), sized from the connector/mode.
- `FlutterView` forwards it to the seat via `DrmDisplay::SetCursor` and pushes the resolved scanout size into the seat's pointer clamp.
- **Self-committing, not staged.** The cursor commits on the seat thread (DrmCursor's default non-staged mode) on its own cursor plane, independent of the per-frame scanout commit — so it stays responsive while the UI is idle and no frames commit. (Staging into the per-frame commit would couple cursor motion to frame production and stall on an idle UI — the lesson from #216 on `drm_kms_egl`.) The cursor's atomic commits and the scene's flips run on separate threads; the kernel serializes them.
- `cursor_` is owned by the backend and torn down before the compositor, so it never outlives the DRM device it commits on. Creation is non-fatal — the shell runs without a sprite if xcursor / drm-cxx-cursor is unavailable or `--disable-cursor` is set.

## Testing

Validated rendering correctly with a smoothly-tracking cursor and responsive UI under pointer motion on:

- **amdgpu** — cursor plane 360
- **Raspberry Pi 5** — cursor plane 655, DPI-scaled sprite at 3840×2160

Closes #218.
