### PR TITLE
Unified IVI_PROFILE frame profiler across backends

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(${PROJECT_NAME}
         libflutter_engine.cc
         main.cc
         main_loop_waker.cc
+        profiling/frame_profile.cc
         timer.cc
         view/flutter_view.cc
         watchdog.cc

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -493,6 +493,9 @@ DrmBackend::DrmBackend(const DrmConfig& cfg, homescreen::DrmSession* session)
 }
 
 DrmBackend::~DrmBackend() {
+  // Cadence profile summary (no-op unless IVI_PROFILE / IVI_DRM_PROFILE ran).
+  frame_profile_.LogSessionSummary("DrmBackend");
+
   // Let any in-flight page flip land so we don't free a BO still being
   // scanned out.
   (void)WaitForPendingFlip();
@@ -1285,6 +1288,14 @@ bool DrmBackend::TextureClearCurrent() {
 }
 
 void DrmBackend::RecordFlipComplete() {
+  // Unified cadence profile is independent of the debug_backend FPS line below:
+  // IVI_PROFILE (or legacy IVI_DRM_PROFILE) drives it without needing -d.
+  static const bool profile_enabled =
+      profiling::FrameProfile::Enabled("IVI_DRM_PROFILE");
+  if (profile_enabled) {
+    frame_profile_.Record("DrmBackend", /*ok=*/true,
+                          LibFlutterEngine->GetCurrentTime());
+  }
   if (!cfg_.debug_backend) {
     return;
   }

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -34,6 +34,7 @@
 #include <shell/platform/embedder/embedder.h>
 
 #include "backend/backend.h"
+#include "profiling/frame_profile.h"
 
 class DrmCompositor;
 class TaskRunner;
@@ -353,6 +354,10 @@ class DrmBackend : public Backend {
   uint64_t flip_submit_ns_{0};
   uint32_t frame_count_{0};
   uint64_t fps_epoch_ns_{0};
+  // Unified cadence profiler (IVI_PROFILE / legacy IVI_DRM_PROFILE),
+  // independent of the debug_backend per-second FPS line above. Written from
+  // the rasterizer thread (PageFlipHandler) only.
+  profiling::FrameProfile frame_profile_;
   void RecordFlipComplete();
 
 #if BUILD_COMPOSITOR

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -266,6 +266,8 @@ VulkanDrmBackend::VulkanDrmBackend(std::string drm_device,
       session_(session) {}
 
 VulkanDrmBackend::~VulkanDrmBackend() {
+  // Cadence profile summary (no-op unless IVI_PROFILE / IVI_DRMVK_PROFILE ran).
+  frame_profile_.LogSessionSummary("VulkanDrmBackend");
   // Tear the cursor down first: it commits on compositor_'s DRM device, so it
   // must not outlive it.
   cursor_.reset();
@@ -771,6 +773,12 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
     spdlog::info(
         "[VulkanDrmBackend] presented frame {} slot {} ({}x{}); ring={}", n,
         slot, store->width(), store->height(), c.slots.size());
+  }
+
+  static const bool profile_enabled =
+      profiling::FrameProfile::Enabled("IVI_DRMVK_PROFILE");
+  if (profile_enabled) {
+    frame_profile_.Record("VulkanDrmBackend", /*ok=*/true);
   }
   return true;
 }

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -25,6 +25,7 @@
 
 #include "backend/backend.h"
 #include "backend/drm_kms_vulkan/device_caps.h"
+#include "profiling/frame_profile.h"
 
 namespace homescreen {
 class DrmSession;
@@ -134,6 +135,9 @@ class VulkanDrmBackend final : public Backend {
   std::string drm_device_;
   // Scanout mode selector ("<W>x<H>[@<R>]"); empty = connector preferred mode.
   std::string mode_spec_;
+  // Unified cadence profiler (IVI_PROFILE / legacy IVI_DRMVK_PROFILE). Written
+  // from the rasterizer thread (PresentLayersImpl) only.
+  profiling::FrameProfile frame_profile_;
   bool enable_validation_ = false;
   // Reused by the session/vsync glue in a later change; held now so Create()'s
   // signature and the FlutterView wiring are stable.

--- a/shell/backend/software/software_backend.cc
+++ b/shell/backend/software/software_backend.cc
@@ -197,105 +197,18 @@ void SoftwareBackend::VsyncTrampoline(void* user_data, const intptr_t baton) {
 }
 
 SoftwareBackend::~SoftwareBackend() {
-  // Session-aggregate profile summary (IVI_SW_PROFILE=1). Logged from
-  // the dtor so it captures the whole run regardless of which sink
-  // was active. No-op when the env var was unset (counters never
-  // accumulated).
-  const auto& s = session_totals_;
-  if (s.presented_frames > 0) {
-    const uint32_t samples =
-        (s.interval_sum_ns > 0) ? s.presented_frames - 1 : s.presented_frames;
-    const uint64_t mean_ns = samples > 0 ? s.interval_sum_ns / samples : 0;
-    const double fps = mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
-    const uint32_t total = s.bucket_60hz + s.bucket_30hz + s.bucket_20hz +
-                           s.bucket_slow + s.bucket_idle;
-    spdlog::info(
-        "[SoftwareBackend] session summary: frames={} fps={:.2f} "
-        "mean_interval={}us max_interval={}us present_failures={}",
-        s.presented_frames, fps, mean_ns / 1000, s.interval_max_ns / 1000,
-        s.present_failures);
-    if (total > 0) {
-      const double inv = 100.0 / static_cast<double>(total);
-      spdlog::info(
-          "[SoftwareBackend] session buckets: "
-          "60Hz(≤17ms)={} ({:.1f}%) 30Hz(18-33ms)={} ({:.1f}%) "
-          "20Hz(34-50ms)={} ({:.1f}%) slow(51-100ms)={} ({:.1f}%) "
-          "idle(>100ms)={} ({:.1f}%)",
-          s.bucket_60hz, s.bucket_60hz * inv, s.bucket_30hz,
-          s.bucket_30hz * inv, s.bucket_20hz, s.bucket_20hz * inv,
-          s.bucket_slow, s.bucket_slow * inv, s.bucket_idle,
-          s.bucket_idle * inv);
-    }
-  }
+  // Session-aggregate profile summary. Logged from the dtor so it captures the
+  // whole run regardless of which sink was active. No-op when no frames were
+  // recorded (profiling disabled).
+  profile_.LogSessionSummary("SoftwareBackend");
 }
 
 void SoftwareBackend::ProfilePresent(const bool ok) {
-  // Single env-var probe per process; the lookup is O(strlen) and we
-  // call this on every frame.
-  static const bool profile_enabled = std::getenv("IVI_SW_PROFILE") != nullptr;
+  // Single env-var probe per process; cached because this runs every frame.
+  static const bool profile_enabled =
+      profiling::FrameProfile::Enabled("IVI_SW_PROFILE");
   if (!profile_enabled) {
     return;
   }
-  timespec ts{};
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  const uint64_t now_ns = static_cast<uint64_t>(ts.tv_sec) * 1'000'000'000ULL +
-                          static_cast<uint64_t>(ts.tv_nsec);
-
-  auto& p = profile_;
-  if (!ok) {
-    ++p.present_failures;
-    return;
-  }
-  if (p.last_present_ns != 0) {
-    const uint64_t dt = now_ns - p.last_present_ns;
-    p.interval_sum_ns += dt;
-    if (dt > p.interval_max_ns) {
-      p.interval_max_ns = dt;
-    }
-    // Same bucket thresholds as wayland_egl / wayland_vulkan so
-    // histograms line up across backends.
-    if (dt <= 17'000'000ULL) {
-      ++p.bucket_60hz;
-    } else if (dt <= 33'000'000ULL) {
-      ++p.bucket_30hz;
-    } else if (dt <= 50'000'000ULL) {
-      ++p.bucket_20hz;
-    } else if (dt <= 100'000'000ULL) {
-      ++p.bucket_slow;
-    } else {
-      ++p.bucket_idle;
-    }
-  }
-  p.last_present_ns = now_ns;
-  ++p.presented_frames;
-
-  constexpr uint32_t kProfileWindow = 60;
-  if (p.presented_frames < kProfileWindow) {
-    return;
-  }
-  const uint32_t samples =
-      (p.interval_sum_ns > 0) ? p.presented_frames - 1 : p.presented_frames;
-  const uint64_t mean_ns = samples > 0 ? p.interval_sum_ns / samples : 0;
-  const double fps = mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
-  spdlog::info(
-      "[SoftwareBackend] profile (n={}): fps={:.2f} mean_interval={}us "
-      "max_interval={}us present_failures={} "
-      "buckets[60Hz/30Hz/20Hz/slow/idle]={}/{}/{}/{}/{}",
-      p.presented_frames, fps, mean_ns / 1000, p.interval_max_ns / 1000,
-      p.present_failures, p.bucket_60hz, p.bucket_30hz, p.bucket_20hz,
-      p.bucket_slow, p.bucket_idle);
-
-  auto& s = session_totals_;
-  s.presented_frames += p.presented_frames;
-  s.present_failures += p.present_failures;
-  s.interval_sum_ns += p.interval_sum_ns;
-  if (p.interval_max_ns > s.interval_max_ns) {
-    s.interval_max_ns = p.interval_max_ns;
-  }
-  s.bucket_60hz += p.bucket_60hz;
-  s.bucket_30hz += p.bucket_30hz;
-  s.bucket_20hz += p.bucket_20hz;
-  s.bucket_slow += p.bucket_slow;
-  s.bucket_idle += p.bucket_idle;
-  p = FrameProfile{.last_present_ns = p.last_present_ns};
+  profile_.Record("SoftwareBackend", ok);
 }

--- a/shell/backend/software/software_backend.h
+++ b/shell/backend/software/software_backend.h
@@ -22,6 +22,7 @@
 
 #include "backend/backend.h"
 #include "backend/software/surface_sink.h"
+#include "profiling/frame_profile.h"
 
 class Engine;
 
@@ -108,33 +109,16 @@ class SoftwareBackend final : public Backend {
   // baton to the sink, which owns the vblank-driven baton lifecycle.
   static void VsyncTrampoline(void* user_data, intptr_t baton);
 
-  // Per-frame cadence profile (IVI_SW_PROFILE=1). CLOCK_MONOTONIC
-  // sampled immediately after each successful sink->Present(); the
-  // rasterizer thread is the only writer, so no locks. Same bucket
-  // thresholds as the wayland_egl / wayland_vulkan profilers
-  // (≤17ms / 18-33ms / 34-50ms / 51-100ms / >100ms) so histograms
-  // line up across backends. For sinks that have no real vblank
-  // source (file/memory/fbdev) the histogram measures Flutter's
-  // wall-clock pacing; the DRM dumb sink's strict ping-pong + page-
-  // flip wait makes the same metric reflect actual scanout cadence.
-  struct FrameProfile {
-    uint64_t last_present_ns{0};
-    uint64_t interval_sum_ns{0};
-    uint64_t interval_max_ns{0};
-    uint32_t presented_frames{0};
-    uint32_t present_failures{0};  // sink->Present returned false
-    uint32_t bucket_60hz{0};       // ≤17ms
-    uint32_t bucket_30hz{0};       // 18-33ms
-    uint32_t bucket_20hz{0};       // 34-50ms
-    uint32_t bucket_slow{0};       // 51-100ms
-    uint32_t bucket_idle{0};       // >100ms
-  };
-  FrameProfile profile_{};
-  FrameProfile session_totals_{};
+  // Per-frame cadence profile, enabled by IVI_PROFILE (or the legacy
+  // IVI_SW_PROFILE). CLOCK_MONOTONIC is sampled after each successful
+  // sink->Present() on the rasterizer thread (the only writer, so no locks).
+  // For sinks with no real vblank source (file/memory/fbdev) the histogram
+  // measures Flutter's wall-clock pacing; the DRM dumb sink's strict ping-pong
+  // + page-flip wait makes the same metric reflect actual scanout cadence.
+  profiling::FrameProfile profile_;
 
-  // Called from PresentTrampoline after sink->Present(); no-op when
-  // IVI_SW_PROFILE is unset. Window log every 60 frames, session
-  // summary emitted from dtor.
+  // Called from PresentTrampoline after sink->Present(); no-op when profiling
+  // is disabled. Window log every 60 frames, session summary emitted from dtor.
   void ProfilePresent(bool ok);
 
   uint32_t width_;

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -32,6 +32,7 @@
 #include "egl.h"
 #include "engine.h"
 #include "logging.h"
+#include "profiling/frame_profile.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #include "shell/platform/homescreen/flutter_desktop_texture_registrar.h"
 #include "task_runner.h"
@@ -131,7 +132,7 @@ FlutterRendererConfig WaylandEglBackend::GetRenderConfig() {
     b->RequestPresentationFeedback();
 
     static const bool profile_enabled =
-        std::getenv("IVI_WL_PROFILE") != nullptr;
+        profiling::FrameProfile::Enabled("IVI_WL_PROFILE");
 
     // Decide the swap mechanism (and do the cheap damage bookkeeping) BEFORE
     // timing, so the measured interval reflects only the swap-call block time
@@ -458,7 +459,8 @@ void WaylandEglBackend::on_feedback_presented(
   // 60 presented frames. Both this handler and on_feedback_discarded
   // fire on Display's event_thread_, so a single non-atomic block of
   // counters is safe (no concurrent writer).
-  static const bool profile_enabled = std::getenv("IVI_WL_PROFILE") != nullptr;
+  static const bool profile_enabled =
+      profiling::FrameProfile::Enabled("IVI_WL_PROFILE");
   if (profile_enabled) {
     auto& p = self->profile_;
     if (p.last_presented_ns != 0) {
@@ -580,7 +582,8 @@ void WaylandEglBackend::on_feedback_discarded(
   // next commit superseded it, or the surface was occluded). Flutter is
   // still waiting on a baton return either way — use the engine's wall
   // clock as the frame_start_time since we have no real timestamp.
-  static const bool profile_enabled = std::getenv("IVI_WL_PROFILE") != nullptr;
+  static const bool profile_enabled =
+      profiling::FrameProfile::Enabled("IVI_WL_PROFILE");
   if (profile_enabled) {
     ++self->profile_.discarded_frames;
   }

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -28,6 +28,7 @@
 #include "config/common.h"
 #include "engine.h"
 #include "logging.h"
+#include "profiling/frame_profile.h"
 #include "task_runner.h"
 #include "wayland/display.h"
 
@@ -1005,7 +1006,8 @@ void* WaylandVulkanBackend::GetInstanceProcAddressCallback(
 void WaylandVulkanBackend::ProfilePresent(const bool ok) {
   // Single env-var probe per process; the lookup is O(strlen) and we
   // call this on every frame.
-  static const bool profile_enabled = std::getenv("IVI_VK_PROFILE") != nullptr;
+  static const bool profile_enabled =
+      profiling::FrameProfile::Enabled("IVI_VK_PROFILE");
   if (!profile_enabled) {
     return;
   }
@@ -1254,7 +1256,8 @@ void WaylandVulkanBackend::on_feedback_presented(
   // Profile accumulation: flags_or only. Interval bucketing is owned by
   // ProfilePresent on the rasterizer thread; doing it twice would
   // double-count.
-  static const bool profile_enabled = std::getenv("IVI_VK_PROFILE") != nullptr;
+  static const bool profile_enabled =
+      profiling::FrameProfile::Enabled("IVI_VK_PROFILE");
   if (profile_enabled) {
     self->profile_.flags_or |= flags;
   }
@@ -1311,7 +1314,8 @@ void WaylandVulkanBackend::on_feedback_discarded(
   if (self == nullptr) {
     return;
   }
-  static const bool profile_enabled = std::getenv("IVI_VK_PROFILE") != nullptr;
+  static const bool profile_enabled =
+      profiling::FrameProfile::Enabled("IVI_VK_PROFILE");
   if (profile_enabled) {
     ++self->profile_.discarded_frames;
   }

--- a/shell/profiling/frame_profile.cc
+++ b/shell/profiling/frame_profile.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "profiling/frame_profile.h"
+
+#include <cstdlib>
+#include <ctime>
+
+#include "spdlog/spdlog.h"
+
+namespace profiling {
+
+namespace {
+
+uint64_t MonotonicNs() {
+  timespec ts{};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1'000'000'000ULL +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+
+// Mean inter-present interval. The first frame of a run has no predecessor, so
+// the divisor is one less than the frame count once any interval exists.
+uint64_t MeanIntervalNs(uint64_t interval_sum_ns, uint32_t frames) {
+  const uint32_t samples = interval_sum_ns > 0 ? frames - 1 : frames;
+  return samples > 0 ? interval_sum_ns / samples : 0;
+}
+
+double FpsFromMean(uint64_t mean_ns) {
+  return mean_ns > 0 ? 1e9 / static_cast<double>(mean_ns) : 0.0;
+}
+
+}  // namespace
+
+void FrameProfile::Stats::AddInterval(const uint64_t dt_ns) {
+  interval_sum_ns += dt_ns;
+  if (dt_ns > interval_max_ns) {
+    interval_max_ns = dt_ns;
+  }
+  if (dt_ns <= 17'000'000ULL) {
+    ++b60;
+  } else if (dt_ns <= 33'000'000ULL) {
+    ++b30;
+  } else if (dt_ns <= 50'000'000ULL) {
+    ++b20;
+  } else if (dt_ns <= 100'000'000ULL) {
+    ++bslow;
+  } else {
+    ++bidle;
+  }
+}
+
+void FrameProfile::Stats::Merge(const Stats& other) {
+  interval_sum_ns += other.interval_sum_ns;
+  if (other.interval_max_ns > interval_max_ns) {
+    interval_max_ns = other.interval_max_ns;
+  }
+  frames += other.frames;
+  failures += other.failures;
+  b60 += other.b60;
+  b30 += other.b30;
+  b20 += other.b20;
+  bslow += other.bslow;
+  bidle += other.bidle;
+}
+
+bool FrameProfile::Enabled(const char* legacy_env) {
+  if (std::getenv("IVI_PROFILE") != nullptr) {
+    return true;
+  }
+  return legacy_env != nullptr && std::getenv(legacy_env) != nullptr;
+}
+
+void FrameProfile::Record(const std::string_view label,
+                          const bool ok,
+                          uint64_t now_ns) {
+  if (!ok) {
+    ++window_.failures;
+    return;
+  }
+  if (now_ns == 0) {
+    now_ns = MonotonicNs();
+  }
+  if (last_present_ns_ != 0) {
+    window_.AddInterval(now_ns - last_present_ns_);
+  }
+  last_present_ns_ = now_ns;
+  ++window_.frames;
+
+  if (window_.frames < kWindow) {
+    return;
+  }
+  const uint64_t mean_ns =
+      MeanIntervalNs(window_.interval_sum_ns, window_.frames);
+  spdlog::info(
+      "[{}] profile (n={}): fps={:.2f} mean_interval={}us max_interval={}us "
+      "present_failures={} buckets[60Hz/30Hz/20Hz/slow/idle]={}/{}/{}/{}/{}",
+      label, window_.frames, FpsFromMean(mean_ns), mean_ns / 1000,
+      window_.interval_max_ns / 1000, window_.failures, window_.b60,
+      window_.b30, window_.b20, window_.bslow, window_.bidle);
+
+  session_.Merge(window_);
+  window_ = Stats{};  // reset the window; last_present_ns_ carries continuity
+}
+
+void FrameProfile::LogSessionSummary(const std::string_view label) const {
+  // Fold the trailing partial window (frames since the last flush) into the
+  // totals so short runs and the tail of long runs are not dropped.
+  Stats s = session_;
+  s.Merge(window_);
+  if (s.frames == 0) {
+    return;
+  }
+  const uint64_t mean_ns = MeanIntervalNs(s.interval_sum_ns, s.frames);
+  spdlog::info(
+      "[{}] session summary: frames={} fps={:.2f} mean_interval={}us "
+      "max_interval={}us present_failures={}",
+      label, s.frames, FpsFromMean(mean_ns), mean_ns / 1000,
+      s.interval_max_ns / 1000, s.failures);
+
+  if (const uint32_t total = s.b60 + s.b30 + s.b20 + s.bslow + s.bidle;
+      total > 0) {
+    const double inv = 100.0 / static_cast<double>(total);
+    spdlog::info(
+        "[{}] session buckets: 60Hz={} ({:.1f}%) 30Hz={} ({:.1f}%) "
+        "20Hz={} ({:.1f}%) slow={} ({:.1f}%) idle={} ({:.1f}%)",
+        label, s.b60, s.b60 * inv, s.b30, s.b30 * inv, s.b20, s.b20 * inv,
+        s.bslow, s.bslow * inv, s.bidle, s.bidle * inv);
+  }
+}
+
+}  // namespace profiling

--- a/shell/profiling/frame_profile.h
+++ b/shell/profiling/frame_profile.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+namespace profiling {
+
+// Unified frame-pacing profiler shared by every backend. A backend calls
+// Record() once per present and LogSessionSummary() from its destructor. When
+// enabled it emits, with the backend's label:
+//
+//   * a window line every kWindow presents:
+//       [<label>] profile (n=N): fps=.. mean_interval=..us max_interval=..us
+//       present_failures=.. buckets[60Hz/30Hz/20Hz/slow/idle]=../../../../..
+//   * a session summary on teardown (folds the trailing partial window):
+//       [<label>] session summary: frames=N fps=.. mean_interval=..us
+//       max_interval=..us present_failures=..
+//       [<label>] session buckets: 60Hz=.. (..%) 30Hz=.. (..%) ...
+//
+// The interval histogram uses fixed thresholds (<=17 / <=33 / <=50 / <=100 ms,
+// then idle) so the numbers line up across backends regardless of how each
+// one drives presents.
+//
+// Enabled by the IVI_PROFILE environment variable. Each backend may also pass
+// its historical per-backend gate (e.g. "IVI_SW_PROFILE") so existing scripts
+// keep working. Evaluate Enabled() once per process and cache it at the call
+// site — Record() is on the per-frame path and does not re-check the env.
+class FrameProfile {
+ public:
+  // True when IVI_PROFILE is set, or (when non-null) the legacy gate is set.
+  static bool Enabled(const char* legacy_env = nullptr);
+
+  // Record one present. When ok is false it counts a present failure and
+  // contributes no interval. now_ns is a CLOCK_MONOTONIC timestamp; pass 0 to
+  // sample it internally. label is the backend tag for the window log line.
+  void Record(std::string_view label, bool ok, uint64_t now_ns = 0);
+
+  // Emit the session-aggregate summary. No-op when no frames were recorded.
+  void LogSessionSummary(std::string_view label) const;
+
+ private:
+  static constexpr uint32_t kWindow = 60;
+
+  struct Stats {
+    uint64_t interval_sum_ns{0};
+    uint64_t interval_max_ns{0};
+    uint32_t frames{0};
+    uint32_t failures{0};
+    uint32_t b60{0};    // <= 17ms  (60Hz)
+    uint32_t b30{0};    // 18-33ms  (30Hz)
+    uint32_t b20{0};    // 34-50ms  (20Hz)
+    uint32_t bslow{0};  // 51-100ms
+    uint32_t bidle{0};  // > 100ms
+
+    void AddInterval(uint64_t dt_ns);
+    void Merge(const Stats& other);
+  };
+
+  uint64_t last_present_ns_{0};
+  Stats window_{};
+  Stats session_{};
+};
+
+}  // namespace profiling


### PR DESCRIPTION
Replaces the per-backend `FrameProfile` structs (gated by `IVI_SW_PROFILE` / `IVI_WL_PROFILE` / `IVI_VK_PROFILE` / `IVI_DRM_PROFILE`) with a single shared `profiling::FrameProfile`, gated by a unified **`IVI_PROFILE`** env var. The legacy per-backend gates are kept as fallbacks, so existing usage and scripts keep working.

## What
- New `shell/profiling/frame_profile.{h,cc}`: `FrameProfile` with `Enabled(legacy_env)`, `Record(label, ok)`, `LogSessionSummary(label)`. 17/33/50/100 ms buckets, 60-frame window, session totals.
- software, drm-kms-egl, drm-kms-vulkan, wayland-egl, wayland-vulkan all record through it — one histogram definition, identical thresholds, so cross-backend comparisons line up.

Rebased onto the current v2.0 (post #222/#223); the software backend's profiler now composes the shared type instead of its own struct.