### PR TITLE
Software backend parity + shared libinput keyboard core

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -92,6 +92,7 @@ if (BUILD_BACKEND_SOFTWARE)
             backend/software/file_sink.cc
             backend/software/sink_factory.cc
             backend/software/software_backend.cc
+            backend/software/software_cursor.cc
             display/software_display.cc
     )
     if (BUILD_SOFTWARE_SINK_DRM)

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -114,6 +114,19 @@ if (BUILD_BACKEND_SOFTWARE)
     endif ()
 endif ()
 
+# Shared libinput keyboard core (xkb translation + key-repeat) used by every
+# libinput-backed seat — SoftwareSeat and (DRM) DrmSeat — so keyboard behavior
+# is identical across backends. Depends only on libxkbcommon, which those seats
+# already link. Added once here to avoid duplicate sources in multi-backend
+# builds.
+if (BUILD_SOFTWARE_INPUT_LIBINPUT OR BUILD_BACKEND_DRM_KMS_EGL OR
+    BUILD_BACKEND_DRM_KMS_VULKAN)
+    target_sources(${PROJECT_NAME} PRIVATE
+            input/xkb_keyboard.cc
+            input/key_repeater.cc
+    )
+endif ()
+
 if (BUILD_BACKEND_DRM_KMS_EGL)
     target_sources(${PROJECT_NAME} PRIVATE
             backend/drm_kms_egl/drm_backend.cc

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -35,6 +35,7 @@
 #endif
 
 #if BUILD_BACKEND_SOFTWARE
+#include "backend/software/software_cursor.h"
 #include "display/software_display.h"
 #if BUILD_SOFTWARE_INPUT_LIBINPUT
 #include "backend/software/input/software_seat.h"
@@ -88,6 +89,17 @@ std::shared_ptr<IDisplay> MakeDisplay(
     spdlog::info("[SoftwareBackend] IVI_SW_INPUT=none — no input seat");
   }
 #endif
+  // Software cursor, gated by --disable-cursor / IVI_SW_CURSOR=0. Owned by the
+  // display; shared with the seat (updates its position on motion) and the sink
+  // (composites it). Harmless for headless sinks — they ignore SetCursor, and
+  // the cursor stays invisible until the first pointer motion.
+  const char* cursor_env = std::getenv("IVI_SW_CURSOR");
+  const bool cursor_enabled =
+      !configs[0].disable_cursor &&
+      (cursor_env == nullptr || std::string_view(cursor_env) != "0");
+  if (cursor_enabled) {
+    display->SetCursor(std::make_shared<SoftwareCursor>());
+  }
   return display;
 #else
   return std::make_shared<Display>(!configs[0].disable_cursor,

--- a/shell/backend/software/drm_dumb_sink.cc
+++ b/shell/backend/software/drm_dumb_sink.cc
@@ -37,6 +37,7 @@
 #include <asio/post.hpp>
 
 #include "backend/software/pixel_swizzle.h"
+#include "backend/software/software_cursor.h"
 #include "libflutter_engine.h"
 #include "logging.h"
 #include "task_runner.h"
@@ -445,6 +446,12 @@ void DrmDumbSink::OnSize(uint32_t /*width*/, uint32_t /*height*/) {
   // Flutter's view geometry doesn't match. No-op here.
 }
 
+void DrmDumbSink::SetCursor(std::shared_ptr<SoftwareCursor> cursor) {
+  cursor_ = std::move(cursor);
+  spdlog::debug("[DrmDumbSink] software cursor {}",
+                cursor_ ? "installed" : "cleared");
+}
+
 void DrmDumbSink::SwizzleInto(const size_t buffer_index,
                               const void* allocation,
                               const size_t src_row_bytes,
@@ -548,6 +555,14 @@ bool DrmDumbSink::Present(const void* allocation,
 
   const size_t back = 1 - front_buffer_;
   SwizzleInto(back, allocation, row_bytes, height);
+
+  // Composite the cursor on top of the freshly-packed frame, before the flip.
+  // The whole back buffer was just repacked, so there's nothing to restore.
+  // XRGB8888 only for now (the RGB565 blend is a follow-up).
+  if (cursor_ && format_ == Format::kXRGB8888) {
+    cursor_->BlendXRGB(buffers_[back].map, mode_width_, mode_height_,
+                       buffers_[back].pitch);
+  }
 
   // Schedule the page-flip. flip_pending_ goes high before the
   // ioctl so an out-of-band OnPageFlip can't observe the prior

--- a/shell/backend/software/drm_dumb_sink.cc
+++ b/shell/backend/software/drm_dumb_sink.cc
@@ -27,6 +27,7 @@
 #include <xf86drmMode.h>
 #include <cerrno>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
@@ -180,23 +181,72 @@ bool DrmDumbSink::InitDevice(const std::string& device_path) {
   }
   connector_id_ = connector->connector_id;
 
-  // Prefer the kernel-flagged preferred mode if present, else mode 0.
-  drmModeModeInfo mode = connector->modes[0];
+  // Find the kernel-flagged preferred mode (the default pick, as before).
+  int preferred_idx = -1;
   for (int i = 0; i < connector->count_modes; ++i) {
     if ((connector->modes[i].type & DRM_MODE_TYPE_PREFERRED) != 0) {
-      mode = connector->modes[i];
+      preferred_idx = i;
       break;
     }
   }
+  int chosen_idx = preferred_idx >= 0 ? preferred_idx : 0;
+  bool mode_from_env = false;
+
+  // IVI_SW_DRM_MODE="<W>x<H>[@<R>]" selects a specific mode (refresh matched
+  // against drmModeModeInfo::vrefresh in integer Hz when the @<R> is given). No
+  // match → fall back to the preferred mode. Mirrors drm-kms-egl's --drm-mode.
+  if (const char* spec = std::getenv("IVI_SW_DRM_MODE");
+      spec != nullptr && spec[0] != '\0') {
+    unsigned want_w = 0, want_h = 0, want_r = 0;
+    const int n = std::sscanf(spec, "%ux%u@%u", &want_w, &want_h, &want_r);
+    if (n >= 2) {
+      int match = -1;
+      for (int i = 0; i < connector->count_modes; ++i) {
+        const auto& m = connector->modes[i];
+        if (m.hdisplay == want_w && m.vdisplay == want_h &&
+            (n < 3 || static_cast<unsigned>(m.vrefresh) == want_r)) {
+          match = i;
+          break;
+        }
+      }
+      if (match >= 0) {
+        chosen_idx = match;
+        mode_from_env = true;
+      } else {
+        spdlog::warn(
+            "[DrmDumbSink] IVI_SW_DRM_MODE='{}' not found on connector {}; "
+            "using the {} mode",
+            spec, connector->connector_id,
+            preferred_idx >= 0 ? "preferred" : "first");
+      }
+    } else {
+      spdlog::warn(
+          "[DrmDumbSink] IVI_SW_DRM_MODE='{}' is not <W>x<H>[@<R>]; ignoring",
+          spec);
+    }
+  }
+
+  // Mode-list log (mirrors drm-kms-egl --drm-list-modes): the preferred mode is
+  // flagged, the chosen mode gets a trailing '*'. Lets the operator see valid
+  // IVI_SW_DRM_MODE values.
+  for (int i = 0; i < connector->count_modes; ++i) {
+    const auto& m = connector->modes[i];
+    spdlog::info("[DrmDumbSink]   mode[{}] {}x{}@{}Hz{}{}", i, m.hdisplay,
+                 m.vdisplay, m.vrefresh,
+                 i == preferred_idx ? " (preferred)" : "",
+                 i == chosen_idx ? " *" : "");
+  }
+
+  const drmModeModeInfo mode = connector->modes[chosen_idx];
   mode_width_ = mode.hdisplay;
   mode_height_ = mode.vdisplay;
   refresh_rate_hz_ =
       mode.vrefresh > 0 ? static_cast<double>(mode.vrefresh) : 60.0;
   refresh_period_ns_.store(static_cast<uint64_t>(1e9 / refresh_rate_hz_),
                            std::memory_order_release);
-  spdlog::info("[DrmDumbSink] connector={} mode={}x{}@{:.2f}Hz",
+  spdlog::info("[DrmDumbSink] connector={} mode={}x{}@{:.2f}Hz{}",
                connector->connector_id, mode_width_, mode_height_,
-               refresh_rate_hz_);
+               refresh_rate_hz_, mode_from_env ? " (IVI_SW_DRM_MODE)" : "");
 
   // Pick a CRTC: prefer the connector's currently-bound encoder/CRTC
   // to avoid disturbing the existing console binding.
@@ -705,4 +755,80 @@ void DrmDumbSink::StopVsyncMonitor() {
       flip_pending_.store(false, std::memory_order_release);
     }
   }
+}
+
+namespace {
+
+// List one card's driver + connectors/modes to stdout. Returns 0 on success,
+// non-zero if the device can't be opened or has no DRM resources (e.g. a
+// render-only node with no KMS).
+int ListCardModes(const std::string& device_path) {
+  const int fd = ::open(device_path.c_str(), O_RDWR | O_CLOEXEC);
+  if (fd < 0) {
+    return 1;  // not present / no permission — silently skipped during a scan
+  }
+  drmModeRes* res = drmModeGetResources(fd);
+  if (res == nullptr) {
+    ::close(fd);  // render node (renderD*) or no KMS — skip
+    return 1;
+  }
+  drmVersion* ver = drmGetVersion(fd);
+  std::printf("%s  driver=%s, %d connector(s):\n", device_path.c_str(),
+              (ver != nullptr && ver->name != nullptr) ? ver->name : "?",
+              res->count_connectors);
+  if (ver != nullptr) {
+    drmFreeVersion(ver);
+  }
+  for (int i = 0; i < res->count_connectors; ++i) {
+    drmModeConnector* c = drmModeGetConnector(fd, res->connectors[i]);
+    if (c == nullptr) {
+      continue;
+    }
+    const bool connected = c->connection == DRM_MODE_CONNECTED;
+    std::printf("  connector %u: %s, %d mode(s)\n", c->connector_id,
+                connected ? "connected" : "disconnected", c->count_modes);
+    for (int m = 0; m < c->count_modes; ++m) {
+      const drmModeModeInfo& mi = c->modes[m];
+      const bool pref = (mi.type & DRM_MODE_TYPE_PREFERRED) != 0;
+      std::printf("    [%d] %ux%u@%uHz%s\n", m, mi.hdisplay, mi.vdisplay,
+                  mi.vrefresh, pref ? "  (preferred)" : "");
+    }
+    drmModeFreeConnector(c);
+  }
+  drmModeFreeResources(res);
+  ::close(fd);
+  return 0;
+}
+
+}  // namespace
+
+int PrintDumbSinkModes(const std::string& device_path) {
+  // An explicit device lists just that card; otherwise scan every
+  // /dev/dri/card* so the operator can see which card to pass to --drm-device
+  // (and which mode to IVI_SW_DRM_MODE) without hard-coding card0.
+  if (!device_path.empty()) {
+    if (ListCardModes(device_path) != 0) {
+      spdlog::error("[DrmDumbSink] {} has no DRM/KMS resources", device_path);
+      return 1;
+    }
+    return 0;
+  }
+  std::printf(
+      "DRM cards (--drm-device /dev/dri/cardN selects one; IVI_SW_DRM_MODE "
+      "picks a mode):\n");
+  int listed = 0;
+  for (int i = 0; i < 16; ++i) {
+    const std::string dev = "/dev/dri/card" + std::to_string(i);
+    if (::access(dev.c_str(), F_OK) != 0) {
+      continue;
+    }
+    if (ListCardModes(dev) == 0) {
+      ++listed;
+    }
+  }
+  if (listed == 0) {
+    spdlog::error("[DrmDumbSink] no KMS-capable /dev/dri/card* found");
+    return 1;
+  }
+  return 0;
 }

--- a/shell/backend/software/drm_dumb_sink.h
+++ b/shell/backend/software/drm_dumb_sink.h
@@ -80,6 +80,10 @@ class DrmDumbSink final : public ISurfaceSink {
                size_t row_bytes,
                size_t height) override;
   void OnSize(uint32_t width, uint32_t height) override;
+  // Composited onto each frame in Present (XRGB8888 path), after the swizzle
+  // and before the page flip — no save/restore needed since the whole back
+  // buffer is repacked every frame.
+  void SetCursor(std::shared_ptr<SoftwareCursor> cursor) override;
 
   // ISurfaceSink — vsync wiring.
   [[nodiscard]] bool SupportsVsync() const override { return true; }
@@ -181,6 +185,10 @@ class DrmDumbSink final : public ISurfaceSink {
   std::atomic<TaskRunner*> platform_task_runner_{nullptr};
   // Refresh period as nanoseconds; computed once from the picked mode.
   std::atomic<uint64_t> refresh_period_ns_{16'666'667};
+
+  // Software cursor composited onto each frame (XRGB8888 path); shared with the
+  // seat, which updates its position. Null when the cursor is disabled.
+  std::shared_ptr<SoftwareCursor> cursor_;
 
   // Tear-down latch.
   std::atomic<bool> stopped_{false};

--- a/shell/backend/software/drm_dumb_sink.h
+++ b/shell/backend/software/drm_dumb_sink.h
@@ -94,6 +94,13 @@ class DrmDumbSink final : public ISurfaceSink {
   [[nodiscard]] uint32_t mode_height() const { return mode_height_; }
   [[nodiscard]] double refresh_rate_hz() const { return refresh_rate_hz_; }
 
+  // The picked connector mode's extent — the SoftwareBackend adopts this as
+  // the engine viewport so Flutter renders at the panel's native resolution.
+  [[nodiscard]] std::optional<std::pair<uint32_t, uint32_t>> NativeSize()
+      const override {
+    return std::make_pair(mode_width_, mode_height_);
+  }
+
  private:
   DrmDumbSink();
 
@@ -178,3 +185,10 @@ class DrmDumbSink final : public ISurfaceSink {
   // Tear-down latch.
   std::atomic<bool> stopped_{false};
 };
+
+// Open @p device_path, enumerate every connector's modes (flagging connected /
+// preferred), print to stdout, and return 0 (non-zero on open/query failure).
+// The dumb-sink analogue of PrintDrmModes — backs --drm-list-modes on software
+// builds so valid IVI_SW_DRM_MODE values can be discovered without launching
+// the app onto the display.
+int PrintDumbSinkModes(const std::string& device_path);

--- a/shell/backend/software/input/software_seat.cc
+++ b/shell/backend/software/input/software_seat.cc
@@ -104,18 +104,8 @@ SoftwareSeat::SoftwareSeat(const int32_t viewport_width,
 
 SoftwareSeat::~SoftwareSeat() {
   Stop();
-  if (xkb_state_ != nullptr) {
-    xkb_state_unref(xkb_state_);
-    xkb_state_ = nullptr;
-  }
-  if (xkb_keymap_ != nullptr) {
-    xkb_keymap_unref(xkb_keymap_);
-    xkb_keymap_ = nullptr;
-  }
-  if (xkb_ctx_ != nullptr) {
-    xkb_context_unref(xkb_ctx_);
-    xkb_ctx_ = nullptr;
-  }
+  // keyboard_ / repeater_ are RAII (reset in Stop, after the dispatch thread
+  // joins). xkb + the repeat timerfd are owned by those now.
   if (li_ != nullptr) {
     libinput_unref(li_);
     li_ = nullptr;
@@ -142,32 +132,28 @@ bool SoftwareSeat::Start() {
     return false;
   }
 
-  // xkb defaults — rules/model/layout/variant/options all picked up
-  // from environment (XKB_DEFAULT_RULES etc.) or built-in defaults.
-  xkb_ctx_ = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-  if (xkb_ctx_ == nullptr) {
-    spdlog::error("[SoftwareSeat] xkb_context_new failed");
+  // Shared keyboard translation + auto-repeat — the same input::XkbKeyboard /
+  // input::KeyRepeater path the DRM seats use, so keyboard behavior (including
+  // 25 Hz repeat with per-tick sym re-resolution + modifiers) is identical
+  // across backends. xkb picks up RMLVO from XKB_DEFAULT_* / built-in defaults.
+  keyboard_ = input::XkbKeyboard::Create();
+  if (!keyboard_) {
+    spdlog::error("[SoftwareSeat] XkbKeyboard::Create failed");
     return false;
   }
-  xkb_keymap_ =
-      xkb_keymap_new_from_names(xkb_ctx_, nullptr, XKB_KEYMAP_COMPILE_NO_FLAGS);
-  if (xkb_keymap_ == nullptr) {
-    spdlog::error("[SoftwareSeat] xkb_keymap_new_from_names failed");
-    return false;
-  }
-  xkb_state_ = xkb_state_new(xkb_keymap_);
-  if (xkb_state_ == nullptr) {
-    spdlog::error("[SoftwareSeat] xkb_state_new failed");
-    return false;
-  }
-
-  // timerfd for key repeat. CLOCK_MONOTONIC + NONBLOCK so the poll
-  // loop can read without ever blocking. CLOEXEC because we fork
-  // nothing but the hygiene is cheap.
-  repeat_fd_ = ::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
-  if (repeat_fd_ < 0) {
-    spdlog::warn("[SoftwareSeat] timerfd_create: {} — key repeat disabled",
-                 std::strerror(errno));
+  repeater_ = input::KeyRepeater::Create(keyboard_.get());
+  if (repeater_) {
+    // A repeat tick re-resolves the held key against the current xkb state and
+    // re-dispatches it as a press with the live modifier mask.
+    repeater_->SetHandler([this](uint32_t evdev_keycode, xkb_keysym_t sym,
+                                 const std::string& /*utf8*/) {
+      if (auto* s = state_.load(std::memory_order_acquire); s != nullptr) {
+        KeyCallback(s, /*released=*/false, sym, evdev_keycode + 8,
+                    keyboard_->Modifiers());
+      }
+    });
+  } else {
+    spdlog::warn("[SoftwareSeat] key repeat unavailable (timerfd_create)");
   }
 
   stop_.store(false, std::memory_order_release);
@@ -182,10 +168,10 @@ void SoftwareSeat::Stop() {
   if (thread_.joinable()) {
     thread_.join();
   }
-  if (repeat_fd_ >= 0) {
-    ::close(repeat_fd_);
-    repeat_fd_ = -1;
-  }
+  // Safe to drop the keyboard + repeater now the dispatch thread has joined
+  // (it is their only user). RAII closes the xkb state + the repeat timerfd.
+  repeater_.reset();
+  keyboard_.reset();
 }
 
 void SoftwareSeat::SetViewControllerState(
@@ -232,10 +218,11 @@ void SoftwareSeat::DispatchLoop() {
   // timeout gives Stop() a worst-case wakeup latency comparable to
   // one vblank.
   const int li_fd = libinput_get_fd(li_);
+  const int repeat_fd = repeater_ ? repeater_->fd() : -1;
   pollfd fds[2];
   fds[0] = pollfd{li_fd, static_cast<short>(POLLIN), 0};
   fds[1] =
-      pollfd{repeat_fd_, static_cast<short>(repeat_fd_ >= 0 ? POLLIN : 0), 0};
+      pollfd{repeat_fd, static_cast<short>(repeat_fd >= 0 ? POLLIN : 0), 0};
   // 16 ms poll cap means a repeat tick scheduled mid-interval is
   // delivered up to 16 ms late — at the 33 ms (~30 Hz) repeat
   // cadence that's tolerable jitter for held keys; matches the
@@ -255,22 +242,10 @@ void SoftwareSeat::DispatchLoop() {
     if ((fds[0].revents & POLLIN) != 0) {
       DispatchLibinputEvents();
     }
-    if (repeat_fd_ >= 0 && (fds[1].revents & POLLIN) != 0) {
-      DispatchRepeatTick();
+    if (repeat_fd >= 0 && (fds[1].revents & POLLIN) != 0) {
+      repeater_->Dispatch();
     }
   }
-}
-
-void SoftwareSeat::DispatchRepeatTick() {
-  // Drain the expiration count. We don't care how many ticks elapsed
-  // (a slow consumer just means a brief burst on recovery); fire
-  // exactly one synthetic press per drain so the cadence stays even.
-  uint64_t expirations = 0;
-  while (::read(repeat_fd_, &expirations, sizeof(expirations)) ==
-         static_cast<ssize_t>(sizeof(expirations))) {
-    // loop until EAGAIN drains the fd
-  }
-  FireRepeat();
 }
 
 void SoftwareSeat::DispatchLibinputEvents() {
@@ -475,87 +450,19 @@ void SoftwareSeat::HandlePointerAxis(libinput_event_pointer* p) {
 
 void SoftwareSeat::HandleKeyboardKey(libinput_event_keyboard* k) {
   const uint32_t key = libinput_event_keyboard_get_key(k);
-  const auto state = libinput_event_keyboard_get_key_state(k);
-  // evdev keycodes are offset by 8 from xkb's scancode space; this is
-  // the universal Linux convention.
-  const uint32_t xkb_scancode = key + 8;
-  const xkb_keysym_t keysym =
-      xkb_state_key_get_one_sym(xkb_state_, xkb_scancode);
-  const bool pressed = state == LIBINPUT_KEY_STATE_PRESSED;
-  xkb_state_update_key(xkb_state_, xkb_scancode,
-                       pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
-  auto* s = state_.load(std::memory_order_acquire);
-  if (s != nullptr) {
-    KeyCallback(s, !pressed, keysym, xkb_scancode, 0);
+  const bool pressed =
+      libinput_event_keyboard_get_key_state(k) == LIBINPUT_KEY_STATE_PRESSED;
+  // The shared keyboard resolves the keysym and advances modifier state (it
+  // applies the universal evdev->xkb +8 offset internally).
+  const xkb_keysym_t keysym = keyboard_->ProcessKey(key, pressed);
+  if (auto* s = state_.load(std::memory_order_acquire); s != nullptr) {
+    KeyCallback(s, !pressed, keysym, key + 8, keyboard_->Modifiers());
   }
-
-  // Key-repeat scheduling. xkbcommon's per-key repeat flag tells us
-  // whether the keymap considers this key repeatable (modifiers and
-  // dead keys typically aren't).
-  if (pressed) {
-    if (xkb_keymap_ != nullptr &&
-        xkb_keymap_key_repeats(xkb_keymap_, xkb_scancode) != 0) {
-      // Pressing a second repeating key while another is held replaces
-      // the first as the "currently repeating" key (the first is
-      // effectively forgotten until released). Matches Wayland's
-      // wl_keyboard.repeat_info handler and typical desktop UX where
-      // the most-recently-pressed key wins the repeat.
-      ArmRepeat(xkb_scancode, keysym);
-    }
-    // Press of a non-repeating key (Shift / Ctrl / dead keys)
-    // doesn't disturb an existing repeat — matches typical terminal
-    // / desktop behaviour.
-  } else if (xkb_scancode == repeat_scancode_) {
-    DisarmRepeat();
+  // Feed the shared repeater — it owns per-key eligibility, most-recent-wins
+  // arming, and the timerfd polled in DispatchLoop.
+  if (repeater_) {
+    repeater_->OnKey(key, pressed);
   }
-}
-
-void SoftwareSeat::ArmRepeat(const uint32_t xkb_scancode,
-                             const xkb_keysym_t keysym) {
-  if (repeat_fd_ < 0) {
-    return;
-  }
-  repeat_scancode_ = xkb_scancode;
-  repeat_keysym_ = keysym;
-  // Default repeat cadence: 500 ms initial delay, ~30 Hz thereafter.
-  // Matches typical desktop defaults (X11 / GNOME / KDE).
-  itimerspec spec{};
-  spec.it_value.tv_sec = 0;
-  spec.it_value.tv_nsec = 500'000'000;  // 500 ms initial delay
-  spec.it_interval.tv_sec = 0;
-  spec.it_interval.tv_nsec = 33'000'000;  // ~30 Hz repeat
-  if (::timerfd_settime(repeat_fd_, 0, &spec, nullptr) != 0) {
-    spdlog::warn("[SoftwareSeat] timerfd_settime(arm): {}",
-                 std::strerror(errno));
-  }
-}
-
-void SoftwareSeat::DisarmRepeat() {
-  if (repeat_fd_ < 0) {
-    return;
-  }
-  repeat_scancode_ = 0;
-  repeat_keysym_ = XKB_KEY_NoSymbol;
-  itimerspec spec{};  // all zero = disarm
-  if (::timerfd_settime(repeat_fd_, 0, &spec, nullptr) != 0) {
-    spdlog::warn("[SoftwareSeat] timerfd_settime(disarm): {}",
-                 std::strerror(errno));
-  }
-}
-
-void SoftwareSeat::FireRepeat() {
-  if (repeat_scancode_ == 0) {
-    return;
-  }
-  auto* s = state_.load(std::memory_order_acquire);
-  if (s == nullptr) {
-    return;
-  }
-  // Mirrors the Wayland-side handler: synthesize a "press" event for
-  // the held key. Flutter's text-input layer (and shortcut bindings)
-  // observe the repeated press just like they would on Wayland's
-  // wl_keyboard.key with the same scancode.
-  KeyCallback(s, /*released=*/false, repeat_keysym_, repeat_scancode_, 0);
 }
 
 void SoftwareSeat::HandleTouchDown(libinput_event_touch* t) {

--- a/shell/backend/software/input/software_seat.cc
+++ b/shell/backend/software/input/software_seat.cc
@@ -30,6 +30,7 @@
 
 #include <asio/dispatch.hpp>
 
+#include "backend/software/software_cursor.h"
 #include "engine.h"
 #include "libflutter_engine.h"
 #include "logging.h"
@@ -51,7 +52,15 @@ namespace {
 // puts themselves in the `input` group (or runs as root).
 int OpenRestricted(const char* path, int flags, void* /*user_data*/) {
   const int fd = ::open(path, flags | O_CLOEXEC);
-  return fd < 0 ? -errno : fd;
+  if (fd < 0) {
+    spdlog::warn(
+        "[SoftwareSeat] open('{}') failed: {} — add the user to the 'input' "
+        "group (or run on an active VT for the logind uaccess ACL)",
+        path, std::strerror(errno));
+    return -errno;
+  }
+  spdlog::debug("[SoftwareSeat] opened input device {}", path);
+  return fd;
 }
 
 void CloseRestricted(int fd, void* /*user_data*/) {
@@ -187,6 +196,33 @@ void SoftwareSeat::SetViewControllerState(
 void SoftwareSeat::SetViewport(const int32_t width, const int32_t height) {
   viewport_w_ = width;
   viewport_h_ = height;
+}
+
+void SoftwareSeat::SetCursor(std::shared_ptr<SoftwareCursor> cursor) {
+  cursor_ = std::move(cursor);
+}
+
+void SoftwareSeat::NotifyCursorMoved() {
+  if (!cursor_) {
+    return;
+  }
+  static bool logged_first = false;
+  if (!logged_first) {
+    logged_first = true;
+    spdlog::debug("[SoftwareSeat] cursor tracking pointer (first motion {},{})",
+                  static_cast<int>(pointer_x_), static_cast<int>(pointer_y_));
+  }
+  // pointer_x_/y_ are in viewport (== framebuffer mode) pixels, the same space
+  // the cursor blends into.
+  cursor_->SetPosition(static_cast<int32_t>(pointer_x_),
+                       static_cast<int32_t>(pointer_y_));
+  // Flutter only presents dirty frames, so without a nudge the cursor would
+  // freeze on an idle UI. ScheduleFrame is thread-safe; the dumb sink then
+  // repaints with the cursor at its new position.
+  if (const EngineRef e = CurrentEngine(); e.engine != nullptr) {
+    LibFlutterEngine->ScheduleFrame(
+        static_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(e.engine));
+  }
 }
 
 void SoftwareSeat::DispatchLoop() {
@@ -327,6 +363,7 @@ void SoftwareSeat::HandlePointerMotion(libinput_event_pointer* p) {
   batch[count].buttons = button_mask_;
   ++count;
 
+  NotifyCursorMoved();
   DispatchPointerEvents(batch, count);
 }
 
@@ -365,6 +402,7 @@ void SoftwareSeat::HandlePointerMotionAbsolute(libinput_event_pointer* p) {
   batch[count].buttons = button_mask_;
   ++count;
 
+  NotifyCursorMoved();
   DispatchPointerEvents(batch, count);
 }
 
@@ -523,6 +561,11 @@ void SoftwareSeat::FireRepeat() {
 void SoftwareSeat::HandleTouchDown(libinput_event_touch* t) {
   if (viewport_w_ <= 0 || viewport_h_ <= 0) {
     return;
+  }
+  // Touch input → hide the mouse cursor (it reappears on the next pointer
+  // motion). Matches typical desktop behaviour.
+  if (cursor_) {
+    cursor_->SetVisible(false);
   }
   const int32_t slot = libinput_event_touch_get_seat_slot(t);
   if (slot < 0 || static_cast<size_t>(slot) >= kMaxTouchSlots) {

--- a/shell/backend/software/input/software_seat.h
+++ b/shell/backend/software/input/software_seat.h
@@ -27,6 +27,8 @@
 #include <shell/platform/embedder/embedder.h>
 
 #include "input/iseat.h"
+#include "input/key_repeater.h"
+#include "input/xkb_keyboard.h"
 
 class SoftwareCursor;
 
@@ -79,7 +81,6 @@ class SoftwareSeat final : public ISeat {
 
   void DispatchLoop();
   void DispatchLibinputEvents();
-  void DispatchRepeatTick();
   void HandleEvent(libinput_event* ev);
   void HandlePointerMotion(libinput_event_pointer* p);
   void HandlePointerMotionAbsolute(libinput_event_pointer* p);
@@ -90,15 +91,6 @@ class SoftwareSeat final : public ISeat {
   void HandleTouchUp(libinput_event_touch* t);
   void HandleTouchMotion(libinput_event_touch* t);
   void HandleTouchCancel(libinput_event_touch* t);
-
-  // Key-repeat helpers. libinput emits a single press event per key;
-  // Flutter text inputs need repeated press events for held keys.
-  // ArmRepeat / DisarmRepeat manage a timerfd polled alongside
-  // libinput's fd; FireRepeat synthesizes the synthetic "press"
-  // event(s) the timer firing represents.
-  void ArmRepeat(uint32_t xkb_scancode, xkb_keysym_t keysym);
-  void DisarmRepeat();
-  void FireRepeat();
 
   // Dispatch a populated FlutterPointerEvent on the platform task
   // runner's strand. Copies the event by value into the lambda.
@@ -123,20 +115,13 @@ class SoftwareSeat final : public ISeat {
   ::udev* udev_{nullptr};
   ::libinput* li_{nullptr};
 
-  // xkb context / keymap / state for keysym translation. Uses the
-  // system default RMLVO (xkbcommon's compiled-in defaults, then
-  // XKB_DEFAULT_* env vars); good enough for the common case.
-  xkb_context* xkb_ctx_{nullptr};
-  xkb_keymap* xkb_keymap_{nullptr};
-  xkb_state* xkb_state_{nullptr};
-
-  // timerfd for key repeat. Polled alongside libinput's fd. Armed on
-  // press of a repeating key, disarmed on release or on press of a
-  // different key. Default delay 500 ms, interval 33 ms (~30 Hz).
-  int repeat_fd_{-1};
-  // Currently-repeating key. 0 = none. xkb scancode = evdev + 8.
-  uint32_t repeat_scancode_{0};
-  xkb_keysym_t repeat_keysym_{XKB_KEY_NoSymbol};
+  // Shared keyboard translation + auto-repeat (input::XkbKeyboard /
+  // input::KeyRepeater in shell/input/), the same path the DRM seats use, so
+  // keyboard behavior is identical across backends. repeater_ may be null if
+  // its timerfd couldn't be created (key repeat then disabled). Both live on,
+  // and are only touched by, the dispatch thread.
+  std::unique_ptr<input::XkbKeyboard> keyboard_;
+  std::unique_ptr<input::KeyRepeater> repeater_;
 
   std::thread thread_;
   std::atomic<bool> stop_{false};

--- a/shell/backend/software/input/software_seat.h
+++ b/shell/backend/software/input/software_seat.h
@@ -19,6 +19,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <thread>
 
 #include <xkbcommon/xkbcommon.h>
@@ -26,6 +27,8 @@
 #include <shell/platform/embedder/embedder.h>
 
 #include "input/iseat.h"
+
+class SoftwareCursor;
 
 struct libinput;
 struct libinput_event;
@@ -64,7 +67,16 @@ class SoftwareSeat final : public ISeat {
   // values without an atomic.
   void SetViewport(int32_t width, int32_t height);
 
+  // Install the shared software cursor. On pointer motion the seat updates the
+  // cursor position and schedules a frame, so the cursor tracks the mouse even
+  // when the UI is otherwise idle. Null leaves the cursor unmanaged.
+  void SetCursor(std::shared_ptr<SoftwareCursor> cursor);
+
  private:
+  // Push the current pointer position to the cursor and schedule a frame so the
+  // dumb sink repaints with the cursor at its new spot. No-op without a cursor.
+  void NotifyCursorMoved();
+
   void DispatchLoop();
   void DispatchLibinputEvents();
   void DispatchRepeatTick();
@@ -135,6 +147,11 @@ class SoftwareSeat final : public ISeat {
   double pointer_y_{0.0};
   int64_t button_mask_{0};
   bool pointer_added_{false};
+
+  // Shared software cursor (owned by SoftwareDisplay). Written here on the
+  // dispatch thread; read on the rasterizer thread in DrmDumbSink::Present.
+  // Its position/visibility are atomics, so no extra locking. Null = disabled.
+  std::shared_ptr<SoftwareCursor> cursor_;
 
   // Per-slot multi-touch state. libinput uses slot indices for
   // multi-touch; we mirror the slot directly as Flutter's `device`

--- a/shell/backend/software/sink_factory.cc
+++ b/shell/backend/software/sink_factory.cc
@@ -33,7 +33,9 @@
 #include "backend/software/fbdev_sink.h"
 #endif
 
-std::unique_ptr<ISurfaceSink> MakeSinkFromSpec(const std::string_view spec) {
+std::unique_ptr<ISurfaceSink> MakeSinkFromSpec(
+    const std::string_view spec,
+    const std::string_view drm_device_hint) {
   if (spec.empty() || spec == "none") {
     spdlog::info("[SoftwareBackend] sink: none (frames discarded)");
     return std::make_unique<NoneSink>();
@@ -56,18 +58,18 @@ std::unique_ptr<ISurfaceSink> MakeSinkFromSpec(const std::string_view spec) {
     return std::make_unique<FileSink>(std::move(pattern));
   }
 
-  // drm-dumb:<device>  (device is optional; defaults to /dev/dri/card0)
+  // drm-dumb[:<device>]  — explicit device wins; else the --drm-device hint;
+  // else empty, which makes DrmDumbSink probe the first usable card.
   constexpr std::string_view kDrmPrefix = "drm-dumb:";
   if (spec == "drm-dumb" || spec.rfind(kDrmPrefix, 0) == 0) {
 #if BUILD_SOFTWARE_SINK_DRM
-    const std::string device(spec == "drm-dumb"
-                                 ? std::string_view{}
-                                 : spec.substr(kDrmPrefix.size()));
+    const std::string device(
+        spec == "drm-dumb" ? drm_device_hint : spec.substr(kDrmPrefix.size()));
     auto drm_sink = DrmDumbSink::Create(device);
     if (drm_sink) {
       spdlog::info(
           "[SoftwareBackend] sink: drm-dumb (device='{}', {}x{}@{:.2f}Hz)",
-          device.empty() ? std::string("/dev/dri/card0") : device,
+          device.empty() ? std::string("(probed)") : device,
           drm_sink->mode_width(), drm_sink->mode_height(),
           drm_sink->refresh_rate_hz());
       return drm_sink;
@@ -118,8 +120,10 @@ std::unique_ptr<ISurfaceSink> MakeSinkFromSpec(const std::string_view spec) {
   return std::make_unique<NoneSink>();
 }
 
-std::unique_ptr<ISurfaceSink> MakeSinkFromEnv() {
+std::unique_ptr<ISurfaceSink> MakeSinkFromEnv(
+    const std::string_view drm_device_hint) {
   const char* env = std::getenv("IVI_SW_SINK");
-  return MakeSinkFromSpec(env != nullptr ? std::string_view(env)
-                                         : std::string_view{});
+  return MakeSinkFromSpec(
+      env != nullptr ? std::string_view(env) : std::string_view{},
+      drm_device_hint);
 }

--- a/shell/backend/software/sink_factory.h
+++ b/shell/backend/software/sink_factory.h
@@ -32,8 +32,18 @@
 //
 // Unrecognized specs log a warn and return NoneSink so the embedder
 // never refuses to start because of a CI typo.
-std::unique_ptr<ISurfaceSink> MakeSinkFromSpec(std::string_view spec);
+//
+// @p drm_device_hint supplies the device for the device-backed sinks
+// (drm-dumb / fbdev) when the spec itself names none — i.e. it lets the
+// --drm-device CLI flag (config.view.drm_device) pick the card instead of the
+// sink probing the first one. An explicit device in the spec
+// (drm-dumb:/dev/dri/cardN) always wins over the hint.
+std::unique_ptr<ISurfaceSink> MakeSinkFromSpec(
+    std::string_view spec,
+    std::string_view drm_device_hint = {});
 
 // Convenience: read IVI_SW_SINK from the environment; falls back to
-// "none" when the env var is unset or empty.
-std::unique_ptr<ISurfaceSink> MakeSinkFromEnv();
+// "none" when the env var is unset or empty. @p drm_device_hint is forwarded
+// (the --drm-device value) to select the card for device-backed sinks.
+std::unique_ptr<ISurfaceSink> MakeSinkFromEnv(
+    std::string_view drm_device_hint = {});

--- a/shell/backend/software/software_backend.cc
+++ b/shell/backend/software/software_backend.cc
@@ -36,6 +36,21 @@ SoftwareBackend::SoftwareBackend(const uint32_t initial_width,
       height_(initial_height),
       sink_(std::move(sink)) {
   if (sink_) {
+    // Adopt the sink's native extent (the DRM mode / fbdev virtual size) so
+    // Flutter renders at the panel's resolution — the frame fills and centers,
+    // and the seat/cursor share the framebuffer coordinate space — instead of
+    // the config view size, which the swizzle would otherwise crop/letterbox
+    // from the top-left.
+    if (const auto native = sink_->NativeSize();
+        native.has_value() &&
+        (native->first != width_ || native->second != height_)) {
+      spdlog::info(
+          "[SoftwareBackend] adopting sink native mode {}x{} (config was "
+          "{}x{})",
+          native->first, native->second, width_, height_);
+      width_ = native->first;
+      height_ = native->second;
+    }
     sink_->OnSize(width_, height_);
   }
   if (const char* env = std::getenv("IVI_SW_STOP_AFTER_FRAMES");

--- a/shell/backend/software/software_backend.h
+++ b/shell/backend/software/software_backend.h
@@ -57,6 +57,13 @@ class SoftwareBackend final : public Backend {
   FlutterRendererConfig GetRenderConfig() override;
   FlutterCompositor GetCompositorConfig() override;
 
+  // Resolved framebuffer extent. Adopted from the sink's NativeSize() (the DRM
+  // mode / fbdev virtual size) when the sink drives a fixed-size display, else
+  // the config view size. FlutterView reads these to drive the engine viewport
+  // + seat coordinate space, mirroring the DRM backends' width()/height().
+  [[nodiscard]] uint32_t width() const { return width_; }
+  [[nodiscard]] uint32_t height() const { return height_; }
+
   // Vsync wiring is gated on the sink advertising a real vblank source
   // (DRM dumb buffer is the only sink that currently does) AND
   // IVI_SW_VSYNC not being "0". Sinks without a vblank source return
@@ -94,7 +101,7 @@ class SoftwareBackend final : public Backend {
 
   // Per-frame cadence profile (IVI_SW_PROFILE=1). CLOCK_MONOTONIC
   // sampled immediately after each successful sink->Present(); the
-  // rasterizer thread is the only writer so no locks. Same bucket
+  // rasterizer thread is the only writer, so no locks. Same bucket
   // thresholds as the wayland_egl / wayland_vulkan profilers
   // (≤17ms / 18-33ms / 34-50ms / 51-100ms / >100ms) so histograms
   // line up across backends. For sinks that have no real vblank
@@ -127,7 +134,7 @@ class SoftwareBackend final : public Backend {
 
   // IVI_SW_STOP_AFTER_FRAMES=N: after N successful presents, raise
   // SIGTERM so the existing shutdown handler exits cleanly. Lets CI
-  // bound runtime by frame count instead of wall-clock. 0 disables.
+  // bound runtime by frame count instead of `wall-clock`. 0 disables.
   // Sampled once at construction; the static check in PresentFrame
   // costs one atomic load on the rasterizer thread when disabled.
   uint64_t stop_after_frames_{0};

--- a/shell/backend/software/software_backend.h
+++ b/shell/backend/software/software_backend.h
@@ -64,6 +64,15 @@ class SoftwareBackend final : public Backend {
   [[nodiscard]] uint32_t width() const { return width_; }
   [[nodiscard]] uint32_t height() const { return height_; }
 
+  // Forward the shared software cursor to the sink (the dumb sink composites
+  // it). Called by FlutterView with the SoftwareDisplay-owned cursor. No-op for
+  // headless sinks. (SoftwareCursor is forward-declared via surface_sink.h.)
+  void SetCursor(std::shared_ptr<SoftwareCursor> cursor) {
+    if (sink_) {
+      sink_->SetCursor(std::move(cursor));
+    }
+  }
+
   // Vsync wiring is gated on the sink advertising a real vblank source
   // (DRM dumb buffer is the only sink that currently does) AND
   // IVI_SW_VSYNC not being "0". Sinks without a vblank source return

--- a/shell/backend/software/software_cursor.cc
+++ b/shell/backend/software/software_cursor.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/software/software_cursor.h"
+
+#include <cstring>
+
+namespace {
+
+// Classic left-pointer arrow, 12x19. 'o' = black outline, 'X' = white fill,
+// space = transparent. Hotspot is the tip at (0, 0). Each row is exactly
+// kCursorW characters.
+constexpr uint32_t kCursorW = 12;
+constexpr uint32_t kCursorH = 19;
+constexpr const char* kArrow[kCursorH] = {
+    "o           ", "oo          ", "oXo         ", "oXXo        ",
+    "oXXXo       ", "oXXXXo      ", "oXXXXXo     ", "oXXXXXXo    ",
+    "oXXXXXXXo   ", "oXXXXXXXXo  ", "oXXXXXoooooo", "oXXoXXo     ",
+    "oXo oXXo    ", "oo  oXXo    ", "o    oXXo   ", "     oXXo   ",
+    "      oXXo  ", "      oXXo  ", "       oo   ",
+};
+
+// Premultiplied ARGB8888.
+constexpr uint32_t kFill = 0xFFFFFFFF;     // opaque white
+constexpr uint32_t kOutline = 0xFF000000;  // opaque black
+constexpr uint32_t kClear = 0x00000000;    // transparent
+
+}  // namespace
+
+SoftwareCursor::SoftwareCursor()
+    : width_(kCursorW), height_(kCursorH), hot_x_(0), hot_y_(0) {
+  pixels_.resize(static_cast<size_t>(width_) * height_, kClear);
+  for (uint32_t row = 0; row < height_; ++row) {
+    const char* line = kArrow[row];
+    const size_t len = std::strlen(line);
+    for (uint32_t col = 0; col < width_; ++col) {
+      const char c = col < len ? line[col] : ' ';
+      uint32_t argb = kClear;
+      if (c == 'X') {
+        argb = kFill;
+      } else if (c == 'o') {
+        argb = kOutline;
+      }
+      pixels_[static_cast<size_t>(row) * width_ + col] = argb;
+    }
+  }
+}
+
+void SoftwareCursor::BlendXRGB(uint8_t* map,
+                               const uint32_t fb_w,
+                               const uint32_t fb_h,
+                               const uint32_t pitch) const {
+  if (map == nullptr || !visible_.load(std::memory_order_acquire)) {
+    return;
+  }
+  const int32_t ox = x_.load(std::memory_order_relaxed) - hot_x_;
+  const int32_t oy = y_.load(std::memory_order_relaxed) - hot_y_;
+
+  for (uint32_t cy = 0; cy < height_; ++cy) {
+    const int32_t dy = oy + static_cast<int32_t>(cy);
+    if (dy < 0 || dy >= static_cast<int32_t>(fb_h)) {
+      continue;
+    }
+    for (uint32_t cx = 0; cx < width_; ++cx) {
+      const int32_t dx = ox + static_cast<int32_t>(cx);
+      if (dx < 0 || dx >= static_cast<int32_t>(fb_w)) {
+        continue;
+      }
+      const uint32_t src = pixels_[static_cast<size_t>(cy) * width_ + cx];
+      const uint32_t a = src >> 24;
+      if (a == 0) {
+        continue;  // fully transparent — leave the framebuffer pixel
+      }
+      const uint32_t sr = (src >> 16) & 0xFF;
+      const uint32_t sg = (src >> 8) & 0xFF;
+      const uint32_t sb = src & 0xFF;
+      const uint32_t ia = 255 - a;  // inverse alpha for the "over" blend
+
+      // XRGB8888 little-endian: byte order in memory is [B, G, R, X].
+      uint8_t* d =
+          map + static_cast<size_t>(dy) * pitch + static_cast<size_t>(dx) * 4;
+      d[0] = static_cast<uint8_t>(sb + (d[0] * ia) / 255);
+      d[1] = static_cast<uint8_t>(sg + (d[1] * ia) / 255);
+      d[2] = static_cast<uint8_t>(sr + (d[2] * ia) / 255);
+      // d[3] (X) left unchanged.
+    }
+  }
+}

--- a/shell/backend/software/software_cursor.h
+++ b/shell/backend/software/software_cursor.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+// Software mouse cursor for the CPU/software backend. The dumb-buffer sinks
+// repaint the whole back buffer from Flutter every Present, so the cursor is
+// just composited on top after the swizzle and before the page flip — no
+// save/restore of the pixels under the cursor is needed.
+//
+// The bitmap is a small embedded arrow (premultiplied ARGB8888), so the
+// software backend keeps its "no GBM / no GL / no extra libraries" property —
+// no libxcursor dependency. The hotspot is the arrow tip.
+//
+// Threading: SetPosition()/SetVisible() are called from the input thread
+// (SoftwareSeat); BlendXRGB() is called from the rasterizer thread (the sink's
+// Present). Position + visibility are atomics; the bitmap is immutable after
+// construction.
+class SoftwareCursor {
+ public:
+  SoftwareCursor();
+
+  // Move the cursor and mark it visible. Coordinates are in framebuffer
+  // (mode) pixels; the hotspot is subtracted in BlendXRGB.
+  void SetPosition(int32_t x, int32_t y) {
+    x_.store(x, std::memory_order_relaxed);
+    y_.store(y, std::memory_order_relaxed);
+    visible_.store(true, std::memory_order_release);
+  }
+
+  void SetVisible(bool visible) {
+    visible_.store(visible, std::memory_order_release);
+  }
+
+  [[nodiscard]] bool visible() const {
+    return visible_.load(std::memory_order_acquire);
+  }
+
+  // Composite the cursor into an XRGB8888 (memory order [B,G,R,X]) buffer of
+  // @p fb_w x @p fb_h with row stride @p pitch bytes. No-op when hidden. Edge
+  // pixels are clipped. Premultiplied "over" blend.
+  void BlendXRGB(uint8_t* map,
+                 uint32_t fb_w,
+                 uint32_t fb_h,
+                 uint32_t pitch) const;
+
+ private:
+  // Premultiplied ARGB8888 (0xAARRGGBB), row-major, width_ * height_ entries.
+  std::vector<uint32_t> pixels_;
+  uint32_t width_{0};
+  uint32_t height_{0};
+  int32_t hot_x_{0};
+  int32_t hot_y_{0};
+
+  std::atomic<int32_t> x_{0};
+  std::atomic<int32_t> y_{0};
+  std::atomic<bool> visible_{false};
+};

--- a/shell/backend/software/surface_sink.h
+++ b/shell/backend/software/surface_sink.h
@@ -18,6 +18,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
+#include <utility>
 
 class TaskRunner;
 typedef void (*VsyncCallback)(void*, intptr_t);
@@ -29,7 +31,7 @@ typedef void (*VsyncCallback)(void*, intptr_t);
 //
 // All Present() calls fire on Flutter's rasterizer thread. The buffer
 // pointer is only valid for the duration of the call — copy if you
-// need to retain. Pixel format is Skia's kN32_SkColorType:
+// need to retain it. Pixel format is Skia's kN32_SkColorType:
 // little-endian hosts deliver premultiplied BGRA8888 (memory bytes
 // [B, G, R, A]); big-endian hosts deliver RGBA8888. Sinks targeting a
 // named on-wire format should route through `pixel_swizzle.h` so the
@@ -54,7 +56,18 @@ class ISurfaceSink {
   // own framebuffers (fbdev, drm-dumb) use this to (re)allocate.
   virtual void OnSize(uint32_t /*width*/, uint32_t /*height*/) {}
 
-  // True when the sink has a real vblank source it can drive Flutter's
+  // The sink's native output extent (the DRM mode / fbdev virtual size),
+  // when it drives a fixed-size display. The SoftwareBackend adopts this as
+  // the engine viewport + seat coordinate space so Flutter renders at the
+  // panel's native resolution (fills + centers, and the pointer/cursor share
+  // the framebuffer's coordinate space). nullopt for sinks with no inherent
+  // size (file / memory / none).
+  [[nodiscard]] virtual std::optional<std::pair<uint32_t, uint32_t>>
+  NativeSize() const {
+    return std::nullopt;
+  }
+
+  // True, when the sink has a real vblank source, it can drive Flutter's
   // vsync_callback from. SoftwareBackend's GetVsyncCallback() returns
   // a trampoline iff this is true.
   [[nodiscard]] virtual bool SupportsVsync() const { return false; }

--- a/shell/backend/software/surface_sink.h
+++ b/shell/backend/software/surface_sink.h
@@ -18,10 +18,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <utility>
 
 class TaskRunner;
+class SoftwareCursor;
 typedef void (*VsyncCallback)(void*, intptr_t);
 
 // Pluggable output destination for SoftwareBackend's
@@ -55,6 +57,11 @@ class ISurfaceSink {
   // geometry is known) and on every Resize. Sinks that allocate their
   // own framebuffers (fbdev, drm-dumb) use this to (re)allocate.
   virtual void OnSize(uint32_t /*width*/, uint32_t /*height*/) {}
+
+  // Install the software mouse cursor (shared with the seat, which updates its
+  // position). Device sinks (drm-dumb) composite it onto each frame; the
+  // headless sinks (file/memory/none) inherit this no-op.
+  virtual void SetCursor(std::shared_ptr<SoftwareCursor> /*cursor*/) {}
 
   // The sink's native output extent (the DRM mode / fbdev virtual size),
   // when it drives a fixed-size display. The SoftwareBackend adopts this as

--- a/shell/display/software_display.cc
+++ b/shell/display/software_display.cc
@@ -18,6 +18,7 @@
 
 #include <utility>
 
+#include "backend/software/input/software_seat.h"
 #include "input/iseat.h"
 
 SoftwareDisplay::SoftwareDisplay(const int32_t width,
@@ -29,6 +30,17 @@ SoftwareDisplay::~SoftwareDisplay() = default;
 
 void SoftwareDisplay::SetSeat(std::unique_ptr<homescreen::ISeat> seat) {
   seat_ = std::move(seat);
+}
+
+void SoftwareDisplay::SetViewportSize(const int32_t width,
+                                      const int32_t height) {
+  width_ = width;
+  height_ = height;
+  // SetViewport is SoftwareSeat-specific (not on ISeat), so downcast — the
+  // only seat type a SoftwareDisplay ever holds.
+  if (auto* sw_seat = dynamic_cast<homescreen::SoftwareSeat*>(seat_.get())) {
+    sw_seat->SetViewport(width, height);
+  }
 }
 
 void SoftwareDisplay::StartEvents() {

--- a/shell/display/software_display.cc
+++ b/shell/display/software_display.cc
@@ -43,6 +43,13 @@ void SoftwareDisplay::SetViewportSize(const int32_t width,
   }
 }
 
+void SoftwareDisplay::SetCursor(std::shared_ptr<SoftwareCursor> cursor) {
+  cursor_ = std::move(cursor);
+  if (auto* sw_seat = dynamic_cast<homescreen::SoftwareSeat*>(seat_.get())) {
+    sw_seat->SetCursor(cursor_);
+  }
+}
+
 void SoftwareDisplay::StartEvents() {
   if (seat_) {
     seat_->Start();

--- a/shell/display/software_display.h
+++ b/shell/display/software_display.h
@@ -20,6 +20,8 @@
 
 #include "display/idisplay.h"
 
+class SoftwareCursor;
+
 namespace homescreen {
 class ISeat;
 }  // namespace homescreen
@@ -45,6 +47,14 @@ class SoftwareDisplay final : public IDisplay {
   // FlutterView once the SoftwareBackend has adopted the sink mode, so the
   // pointer coordinate space matches the framebuffer.
   void SetViewportSize(int32_t width, int32_t height);
+
+  // Install the shared software cursor (created in app.cc when enabled). Stored
+  // here so it outlives both the seat and the sink, and forwarded to the seat.
+  // FlutterView reads cursor() to hand it to the backend's sink.
+  void SetCursor(std::shared_ptr<SoftwareCursor> cursor);
+  [[nodiscard]] const std::shared_ptr<SoftwareCursor>& cursor() const {
+    return cursor_;
+  }
 
   void StartEvents() override;
   void StopEvents() override;
@@ -81,4 +91,5 @@ class SoftwareDisplay final : public IDisplay {
   double refresh_rate_hz_;
   FlutterDesktopViewControllerState* view_controller_state_ = nullptr;
   std::unique_ptr<homescreen::ISeat> seat_;
+  std::shared_ptr<SoftwareCursor> cursor_;
 };

--- a/shell/display/software_display.h
+++ b/shell/display/software_display.h
@@ -40,6 +40,12 @@ class SoftwareDisplay final : public IDisplay {
   // pointer / keyboard events drive Flutter.
   void SetSeat(std::unique_ptr<homescreen::ISeat> seat);
 
+  // Resize the seat's pointer-clamp viewport to the backend's resolved size
+  // (the sink's native mode). Mirrors DrmDisplay::SetViewportSize; called by
+  // FlutterView once the SoftwareBackend has adopted the sink mode, so the
+  // pointer coordinate space matches the framebuffer.
+  void SetViewportSize(int32_t width, int32_t height);
+
   void StartEvents() override;
   void StopEvents() override;
   [[nodiscard]] int PollEvents() const override { return 0; }

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -28,9 +28,11 @@
 #include <algorithm>
 #include <atomic>
 #include <cerrno>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <variant>
@@ -214,32 +216,38 @@ bool DrmSeat::Start() {
   seat_->set_event_handler(
       [this](const drm::input::InputEvent& ev) { HandleEvent(ev); });
 
-  // drm-cxx leaves KeyboardEvent::sym/utf8 zero unless the caller runs
-  // events through a Keyboard (xkbcommon state machine). Without this,
-  // every key is dropped at the sym==0 check in HandleKeyboard.
-  auto kb = drm::input::Keyboard::create();
-  if (!kb) {
-    spdlog::error("[DrmSeat] xkb keymap create failed: {}",
-                  kb.error().message());
+  // Keyboard translation comes from the backend-shared XkbKeyboard (xkbcommon
+  // state machine), the same path SoftwareSeat uses. drm::input::Seat leaves
+  // KeyboardEvent::sym/utf8 zero; HandleKeyboard fills them in, otherwise every
+  // key is dropped at the sym==0 check in DispatchKeyToFlutter.
+  keyboard_ = input::XkbKeyboard::Create();
+  if (!keyboard_) {
+    spdlog::error("[DrmSeat] XkbKeyboard::Create failed");
     return false;
   }
-  keyboard_ = std::make_unique<drm::input::Keyboard>(std::move(*kb));
 
-  // Auto-repeat for held keys. libinput doesn't repeat by design — the
-  // compositor/embedder synthesizes it. KeyRepeater is timerfd-driven and
-  // re-resolves sym/utf8 every tick so modifier changes mid-hold (Shift,
-  // AltGr) apply to the next repeat. Failure is non-fatal: zero repeat
-  // events still beats failing to start. IVI_DRM_KEY_REPEAT=0 disables.
+  // Auto-repeat for held keys (libinput doesn't repeat by design — the embedder
+  // synthesizes it). The shared KeyRepeater is timerfd-driven and re-resolves
+  // sym/utf8 every tick so modifier changes mid-hold (Shift, AltGr) apply to
+  // the next repeat. Failure is non-fatal. IVI_DRM_KEY_REPEAT=0 disables.
   const char* repeat_gate = std::getenv("IVI_DRM_KEY_REPEAT");
   if (repeat_gate == nullptr || std::string_view(repeat_gate) != "0") {
-    if (auto rep = drm::input::KeyRepeater::create(keyboard_.get())) {
-      repeater_.emplace(std::move(*rep));
-      repeater_->set_handler([this](const drm::input::KeyboardEvent& e) {
-        DispatchKeyToFlutter(e);
-      });
+    repeater_ = input::KeyRepeater::Create(keyboard_.get());
+    if (repeater_) {
+      repeater_->SetHandler(
+          [this](uint32_t key, xkb_keysym_t sym, const std::string& utf8) {
+            // Re-pack the synthesized repeat into the drm-cxx KeyboardEvent
+            // carrier that DispatchKeyToFlutter consumes.
+            drm::input::KeyboardEvent e{};
+            e.key = key;
+            e.pressed = true;
+            e.repeat = true;
+            e.sym = sym;
+            std::snprintf(e.utf8, sizeof(e.utf8), "%s", utf8.c_str());
+            DispatchKeyToFlutter(e);
+          });
     } else {
-      spdlog::warn("[DrmSeat] KeyRepeater unavailable: {}",
-                   rep.error().message());
+      spdlog::warn("[DrmSeat] KeyRepeater unavailable (timerfd_create)");
     }
   }
 
@@ -256,7 +264,7 @@ void DrmSeat::Stop() {
   }
   // Defensive: cancel any in-flight repeat before the repeater destructs.
   if (repeater_) {
-    repeater_->cancel();
+    repeater_->Cancel();
   }
   seat_.reset();
 
@@ -352,7 +360,7 @@ void DrmSeat::DispatchLoop() {
           repeater_.reset();
           repeat_fd = -1;
         } else if ((pfds[1].revents & POLLIN) != 0) {
-          repeater_->dispatch();
+          repeater_->Dispatch();
         }
       }
     }
@@ -440,18 +448,18 @@ void DrmSeat::ApplyPendingKeymap() {
   if (!cfg || !keyboard_) {
     return;
   }
-  drm::input::KeymapOptions opts;
+  input::KeymapOptions opts;
   opts.rules = cfg->rules;
   opts.model = cfg->model;
   opts.layout = cfg->layout;
   opts.variant = cfg->variant;
   opts.options = cfg->options;
-  if (auto r = keyboard_->reload(opts); !r) {
+  if (!keyboard_->Reload(opts)) {
     spdlog::warn(
         "[DrmSeat] keymap reload failed (rules='{}' model='{}' layout='{}' "
-        "variant='{}' options='{}'): {} — existing keymap kept",
+        "variant='{}' options='{}') — existing keymap kept",
         Sanitize(cfg->rules), Sanitize(cfg->model), Sanitize(cfg->layout),
-        Sanitize(cfg->variant), Sanitize(cfg->options), r.error().message());
+        Sanitize(cfg->variant), Sanitize(cfg->options));
     return;
   }
   spdlog::info(
@@ -462,14 +470,20 @@ void DrmSeat::ApplyPendingKeymap() {
   if (seat_) {
     // Push the latched Caps/Num/Scroll Lock state to physical LEDs so
     // they don't lag the freshly-rebuilt xkb state.
-    seat_->update_keyboard_leds(keyboard_->leds_state());
+    const auto leds = keyboard_->Leds();
+    seat_->update_keyboard_leds(drm::input::KeyboardLeds{
+        leds.caps_lock, leds.num_lock, leds.scroll_lock});
   }
 }
 
 void DrmSeat::HandleKeyboard(const drm::input::KeyboardEvent& ev) {
   drm::input::KeyboardEvent resolved = ev;
   if (keyboard_) {
-    keyboard_->process_key(resolved);
+    // Fill sym/utf8 and advance modifier state (the chord check below and the
+    // repeater's per-key eligibility both rely on the updated state).
+    std::string utf8;
+    resolved.sym = keyboard_->ProcessKey(ev.key, ev.pressed, &utf8);
+    std::snprintf(resolved.utf8, sizeof(resolved.utf8), "%s", utf8.c_str());
   }
 
   // VT-switch chord interception. With K_OFF the kernel keymap layer
@@ -481,7 +495,7 @@ void DrmSeat::HandleKeyboard(const drm::input::KeyboardEvent& ev) {
   // (Ctrl/Alt themselves) skip this entirely so they still latch the
   // keyboard_ state above.
   if (resolved.pressed && !resolved.repeat && keyboard_ &&
-      keyboard_->ctrl_active() && keyboard_->alt_active()) {
+      keyboard_->CtrlActive() && keyboard_->AltActive()) {
     int vt = 0;
     switch (resolved.key) {
       case KEY_F1:
@@ -537,11 +551,11 @@ void DrmSeat::HandleKeyboard(const drm::input::KeyboardEvent& ev) {
     }
   }
 
-  // Track press/release in the repeater so it arms on press of an
-  // eligible key and cancels on release. The repeater filters its own
-  // synthesized events out of on_key (event.repeat == true is dropped).
+  // Track press/release in the repeater so it arms on press of an eligible key
+  // and disarms on release. Only real events are fed here; synthesized repeats
+  // come from the repeater's own handler, never back through HandleKeyboard.
   if (repeater_) {
-    repeater_->on_key(ev);
+    repeater_->OnKey(ev.key, ev.pressed);
   }
   DispatchKeyToFlutter(resolved);
 }

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -37,16 +37,26 @@
 #include <utility>
 #include <variant>
 
+#include <xkbcommon/xkbcommon-keysyms.h>
+
 #include "asio/dispatch.hpp"
 #include "asio/post.hpp"
 #include "backend/drm_kms_egl/drm_cursor.h"
 #include "engine.h"
-#include "input/key_mapping.h"
 #include "libflutter_engine.h"
 #include "logging.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #include "shell/platform/homescreen/flutter_desktop_view_controller_state.h"
 #include "task_runner.h"
+
+// Defined in flutter_desktop.cc. Fans a key event out to the platform
+// keyboard-hook handlers (flutter/keyevent channel + TextInputPlugin) — the
+// same entry point the Wayland and software seats dispatch through.
+extern void KeyCallback(FlutterDesktopViewControllerState* view_state,
+                        bool released,
+                        xkb_keysym_t keysym,
+                        uint32_t xkb_scancode,
+                        uint32_t modifiers);
 
 namespace homescreen {
 namespace {
@@ -250,6 +260,10 @@ bool DrmSeat::Start() {
       spdlog::warn("[DrmSeat] KeyRepeater unavailable (timerfd_create)");
     }
   }
+
+  // Sync the physical LEDs to the keyboard's initial (all-off) latch so a
+  // console that left Caps/Num lit doesn't stay stuck on after we take over.
+  SyncKeyboardLeds();
 
   stop_.store(false, std::memory_order_release);
   thread_ = std::thread([this] { DispatchLoop(); });
@@ -467,13 +481,18 @@ void DrmSeat::ApplyPendingKeymap() {
       "variant='{}' options='{}')",
       Sanitize(cfg->rules), Sanitize(cfg->model), Sanitize(cfg->layout),
       Sanitize(cfg->variant), Sanitize(cfg->options));
-  if (seat_) {
-    // Push the latched Caps/Num/Scroll Lock state to physical LEDs so
-    // they don't lag the freshly-rebuilt xkb state.
-    const auto leds = keyboard_->Leds();
-    seat_->update_keyboard_leds(drm::input::KeyboardLeds{
-        leds.caps_lock, leds.num_lock, leds.scroll_lock});
+  // Push the latched Caps/Num/Scroll Lock state to the physical LEDs so they
+  // don't lag the freshly-rebuilt xkb state.
+  SyncKeyboardLeds();
+}
+
+void DrmSeat::SyncKeyboardLeds() {
+  if (seat_ == nullptr || keyboard_ == nullptr) {
+    return;
   }
+  const auto leds = keyboard_->Leds();
+  seat_->update_keyboard_leds(drm::input::KeyboardLeds{
+      leds.caps_lock, leds.num_lock, leds.scroll_lock});
 }
 
 void DrmSeat::HandleKeyboard(const drm::input::KeyboardEvent& ev) {
@@ -558,60 +577,31 @@ void DrmSeat::HandleKeyboard(const drm::input::KeyboardEvent& ev) {
     repeater_->OnKey(ev.key, ev.pressed);
   }
   DispatchKeyToFlutter(resolved);
+
+  // A lock key just toggled the xkb latch — refresh the physical LEDs (the Seat
+  // doesn't track the latch itself).
+  if (resolved.sym == XKB_KEY_Caps_Lock || resolved.sym == XKB_KEY_Num_Lock ||
+      resolved.sym == XKB_KEY_Scroll_Lock) {
+    SyncKeyboardLeds();
+  }
 }
 
 void DrmSeat::DispatchKeyToFlutter(
     const drm::input::KeyboardEvent& resolved) const {
-  const uint64_t physical = keys::EvdevToPhysical(resolved.key);
-  const uint64_t logical = keys::DeriveLogicalKey(resolved.utf8, resolved.sym);
-
-  if (physical == 0 || logical == 0) {
-    spdlog::warn(
-        "[DrmSeat] dropping key={} sym=0x{:x} utf8='{}' (phys=0x{:x} "
-        "log=0x{:x})",
-        resolved.key, resolved.sym, resolved.utf8, physical, logical);
-    return;
-  }
-
   auto* s = state_.load(std::memory_order_acquire);
-  if (!s || !s->engine) {
+  if (s == nullptr) {
     return;
   }
-
-  FlutterKeyEvent ke{};
-  ke.struct_size = sizeof(FlutterKeyEvent);
-  ke.timestamp = static_cast<double>(FlutterTimestampMicros());
-  if (resolved.repeat) {
-    ke.type = kFlutterKeyEventTypeRepeat;
-  } else if (resolved.pressed) {
-    ke.type = kFlutterKeyEventTypeDown;
-  } else {
-    ke.type = kFlutterKeyEventTypeUp;
-  }
-  ke.physical = physical;
-  ke.logical = logical;
-  ke.synthesized = false;
-  ke.device_type = kFlutterKeyEventDeviceTypeKeyboard;
-
-  // Flutter's hardware_keyboard.dart asserts that `character` is null
-  // for KEY_UP, synthesized, and repeat events. Attach it only to the
-  // initial DOWN transition.
-  std::string character_owned;
-  if (resolved.pressed && !resolved.repeat && resolved.utf8[0] != '\0') {
-    character_owned = resolved.utf8;
-  }
-
-  auto* runner = s->engine->GetPlatformTaskRunner();
-  auto engine_handle = s->engine->GetFlutterEngine();
-  if (runner && engine_handle) {
-    asio::post(*runner->GetStrandContext(),
-               [engine_handle, ke, ch = std::move(character_owned)]() {
-                 FlutterKeyEvent event = ke;
-                 event.character = ch.empty() ? nullptr : ch.c_str();
-                 LibFlutterEngine->SendKeyEvent(engine_handle, &event, nullptr,
-                                                nullptr);
-               });
-  }
+  // Route through KeyCallback → the platform keyboard-hook handlers
+  // (KeyEventHandler's flutter/keyevent channel + TextInputPlugin), exactly as
+  // the Wayland and software backends do. That is the path the framework
+  // actually consumes for text editing and Tab/arrow/lock keys. The DRM backend
+  // previously used only the embedder SendKeyEvent (HardwareKeyboard) path,
+  // which this app doesn't observe — so non-printable keys were silently
+  // dropped while printable ones happened to round-trip. Going through
+  // KeyCallback makes keyboard behavior identical across all three backends.
+  const uint32_t modifiers = keyboard_ ? keyboard_->Modifiers() : 0;
+  KeyCallback(s, !resolved.pressed, resolved.sym, resolved.key + 8, modifiers);
 }
 
 void DrmSeat::HandlePointerMotion(const drm::input::PointerMotionEvent& ev) {

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -133,6 +133,10 @@ class DrmSeat final : public ISeat {
   void HandleEvent(const drm::input::InputEvent& ev);
   void HandleKeyboard(const drm::input::KeyboardEvent& ev);
   void DispatchKeyToFlutter(const drm::input::KeyboardEvent& resolved) const;
+  // Push the keyboard's current Caps/Num/Scroll latch to the physical LEDs.
+  // The Seat only re-applies LEDs on device-add, so this must be called at
+  // startup and whenever a lock key toggles.
+  void SyncKeyboardLeds();
   void HandlePointerMotion(const drm::input::PointerMotionEvent& ev);
   void HandlePointerButton(const drm::input::PointerButtonEvent& ev);
   void HandlePointerAxis(const drm::input::PointerAxisEvent& ev) const;

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -24,13 +24,17 @@
 #include <string>
 #include <thread>
 
-#include <drm-cxx/input/key_repeater.hpp>
+// drm::input::Seat (input events + device opening + VT suspend/resume) and the
+// KeyboardEvent / KeyboardLeds data types stay; keyboard translation + repeat
+// now come from the backend-shared input core below.
 #include <drm-cxx/input/keyboard.hpp>
 #include <drm-cxx/input/seat.hpp>
 
 #include <shell/platform/embedder/embedder.h>
 
 #include "input/iseat.h"
+#include "input/key_repeater.h"
+#include "input/xkb_keyboard.h"
 
 namespace homescreen {
 
@@ -152,10 +156,11 @@ class DrmSeat final : public ISeat {
   drm::input::InputDeviceOpener opener_;
 
   std::unique_ptr<drm::input::Seat> seat_;
-  std::unique_ptr<drm::input::Keyboard> keyboard_;
-  // Synthesizes auto-repeat KeyboardEvents for held keys. Absent when
-  // disabled via IVI_DRM_KEY_REPEAT=0 or when KeyRepeater::create fails.
-  std::optional<drm::input::KeyRepeater> repeater_;
+  // Backend-shared keyboard translation + auto-repeat (shell/input/), the same
+  // path SoftwareSeat uses. repeater_ is null when disabled via
+  // IVI_DRM_KEY_REPEAT=0 or when its timerfd can't be created.
+  std::unique_ptr<input::XkbKeyboard> keyboard_;
+  std::unique_ptr<input::KeyRepeater> repeater_;
   std::thread thread_;
   std::atomic<bool> stop_{false};
 

--- a/shell/input/key_repeater.cc
+++ b/shell/input/key_repeater.cc
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "input/key_repeater.h"
+
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <ctime>
+
+#include "input/xkb_keyboard.h"
+
+namespace homescreen::input {
+
+namespace {
+
+timespec MsToTimespec(uint32_t ms) {
+  return timespec{static_cast<time_t>(ms / 1000),
+                  static_cast<long>((ms % 1000) * 1'000'000L)};
+}
+
+}  // namespace
+
+std::unique_ptr<KeyRepeater> KeyRepeater::Create(const XkbKeyboard* keyboard,
+                                                 RepeatConfig cfg) {
+  if (keyboard == nullptr) {
+    return nullptr;
+  }
+  const int fd = ::timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+  if (fd < 0) {
+    return nullptr;
+  }
+  return std::unique_ptr<KeyRepeater>(new KeyRepeater(keyboard, cfg, fd));
+}
+
+KeyRepeater::KeyRepeater(const XkbKeyboard* keyboard,
+                         RepeatConfig cfg,
+                         int timer_fd)
+    : kb_(keyboard), cfg_(cfg), timer_fd_(timer_fd) {}
+
+KeyRepeater::~KeyRepeater() {
+  if (timer_fd_ >= 0) {
+    ::close(timer_fd_);
+  }
+}
+
+void KeyRepeater::OnKey(const uint32_t evdev_keycode, const bool pressed) {
+  if (pressed) {
+    // Only repeatable keys arm; a non-repeating press (Shift/Ctrl/dead key)
+    // leaves any in-flight repeat alone. The most recently pressed repeatable
+    // key wins (matches wl_keyboard.repeat_info and desktop UX).
+    if (kb_->KeyRepeats(evdev_keycode)) {
+      held_key_ = evdev_keycode;
+      is_held_ = true;
+      Arm();
+    }
+  } else if (is_held_ && evdev_keycode == held_key_) {
+    is_held_ = false;
+    Disarm();
+  }
+}
+
+void KeyRepeater::Arm() {
+  if (timer_fd_ < 0) {
+    return;
+  }
+  // Fire once after the initial delay, then every interval.
+  const itimerspec its{MsToTimespec(cfg_.interval_ms),
+                       MsToTimespec(cfg_.delay_ms)};
+  ::timerfd_settime(timer_fd_, 0, &its, nullptr);
+}
+
+void KeyRepeater::Disarm() {
+  if (timer_fd_ < 0) {
+    return;
+  }
+  const itimerspec its{};  // all-zero disarms
+  ::timerfd_settime(timer_fd_, 0, &its, nullptr);
+}
+
+void KeyRepeater::Dispatch() {
+  if (timer_fd_ < 0) {
+    return;
+  }
+  uint64_t expirations = 0;
+  // Drain the timerfd; the count is consumed but we emit a single repeat per
+  // dispatch (the poll loop runs at least as often as the interval, and
+  // emitting a burst on a stalled loop would just spam stale events).
+  const ssize_t n = ::read(timer_fd_, &expirations, sizeof(expirations));
+  (void)n;
+  if (!is_held_ || !handler_) {
+    return;
+  }
+  std::string utf8;
+  const xkb_keysym_t sym = kb_->ResolveSym(held_key_, &utf8);
+  handler_(held_key_, sym, utf8);
+}
+
+void KeyRepeater::Cancel() {
+  is_held_ = false;
+  Disarm();
+}
+
+}  // namespace homescreen::input

--- a/shell/input/key_repeater.h
+++ b/shell/input/key_repeater.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <xkbcommon/xkbcommon.h>
+
+namespace homescreen::input {
+
+class XkbKeyboard;
+
+// Auto-repeat timing. Defaults match X11/Wayland convention (600 ms initial
+// delay, 25 Hz thereafter) — and, deliberately, drm-cxx's KeyRepeater, so every
+// backend repeats identically.
+struct RepeatConfig {
+  uint32_t delay_ms{600};
+  uint32_t interval_ms{40};  // 25 Hz (1000 / 40)
+};
+
+// timerfd-driven key auto-repeat shared by every libinput-backed seat. The
+// kernel does not synthesize repeats for evdev/libinput, so each seat: feeds
+// every real key into OnKey(), polls fd() alongside its libinput fd, and calls
+// Dispatch() when fd() is readable. Synthesized repeats are delivered through
+// the handler with the keysym/UTF-8 RE-RESOLVED against the keyboard's current
+// state each tick (so Shift/AltGr level changes mid-hold take effect on the
+// next repeat). Per-key eligibility comes from XkbKeyboard::KeyRepeats(), so
+// modifiers / lock / dead keys never repeat. Single-threaded: all calls from
+// the owning input-dispatch thread.
+class KeyRepeater {
+ public:
+  // handler(evdev_keycode, keysym, utf8) — called once per repeat tick.
+  using Handler =
+      std::function<void(uint32_t, xkb_keysym_t, const std::string&)>;
+
+  // @p keyboard must outlive the repeater (the seat owns both). Returns nullptr
+  // if the timerfd can't be created (the seat then runs with no auto-repeat).
+  static std::unique_ptr<KeyRepeater> Create(const XkbKeyboard* keyboard,
+                                             RepeatConfig cfg = {});
+
+  ~KeyRepeater();
+  KeyRepeater(const KeyRepeater&) = delete;
+  KeyRepeater& operator=(const KeyRepeater&) = delete;
+
+  void SetHandler(Handler handler) { handler_ = std::move(handler); }
+
+  // Feed a real key event. Pressing a repeatable key (re)arms the repeat with
+  // that key as the held key (most-recent wins). Releasing the held key
+  // disarms. A non-repeating press leaves an existing repeat undisturbed.
+  void OnKey(uint32_t evdev_keycode, bool pressed);
+
+  // timerfd for poll/epoll integration. -1 if unavailable (no repeat).
+  [[nodiscard]] int fd() const noexcept { return timer_fd_; }
+
+  // Drain the timerfd and emit one repeat for the held key (if any).
+  void Dispatch();
+
+  // Drop any in-flight repeat — e.g. on session pause / focus loss.
+  void Cancel();
+
+  [[nodiscard]] uint32_t held_key() const noexcept {
+    return is_held_ ? held_key_ : 0;
+  }
+
+ private:
+  KeyRepeater(const XkbKeyboard* keyboard, RepeatConfig cfg, int timer_fd);
+  void Arm();
+  void Disarm();
+
+  const XkbKeyboard* kb_;
+  RepeatConfig cfg_;
+  Handler handler_;
+  int timer_fd_{-1};
+  uint32_t held_key_{0};
+  bool is_held_{false};
+};
+
+}  // namespace homescreen::input

--- a/shell/input/xkb_keyboard.cc
+++ b/shell/input/xkb_keyboard.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "input/xkb_keyboard.h"
+
+#include <vector>
+
+namespace homescreen::input {
+
+namespace {
+
+// evdev keycodes are offset by 8 from xkb's scancode space — the universal
+// Linux convention.
+constexpr uint32_t kEvdevXkbOffset = 8;
+
+// Build a keymap from RMLVO options. Empty fields fall through to xkbcommon's
+// compiled-in defaults and the XKB_DEFAULT_* env vars (passing a names struct
+// of all-NULL is equivalent to xkb_keymap_new_from_names(ctx, nullptr, ...)).
+xkb_keymap* CompileKeymap(xkb_context* ctx, const KeymapOptions& opts) {
+  const xkb_rule_names names{
+      opts.rules.empty() ? nullptr : opts.rules.c_str(),
+      opts.model.empty() ? nullptr : opts.model.c_str(),
+      opts.layout.empty() ? nullptr : opts.layout.c_str(),
+      opts.variant.empty() ? nullptr : opts.variant.c_str(),
+      opts.options.empty() ? nullptr : opts.options.c_str(),
+  };
+  const bool any = !opts.rules.empty() || !opts.model.empty() ||
+                   !opts.layout.empty() || !opts.variant.empty() ||
+                   !opts.options.empty();
+  return xkb_keymap_new_from_names(ctx, any ? &names : nullptr,
+                                   XKB_KEYMAP_COMPILE_NO_FLAGS);
+}
+
+std::string Utf8For(xkb_state* state, uint32_t scancode) {
+  const int n = xkb_state_key_get_utf8(state, scancode, nullptr, 0);
+  if (n <= 0) {
+    return {};
+  }
+  std::string out(static_cast<size_t>(n), '\0');
+  // Buffer must hold the NUL too; n excludes it, so size n+1.
+  out.resize(static_cast<size_t>(n) + 1);
+  xkb_state_key_get_utf8(state, scancode, out.data(), out.size());
+  out.resize(static_cast<size_t>(n));  // drop the trailing NUL
+  return out;
+}
+
+bool LedActive(xkb_state* state, const char* name) {
+  return xkb_state_led_name_is_active(state, name) > 0;
+}
+
+}  // namespace
+
+std::unique_ptr<XkbKeyboard> XkbKeyboard::Create(const KeymapOptions& opts) {
+  xkb_context* ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+  if (ctx == nullptr) {
+    return nullptr;
+  }
+  xkb_keymap* keymap = CompileKeymap(ctx, opts);
+  if (keymap == nullptr) {
+    xkb_context_unref(ctx);
+    return nullptr;
+  }
+  xkb_state* state = xkb_state_new(keymap);
+  if (state == nullptr) {
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(ctx);
+    return nullptr;
+  }
+  return std::unique_ptr<XkbKeyboard>(new XkbKeyboard(ctx, keymap, state));
+}
+
+XkbKeyboard::XkbKeyboard(xkb_context* ctx, xkb_keymap* keymap, xkb_state* state)
+    : ctx_(ctx), keymap_(keymap), state_(state) {}
+
+XkbKeyboard::~XkbKeyboard() {
+  if (state_ != nullptr) {
+    xkb_state_unref(state_);
+  }
+  if (keymap_ != nullptr) {
+    xkb_keymap_unref(keymap_);
+  }
+  if (ctx_ != nullptr) {
+    xkb_context_unref(ctx_);
+  }
+}
+
+xkb_keysym_t XkbKeyboard::ProcessKey(const uint32_t evdev_keycode,
+                                     const bool pressed,
+                                     std::string* utf8_out) {
+  const uint32_t scancode = evdev_keycode + kEvdevXkbOffset;
+  const xkb_keysym_t sym = xkb_state_key_get_one_sym(state_, scancode);
+  if (utf8_out != nullptr) {
+    *utf8_out = Utf8For(state_, scancode);
+  }
+  xkb_state_update_key(state_, scancode, pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
+  return sym;
+}
+
+xkb_keysym_t XkbKeyboard::ResolveSym(const uint32_t evdev_keycode,
+                                     std::string* utf8_out) const {
+  const uint32_t scancode = evdev_keycode + kEvdevXkbOffset;
+  if (utf8_out != nullptr) {
+    *utf8_out = Utf8For(state_, scancode);
+  }
+  return xkb_state_key_get_one_sym(state_, scancode);
+}
+
+bool XkbKeyboard::KeyRepeats(const uint32_t evdev_keycode) const {
+  return xkb_keymap_key_repeats(keymap_, evdev_keycode + kEvdevXkbOffset) != 0;
+}
+
+uint32_t XkbKeyboard::Modifiers() const {
+  return xkb_state_serialize_mods(state_, XKB_STATE_MODS_EFFECTIVE);
+}
+
+LedState XkbKeyboard::Leds() const {
+  return LedState{
+      LedActive(state_, XKB_LED_NAME_CAPS),
+      LedActive(state_, XKB_LED_NAME_NUM),
+      LedActive(state_, XKB_LED_NAME_SCROLL),
+  };
+}
+
+bool XkbKeyboard::Reload(const KeymapOptions& opts) {
+  xkb_keymap* keymap = CompileKeymap(ctx_, opts);
+  if (keymap == nullptr) {
+    return false;
+  }
+  xkb_state* state = xkb_state_new(keymap);
+  if (state == nullptr) {
+    xkb_keymap_unref(keymap);
+    return false;
+  }
+  xkb_state_unref(state_);
+  xkb_keymap_unref(keymap_);
+  keymap_ = keymap;
+  state_ = state;
+  return true;
+}
+
+}  // namespace homescreen::input

--- a/shell/input/xkb_keyboard.cc
+++ b/shell/input/xkb_keyboard.cc
@@ -126,6 +126,16 @@ uint32_t XkbKeyboard::Modifiers() const {
   return xkb_state_serialize_mods(state_, XKB_STATE_MODS_EFFECTIVE);
 }
 
+bool XkbKeyboard::CtrlActive() const {
+  return xkb_state_mod_name_is_active(state_, XKB_MOD_NAME_CTRL,
+                                      XKB_STATE_MODS_EFFECTIVE) > 0;
+}
+
+bool XkbKeyboard::AltActive() const {
+  return xkb_state_mod_name_is_active(state_, XKB_MOD_NAME_ALT,
+                                      XKB_STATE_MODS_EFFECTIVE) > 0;
+}
+
 LedState XkbKeyboard::Leds() const {
   return LedState{
       LedActive(state_, XKB_LED_NAME_CAPS),

--- a/shell/input/xkb_keyboard.h
+++ b/shell/input/xkb_keyboard.h
@@ -80,6 +80,11 @@ class XkbKeyboard {
   // xkbcommon's modifier-index bitspace — handed to the embedder.
   [[nodiscard]] uint32_t Modifiers() const;
 
+  // Whether a Ctrl / Alt modifier is currently effective — for chord detection
+  // (e.g. the VT-switch Ctrl+Alt+Fn) without decoding the raw mask.
+  [[nodiscard]] bool CtrlActive() const;
+  [[nodiscard]] bool AltActive() const;
+
   // Caps/Num/Scroll Lock latch, for drivers that surface keyboard LEDs.
   [[nodiscard]] LedState Leds() const;
 

--- a/shell/input/xkb_keyboard.h
+++ b/shell/input/xkb_keyboard.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <xkbcommon/xkbcommon.h>
+
+namespace homescreen::input {
+
+// RMLVO keymap selector. All-empty uses xkbcommon's compiled-in defaults plus
+// the XKB_DEFAULT_* environment variables (the common case).
+struct KeymapOptions {
+  std::string rules;
+  std::string model;
+  std::string layout;
+  std::string variant;
+  std::string options;
+};
+
+// Caps / Num / Scroll Lock latch snapshot, as tracked by xkb.
+struct LedState {
+  bool caps_lock{false};
+  bool num_lock{false};
+  bool scroll_lock{false};
+};
+
+// Owns an xkbcommon context + keymap + state and translates raw evdev keycodes
+// into keysyms / UTF-8 / modifier masks. Shared by every libinput-backed seat
+// (DrmSeat, SoftwareSeat) so keyboard translation is identical across backends
+// and depends only on libxkbcommon — no drm-cxx.
+//
+// Callers pass RAW libinput keycodes (the evdev value); the universal evdev→xkb
+// +8 offset is applied internally. Single-threaded: all calls must come from
+// the owning input-dispatch thread.
+class XkbKeyboard {
+ public:
+  // Build from RMLVO options (empty = xkb defaults / env). Returns nullptr if
+  // the context, keymap, or state can't be created.
+  static std::unique_ptr<XkbKeyboard> Create(const KeymapOptions& opts = {});
+
+  ~XkbKeyboard();
+  XkbKeyboard(const XkbKeyboard&) = delete;
+  XkbKeyboard& operator=(const XkbKeyboard&) = delete;
+
+  // Resolve the keysym for @p evdev_keycode at the current state AND advance
+  // the modifier state for the press/release. Fills @p utf8_out (if non-null)
+  // with the key's UTF-8 string. Call once per real key event.
+  xkb_keysym_t ProcessKey(uint32_t evdev_keycode,
+                          bool pressed,
+                          std::string* utf8_out = nullptr);
+
+  // Resolve the keysym/UTF-8 for @p evdev_keycode at the current state WITHOUT
+  // mutating it — used by KeyRepeater to re-resolve a held key each tick so a
+  // Shift/AltGr level change mid-hold takes effect on the next repeat.
+  [[nodiscard]] xkb_keysym_t ResolveSym(uint32_t evdev_keycode,
+                                        std::string* utf8_out = nullptr) const;
+
+  // True when the keymap marks @p evdev_keycode as auto-repeating (modifiers /
+  // lock / dead keys are not).
+  [[nodiscard]] bool KeyRepeats(uint32_t evdev_keycode) const;
+
+  // Current effective modifier mask (depressed | latched | locked), in
+  // xkbcommon's modifier-index bitspace — handed to the embedder.
+  [[nodiscard]] uint32_t Modifiers() const;
+
+  // Caps/Num/Scroll Lock latch, for drivers that surface keyboard LEDs.
+  [[nodiscard]] LedState Leds() const;
+
+  // Swap in a new keymap (e.g. layout change). Preserves nothing of the old
+  // latch state. Returns false on failure, leaving the previous keymap intact.
+  bool Reload(const KeymapOptions& opts);
+
+ private:
+  XkbKeyboard(xkb_context* ctx, xkb_keymap* keymap, xkb_state* state);
+
+  xkb_context* ctx_{nullptr};
+  xkb_keymap* keymap_{nullptr};
+  xkb_state* state_{nullptr};
+};
+
+}  // namespace homescreen::input

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -30,6 +30,10 @@
 #include "backend/drm_kms_egl/drm_backend.h"
 #endif
 
+#if BUILD_BACKEND_SOFTWARE
+#include "backend/software/drm_dumb_sink.h"
+#endif
+
 #if BUILD_CRASH_HANDLER
 #include "crash_handler.h"
 #endif
@@ -81,9 +85,11 @@ int main(const int argc, char** argv) {
   auto crash_handler = std::make_unique<CrashHandler>();
 #endif
 
-#if BUILD_BACKEND_DRM_KMS_EGL
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_SOFTWARE
   // Handle --drm-list-modes[=<path>] before the main config parse so the
-  // user doesn't need to supply a bundle path just to inspect modes.
+  // user doesn't need to supply a bundle path just to inspect modes. On
+  // software builds this lists the DRM dumb-sink's modes (the values valid
+  // for IVI_SW_DRM_MODE); on drm-kms-egl it lists the scanout connector's.
   // Device resolution precedence (first match wins):
   //   1. --drm-list-modes=<path> (explicit attached value)
   //   2. --drm-list-modes <path> (next positional, unless it starts with -)
@@ -120,10 +126,17 @@ int main(const int argc, char** argv) {
     }
   }
   if (list_modes_requested) {
+#if BUILD_BACKEND_DRM_KMS_EGL
     if (list_modes_dev.empty()) {
       list_modes_dev = "/dev/dri/card1";
     }
     return PrintDrmModes(list_modes_dev) == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+#else  // BUILD_BACKEND_SOFTWARE
+    // Empty device → PrintDumbSinkModes scans every /dev/dri/card* so the
+    // operator can discover which card to pass to --drm-device.
+    return PrintDumbSinkModes(list_modes_dev) == 0 ? EXIT_SUCCESS
+                                                   : EXIT_FAILURE;
+#endif
   }
 #endif
 

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -536,9 +536,13 @@ void FlutterView::Initialize() {
                  height, static_cast<int>(result));
   }
   // Match the seat's pointer-clamp viewport to the rendered size so the
-  // pointer (and the software cursor) share the framebuffer coordinate space.
+  // pointer (and the software cursor) share the framebuffer coordinate space,
+  // and hand the display's cursor to the sink (which composites it).
   if (auto* sw_display = dynamic_cast<SoftwareDisplay*>(m_display.get())) {
     sw_display->SetViewportSize(width, height);
+    if (auto* sw_backend = dynamic_cast<SoftwareBackend*>(m_backend.get())) {
+      sw_backend->SetCursor(sw_display->cursor());
+    }
   }
 #else
   // Engine events are decoded by surface pointer

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -33,6 +33,7 @@
 #elif BUILD_BACKEND_SOFTWARE
 #include "backend/software/sink_factory.h"
 #include "backend/software/software_backend.h"
+#include "display/software_display.h"
 #elif BUILD_BACKEND_WAYLAND_EGL
 #include "backend/wayland_egl/wayland_egl.h"
 #elif BUILD_BACKEND_WAYLAND_VULKAN
@@ -296,9 +297,13 @@ FlutterView::FlutterView(Configuration::Config config,
     // Sink is picked at startup from IVI_SW_SINK. Default 'none' just
     // discards frames; 'memory' keeps the latest in-process; 'file:
     // <pattern>' writes PAM-format snapshots to disk.
+    // --drm-device (config.view.drm_device) selects the card for the drm-dumb
+    // sink, mirroring drm-kms-egl; empty lets the sink probe the first usable
+    // card. An explicit IVI_SW_SINK=drm-dumb:/dev/dri/cardN still overrides.
     m_backend = std::make_shared<SoftwareBackend>(
         m_config.view.width.value_or(kDefaultViewWidth),
-        m_config.view.height.value_or(kDefaultViewHeight), MakeSinkFromEnv());
+        m_config.view.height.value_or(kDefaultViewHeight),
+        MakeSinkFromEnv(m_config.view.drm_device.value_or(std::string{})));
   }
 #endif
 
@@ -480,12 +485,17 @@ void FlutterView::Initialize() {
   const auto width = static_cast<int32_t>(m_backend->width());
   const auto height = static_cast<int32_t>(m_backend->height());
 #elif BUILD_BACKEND_SOFTWARE
-  // No WaylandWindow + no DRM backend size source — use the config dims
-  // directly.
-  const auto width =
-      static_cast<int32_t>(m_config.view.width.value_or(kDefaultViewWidth));
-  const auto height =
-      static_cast<int32_t>(m_config.view.height.value_or(kDefaultViewHeight));
+  // The SoftwareBackend adopts the sink's native mode (DRM / fbdev) as its
+  // resolved extent; render the engine at that so the frame fills + centers on
+  // the panel instead of being top-left cropped from a config-sized view.
+  // Falls back to the config dims for sinks with no native size (file/memory).
+  auto* sw_backend = dynamic_cast<SoftwareBackend*>(m_backend.get());
+  const auto width = static_cast<int32_t>(
+      sw_backend ? sw_backend->width()
+                 : m_config.view.width.value_or(kDefaultViewWidth));
+  const auto height = static_cast<int32_t>(
+      sw_backend ? sw_backend->height()
+                 : m_config.view.height.value_or(kDefaultViewHeight));
 #else
   auto [width, height] = m_wayland_window->GetSize();
 #endif
@@ -524,6 +534,11 @@ void FlutterView::Initialize() {
         static_cast<size_t>(height), static_cast<size_t>(width));
     spdlog::info("[SoftwareBackend] SendWindowMetrics {}x{} result={}", width,
                  height, static_cast<int>(result));
+  }
+  // Match the seat's pointer-clamp viewport to the rendered size so the
+  // pointer (and the software cursor) share the framebuffer coordinate space.
+  if (auto* sw_display = dynamic_cast<SoftwareDisplay*>(m_display.get())) {
+    sw_display->SetViewportSize(width, height);
   }
 #else
   // Engine events are decoded by surface pointer


### PR DESCRIPTION
Brings the software backend to parity with the DRM backends and unifies keyboard handling across all libinput-backed seats. Validated on a Radxa Zero 3 (RK3566).

## Software backend parity
- **Native-mode sizing** — the software backend rendered at the config view size while the DRM dumb sink drove the panel's native mode, cropping/letterboxing the frame. `ISurfaceSink::NativeSize()` lets the backend adopt the sink's mode; the CI sinks (file/memory/none) return nullopt and stay strictly size-based — no mode query, no DRM device opened.
- **Mode/card selection** — `IVI_SW_DRM_MODE="<W>x<H>[@<R>]"`, `--drm-list-modes` (per-card, or scan every `/dev/dri/card*` with driver name), and `--drm-device` for the dumb sink.
- **Composited cursor** — a dependency-light embedded-arrow cursor (no libxcursor) blended into the dumb buffer; tracks the pointer and schedules a frame on motion so it moves even on an idle UI. Gated by `--disable-cursor` / `IVI_SW_CURSOR=0`.

## Shared keyboard core (`shell/input/`)
- New `XkbKeyboard` + `KeyRepeater` (libxkbcommon only — no drm-cxx, so the minimal-dependency software backend can use them): xkb translation, modifiers, Caps/Num/Scroll LEDs, keymap reload, and timerfd auto-repeat (600 ms / 25 Hz, per-key eligibility, keysym re-resolved each tick).
- Both `SoftwareSeat` and `DrmSeat` now compose these, replacing their divergent xkb + repeat implementations (`DrmSeat` drops drm-cxx's `Keyboard`/`KeyRepeater`; `SoftwareSeat` drops its inline xkb + timerfd).
- `DrmSeat` now dispatches keys via `KeyCallback` — the platform keyboard-hook handlers (KeyEventHandler's `flutter/keyevent` channel + TextInputPlugin), matching the software and wayland backends. The DRM backend previously used only the embedder `SendKeyEvent` (HardwareKeyboard) path, which this app doesn't observe, so Tab/arrows/locks were silently dropped.
- `DrmSeat` forwards Caps/Num/Scroll Lock to the physical LEDs on toggle (`drm::input::Seat` only re-applies LEDs on device-add).

## Validation (Radxa Zero 3 — drm-kms-egl + software)
Printable typing, Shift, key repeat, Tab focus traversal, Caps/Num Lock with LEDs, and the Ctrl+Alt+Fn VT-switch chord (plus libinput suspend/resume across it) all work and behave identically across backends.