### PR TITLE
drm_kms_vulkan: input transforms for a rotated display (touch + cursor)

### DIFF
--- a/shell/backend/drm_kms_egl/drm_cursor.cc
+++ b/shell/backend/drm_kms_egl/drm_cursor.cc
@@ -135,7 +135,8 @@ std::unique_ptr<DrmCursor> DrmCursor::Create(drm::Device& dev,
                                              const uint32_t connector_id,
                                              const drmModeModeInfo& mode,
                                              const uint32_t fb_w,
-                                             const uint32_t fb_h) {
+                                             const uint32_t fb_h,
+                                             const int rotation_degrees) {
   if (const char* gate = std::getenv("IVI_DRM_CURSOR");
       gate != nullptr && std::string_view(gate) == "0") {
     spdlog::info("[DrmCursor] disabled via IVI_DRM_CURSOR=0");
@@ -170,6 +171,23 @@ std::unique_ptr<DrmCursor> DrmCursor::Create(drm::Device& dev,
   drm::cursor::RendererConfig rcfg;
   rcfg.crtc_id = crtc_id;
   rcfg.preferred_size = sizing.buffer;
+  // drm-cxx's cursor Rotation runs opposite to the primary plane's
+  // DRM_MODE_ROTATE_* (k270 on a 270 raster points the sprite "down"), so apply
+  // the inverse here to keep the sprite visually aligned with the content.
+  switch (rotation_degrees) {
+    case 90:
+      rcfg.rotation = drm::cursor::Rotation::k270;
+      break;
+    case 180:
+      rcfg.rotation = drm::cursor::Rotation::k180;
+      break;
+    case 270:
+      rcfg.rotation = drm::cursor::Rotation::k90;
+      break;
+    default:
+      rcfg.rotation = drm::cursor::Rotation::k0;
+      break;
+  }
   auto renderer = drm::cursor::Renderer::create(dev, rcfg);
   if (!renderer) {
     spdlog::warn("[DrmCursor] renderer create: {}; no cursor sprite",

--- a/shell/backend/drm_kms_egl/drm_cursor.h
+++ b/shell/backend/drm_kms_egl/drm_cursor.h
@@ -66,12 +66,17 @@ class DrmCursor {
   // suitable plane, drm-cxx built without DRM_CXX_CURSOR, etc.) or
   // when disabled via IVI_DRM_CURSOR=0 — non-fatal: the shell continues
   // without an on-screen cursor.
+  // rotation_degrees (0|90|180|270) rotates the sprite to match a rotated
+  // scanout. The drm-cxx cursor Renderer drives the plane's rotation property
+  // when present, else pre-rotates the pixels + hotspot in software (amdgpu's
+  // cursor plane is rotate-0 only, so it takes the software path).
   static std::unique_ptr<DrmCursor> Create(drm::Device& dev,
                                            uint32_t crtc_id,
                                            uint32_t connector_id,
                                            const drmModeModeInfo& mode,
                                            uint32_t fb_w,
-                                           uint32_t fb_h);
+                                           uint32_t fb_h,
+                                           int rotation_degrees = 0);
 
   DrmCursor(const DrmCursor&) = delete;
   DrmCursor& operator=(const DrmCursor&) = delete;

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -635,9 +635,13 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
   // non-fatal — the shell runs without an on-screen sprite. Built on
   // compositor_'s DRM device (master held above), so it lives in cursor_ and is
   // torn down before compositor_.
-  cursor_ = homescreen::DrmCursor::Create(compositor_->device, target.crtc_id,
-                                          target.connector_id, target.mode,
-                                          width_, height_);
+  // The cursor plane lives on the CRTC, so its bounds are the panel (mode)
+  // size, not the (possibly rotation-swapped) render size. The seat transforms
+  // pointer positions from render space into this panel space before placing
+  // the sprite.
+  cursor_ = homescreen::DrmCursor::Create(
+      compositor_->device, target.crtc_id, target.connector_id, target.mode,
+      target.mode_width, target.mode_height, rotation_);
   if (!cursor_) {
     spdlog::info("[VulkanDrmBackend] no HW cursor (disabled or unavailable)");
   }

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -123,3 +123,9 @@ void DrmDisplay::SetCursor(homescreen::DrmCursor* cursor) {
     drm_seat->SetCursor(cursor);
   }
 }
+
+void DrmDisplay::SetCursorRotation(const int32_t degrees) {
+  if (auto* drm_seat = dynamic_cast<homescreen::DrmSeat*>(seat_.get())) {
+    drm_seat->SetCursorRotation(degrees);
+  }
+}

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -53,6 +53,10 @@ class DrmDisplay final : public IDisplay {
   // DrmCursor it owns).
   void SetCursor(homescreen::DrmCursor* cursor);
 
+  // Forward the scanout rotation to the seat so the HW cursor sprite is
+  // transformed from render space into panel space (0|90|180|270).
+  void SetCursorRotation(int32_t degrees);
+
   // Update the seat's cursor clamping rectangle to match the actual
   // backend framebuffer size. App::MakeDisplay constructs DrmDisplay
   // with the config's view.width/height (defaults 1024x768) — but

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -387,10 +387,35 @@ void DrmSeat::FlushCursorMotion() {
   }
   cursor_motion_pending_ = false;
   if (auto* c = cursor_.load(std::memory_order_acquire); c != nullptr) {
+    // The pointer lives in render (viewport) space; the cursor plane lives in
+    // panel space. For a 90/270 scanout rotation these differ (axes swapped),
+    // so rotate the position by the scanout amount before placing the sprite.
+    // 0/180 leave the extent unchanged. (Flutter pointer events keep the
+    // un-rotated render coords, so hit-testing stays correct.)
+    const int rx = static_cast<int>(pointer_x_);
+    const int ry = static_cast<int>(pointer_y_);
+    int px = rx;
+    int py = ry;
+    switch (cursor_rotation_) {
+      case 90:
+        px = ry;
+        py = viewport_w_ - 1 - rx;
+        break;
+      case 180:
+        px = viewport_w_ - 1 - rx;
+        py = viewport_h_ - 1 - ry;
+        break;
+      case 270:
+        px = viewport_h_ - 1 - ry;
+        py = rx;
+        break;
+      default:
+        break;
+    }
     // SetPosition records the position for the compositor to stage (staged
     // mode) or self-commits via Move (legacy). Either way, no DRM commit
     // here in staged mode — the compositor owns the cursor plane.
-    c->SetPosition(static_cast<int>(pointer_x_), static_cast<int>(pointer_y_));
+    c->SetPosition(px, py);
   }
 }
 
@@ -772,12 +797,53 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
       return;
   }
 
+  // ev.x/ev.y are normalized [0,1) in the device's native orientation. Scale to
+  // the render viewport, applying the INVERSE of the display rotation so a
+  // touch lands under the finger on the rotated image (the cursor uses the
+  // forward rotation; touch is its inverse).
+  const double nx = ev.x;
+  const double ny = ev.y;
+  const auto w = static_cast<double>(viewport_w_);
+  const auto h = static_cast<double>(viewport_h_);
+  double fx = nx * w;
+  double fy = ny * h;
+  switch (cursor_rotation_) {
+    case 90:
+      fx = (1.0 - ny) * w;
+      fy = nx * h;
+      break;
+    case 180:
+      fx = (1.0 - nx) * w;
+      fy = (1.0 - ny) * h;
+      break;
+    case 270:
+      fx = ny * w;
+      fy = (1.0 - nx) * h;
+      break;
+    default:
+      break;
+  }
+
+  // libinput touch-UP/CANCEL carry no coordinates (they default to 0,0, which
+  // the transform maps to a corner and snaps the gesture there — breaking
+  // swipes). Reuse the slot's last down/motion position instead; down/motion
+  // record it.
+  if (phase == kUp || phase == kCancel) {
+    if (const auto it = touch_pos_.find(ev.slot); it != touch_pos_.end()) {
+      fx = it->second.first;
+      fy = it->second.second;
+      touch_pos_.erase(it);
+    }
+  } else {
+    touch_pos_[ev.slot] = {fx, fy};
+  }
+
   FlutterPointerEvent pe{};
   pe.struct_size = sizeof(FlutterPointerEvent);
   pe.phase = phase;
   pe.timestamp = FlutterTimestampMicros();
-  pe.x = ev.x;
-  pe.y = ev.y;
+  pe.x = fx;
+  pe.y = fy;
   pe.device = ev.slot;
   pe.device_kind = kFlutterPointerDeviceKindTouch;
   pe.buttons = 0;

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -23,6 +23,8 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <unordered_map>
+#include <utility>
 
 // drm::input::Seat (input events + device opening + VT suspend/resume) and the
 // KeyboardEvent / KeyboardLeds data types stay; keyboard translation + repeat
@@ -121,6 +123,13 @@ class DrmSeat final : public ISeat {
   // dispatch thread's pointer math reads these once on the hot path.
   void SetViewport(int32_t width, int32_t height);
 
+  // Scanout rotation in degrees (0|90|180|270). The pointer accumulates in
+  // render (viewport) space — where Flutter hit-tests, so events stay correct
+  // — but the HW cursor plane lives in panel space, so FlushCursorMotion
+  // rotates the position by this amount before placing the sprite. Touch is
+  // unaffected (the digitizer already tracks the panel). Set before Start().
+  void SetCursorRotation(int32_t degrees) { cursor_rotation_ = degrees; }
+
  private:
   void DispatchLoop();
   void ApplyPendingKeymap();
@@ -151,6 +160,12 @@ class DrmSeat final : public ISeat {
   // Start() is called, so no atomic needed.
   int32_t viewport_w_;
   int32_t viewport_h_;
+  // Scanout rotation (0|90|180|270) applied to the cursor sprite position only.
+  int32_t cursor_rotation_ = 0;
+  // Last transformed render position per touch slot, so a touch-UP (which
+  // libinput delivers with no coordinates) reuses it instead of snapping to a
+  // corner. Touched only from the seat dispatch thread (HandleTouch is const).
+  mutable std::unordered_map<int32_t, std::pair<double, double>> touch_pos_;
 
   std::atomic<FlutterDesktopViewControllerState*> state_{nullptr};
 

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -261,6 +261,7 @@ FlutterView::FlutterView(Configuration::Config config,
     drm_display->SetViewportSize(static_cast<int32_t>(vk_backend->width()),
                                  static_cast<int32_t>(vk_backend->height()));
     drm_display->SetCursor(vk_backend->drm_cursor());
+    drm_display->SetCursorRotation(vk_backend->rotation());
     m_backend = vk_backend;
   }
 #elif BUILD_BACKEND_WAYLAND_EGL


### PR DESCRIPTION
Builds on the rotation feature merged in #226 (now on `v2.0`). Makes a rotated display **usable** — touchscreen + cursor remapped to the rotated frame. Validated on a Steam Deck at `--drm-rotation 270` (taps land, swipes full-range, cursor tracks, sprite upright).

> **Depends on jwinarske/drm-cxx#79** (normalized touch). This PR bumps the drm-cxx submodule to that commit; merge #79 first, then this submodule pointer aligns with drm-cxx `main`.

## Changes
- **Cursor position** — transform the pointer render→panel before placing the HW sprite (the sprite plane is on the CRTC, in panel space).
- **Cursor sprite** — rotate the bitmap + hotspot via the drm-cxx cursor `Renderer` (software pre-rotation; amdgpu's cursor plane is rotate-0 only). drm-cxx's cursor `Rotation` enum runs opposite the primary plane's `DRM_MODE_ROTATE_*`, so a 270° display maps to cursor `k90`.
- **Cursor bounds** — create the cursor at the **panel (mode)** size, not the (rotation-swapped) render size.
- **Touch** — scale the normalized device coords to the render viewport and apply the **inverse** rotation; **touch-UP reuses the slot's last position** (libinput delivers UP with no coordinates) so swipes reach full range instead of snapping to a corner.
- **drm-cxx bump** → jwinarske/drm-cxx#79: touch coords were **millimeters**, unusable as pixels — a pre-existing bug on both DRM backends; now normalized [0,1], scaled by the consumer.

## Scope
- The touch mm→pixel fix benefits **both DRM backends**; the rotation transforms apply when `--drm-rotation` is non-zero (only drm_kms_vulkan wires it today, so drm_kms_egl runs the identity path).

### Follow-up (parked)
**Per-device** input — the Deck's trackpads sit in a different physical frame than the touchscreen, so one rotation can't align them; needs per-libinput-device transforms (the `drm::input` events don't carry device identity yet).