### PR TITLE
drm: --input-transform for per-device pointer rotation

### DIFF
--- a/shell/backend/drm_kms_vulkan/README.md
+++ b/shell/backend/drm_kms_vulkan/README.md
@@ -172,10 +172,30 @@ modifier (filtered from the negotiated set) for those angles, while 0/180 stay
 LINEAR. If no tiled modifier is available the rotated commit will not succeed
 and the backend says so.
 
-Input-device transforms for a rotated display (touch / pointer / HW-cursor
-sprite remapped to the rotated frame) are a **follow-up** — they are
-per-input-device (a panel can carry a touchscreen *and* trackpads in different
-physical frames), so a single rotation value does not align them all.
+### Input on a rotated display
+
+Touch and the HW cursor track the rotation automatically: the touchscreen
+position is scaled and inverse-rotated into the render viewport, and the cursor
+sprite + position are rotated to match (amdgpu's cursor plane is rotate-0 only,
+so the sprite is pre-rotated in software).
+
+Relative pointers are **not** rotated by default — an external mouse is
+user-relative, so its motion already matches the screen. A pointer bolted to a
+rotated chassis (a built-in trackpad) can be corrected per device with a
+repeatable flag, matched on the libinput device-name substring (first match
+wins; unmatched devices pass through):
+
+    --input-transform "<device-name-substring>=<0|90|180|270>[,flip-x][,flip-y]"
+
+This is handled in the shared DRM seat, so it applies to both DRM backends.
+
+**Steam Deck** (validated at `--drm-rotation 270`): touchscreen, HW cursor, and
+the right trackpad all work. The right trackpad (a relative pointer) needs **no**
+transform (`=0`) — its sensor is aligned to the landscape chassis. The left
+trackpad is scroll / d-pad emulation in the controller's lizard mode (it folds
+into the keyboard/scroll path, not a second pointer), so it is not separately
+addressable through libinput; per-pad control would need the Steam Input /
+hidraw protocol instead.
 
 ## Running
 

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -226,6 +226,9 @@ void Configuration::get_cli_override(const std::string& bundle_path,
   if (cli.view.drm_rotation.has_value()) {
     instance.view.drm_rotation = cli.view.drm_rotation.value();
   }
+  if (!cli.view.drm_input_transforms.empty()) {
+    instance.view.drm_input_transforms = cli.view.drm_input_transforms;
+  }
   if (cli.view.drm_compositor.has_value()) {
     instance.view.drm_compositor = cli.view.drm_compositor.value();
   }
@@ -417,7 +420,11 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
             cxxopts::value<std::string>())(
             "drm-stage-cursor",
             "Stage the HW cursor into the compositor commit: auto|yes|no",
-            cxxopts::value<std::string>());
+            cxxopts::value<std::string>())(
+            "input-transform",
+            "Per-device pointer transform (repeatable): "
+            "\"<device-name-substring>=<0|90|180|270>[,flip-x][,flip-y]\"",
+            cxxopts::value<std::vector<std::string>>());
 
     const auto result = allocated->parse(argc, argv);
 
@@ -586,6 +593,13 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
         }
         config.view.drm_rotation = *rot;
       }
+    }
+
+    // Per-device pointer transforms (repeatable). Validated downstream in
+    // DrmSeat::SetInputTransforms, which warns + skips malformed specs.
+    if (result.count("input-transform")) {
+      config.view.drm_input_transforms =
+          result["input-transform"].as<std::vector<std::string>>();
     }
 
     config.view.vm_args.reserve(result.unmatched().size());

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -80,6 +80,12 @@ class Configuration {
       std::optional<std::string> drm_explicit_sync;
       std::optional<std::string> drm_async_flip;
       std::optional<std::string> drm_stage_cursor;
+      // Per-device relative-pointer transforms, repeatable:
+      //   "<device-name-substring>=<0|90|180|270>[,flip-x][,flip-y]"
+      // Rotates a built-in pointer's deltas to a rotated display (e.g. the
+      // Steam Deck's right trackpad) while leaving an external mouse alone.
+      // Matched by libinput device-name substring; first match wins.
+      std::vector<std::string> drm_input_transforms;
     } view;
   };
 

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -129,3 +129,9 @@ void DrmDisplay::SetCursorRotation(const int32_t degrees) {
     drm_seat->SetCursorRotation(degrees);
   }
 }
+
+void DrmDisplay::SetInputTransforms(const std::vector<std::string>& specs) {
+  if (auto* drm_seat = dynamic_cast<homescreen::DrmSeat*>(seat_.get())) {
+    drm_seat->SetInputTransforms(specs);
+  }
+}

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "display/idisplay.h"
 #include "input/iseat.h"
@@ -56,6 +58,10 @@ class DrmDisplay final : public IDisplay {
   // Forward the scanout rotation to the seat so the HW cursor sprite is
   // transformed from render space into panel space (0|90|180|270).
   void SetCursorRotation(int32_t degrees);
+
+  // Forward per-device relative-pointer transforms to the seat
+  // ("<name>=<rot>[,flip-x][,flip-y]"; see DrmSeat::SetInputTransforms).
+  void SetInputTransforms(const std::vector<std::string>& specs);
 
   // Update the seat's cursor clamping rectangle to match the actual
   // backend framebuffer size. App::MakeDisplay constructs DrmDisplay

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -468,6 +468,57 @@ void DrmSeat::SetViewport(const int32_t width, const int32_t height) {
   pointer_y_ = viewport_h_ / 2.0;
 }
 
+void DrmSeat::SetInputTransforms(const std::vector<std::string>& specs) {
+  pointer_transforms_.clear();
+  for (const auto& spec : specs) {
+    const auto eq = spec.rfind('=');
+    if (eq == std::string::npos || eq == 0) {
+      spdlog::warn(
+          "[DrmSeat] --input-transform '{}' ignored "
+          "(expected <name>=<0|90|180|270>[,flip-x][,flip-y])",
+          Sanitize(spec));
+      continue;
+    }
+    PointerTransform t;
+    t.match = spec.substr(0, eq);
+    bool valid = true;
+    const std::string rest = spec.substr(eq + 1);
+    for (size_t start = 0; start <= rest.size();) {
+      const auto comma = rest.find(',', start);
+      const std::string tok =
+          rest.substr(start, comma == std::string::npos ? std::string::npos
+                                                        : comma - start);
+      if (tok == "flip-x") {
+        t.flip_x = true;
+      } else if (tok == "flip-y") {
+        t.flip_y = true;
+      } else if (tok == "0") {
+        t.rotation = 0;
+      } else if (tok == "90") {
+        t.rotation = 90;
+      } else if (tok == "180") {
+        t.rotation = 180;
+      } else if (tok == "270") {
+        t.rotation = 270;
+      } else {
+        spdlog::warn("[DrmSeat] --input-transform '{}': bad token '{}'",
+                     Sanitize(spec), Sanitize(tok));
+        valid = false;
+      }
+      if (comma == std::string::npos) {
+        break;
+      }
+      start = comma + 1;
+    }
+    if (valid) {
+      spdlog::info(
+          "[DrmSeat] input-transform: match='{}' rot={} flip_x={} flip_y={}",
+          Sanitize(t.match), t.rotation, t.flip_x, t.flip_y);
+      pointer_transforms_.push_back(std::move(t));
+    }
+  }
+}
+
 void DrmSeat::OnSessionPaused() {
   pending_session_action_.store(PendingSessionAction::kSuspend,
                                 std::memory_order_release);
@@ -634,10 +685,46 @@ void DrmSeat::HandlePointerMotion(const drm::input::PointerMotionEvent& ev) {
     return;
   }
 
+  // Apply a per-device delta transform when the source device matches a
+  // configured rule (e.g. the Steam Deck's right trackpad, whose deltas are in
+  // the rotated chassis frame). Unmatched devices (an external mouse) pass
+  // through. First match wins.
+  double dx = ev.dx;
+  double dy = ev.dy;
+  if (ev.device_name != nullptr && !pointer_transforms_.empty()) {
+    const std::string_view name(ev.device_name);
+    for (const auto& t : pointer_transforms_) {
+      if (name.find(t.match) == std::string_view::npos) {
+        continue;
+      }
+      double rx = dx;
+      double ry = dy;
+      switch (t.rotation) {
+        case 90:
+          rx = -dy;
+          ry = dx;
+          break;
+        case 180:
+          rx = -dx;
+          ry = -dy;
+          break;
+        case 270:
+          rx = dy;
+          ry = -dx;
+          break;
+        default:
+          break;
+      }
+      dx = t.flip_x ? -rx : rx;
+      dy = t.flip_y ? -ry : ry;
+      break;
+    }
+  }
+
   pointer_x_ =
-      std::clamp(pointer_x_ + ev.dx, 0.0, static_cast<double>(viewport_w_ - 1));
+      std::clamp(pointer_x_ + dx, 0.0, static_cast<double>(viewport_w_ - 1));
   pointer_y_ =
-      std::clamp(pointer_y_ + ev.dy, 0.0, static_cast<double>(viewport_h_ - 1));
+      std::clamp(pointer_y_ + dy, 0.0, static_cast<double>(viewport_h_ - 1));
 
   // Defer the cursor commit to FlushCursorMotion (called after the
   // dispatch batch). A blocking atomic cursor flip per libinput event

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -25,6 +25,7 @@
 #include <thread>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 // drm::input::Seat (input events + device opening + VT suspend/resume) and the
 // KeyboardEvent / KeyboardLeds data types stay; keyboard translation + repeat
@@ -130,6 +131,14 @@ class DrmSeat final : public ISeat {
   // unaffected (the digitizer already tracks the panel). Set before Start().
   void SetCursorRotation(int32_t degrees) { cursor_rotation_ = degrees; }
 
+  // Per-device relative-pointer transforms. Each spec is
+  // "<device-name-substring>=<rot>[,flip-x][,flip-y]" (rot = 0|90|180|270). A
+  // pointer bolted to a rotated chassis (e.g. the Steam Deck's right trackpad)
+  // emits deltas in the panel's physical frame; this rotates/reflects them to
+  // match the rotated display, leaving unmatched devices (an external mouse)
+  // alone. Set before Start().
+  void SetInputTransforms(const std::vector<std::string>& specs);
+
  private:
   void DispatchLoop();
   void ApplyPendingKeymap();
@@ -162,6 +171,15 @@ class DrmSeat final : public ISeat {
   int32_t viewport_h_;
   // Scanout rotation (0|90|180|270) applied to the cursor sprite position only.
   int32_t cursor_rotation_ = 0;
+  // Per-device relative-pointer delta transforms (see SetInputTransforms).
+  // Matched by device-name substring in HandlePointerMotion; first match wins.
+  struct PointerTransform {
+    std::string match;
+    int rotation = 0;  // 0|90|180|270 applied to (dx, dy)
+    bool flip_x = false;
+    bool flip_y = false;
+  };
+  std::vector<PointerTransform> pointer_transforms_;
   // Last transformed render position per touch slot, so a touch-UP (which
   // libinput delivers with no coordinates) reuses it instead of snapping to a
   // corner. Touched only from the seat dispatch thread (HandleTouch is const).

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -262,6 +262,7 @@ FlutterView::FlutterView(Configuration::Config config,
                                  static_cast<int32_t>(vk_backend->height()));
     drm_display->SetCursor(vk_backend->drm_cursor());
     drm_display->SetCursorRotation(vk_backend->rotation());
+    drm_display->SetInputTransforms(m_config.view.drm_input_transforms);
     m_backend = vk_backend;
   }
 #elif BUILD_BACKEND_WAYLAND_EGL


### PR DESCRIPTION
Adds **per-device pointer transforms** for a rotated display — the parked input follow-up from the rotation work. Validated on a Steam Deck at `--drm-rotation 270`.

> **drm-cxx#80** (device name on pointer/touch events) is **merged**; the submodule is pointed at drm-cxx `main` HEAD (`52b6fab`), so this is self-contained and ready to merge.

## What
`--input-transform "<device-name-substring>=<0|90|180|270>[,flip-x][,flip-y]"` (repeatable) rotates/reflects a **relative pointer's** deltas per device, matched on the libinput device name. First match wins; unmatched devices pass through. Parsed + applied in the shared `DrmSeat`, so it covers **both DRM backends**; plumbed `config → FlutterView → DrmDisplay → DrmSeat`.

## Why
A pointer bolted to a rotated chassis (a built-in trackpad) emits deltas in the panel's physical frame, so they don't match a rotated display; an external mouse is user-relative and shouldn't be touched. Per-device matching is the only way to tell them apart — hence the drm-cxx device-name addition (#80).

## Steam Deck findings
- **Touchscreen + HW cursor**: already handled by the display rotation. ✓
- **Right trackpad** (relative pointer): needs **no** transform (`=0`) — its sensor is aligned to the landscape chassis. So the Deck doesn't strictly need this flag; the value is the general mechanism + the device-identity plumbing for future boards whose built-in pointers *are* mounted rotated.
- **Left trackpad**: scroll / d-pad emulation in the controller's *lizard mode* (folds into the keyboard/scroll path, **not** a second pointer), so it isn't separately addressable via libinput. Conventional scroll-wheel direction, left as-is. A true per-pad split would need the Steam Input / hidraw protocol.