### PR TITLE
drm: --drm-rotation (tiled scanout) + shared --drm-list-modes

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -135,6 +135,7 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
             backend/drm_kms_egl/driver_probe.cc
             backend/gl_process_resolver.cc
             display/drm_display.cc
+            display/drm_mode_list.cc
             input/drm_seat.cc
     )
     # DRM HW cursor depends on drm-cxx's cursor module, which gates on
@@ -216,6 +217,7 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN)
             backend/drm_kms_egl/drm_session.cc
             backend/drm_kms_egl/driver_probe.cc
             display/drm_display.cc
+            display/drm_mode_list.cc
             input/drm_seat.cc
     )
     # HW cursor shares drm_kms_egl's drm-cxx-backed cursor (GL-free). Mirror

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/drm_backend.h"
+#include "display/drm_mode_list.h"  // ConnectorTypeName, PrintDrmModes (shared)
 #include "logging/logging.h"
 
 #include <drm_fourcc.h>
@@ -248,93 +249,7 @@ bool VerifyForegroundVt(const std::string& drm_device) {
   return true;
 }
 
-const char* ConnectorTypeName(uint32_t type) {
-  switch (type) {
-    case DRM_MODE_CONNECTOR_Unknown:
-      return "Unknown";
-    case DRM_MODE_CONNECTOR_VGA:
-      return "VGA";
-    case DRM_MODE_CONNECTOR_DVII:
-      return "DVI-I";
-    case DRM_MODE_CONNECTOR_DVID:
-      return "DVI-D";
-    case DRM_MODE_CONNECTOR_DVIA:
-      return "DVI-A";
-    case DRM_MODE_CONNECTOR_Composite:
-      return "Composite";
-    case DRM_MODE_CONNECTOR_SVIDEO:
-      return "S-Video";
-    case DRM_MODE_CONNECTOR_LVDS:
-      return "LVDS";
-    case DRM_MODE_CONNECTOR_Component:
-      return "Component";
-    case DRM_MODE_CONNECTOR_9PinDIN:
-      return "9PinDIN";
-    case DRM_MODE_CONNECTOR_DisplayPort:
-      return "DP";
-    case DRM_MODE_CONNECTOR_HDMIA:
-      return "HDMI-A";
-    case DRM_MODE_CONNECTOR_HDMIB:
-      return "HDMI-B";
-    case DRM_MODE_CONNECTOR_TV:
-      return "TV";
-    case DRM_MODE_CONNECTOR_eDP:
-      return "eDP";
-    case DRM_MODE_CONNECTOR_VIRTUAL:
-      return "Virtual";
-    case DRM_MODE_CONNECTOR_DSI:
-      return "DSI";
-    case DRM_MODE_CONNECTOR_DPI:
-      return "DPI";
-    case DRM_MODE_CONNECTOR_WRITEBACK:
-      return "Writeback";
-    default:
-      return "?";
-  }
-}
-
 }  // namespace
-
-int PrintDrmModes(const std::string& device) {
-  const int fd = ::open(device.c_str(), O_RDWR | O_CLOEXEC);
-  if (fd < 0) {
-    std::fprintf(stderr, "open(%s): %s\n", device.c_str(),
-                 std::strerror(errno));
-    return 1;
-  }
-  drmModeRes* res = drmModeGetResources(fd);
-  if (!res) {
-    std::fprintf(stderr, "drmModeGetResources(%s): %s\n", device.c_str(),
-                 std::strerror(errno));
-    ::close(fd);
-    return 1;
-  }
-  std::printf("Device: %s\n", device.c_str());
-  std::printf("Connectors: %d\n\n", res->count_connectors);
-  for (int ci = 0; ci < res->count_connectors; ++ci) {
-    drmModeConnector* c = drmModeGetConnector(fd, res->connectors[ci]);
-    if (!c)
-      continue;
-    const char* state = (c->connection == DRM_MODE_CONNECTED) ? "connected"
-                        : (c->connection == DRM_MODE_DISCONNECTED)
-                            ? "disconnected"
-                            : "unknown";
-    std::printf("[%u] %s-%u  %s  modes=%d\n", c->connector_id,
-                ConnectorTypeName(c->connector_type), c->connector_type_id,
-                state, c->count_modes);
-    for (int mi = 0; mi < c->count_modes; ++mi) {
-      const drmModeModeInfo& m = c->modes[mi];
-      const bool preferred = (m.type & DRM_MODE_TYPE_PREFERRED) != 0;
-      std::printf("  %4dx%-4d @ %3dHz  %-20s  %s\n", m.hdisplay, m.vdisplay,
-                  m.vrefresh, m.name, preferred ? "[preferred]" : "");
-    }
-    std::printf("\n");
-    drmModeFreeConnector(c);
-  }
-  drmModeFreeResources(res);
-  ::close(fd);
-  return 0;
-}
 
 std::unique_ptr<DrmBackend> DrmBackend::Create(
     const DrmConfig& cfg,

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -121,11 +121,8 @@ struct DrmConfig {
   drm_config::TriState async_flip{drm_config::TriState::kAuto};
 };
 
-// Probe-and-print helper: opens `device`, lists every connector's modes
-// (flagging connected vs disconnected, and the preferred mode), prints to
-// stdout. Returns 0 on success, non-zero if the device can't be opened or
-// has no resources. Intended for the --drm-list-modes CLI path.
-int PrintDrmModes(const std::string& device);
+// PrintDrmModes / ConnectorTypeName moved to display/drm_mode_list.h so the
+// --drm-list-modes path is shared verbatim with the drm_kms_vulkan backend.
 
 class DrmBackend : public Backend {
   friend class DrmCompositor;

--- a/shell/backend/drm_kms_vulkan/README.md
+++ b/shell/backend/drm_kms_vulkan/README.md
@@ -63,13 +63,23 @@ can address the render GPU's exported (MMU-mapped, possibly scattered) buffer �
 either because it is the same device, or because the display has its own
 address translation.
 
+All rows below were validated on real hardware. The `Works` rows were confirmed
+with a live run; the `Fails` / `Refuses` rows with `drm_kms_vulkan_probe` and/or
+a live run. The negotiated set is logged decoded (e.g. `AMD(GFX10_RBPLUS
+64K_R_X dcc=1 retile)`) — but note this lists what the plane *can* scan out, not
+what is used: the backing stores are allocated **LINEAR** by default (a tiled,
+non-DCC modifier only for a 90/270 rotation, which amdgpu requires; see
+"Rotation" below). So DCC is advertised but not yet consumed — making it real is
+a follow-on once the negotiated modifier drives allocation in the unrotated path.
+
 | Platform | Render → display | Result |
 | --- | --- | --- |
-| amdgpu (and unified-memory GPUs) | one device, unified memory + IOMMU | **Works** — validated, renders correctly, tear-free |
-| Raspberry Pi 5 | `v3d` (V3D 7.x) → `vc4-drm`, display can address V3D buffers | **Works** — validated, renders correctly, tear-free at 3840×2160 |
+| amdgpu — desktop / iGPU (RADV) | one device, unified memory + IOMMU | **Works** — validated, tear-free; scans out LINEAR (DCC advertised, not yet used) |
+| Steam Deck "Galileo" (Van Gogh, RADV) | RDNA2 APU, unified memory + IOMMU | **Works** — validated **end-to-end** (interactive, LINEAR zero-copy, triple-buffered, 1000+ frames) |
+| Raspberry Pi 5 | `v3d` (V3D 7.x) → `vc4-drm`, display can address V3D buffers | **Works** — validated, tear-free at 3840×2160; scans out `BROADCOM(VC4_T_TILED)` |
 | Raspberry Pi 4 | `v3d` (V3D 4.2) → `vc4-drm`, **no display IOMMU** | **Fails** — `AddFB` EINVAL (see below) |
-| Arduino Uno Q | Turnip Adreno 702 via virtio/gfxstream → `msm_dpu` | **Fails** — device exposes Vulkan 1.0 (engine needs 1.1); virtualized GPU |
-| NanoPC-T6 (rk3588) | Mali-G610 (blob, Vulkan 1.3) → `rockchip-drm` (vop2) | **Refuses** — vop2 rejects the LINEAR import at any resolution; its planes want AFBC, which the LINEAR-only source can't produce |
+| Arduino Uno Q | Adreno 702 via **virtio-gpu / gfxstream** (virtualized) → `msm_dpu` | **Fails** — virtgpu fails resource allocation under DRM master; Vulkan falls back to llvmpipe (see below) |
+| NanoPC-T6 (rk3588) | Mali-G610 (blob, Vulkan 1.3) → `rockchip-drm` (vop2) | **Refuses** — vop2 planes want AFBC (on their Cluster/overlay planes); the Mali-blob Vulkan exports only `LINEAR`, so no common modifier |
 | BeaglePlay (AM625) | PowerVR AXE-1-16M (Mesa `pvr`, Vulkan 1.2) → `tidss` display | **Refuses** — Mesa `pvr` does not implement `VK_EXT_image_drm_format_modifier` (nor `synchronization2`), so there is no modifier image to export for scanout |
 
 ### Unified-memory GPUs (render device == scanout device)
@@ -133,13 +143,39 @@ GBM scanout buffers) is the working path today.
 ### Vulkan version and virtualized GPUs
 
 Independent of scanout, the device must expose **Vulkan 1.1** (the engine's
-Skia backend requires it). Some stacks expose only 1.0 and are rejected at the
-gate. The confirmed example is the **Arduino Uno Q**, whose Adreno 702 is
-driven by a **virtio-gpu / gfxstream** Turnip (the board runs Linux over a
-Qualcomm hypervisor): it reports Vulkan 1.0, so the backend refuses before the
-engine starts. The scanout side there is otherwise fine — the `msm_dpu` display
-has an SMMU and advertises `LINEAR`, so a native ≥1.1 Adreno/Turnip would be
-expected to work.
+Skia backend requires it); stacks that expose only 1.0 are rejected at the gate.
+
+A **virtualized GPU** is a subtler case: it can pass a read-only capability
+check yet fail in the live backend. The confirmed example is the **Arduino
+Uno Q**, whose Adreno 702 is presented through **virtio-gpu / gfxstream** (the
+board runs Linux over a Qualcomm hypervisor). A read-only probe may enumerate a
+capable Turnip device and pass the gate — but once the backend takes **DRM
+master** and the guest tries to allocate GPU resources, virtgpu fails
+(`DRM_IOCTL_VIRTGPU_… Bad file descriptor`, `Failed to create virtgpu
+AddressSpaceStream`) and the Vulkan loader falls back to **llvmpipe** (software),
+which the gate then rejects. The scanout side is otherwise fine — the `msm_dpu`
+display has an SMMU and advertises `LINEAR` — but the virtualized render path
+cannot produce a real scanout buffer under master. Lesson: the read-only gate
+is necessary, not sufficient, on virtualized GPUs — the live master-holding run
+is the decisive test.
+
+## Rotation
+
+`--drm-rotation <0|90|180|270>` rotates the scanout. The CRTC keeps its native
+mode; for 90/270 the **render extent** (Flutter viewport + backing stores) is
+swapped, the buffer is scanned out through the plane's `rotation` property, and
+`drm_kms_vulkan_probe` / `--drm-list-modes` report which planes can rotate.
+
+A 90/270 rotation needs a **tiled, non-DCC** scanout buffer — amdgpu rejects
+both LINEAR and DCC under rotation — so the backend allocates a tiled non-DCC
+modifier (filtered from the negotiated set) for those angles, while 0/180 stay
+LINEAR. If no tiled modifier is available the rotated commit will not succeed
+and the backend says so.
+
+Input-device transforms for a rotated display (touch / pointer / HW-cursor
+sprite remapped to the rotated frame) are a **follow-up** — they are
+per-input-device (a panel can carry a touchscreen *and* trackpads in different
+physical frames), so a single rotation value does not align them all.
 
 ## Running
 

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -22,6 +22,7 @@
 #include "vulkan_drm_backend.h"
 
 #include <drm_fourcc.h>
+#include <drm_mode.h>  // DRM_MODE_ROTATE_*
 
 #include <array>
 #include <cerrno>
@@ -54,6 +55,40 @@
 namespace {
 
 const auto& d = vk::detail::defaultDispatchLoaderDynamic;
+
+// Map a rotation in degrees (validated to 0|90|180|270 at config time) to the
+// KMS plane rotation bitflag. drm-cxx lowers DisplayParams::rotation to the
+// plane's `rotation` property (or software pre-rotation if the plane lacks it).
+uint64_t RotationToDrmFlag(const int degrees) {
+  switch (degrees) {
+    case 90:
+      return DRM_MODE_ROTATE_90;
+    case 180:
+      return DRM_MODE_ROTATE_180;
+    case 270:
+      return DRM_MODE_ROTATE_270;
+    default:
+      return DRM_MODE_ROTATE_0;
+  }
+}
+
+// Whether the display can scan out a buffer with this modifier under a 90/270
+// rotation. amdgpu rejects both LINEAR (the rotated fetch needs a tiled read
+// pattern) and DCC (delta-color compression is incompatible with the rotated
+// read) for 90/270, so keep only tiled, non-DCC modifiers. Non-AMD tiled
+// modifiers are assumed rotatable (the kernel still validates at AddFB/commit).
+bool RotationCompatible(const uint64_t mod) {
+  if (mod == DRM_FORMAT_MOD_LINEAR) {
+    return false;
+  }
+#ifdef AMD_FMT_MOD
+  if (static_cast<uint8_t>(mod >> 56) == DRM_FORMAT_MOD_VENDOR_AMD &&
+      AMD_FMT_MOD_GET(DCC, mod) != 0U) {
+    return false;
+  }
+#endif
+  return true;
+}
 
 // Device extensions required for zero-copy dma-buf scanout and explicit
 // synchronization. The dependencies of VK_EXT_image_drm_format_modifier
@@ -187,15 +222,19 @@ class VkScanoutRing final : public drm::scene::LayerBufferSource {
       info.pitch = static_cast<uint32_t>(pl.pitch);
       planes.push_back(info);
     }
+    // Import the FB with the buffer's ACTUAL modifier (LINEAR or a tiled AMD
+    // swizzle), not a hard-coded LINEAR — drm-cxx forwards it verbatim to
+    // drmModeAddFB2WithModifiers and the kernel validates the tiling. A tiled
+    // layout is what amdgpu requires to scan out a 90/270-rotated plane.
+    const uint64_t mod = store.modifier();
     auto src = drm::scene::ExternalDmaBufSource::create(
-        dev, store.width(), store.height(), fourcc, DRM_FORMAT_MOD_LINEAR,
-        planes);
+        dev, store.width(), store.height(), fourcc, mod, planes);
     if (!src) {
       spdlog::error(
           "[VulkanDrmBackend] framebuffer import ({}x{} fourcc=0x{:08x} "
           "mod=0x{:016x} planes={} offset={} pitch={}): {}",
-          store.width(), store.height(), fourcc, DRM_FORMAT_MOD_LINEAR,
-          planes.size(), planes.empty() ? 0u : planes[0].offset,
+          store.width(), store.height(), fourcc, mod, planes.size(),
+          planes.empty() ? 0u : planes[0].offset,
           planes.empty() ? 0u : planes[0].pitch, src.error().message());
       return std::nullopt;
     }
@@ -260,9 +299,11 @@ void WaitForFlip(const int drm_fd, drmEventContext& evctx) {
 VulkanDrmBackend::VulkanDrmBackend(std::string drm_device,
                                    const bool enable_validation,
                                    homescreen::DrmSession* session,
-                                   std::string mode_spec)
+                                   std::string mode_spec,
+                                   const int rotation)
     : drm_device_(std::move(drm_device)),
       mode_spec_(std::move(mode_spec)),
+      rotation_(rotation),
       enable_validation_(enable_validation),
       session_(session) {}
 
@@ -282,9 +323,10 @@ std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
     const std::string& drm_device,
     const bool enable_validation,
     homescreen::DrmSession* session,
-    const std::string& mode_spec) {
-  auto backend = std::shared_ptr<VulkanDrmBackend>(
-      new VulkanDrmBackend(drm_device, enable_validation, session, mode_spec));
+    const std::string& mode_spec,
+    const int rotation) {
+  auto backend = std::shared_ptr<VulkanDrmBackend>(new VulkanDrmBackend(
+      drm_device, enable_validation, session, mode_spec, rotation));
 
   std::string err;
   if (!backend->BringUp(err)) {
@@ -382,8 +424,21 @@ struct VulkanDrmBackend::CompositorState {
   std::unique_ptr<drm::scene::LayerScene> scene;
   bool have_master = false;
   uint32_t fourcc = 0;
+  // Render extent: the backing-store / Flutter-viewport size. For a 90/270
+  // rotation this is the CRTC mode with width/height swapped (the GPU renders
+  // landscape into a buffer the plane rotates onto a portrait panel).
   uint32_t width = 0;
   uint32_t height = 0;
+  // Scanout extent: the CRTC mode (the plane's dst_rect). Equals width/height
+  // when rotation is 0/180.
+  uint32_t crtc_width = 0;
+  uint32_t crtc_height = 0;
+  // Plane rotation (DRM_MODE_ROTATE_*) applied to the scanned-out buffer.
+  uint64_t rotation = 0;
+  // Modifiers the backing stores allocate against. LINEAR for an unrotated
+  // scanout (simple, universally importable); tiled non-DCC for 90/270 (amdgpu
+  // requires a tiled layout to rotate, and rejects DCC + rotation).
+  std::vector<uint64_t> scanout_modifiers;
 
   // Ring of scanout buffers. The engine cycles through them
   // (avoid_backing_store_cache), rendering into a free slot while KMS scans
@@ -455,8 +510,45 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
   (void)state->device.enable_atomic();
   (void)state->device.enable_universal_planes();
   state->fourcc = DRM_FORMAT_XRGB8888;
-  state->width = target.mode_width;
-  state->height = target.mode_height;
+  // The CRTC always scans its native mode; a 90/270 rotation swaps the render
+  // extent (backing stores + Flutter viewport) so the GPU paints landscape into
+  // a buffer the plane rotates onto the portrait panel. 0/180 keep the extents
+  // equal.
+  state->crtc_width = target.mode_width;
+  state->crtc_height = target.mode_height;
+  const bool swap = (rotation_ == 90 || rotation_ == 270);
+  state->width = swap ? target.mode_height : target.mode_width;
+  state->height = swap ? target.mode_width : target.mode_height;
+  state->rotation = RotationToDrmFlag(rotation_);
+
+  // Pick the backing-store modifiers. Unrotated: LINEAR (simple, importable
+  // everywhere). 90/270: a tiled non-DCC modifier from the negotiated set —
+  // amdgpu needs tiling to rotate and rejects DCC + rotation. If the filter
+  // empties (no tiled scanout modifier), fall back to LINEAR so allocation
+  // still succeeds; the rotated commit then fails loudly rather than silently.
+  if (swap) {
+    for (const auto m : allowed) {
+      if (RotationCompatible(m)) {
+        state->scanout_modifiers.push_back(m);
+      }
+    }
+    if (state->scanout_modifiers.empty()) {
+      spdlog::warn(
+          "[VulkanDrmBackend] no tiled non-DCC modifier available for a "
+          "{}-degree rotation; the rotated scanout will not commit",
+          rotation_);
+      state->scanout_modifiers.push_back(DRM_FORMAT_MOD_LINEAR);
+    } else {
+      std::string picked;
+      for (const auto m : state->scanout_modifiers) {
+        picked += " " + drm_kms_vulkan::DescribeModifier(m);
+      }
+      spdlog::info("[VulkanDrmBackend] rotation {} backing-store modifiers:{}",
+                   rotation_, picked);
+    }
+  } else {
+    state->scanout_modifiers.push_back(DRM_FORMAT_MOD_LINEAR);
+  }
 
   drm::scene::LayerScene::Config scfg{};
   scfg.crtc_id = target.crtc_id;
@@ -480,7 +572,7 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
     std::string probe_err;
     auto probe = drm_kms_vulkan::VulkanBackingStore::Create(
         physical_device_, device_, state->width, state->height,
-        VK_FORMAT_B8G8R8A8_UNORM, state->fourcc, {DRM_FORMAT_MOD_LINEAR},
+        VK_FORMAT_B8G8R8A8_UNORM, state->fourcc, state->scanout_modifiers,
         probe_err);
     if (!probe) {
       err = "scanout buffer allocation failed: " + probe_err;
@@ -623,11 +715,13 @@ bool VulkanDrmBackend::CreateBackingStoreImpl(
       return false;
     }
     std::string err;
-    // LINEAR is the modifier ExternalDmaBufSource accepts today; tiled is a
-    // follow-on once that wrapper learns multi-plane tiled modifiers.
+    // Allocate against the negotiated modifier set chosen in SetupCompositor:
+    // LINEAR when unrotated, a tiled non-DCC modifier for 90/270. The driver
+    // picks one and exports its per-plane layout; AddSlot imports the FB with
+    // store.modifier() so the tiling is honored end to end.
     auto store = drm_kms_vulkan::VulkanBackingStore::Create(
         physical_device_, device_, w, h, VK_FORMAT_B8G8R8A8_UNORM, c.fourcc,
-        {DRM_FORMAT_MOD_LINEAR}, err);
+        c.scanout_modifiers, err);
     if (!store) {
       spdlog::error("[VulkanDrmBackend] CreateBackingStore({}x{}): {}", w, h,
                     err);
@@ -739,7 +833,11 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
     }
     drm::scene::LayerDesc desc;
     desc.source = std::move(c.ring_owner);
-    desc.display.dst_rect = {0, 0, c.width, c.height};
+    // dst_rect is the CRTC mode; src_rect defaults to the buffer's full extent
+    // (the render size). For a 90/270 rotation the render buffer is landscape
+    // and the plane rotates it onto the portrait CRTC, so dst != src extent.
+    desc.display.dst_rect = {0, 0, c.crtc_width, c.crtc_height};
+    desc.display.rotation = c.rotation;
     auto layer = c.scene->add_layer(std::move(desc));
     if (!layer) {
       spdlog::error("[VulkanDrmBackend] add_layer: {}",

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -54,7 +54,8 @@ class VulkanDrmBackend final : public Backend {
       const std::string& drm_device,
       bool enable_validation,
       homescreen::DrmSession* session,
-      const std::string& mode_spec);
+      const std::string& mode_spec,
+      int rotation);
 
   ~VulkanDrmBackend() override;
 
@@ -80,6 +81,10 @@ class VulkanDrmBackend final : public Backend {
 
   [[nodiscard]] uint32_t width() const { return width_; }
   [[nodiscard]] uint32_t height() const { return height_; }
+  // Scanout rotation in degrees (0|90|180|270). FlutterView forwards it to the
+  // seat so the HW cursor sprite is transformed from render space (where the
+  // pointer lives) into panel space (where the cursor plane lives).
+  [[nodiscard]] int rotation() const { return rotation_; }
   [[nodiscard]] const drm_kms_vulkan::DeviceCaps& caps() const { return caps_; }
 
   // The self-committing DRM HW cursor (null when xcursor/drm-cxx-cursor is
@@ -93,7 +98,8 @@ class VulkanDrmBackend final : public Backend {
   VulkanDrmBackend(std::string drm_device,
                    bool enable_validation,
                    homescreen::DrmSession* session,
-                   std::string mode_spec);
+                   std::string mode_spec,
+                   int rotation);
 
   // Bring-up steps. Each logs and returns false on failure; refusal_reason
   // carries the cause for gate failures.
@@ -135,6 +141,10 @@ class VulkanDrmBackend final : public Backend {
   std::string drm_device_;
   // Scanout mode selector ("<W>x<H>[@<R>]"); empty = connector preferred mode.
   std::string mode_spec_;
+  // DRM scanout rotation in degrees (0|90|180|270). 90/270 swap the render /
+  // viewport extent against the CRTC mode; lowered to the plane rotation
+  // property at present time.
+  int rotation_ = 0;
   // Unified cadence profiler (IVI_PROFILE / legacy IVI_DRMVK_PROFILE). Written
   // from the rasterizer thread (PresentLayersImpl) only.
   profiling::FrameProfile frame_profile_;

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -223,6 +223,9 @@ void Configuration::get_cli_override(const std::string& bundle_path,
   if (cli.view.drm_mode.has_value()) {
     instance.view.drm_mode = cli.view.drm_mode.value();
   }
+  if (cli.view.drm_rotation.has_value()) {
+    instance.view.drm_rotation = cli.view.drm_rotation.value();
+  }
   if (cli.view.drm_compositor.has_value()) {
     instance.view.drm_compositor = cli.view.drm_compositor.value();
   }
@@ -390,8 +393,11 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
             "drm-mode",
             "DRM mode <WxH@R> (e.g. 1920x1080@120); default = preferred mode",
             cxxopts::value<std::string>())(
-            "drm-compositor", "DRM compositor strategy: auto|planes|gl",
-            cxxopts::value<std::string>())(
+            "drm-rotation",
+            "DRM scanout rotation in degrees: 0|90|180|270 (default 0)",
+            cxxopts::value<int>())("drm-compositor",
+                                   "DRM compositor strategy: auto|planes|gl",
+                                   cxxopts::value<std::string>())(
             "drm-modeset", "DRM modeset API: auto|legacy|atomic",
             cxxopts::value<std::string>())(
             "drm-allow-nonblock-modeset",
@@ -561,6 +567,26 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
                 config.view.drm_async_flip);
     pick_string("drm-stage-cursor", "HOMESCREEN_DRM_STAGE_CURSOR",
                 config.view.drm_stage_cursor);
+
+    // drm-rotation is an int (0|90|180|270); CLI wins, then env. Reject any
+    // other value so a typo fails loud instead of silently scanning unrotated.
+    {
+      std::optional<int> rot;
+      if (result.count("drm-rotation")) {
+        rot = result["drm-rotation"].as<int>();
+      } else if (const char* e = std::getenv("HOMESCREEN_DRM_ROTATION");
+                 e && *e) {
+        rot = static_cast<int>(std::strtol(e, nullptr, 10));
+      }
+      if (rot.has_value()) {
+        if (*rot != 0 && *rot != 90 && *rot != 180 && *rot != 270) {
+          spdlog::critical("--drm-rotation must be 0, 90, 180, or 270 (got {})",
+                           *rot);
+          exit(EXIT_FAILURE);
+        }
+        config.view.drm_rotation = *rot;
+      }
+    }
 
     config.view.vm_args.reserve(result.unmatched().size());
     for (const auto& option : result.unmatched()) {

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -68,6 +68,10 @@ class Configuration {
       // unrecognized is treated as "auto" with a warning.
       std::optional<std::string> drm_connector;
       std::optional<std::string> drm_mode;
+      // DRM scanout rotation in degrees: 0 | 90 | 180 | 270. 90/270 swap the
+      // Flutter viewport to the rotated extent and set the plane's rotation
+      // property (the panel keeps its native mode). Default 0.
+      std::optional<int> drm_rotation;
       std::optional<std::string> drm_compositor;
       std::optional<std::string> drm_modeset;
       std::optional<std::string> drm_allow_nonblock_modeset;

--- a/shell/display/drm_mode_list.cc
+++ b/shell/display/drm_mode_list.cc
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "display/drm_mode_list.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include <drm_mode.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+const char* ConnectorTypeName(const uint32_t type) {
+  switch (type) {
+    case DRM_MODE_CONNECTOR_Unknown:
+      return "Unknown";
+    case DRM_MODE_CONNECTOR_VGA:
+      return "VGA";
+    case DRM_MODE_CONNECTOR_DVII:
+      return "DVI-I";
+    case DRM_MODE_CONNECTOR_DVID:
+      return "DVI-D";
+    case DRM_MODE_CONNECTOR_DVIA:
+      return "DVI-A";
+    case DRM_MODE_CONNECTOR_Composite:
+      return "Composite";
+    case DRM_MODE_CONNECTOR_SVIDEO:
+      return "S-Video";
+    case DRM_MODE_CONNECTOR_LVDS:
+      return "LVDS";
+    case DRM_MODE_CONNECTOR_Component:
+      return "Component";
+    case DRM_MODE_CONNECTOR_9PinDIN:
+      return "9PinDIN";
+    case DRM_MODE_CONNECTOR_DisplayPort:
+      return "DP";
+    case DRM_MODE_CONNECTOR_HDMIA:
+      return "HDMI-A";
+    case DRM_MODE_CONNECTOR_HDMIB:
+      return "HDMI-B";
+    case DRM_MODE_CONNECTOR_TV:
+      return "TV";
+    case DRM_MODE_CONNECTOR_eDP:
+      return "eDP";
+    case DRM_MODE_CONNECTOR_VIRTUAL:
+      return "Virtual";
+    case DRM_MODE_CONNECTOR_DSI:
+      return "DSI";
+    case DRM_MODE_CONNECTOR_DPI:
+      return "DPI";
+    case DRM_MODE_CONNECTOR_WRITEBACK:
+      return "Writeback";
+    default:
+      return "?";
+  }
+}
+
+namespace {
+
+const char* PlaneTypeName(const uint64_t type) {
+  switch (type) {
+    case DRM_PLANE_TYPE_PRIMARY:
+      return "PRIMARY";
+    case DRM_PLANE_TYPE_OVERLAY:
+      return "OVERLAY";
+    case DRM_PLANE_TYPE_CURSOR:
+      return "CURSOR";
+    default:
+      return "?";
+  }
+}
+
+// Report each plane's rotation capability. Rotation is a per-plane KMS property
+// (a bitmask whose enum entries are the supported rotate-*/reflect-* bits), not
+// a per-mode attribute — so this is the honest place to answer "what can
+// rotate". A plane that lists rotate-90/rotate-270 can rotate in hardware,
+// subject to the scanout buffer's layout (see the note below).
+void PrintPlaneRotation(const int fd) {
+  drmSetClientCap(fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+  drmModePlaneRes* planes = drmModeGetPlaneResources(fd);
+  if (planes == nullptr) {
+    return;
+  }
+  std::printf("Planes (rotation = hardware capability):\n");
+  for (uint32_t i = 0; i < planes->count_planes; ++i) {
+    drmModeObjectProperties* props = drmModeObjectGetProperties(
+        fd, planes->planes[i], DRM_MODE_OBJECT_PLANE);
+    if (props == nullptr) {
+      continue;
+    }
+    uint64_t type = ~0ULL;
+    std::string rot;
+    bool has_rotation = false;
+    for (uint32_t p = 0; p < props->count_props; ++p) {
+      drmModePropertyRes* pr = drmModeGetProperty(fd, props->props[p]);
+      if (pr == nullptr) {
+        continue;
+      }
+      if (std::strcmp(pr->name, "type") == 0) {
+        type = props->prop_values[p];
+      } else if (std::strcmp(pr->name, "rotation") == 0) {
+        has_rotation = true;
+        for (int e = 0; e < pr->count_enums; ++e) {
+          if (!rot.empty()) {
+            rot += ",";
+          }
+          rot += pr->enums[e].name;
+        }
+      }
+      drmModeFreeProperty(pr);
+    }
+    drmModeFreeObjectProperties(props);
+    std::printf("  [%u] %-7s  rotation: %s\n", planes->planes[i],
+                PlaneTypeName(type),
+                has_rotation ? (rot.empty() ? "(none listed)" : rot.c_str())
+                             : "not supported (rotate-0 only)");
+  }
+  drmModeFreePlaneResources(planes);
+  std::printf(
+      "\nNote: rotation is a per-plane hardware capability, not a per-mode "
+      "one.\n"
+      "90/270 additionally requires a tiled scanout buffer on some GPUs (e.g.\n"
+      "amdgpu rejects 90/270 on a LINEAR framebuffer); --drm-rotation sets "
+      "the\n"
+      "plane property, but the buffer's modifier must also be compatible.\n");
+}
+
+}  // namespace
+
+int PrintDrmModes(const std::string& device) {
+  // Read-only: listing modes + plane properties needs no master/RW, so this can
+  // run alongside a live compositor (and under a uaccess ACL that only grants
+  // read). UNIVERSAL_PLANES is a client cap, settable on an O_RDONLY fd.
+  const int fd = ::open(device.c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd < 0) {
+    std::fprintf(stderr, "open(%s): %s\n", device.c_str(),
+                 std::strerror(errno));
+    return 1;
+  }
+  drmModeRes* res = drmModeGetResources(fd);
+  if (res == nullptr) {
+    std::fprintf(stderr, "drmModeGetResources(%s): %s\n", device.c_str(),
+                 std::strerror(errno));
+    ::close(fd);
+    return 1;
+  }
+  std::printf("Device: %s\n", device.c_str());
+  std::printf("Connectors: %d\n\n", res->count_connectors);
+  for (int ci = 0; ci < res->count_connectors; ++ci) {
+    drmModeConnector* c = drmModeGetConnector(fd, res->connectors[ci]);
+    if (c == nullptr) {
+      continue;
+    }
+    const char* state = (c->connection == DRM_MODE_CONNECTED) ? "connected"
+                        : (c->connection == DRM_MODE_DISCONNECTED)
+                            ? "disconnected"
+                            : "unknown";
+    std::printf("[%u] %s-%u  %s  modes=%d\n", c->connector_id,
+                ConnectorTypeName(c->connector_type), c->connector_type_id,
+                state, c->count_modes);
+    for (int mi = 0; mi < c->count_modes; ++mi) {
+      const drmModeModeInfo& m = c->modes[mi];
+      const bool preferred = (m.type & DRM_MODE_TYPE_PREFERRED) != 0;
+      std::printf("  %4dx%-4d @ %3dHz  %-20s  %s\n", m.hdisplay, m.vdisplay,
+                  m.vrefresh, m.name, preferred ? "[preferred]" : "");
+    }
+    std::printf("\n");
+    drmModeFreeConnector(c);
+  }
+  PrintPlaneRotation(fd);
+  drmModeFreeResources(res);
+  ::close(fd);
+  return 0;
+}

--- a/shell/display/drm_mode_list.h
+++ b/shell/display/drm_mode_list.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+// `--drm-list-modes` support, shared verbatim by the drm_kms_egl and
+// drm_kms_vulkan backends (it only reads connector modes + plane properties via
+// libdrm — no GL/Vulkan/GBM dependency). Read-only: opens the device, prints
+// every connector's modes and each plane's rotation capability, and returns.
+
+// Friendly connector-type name (libdrm's drmModeGetConnectorTypeName can return
+// NULL on older libdrm, so we keep our own table).
+const char* ConnectorTypeName(uint32_t type);
+
+// Print all connectors + their modes, plus a per-plane rotation-capability
+// section, for `--drm-list-modes`. Returns 0 on success, non-zero on open /
+// resource-query failure.
+int PrintDrmModes(const std::string& device);

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -30,6 +30,11 @@
 #include "backend/drm_kms_egl/drm_backend.h"
 #endif
 
+// --drm-list-modes uses the shared PrintDrmModes for both DRM backends.
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
+#include "display/drm_mode_list.h"
+#endif
+
 #if BUILD_BACKEND_SOFTWARE
 #include "backend/software/drm_dumb_sink.h"
 #endif
@@ -85,7 +90,8 @@ int main(const int argc, char** argv) {
   auto crash_handler = std::make_unique<CrashHandler>();
 #endif
 
-#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_SOFTWARE
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN || \
+    BUILD_BACKEND_SOFTWARE
   // Handle --drm-list-modes[=<path>] before the main config parse so the
   // user doesn't need to supply a bundle path just to inspect modes. On
   // software builds this lists the DRM dumb-sink's modes (the values valid
@@ -126,7 +132,7 @@ int main(const int argc, char** argv) {
     }
   }
   if (list_modes_requested) {
-#if BUILD_BACKEND_DRM_KMS_EGL
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
     if (list_modes_dev.empty()) {
       list_modes_dev = "/dev/dri/card1";
     }

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -240,7 +240,7 @@ FlutterView::FlutterView(Configuration::Config config,
     auto vk_backend = VulkanDrmBackend::Create(
         m_config.view.drm_device.value_or("/dev/dri/card1"),
         m_config.debug_backend.value_or(false), drm_display->session(),
-        drm_mode);
+        drm_mode, m_config.view.drm_rotation.value_or(0));
 
     // Create returns nullptr on any init failure (unsupported device, no
     // zero-copy scanout path). Continuing would dereference a null backend in
@@ -309,7 +309,7 @@ FlutterView::FlutterView(Configuration::Config config,
 
   SPDLOG_DEBUG("Width: {}, Height: {}",
                m_config.view.width.value_or(kDefaultViewWidth),
-               m_config.view.height.value_or(kDefaultViewWidth));
+               m_config.view.height.value_or(kDefaultViewHeight));
 
 #if !BUILD_BACKEND_DRM_KMS_EGL && !BUILD_BACKEND_DRM_KMS_VULKAN && \
     !BUILD_BACKEND_SOFTWARE
@@ -321,7 +321,7 @@ FlutterView::FlutterView(Configuration::Config config,
       m_config.view.wl_output_index.value_or(0), m_config.app_id,
       m_config.view.fullscreen.value_or(false),
       m_config.view.width.value_or(kDefaultViewWidth),
-      m_config.view.height.value_or(kDefaultViewWidth),
+      m_config.view.height.value_or(kDefaultViewHeight),
       m_config.view.pixel_ratio.value_or(kDefaultPixelRatio),
       m_config.view.activation_area_x, m_config.view.activation_area_y,
       m_config.view.activation_area_width, m_config.view.activation_area_height,


### PR DESCRIPTION
Two commits, on `v2.0` (the `DescribeModifier` it reuses landed with #225).

## 1. `--drm-list-modes` shared across both KMS backends + plane rotation report
`PrintDrmModes` + `ConnectorTypeName` move from the drm_kms_egl backend into a shared `shell/display/drm_mode_list.{h,cc}` (libdrm-only — no GL/Vulkan/GBM), so **`--drm-list-modes` now works identically on `drm_kms_egl` and `drm_kms_vulkan`** (it was wired only for EGL/software before). Opens the device **read-only** (safe alongside a live compositor) and adds a **per-plane rotation-capability** section — rotation is a plane property, so this is the honest place to report it.

## 2. `--drm-rotation` scanout rotation with tiled buffers
`--drm-rotation <0|90|180|270>` (CLI + `HOMESCREEN_DRM_ROTATION`). 90/270 swap the **render extent** (Flutter viewport + backing stores) against the CRTC mode and set the plane's `rotation` property via drm-cxx's `DisplayParams`.

90/270 need a **tiled, non-DCC** scanout buffer — amdgpu rejects both LINEAR and DCC under rotation — so the backend allocates a tiled non-DCC modifier filtered from the negotiated set for those angles and imports the FB with the buffer's **real** modifier (`store.modifier()`) instead of a hard-coded LINEAR; 0/180 stay LINEAR. **Validated on a Steam Deck (Van Gogh): `--drm-rotation 270` renders upright landscape, zero-copy.**

Also fixes a view-size copy-paste bug (`height` fell back to `kDefaultViewWidth`) and **corrects the README scanout claim** (the buffer is LINEAR, not DCC; DCC is advertised but not yet consumed).

### Follow-up (separate PR)
**Input-device transforms for a rotated display** (touch / pointer / HW-cursor sprite remapped to the rotated frame) — they're per-input-device (a panel can carry a touchscreen *and* trackpads in different physical frames), so one rotation value can't align them all. That work also carries a genuine pre-existing **touch mm→pixel** fix in the drm-cxx submodule.