### PR TITLE
drm_kms_vulkan: note Steam Deck rotation + input in the platform matrix

### DIFF
--- a/shell/backend/drm_kms_vulkan/README.md
+++ b/shell/backend/drm_kms_vulkan/README.md
@@ -75,7 +75,7 @@ a follow-on once the negotiated modifier drives allocation in the unrotated path
 | Platform | Render → display | Result |
 | --- | --- | --- |
 | amdgpu — desktop / iGPU (RADV) | one device, unified memory + IOMMU | **Works** — validated, tear-free; scans out LINEAR (DCC advertised, not yet used) |
-| Steam Deck "Galileo" (Van Gogh, RADV) | RDNA2 APU, unified memory + IOMMU | **Works** — validated **end-to-end** (interactive, LINEAR zero-copy, triple-buffered, 1000+ frames) |
+| Steam Deck "Galileo" (Van Gogh, RADV) | RDNA2 APU, unified memory + IOMMU | **Works** — validated **end-to-end** (interactive, LINEAR zero-copy, triple-buffered, 1000+ frames). **Rotation** validated at `--drm-rotation 270` (upright landscape, tiled non-DCC scanout) with touchscreen, HW cursor, and trackpad input remapped (see "Rotation" / "Input on a rotated display") |
 | Raspberry Pi 5 | `v3d` (V3D 7.x) → `vc4-drm`, display can address V3D buffers | **Works** — validated, tear-free at 3840×2160; scans out `BROADCOM(VC4_T_TILED)` |
 | Raspberry Pi 4 | `v3d` (V3D 4.2) → `vc4-drm`, **no display IOMMU** | **Fails** — `AddFB` EINVAL (see below) |
 | Arduino Uno Q | Adreno 702 via **virtio-gpu / gfxstream** (virtualized) → `msm_dpu` | **Fails** — virtgpu fails resource allocation under DRM master; Vulkan falls back to llvmpipe (see below) |


### PR DESCRIPTION
Docs only. Updates the validated-platform matrix so the Steam Deck row reflects the rotation work merged in #226/#227/#229: `--drm-rotation 270` validated end-to-end (upright landscape, tiled non-DCC scanout) with touchscreen, HW cursor, and trackpad input remapped, cross-referencing the Rotation and Input sections.