### PR TITLE
[drm_kms_egl] GL-composited cursor fallback + i.MX8MM cross-build script

### DIFF
--- a/scripts/build_nitrogen8mm.sh
+++ b/scripts/build_nitrogen8mm.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+# Copyright 2026 Toyota Connected North America
+#
+# Cross-build of ivi-homescreen (drm_kms_egl backend) for the Boundary Devices
+# Nitrogen8MM (NXP i.MX8MM — quad Cortex-A53, Vivante GC7000NanoUltra GPU,
+# imx-drm/LCDIF display, Yocto "fsl-imx-wayland" userspace, GLES2/EGL only).
+#
+# Unlike build_unoq.sh / build_radxa_zero3.sh, this board's userspace comes from
+# a local Yocto build, not a Debian image — so there is no rootfs to rsync and
+# no apt to install -dev packages. Instead this script reuses the Yocto build
+# tree directly:
+#
+#   * the weston recipe's recipe-sysroot is already a complete cross dev sysroot
+#     (libdrm/gbm/EGL/GLESv2/libinput/libudev/libxkbcommon/libseat + headers),
+#     and its recipe-sysroot-native ships the matching aarch64-poky-linux gcc;
+#   * libdisplay-info >= 0.2.0 (required by drm-cxx, absent from the image) is
+#     cross-built static and installed into that sysroot;
+#   * the Flutter engine is dlopen'd at runtime, so it is NOT needed to build —
+#     a self-contained app bundle (lib/libflutter_engine.so + lib/libapp.so +
+#     data/) is deployed instead.
+#
+# The i.MX8MM LCDIF has a single primary plane (no HW cursor plane) and the
+# image has no libxcursor, so the build uses the GL-composited cursor fallback.
+#
+# Sandbox layout (nothing is written under /usr, /opt, etc. on the host):
+#
+#   $XC_ROOT/                  default: $XDG_CACHE_HOME/ivi-homescreen-xc-nitrogen8mm
+#     downloads/               cached libdisplay-info tarball
+#     src/                     extracted libdisplay-info source + meson build
+#
+#   <repo>/cmake-build-xc-nitrogen8mm-drm-kms-egl/   CMake build dir (gitignored)
+#
+# NOTE: libdisplay-info is installed (static) INTO the weston recipe-sysroot.
+# That is a build artifact you own; re-running weston's do_populate_sysroot in
+# Yocto would wipe it, in which case just re-run this script (the step is
+# idempotent).
+#
+# Host requirements: Linux with cmake, ninja, meson, pkg-config, curl, tar,
+# ssh/scp, file. SSH key access to the board (root@nitrogen8mm.local).
+#
+# Usage:
+#   scripts/build_nitrogen8mm.sh [options]
+#     --yocto-build <dir>     Yocto build dir holding tmp/work/...
+#                               (default: /mnt/raid10/yocto/nxp-imx/bld-wayland)
+#     --machine-tuple <t>     Yocto package arch dir under tmp/work
+#                               (default: armv8a-mx8mm-poky-linux)
+#     --device-host <u@host>  SSH target for --deploy (default: root@nitrogen8mm.local)
+#     --ssh-port <n>          SSH port (default: 22)
+#     --ssh-opts <str>        extra ssh/scp options (e.g. "-i ~/.ssh/id_board")
+#     --bundle <path>         self-contained Flutter app bundle to deploy
+#                               (default: ../flutter-wonderous-app/.desktop-homescreen)
+#     --plugins-dir <path>    ivi-homescreen-plugins/plugins (default: ../ivi-homescreen-plugins/plugins)
+#     --no-plugins            build homescreen only
+#     --with-scene            enable the plane compositor + drm-cxx LayerScene
+#                               (BUILD_COMPOSITOR + USE_DRM_SCENE)
+#     --display-info-version <v>  libdisplay-info source tag (default: 0.2.0)
+#     --jobs <N>              parallel build jobs (default: nproc)
+#     --clean                 wipe the CMake build dir before configuring
+#     --prepare-only          locate toolchain + build libdisplay-info, then exit
+#     --deploy                scp binary + bundle to the board and install the
+#                               seatd + kiosk systemd units
+#     --restart               with --deploy, (re)start the service now
+#     -h | --help             this help
+set -euo pipefail
+
+# ── Defaults ─────────────────────────────────────────────────────────────
+YOCTO_BUILD="/mnt/raid10/yocto/nxp-imx/bld-wayland"
+MACHINE_TUPLE="armv8a-mx8mm-poky-linux"
+DEVICE_HOST="root@nitrogen8mm.local"
+SSH_PORT="22"
+SSH_OPTS=""
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUNDLE="$REPO_DIR/../flutter-wonderous-app/.desktop-homescreen"
+PLUGINS_DIR="$REPO_DIR/../ivi-homescreen-plugins/plugins"
+NO_PLUGINS=0
+WITH_SCENE=0
+LIBDISPLAY_INFO_VERSION="0.2.0"
+JOBS="$(nproc)"
+CLEAN=0
+PREPARE_ONLY=0
+DO_DEPLOY=0
+DO_RESTART=0
+
+XC_ROOT="${XC_ROOT:-${XDG_CACHE_HOME:-$HOME/.cache}/ivi-homescreen-xc-nitrogen8mm}"
+BUILD_DIR="$REPO_DIR/cmake-build-xc-nitrogen8mm-drm-kms-egl"
+
+# i.MX8MM Cortex-A53 tune, mirrored from the weston recipe's CC.
+XC_CPU_FLAGS="-march=armv8-a+crc+crypto -mbranch-protection=standard"
+CROSS_TRIPLE="aarch64-poky-linux"
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+log()  { printf '\033[1;34m[build]\033[0m %s\n' "$*"; }
+note() { printf '       %s\n' "$*"; }
+die()  { printf '\033[1;31m[build] error:\033[0m %s\n' "$*" >&2; exit 1; }
+
+ssh_dev() { ssh -p "$SSH_PORT" $SSH_OPTS "$DEVICE_HOST" "$@"; }
+scp_dev() { scp -P "$SSH_PORT" $SSH_OPTS "$@"; }
+
+# ── Arg parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --yocto-build)         YOCTO_BUILD="$2"; shift 2 ;;
+    --machine-tuple)       MACHINE_TUPLE="$2"; shift 2 ;;
+    --device-host)         DEVICE_HOST="$2"; shift 2 ;;
+    --ssh-port)            SSH_PORT="$2"; shift 2 ;;
+    --ssh-opts)            SSH_OPTS="$2"; shift 2 ;;
+    --bundle)              BUNDLE="$2"; shift 2 ;;
+    --plugins-dir)         PLUGINS_DIR="$2"; shift 2 ;;
+    --no-plugins)          NO_PLUGINS=1; shift ;;
+    --with-scene)          WITH_SCENE=1; shift ;;
+    --display-info-version) LIBDISPLAY_INFO_VERSION="$2"; shift 2 ;;
+    --jobs)                JOBS="$2"; shift 2 ;;
+    --clean)               CLEAN=1; shift ;;
+    --prepare-only)        PREPARE_ONLY=1; shift ;;
+    --deploy)              DO_DEPLOY=1; shift ;;
+    --restart)             DO_RESTART=1; shift ;;
+    -h|--help)             sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//; s/^#$//'; exit 0 ;;
+    *) die "unknown option: $1 (try --help)" ;;
+  esac
+done
+
+LIBDISPLAY_INFO_URL="https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${LIBDISPLAY_INFO_VERSION}/libdisplay-info-${LIBDISPLAY_INFO_VERSION}.tar.gz"
+
+# ── Phase 0: preflight ───────────────────────────────────────────────────
+phase0_preflight() {
+  log "Phase 0: preflight"
+  local missing=()
+  for t in cmake ninja meson pkg-config curl tar file; do
+    command -v "$t" >/dev/null || missing+=("$t")
+  done
+  if [[ "$DO_DEPLOY" -eq 1 ]]; then
+    for t in ssh scp; do command -v "$t" >/dev/null || missing+=("$t"); done
+  fi
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    die "missing host tools: ${missing[*]}
+  Fedora: sudo dnf install cmake ninja-build meson pkgconf-pkg-config curl tar file openssh-clients
+  Debian: sudo apt install cmake ninja-build meson pkg-config curl tar file openssh-client"
+  fi
+  [[ -d "$REPO_DIR/third_party/drm-cxx" && -f "$REPO_DIR/third_party/drm-cxx/CMakeLists.txt" ]] \
+    || die "third_party/drm-cxx missing — run: git submodule update --init --recursive third_party/drm-cxx"
+}
+
+# ── Phase 1: locate Yocto sysroot + cross toolchain ──────────────────────
+phase1_locate() {
+  log "Phase 1: locate Yocto weston sysroot + cross toolchain"
+  local weston_glob="$YOCTO_BUILD/tmp/work/$MACHINE_TUPLE/weston"
+  [[ -d "$weston_glob" ]] \
+    || die "weston not built under $weston_glob
+  Point --yocto-build at your i.MX8MM Yocto build (the dir with tmp/work/...),
+  and ensure weston has been built (it stages the full graphics dev sysroot)."
+
+  # Newest weston version dir (|| true: don't let an empty glob trip set -e).
+  local wdir
+  wdir="$( (ls -d "$weston_glob"/*/ 2>/dev/null || true) | sort -V | tail -1)"
+  [[ -n "$wdir" ]] || die "no weston version dir under $weston_glob"
+
+  XC_SYSROOT="${wdir%/}/recipe-sysroot"
+  local native="${wdir%/}/recipe-sysroot-native"
+  CROSS_BIN="$native/usr/bin/$CROSS_TRIPLE"
+
+  [[ -x "$CROSS_BIN/$CROSS_TRIPLE-gcc" ]] \
+    || die "cross gcc not found: $CROSS_BIN/$CROSS_TRIPLE-gcc"
+  [[ -f "$XC_SYSROOT/usr/include/EGL/egl.h" ]] \
+    || die "sysroot missing EGL headers: $XC_SYSROOT (is this the weston recipe-sysroot?)"
+
+  export XC_SYSROOT CROSS_BIN XC_CPU_FLAGS
+  note "sysroot   = $XC_SYSROOT"
+  note "cross gcc = $CROSS_BIN/$CROSS_TRIPLE-gcc ($("$CROSS_BIN/$CROSS_TRIPLE-gcc" -dumpversion 2>/dev/null))"
+  note "cpu flags = $XC_CPU_FLAGS"
+}
+
+# ── Phase 2: libdisplay-info >= 0.2.0 (static) into the sysroot ───────────
+displayinfo_ok() {
+  PKG_CONFIG_LIBDIR="$XC_SYSROOT/usr/lib/pkgconfig" PKG_CONFIG_SYSROOT_DIR="$XC_SYSROOT" \
+    pkg-config --atleast-version="$LIBDISPLAY_INFO_VERSION" libdisplay-info 2>/dev/null
+}
+
+phase2_display_info() {
+  log "Phase 2: libdisplay-info >= $LIBDISPLAY_INFO_VERSION (static, drm-cxx dep)"
+  if displayinfo_ok; then
+    note "sysroot already has libdisplay-info $(PKG_CONFIG_LIBDIR="$XC_SYSROOT/usr/lib/pkgconfig" PKG_CONFIG_SYSROOT_DIR="$XC_SYSROOT" pkg-config --modversion libdisplay-info); skipping"
+    return
+  fi
+
+  mkdir -p "$XC_ROOT/downloads" "$XC_ROOT/src"
+  local tarball="$XC_ROOT/downloads/libdisplay-info-${LIBDISPLAY_INFO_VERSION}.tar.gz"
+  local src="$XC_ROOT/src/libdisplay-info-${LIBDISPLAY_INFO_VERSION}"
+  local cross="$XC_ROOT/src/di-cross.ini"
+  local bld="$XC_ROOT/src/di-build"
+
+  if [[ ! -f "$tarball" ]]; then
+    log "fetching libdisplay-info $LIBDISPLAY_INFO_VERSION"
+    curl -fsSL -o "$tarball" "$LIBDISPLAY_INFO_URL" || die "download failed: $LIBDISPLAY_INFO_URL"
+  fi
+  if [[ ! -f "$src/meson.build" ]]; then
+    rm -rf "$src"; local tmp; tmp="$(mktemp -d "$XC_ROOT/src/.unpack.XXXXXX")"
+    tar -xzf "$tarball" -C "$tmp"; mv "$tmp"/*/ "$src"; rmdir "$tmp"
+  fi
+
+  cat > "$cross" <<EOF
+[binaries]
+c = '$CROSS_BIN/$CROSS_TRIPLE-gcc'
+cpp = '$CROSS_BIN/$CROSS_TRIPLE-g++'
+ar = '$CROSS_BIN/$CROSS_TRIPLE-ar'
+strip = '$CROSS_BIN/$CROSS_TRIPLE-strip'
+pkg-config = 'pkg-config'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[built-in options]
+c_args = ['--sysroot=$XC_SYSROOT', '-march=armv8-a+crc+crypto', '-mbranch-protection=standard']
+c_link_args = ['--sysroot=$XC_SYSROOT']
+EOF
+
+  log "configuring + building libdisplay-info (meson cross, static)"
+  rm -rf "$bld"
+  PKG_CONFIG_LIBDIR="$XC_SYSROOT/usr/lib/pkgconfig:$XC_SYSROOT/usr/share/pkgconfig" \
+  PKG_CONFIG_SYSROOT_DIR="$XC_SYSROOT" \
+    meson setup "$bld" "$src" --cross-file "$cross" \
+      --prefix /usr --libdir lib --buildtype release --default-library static
+  ninja -C "$bld"
+  DESTDIR="$XC_SYSROOT" ninja -C "$bld" install
+  # Drop the shared sibling (install builds only static, but be safe) so the
+  # linker picks the .a and homescreen needs no libdisplay-info.so on-target.
+  rm -f "$XC_SYSROOT/usr/lib/libdisplay-info.so"*
+
+  displayinfo_ok || die "libdisplay-info install did not yield >= $LIBDISPLAY_INFO_VERSION"
+  note "installed libdisplay-info (static) into $XC_SYSROOT"
+}
+
+# ── Phase 3: emit toolchain file + sysroot-aware pkg-config wrapper ───────
+phase3_emit() {
+  log "Phase 3: emit toolchain file + pkg-config wrapper"
+  mkdir -p "$BUILD_DIR"
+
+  cat > "$BUILD_DIR/.xc-pkg-config" <<'EOF'
+#!/bin/sh
+# Sysroot-aware pkg-config wrapper for the Yocto (weston recipe) sysroot.
+export PKG_CONFIG_DIR=
+export PKG_CONFIG_LIBDIR="$XC_SYSROOT/usr/lib/pkgconfig:$XC_SYSROOT/usr/share/pkgconfig"
+export PKG_CONFIG_SYSROOT_DIR="$XC_SYSROOT"
+unset PKG_CONFIG_PATH
+exec pkg-config "$@"
+EOF
+  chmod +x "$BUILD_DIR/.xc-pkg-config"
+
+  cat > "$BUILD_DIR/.xc-toolchain.cmake" <<EOF
+# Generated by scripts/build_nitrogen8mm.sh — do not edit.
+# i.MX8MM, Yocto weston recipe-sysroot + aarch64-poky-linux gcc.
+set(CMAKE_SYSTEM_NAME      Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_SYSROOT          "\$ENV{XC_SYSROOT}")
+set(CMAKE_C_COMPILER       "\$ENV{CROSS_BIN}/$CROSS_TRIPLE-gcc")
+set(CMAKE_CXX_COMPILER     "\$ENV{CROSS_BIN}/$CROSS_TRIPLE-g++")
+set(CMAKE_FIND_ROOT_PATH   "\$ENV{XC_SYSROOT}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# Yocto sysroot has no Debian multiarch layout (libs live in /usr/lib).
+set(_xc_cpu "-march=armv8-a+crc+crypto -mbranch-protection=standard")
+set(CMAKE_C_FLAGS_INIT   "\${_xc_cpu}")
+set(CMAKE_CXX_FLAGS_INIT "\${_xc_cpu}")
+
+set(PKG_CONFIG_EXECUTABLE  "$BUILD_DIR/.xc-pkg-config"
+    CACHE FILEPATH "sysroot-aware pkg-config wrapper" FORCE)
+EOF
+  note "toolchain file: $BUILD_DIR/.xc-toolchain.cmake"
+}
+
+# ── Phase 4: configure & build ───────────────────────────────────────────
+phase4_build() {
+  log "Phase 4: configure & build (drm-kms-egl, jobs=$JOBS)"
+  [[ "$CLEAN" -eq 1 ]] && rm -rf "$BUILD_DIR"/CMakeCache.txt "$BUILD_DIR"/CMakeFiles
+  export XC_SYSROOT CROSS_BIN
+  export PATH="$CROSS_BIN:$PATH"
+
+  local args=(
+    -G Ninja -S "$REPO_DIR" -B "$BUILD_DIR"
+    -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/.xc-toolchain.cmake"
+    -DCMAKE_BUILD_TYPE=Release
+    -DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF
+    -DBUILD_BACKEND_DRM_KMS_EGL=ON  -DBUILD_BACKEND_SOFTWARE=OFF
+    -DBUILD_BACKEND_HEADLESS_EGL=OFF
+  )
+  [[ "$WITH_SCENE" -eq 1 ]] && args+=(-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON)
+  if [[ "$NO_PLUGINS" -eq 1 ]]; then
+    args+=(-DDISABLE_PLUGINS=ON)
+  else
+    [[ -d "$PLUGINS_DIR" ]] || die "plugins dir not found: $PLUGINS_DIR (use --no-plugins or --plugins-dir)"
+    args+=(-DDISABLE_PLUGINS=OFF -DPLUGINS_DIR="$PLUGINS_DIR")
+  fi
+
+  cmake "${args[@]}"
+  cmake --build "$BUILD_DIR" -j "$JOBS"
+}
+
+# ── Phase 5: report ──────────────────────────────────────────────────────
+phase5_report() {
+  local exe="$BUILD_DIR/shell/homescreen"
+  [[ -x "$exe" ]] || die "no homescreen binary produced"
+  log "Phase 5: artifacts"
+  echo "  binary  : $exe"
+  file "$exe" | sed 's/^/      /'
+  echo "  sysroot : $XC_SYSROOT"
+}
+
+# ── Phase 6: deploy ──────────────────────────────────────────────────────
+phase6_deploy() {
+  [[ "$DO_DEPLOY" -eq 1 ]] || return 0
+  log "Phase 6: deploy to $DEVICE_HOST"
+  local exe="$BUILD_DIR/shell/homescreen"
+  [[ -d "$BUNDLE" && -f "$BUNDLE/lib/libflutter_engine.so" ]] \
+    || die "bundle not found / not self-contained: $BUNDLE
+  Expected a dir with lib/libflutter_engine.so + lib/libapp.so + data/."
+
+  local stage="/tmp/ivi-homescreen-stage"
+  ssh_dev "rm -rf '$stage' && mkdir -p '$stage'"
+  log "staging binary + bundle"
+  scp_dev "$exe" "$DEVICE_HOST:$stage/homescreen" >/dev/null
+  scp_dev -r "$BUNDLE" "$DEVICE_HOST:$stage/bundle" >/dev/null
+
+  log "installing on board (seatd + kiosk units)"
+  ssh_dev "bash -s" <<'REMOTE'
+set -e
+stage="/tmp/ivi-homescreen-stage"
+install -Dm755 "$stage/homescreen" /usr/local/bin/ivi-homescreen
+rm -rf /opt/ivi-homescreen/bundle
+mkdir -p /opt/ivi-homescreen
+cp -a "$stage/bundle" /opt/ivi-homescreen/bundle
+
+# seatd: the image ships the binary but runs no seatd; libseat's logind backend
+# has no seat in a headless systemd service, so drive a VT-bound seatd seat.
+cat > /etc/systemd/system/seatd.service <<'UNIT'
+[Unit]
+Description=Seat management daemon
+[Service]
+Type=simple
+ExecStart=/usr/bin/seatd -g root
+Restart=on-failure
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+cat > /etc/systemd/system/ivi-homescreen.service <<'UNIT'
+[Unit]
+Description=ivi-homescreen (drm_kms_egl)
+After=seatd.service systemd-udev-settle.service
+Wants=seatd.service
+[Service]
+Type=simple
+Environment=LIBSEAT_BACKEND=seatd
+Environment=XDG_RUNTIME_DIR=/run/user/0
+# Flutter apps (path_provider/shared_preferences) require HOME; a systemd
+# service has none by default, unlike an interactive login shell.
+Environment=HOME=/root
+WorkingDirectory=/opt/ivi-homescreen
+ExecStartPre=/bin/mkdir -p /run/user/0
+ExecStartPre=-/bin/sh -c 'for g in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do echo performance > "$g" 2>/dev/null || true; done'
+ExecStart=/usr/local/bin/ivi-homescreen -b /opt/ivi-homescreen/bundle
+Restart=on-failure
+RestartSec=3
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable seatd.service ivi-homescreen.service
+rm -rf "$stage"
+echo "install: done"
+REMOTE
+
+  if [[ "$DO_RESTART" -eq 1 ]]; then
+    log "starting service"
+    ssh_dev "systemctl restart seatd.service ivi-homescreen.service || true"
+  fi
+  echo
+  echo "  Deployed + enabled on $DEVICE_HOST (starts on boot)."
+  echo "  Inspect: ssh $DEVICE_HOST 'journalctl -u ivi-homescreen -b'"
+  [[ "$DO_RESTART" -eq 1 ]] || echo "  Pass --restart to start it now."
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────
+phase0_preflight
+phase1_locate
+phase2_display_info
+if [[ "$PREPARE_ONLY" -eq 1 ]]; then
+  log "prepare-only: toolchain located + libdisplay-info ready; exiting"
+  exit 0
+fi
+phase3_emit
+phase4_build
+phase5_report
+phase6_deploy
+log "done"

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -133,6 +133,7 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
             backend/drm_kms_egl/drm_backend.cc
             backend/drm_kms_egl/drm_session.cc
             backend/drm_kms_egl/driver_probe.cc
+            backend/drm_kms_egl/gl_cursor.cc
             backend/gl_process_resolver.cc
             display/drm_display.cc
             display/drm_mode_list.cc

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -50,6 +50,7 @@
 #include "backend/drm_kms_egl/drm_compositor.h"
 #include "backend/drm_kms_egl/drm_cursor.h"
 #include "backend/drm_kms_egl/drm_session.h"
+#include "backend/drm_kms_egl/gl_cursor.h"
 #include "backend/gl_process_resolver.h"
 #include "engine.h"
 #include "logging.h"
@@ -341,6 +342,24 @@ std::unique_ptr<DrmBackend> DrmBackend::Create(
   }
 #endif
 #endif
+
+  // GL-composited cursor fallback: drawn into FBO 0 each Present, used when no
+  // hardware cursor plane is active (HAVE_DRM_CURSOR off, no cursor plane, no
+  // XCursor theme, or HW Create() returned null). Skipped under
+  // --disable-cursor. Single-plane CRTCs (i.MX LCDIF, etc.) land here.
+  {
+    bool hw_cursor_active = false;
+#if HAVE_DRM_CURSOR
+    hw_cursor_active = (backend->cursor_ != nullptr);
+#endif
+    if (!hw_cursor_active && !backend->cfg_.disable_cursor) {
+      backend->gl_cursor_ = std::make_unique<homescreen::GlCursor>();
+      spdlog::info(
+          "[DrmBackend] no HW cursor plane active — using GL-composited "
+          "cursor");
+    }
+  }
+
 #if HAVE_DRM_CAPTURE
   backend->capture_ = homescreen::DrmCapture::Create();
 #endif
@@ -407,6 +426,10 @@ DrmBackend::DrmBackend(const DrmConfig& cfg, homescreen::DrmSession* session)
   InstallDrmCxxLogSink();
 }
 
+homescreen::ICursorPositionSink* DrmBackend::gl_cursor() const {
+  return gl_cursor_.get();
+}
+
 DrmBackend::~DrmBackend() {
   // Cadence profile summary (no-op unless IVI_PROFILE / IVI_DRM_PROFILE ran).
   frame_profile_.LogSessionSummary("DrmBackend");
@@ -414,6 +437,14 @@ DrmBackend::~DrmBackend() {
   // Let any in-flight page flip land so we don't free a BO still being
   // scanned out.
   (void)WaitForPendingFlip();
+
+  // Release the GL-composited cursor's GL objects while the context is current.
+  if (gl_cursor_ && egl_display_ != EGL_NO_DISPLAY &&
+      egl_context_ != EGL_NO_CONTEXT) {
+    eglMakeCurrent(egl_display_, egl_surface_, egl_surface_, egl_context_);
+    gl_cursor_->Destroy();
+  }
+  gl_cursor_.reset();
 
 #if BUILD_COMPOSITOR
   // Release compositor GL resources while the context is still current.
@@ -1646,6 +1677,12 @@ bool DrmBackend::Present() {
   MaybeCaptureSnapshot();
   if (!WaitForPendingFlip()) {
     return false;
+  }
+
+  // Composite the cursor over the rendered Flutter scene (still in FBO 0's
+  // back buffer) before the swap. No-op until the cursor is visible / absent.
+  if (gl_cursor_) {
+    gl_cursor_->Draw(fb_w_, fb_h_);
   }
 
   if (!eglSwapBuffers(egl_display_, egl_surface_)) {

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -41,6 +41,8 @@ class TaskRunner;
 namespace homescreen {
 class DrmCapture;
 class DrmCursor;
+class GlCursor;
+class ICursorPositionSink;
 class DrmSession;
 }  // namespace homescreen
 
@@ -360,15 +362,29 @@ class DrmBackend : public Backend {
 #if BUILD_COMPOSITOR
   std::unique_ptr<DrmCompositor> compositor_{};
 #endif
+#if HAVE_DRM_CURSOR
   std::unique_ptr<homescreen::DrmCursor> cursor_{};
+#endif
+  // Composited cursor fallback, created only when no HW cursor plane is
+  // available (this display controller has none) and the cursor isn't
+  // disabled. Drawn into FBO 0 each Present.
+  std::unique_ptr<homescreen::GlCursor> gl_cursor_{};
 #if HAVE_DRM_CAPTURE
   std::unique_ptr<homescreen::DrmCapture> capture_;
 #endif
 
  public:
   [[nodiscard]] homescreen::DrmCursor* drm_cursor() const {
+#if HAVE_DRM_CURSOR
     return cursor_.get();
+#else
+    return nullptr;
+#endif
   }
+
+  // The composited cursor sink (nullptr when a HW cursor is in use or the
+  // cursor is disabled). Defined out-of-line where GlCursor is complete.
+  [[nodiscard]] homescreen::ICursorPositionSink* gl_cursor() const;
 
   // Called once per frame from both Present() (GL fallback) and
   // DrmCompositor::PresentLayers (plane path). Always defined so call

--- a/shell/backend/drm_kms_egl/gl_cursor.cc
+++ b/shell/backend/drm_kms_egl/gl_cursor.cc
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/drm_kms_egl/gl_cursor.h"
+
+#include <array>
+#include <cstring>
+
+#include "logging.h"
+
+namespace homescreen {
+
+namespace {
+
+// Classic left-pointer arrow, 12x19 (same sprite as the software backend's
+// SoftwareCursor). 'o' = black outline, 'X' = white fill, space = transparent.
+// Hotspot is the tip at (0, 0). Each row is exactly kCursorW characters.
+constexpr uint32_t kCursorW = 12;
+constexpr uint32_t kCursorH = 19;
+constexpr std::array<const char*, kCursorH> kArrow = {
+    "o           ", "oo          ", "oXo         ", "oXXo        ",
+    "oXXXo       ", "oXXXXo      ", "oXXXXXo     ", "oXXXXXXo    ",
+    "oXXXXXXXo   ", "oXXXXXXXXo  ", "oXXXXXoooooo", "oXXoXXo     ",
+    "oXo oXXo    ", "oo  oXXo    ", "o    oXXo   ", "     oXXo   ",
+    "      oXXo  ", "      oXXo  ", "       oo   ",
+};
+
+constexpr char kVertexShader[] =
+    "attribute vec2 a_pos;\n"
+    "attribute vec2 a_uv;\n"
+    "varying vec2 v_uv;\n"
+    "void main() {\n"
+    "  v_uv = a_uv;\n"
+    "  gl_Position = vec4(a_pos, 0.0, 1.0);\n"
+    "}\n";
+
+constexpr char kFragmentShader[] =
+    "precision mediump float;\n"
+    "varying vec2 v_uv;\n"
+    "uniform sampler2D u_tex;\n"
+    "void main() {\n"
+    "  gl_FragColor = texture2D(u_tex, v_uv);\n"
+    "}\n";
+
+GLuint CompileShader(const GLenum type, const char* src) {
+  const GLuint sh = glCreateShader(type);
+  glShaderSource(sh, 1, &src, nullptr);
+  glCompileShader(sh);
+  GLint ok = GL_FALSE;
+  glGetShaderiv(sh, GL_COMPILE_STATUS, &ok);
+  if (ok != GL_TRUE) {
+    char log[512] = {};
+    glGetShaderInfoLog(sh, sizeof(log), nullptr, log);
+    spdlog::error("[GlCursor] shader compile failed: {}", log);
+    glDeleteShader(sh);
+    return 0;
+  }
+  return sh;
+}
+
+}  // namespace
+
+GlCursor::GlCursor() : w_(kCursorW), h_(kCursorH) {
+  // Build the premultiplied RGBA8888 sprite (memory order [R,G,B,A]). The
+  // fill/outline colors are already opaque, so premultiplication is a no-op
+  // on them; transparent texels are all-zero.
+  rgba_.assign(static_cast<size_t>(w_) * h_ * 4, 0);
+  for (uint32_t row = 0; row < h_; ++row) {
+    const char* line = kArrow[row];
+    const size_t len = std::strlen(line);
+    for (uint32_t col = 0; col < w_; ++col) {
+      const char c = col < len ? line[col] : ' ';
+      uint8_t r = 0;
+      uint8_t g = 0;
+      uint8_t b = 0;
+      uint8_t a = 0;
+      if (c == 'X') {  // opaque white fill
+        r = g = b = a = 0xFF;
+      } else if (c == 'o') {  // opaque black outline
+        a = 0xFF;
+      }
+      uint8_t* px = rgba_.data() + (static_cast<size_t>(row) * w_ + col) * 4;
+      px[0] = r;
+      px[1] = g;
+      px[2] = b;
+      px[3] = a;
+    }
+  }
+}
+
+GlCursor::~GlCursor() = default;
+
+bool GlCursor::EnsureGl() {
+  if (gl_ready_) {
+    return true;
+  }
+  if (gl_failed_) {
+    return false;
+  }
+
+  const GLuint vs = CompileShader(GL_VERTEX_SHADER, kVertexShader);
+  const GLuint fs = CompileShader(GL_FRAGMENT_SHADER, kFragmentShader);
+  if (vs == 0 || fs == 0) {
+    if (vs != 0) {
+      glDeleteShader(vs);
+    }
+    if (fs != 0) {
+      glDeleteShader(fs);
+    }
+    gl_failed_ = true;
+    return false;
+  }
+
+  program_ = glCreateProgram();
+  glAttachShader(program_, vs);
+  glAttachShader(program_, fs);
+  glLinkProgram(program_);
+  glDeleteShader(vs);
+  glDeleteShader(fs);
+  GLint linked = GL_FALSE;
+  glGetProgramiv(program_, GL_LINK_STATUS, &linked);
+  if (linked != GL_TRUE) {
+    char log[512] = {};
+    glGetProgramInfoLog(program_, sizeof(log), nullptr, log);
+    spdlog::error("[GlCursor] program link failed: {}", log);
+    glDeleteProgram(program_);
+    program_ = 0;
+    gl_failed_ = true;
+    return false;
+  }
+
+  a_pos_ = glGetAttribLocation(program_, "a_pos");
+  a_uv_ = glGetAttribLocation(program_, "a_uv");
+  u_tex_ = glGetUniformLocation(program_, "u_tex");
+  if (a_pos_ < 0 || a_uv_ < 0 || u_tex_ < 0) {
+    // A driver that dropped one of these would turn the GLuint casts below
+    // into out-of-range attribute indices; bail instead.
+    spdlog::error("[GlCursor] shader attribute/uniform location missing");
+    glDeleteProgram(program_);
+    program_ = 0;
+    gl_failed_ = true;
+    return false;
+  }
+
+  glGenTextures(1, &texture_);
+  glBindTexture(GL_TEXTURE_2D, texture_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, static_cast<GLsizei>(w_),
+               static_cast<GLsizei>(h_), 0, GL_RGBA, GL_UNSIGNED_BYTE,
+               rgba_.data());
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  gl_ready_ = true;
+  return true;
+}
+
+void GlCursor::Draw(const uint32_t fb_w, const uint32_t fb_h) {
+  if (!visible_.load(std::memory_order_acquire)) {
+    return;
+  }
+  if (fb_w == 0 || fb_h == 0 || !EnsureGl()) {
+    return;
+  }
+
+  const auto fw = static_cast<float>(fb_w);
+  const auto fh = static_cast<float>(fb_h);
+  const auto w = static_cast<float>(w_ * scale_);
+  const auto h = static_cast<float>(h_ * scale_);
+  const auto x0 = static_cast<float>(x_.load(std::memory_order_relaxed) -
+                                     hot_x_ * static_cast<int32_t>(scale_));
+  const auto y0 = static_cast<float>(y_.load(std::memory_order_relaxed) -
+                                     hot_y_ * static_cast<int32_t>(scale_));
+  const float x1 = x0 + w;
+  const float y1 = y0 + h;
+
+  // Pixel space (top-left origin, y-down) → NDC. The window framebuffer shows
+  // the Flutter scene upright, so top-left pixel (0,0) maps to NDC (-1, +1).
+  auto nx = [fw](const float x) { return x / fw * 2.0F - 1.0F; };
+  auto ny = [fh](const float y) { return 1.0F - y / fh * 2.0F; };
+
+  // Triangle strip: TL, BL, TR, BR. Texture V=0 is the top (arrow tip row).
+  const std::array<float, 16> verts = {
+      nx(x0), ny(y0), 0.0F, 0.0F,  // TL
+      nx(x0), ny(y1), 0.0F, 1.0F,  // BL
+      nx(x1), ny(y0), 1.0F, 0.0F,  // TR
+      nx(x1), ny(y1), 1.0F, 1.0F,  // BR
+  };
+
+  // Flutter's renderer (Skia) caches GL state and does NOT re-query it between
+  // frames. Any state we change and leave changed desyncs that cache and
+  // corrupts the next frame (e.g. a disabled scissor → full-field flashing).
+  // So snapshot every piece of state we touch and restore it exactly, leaving
+  // the context byte-for-byte as Skia left it.
+  GLint s_prog = 0;
+  GLint s_fbo = 0;
+  GLint s_vp[4] = {0, 0, 0, 0};
+  GLint s_array_buf = 0;
+  GLint s_active_tex = GL_TEXTURE0;
+  GLint s_tex2d = 0;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &s_prog);
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &s_fbo);
+  glGetIntegerv(GL_VIEWPORT, s_vp);
+  glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &s_array_buf);
+  glGetIntegerv(GL_ACTIVE_TEXTURE, &s_active_tex);
+  glActiveTexture(GL_TEXTURE0);
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &s_tex2d);
+
+  const GLboolean s_blend = glIsEnabled(GL_BLEND);
+  const GLboolean s_scissor = glIsEnabled(GL_SCISSOR_TEST);
+  const GLboolean s_depth = glIsEnabled(GL_DEPTH_TEST);
+  const GLboolean s_cull = glIsEnabled(GL_CULL_FACE);
+  const GLboolean s_stencil = glIsEnabled(GL_STENCIL_TEST);
+  GLint s_bsrc_rgb = GL_ONE;
+  GLint s_bdst_rgb = GL_ZERO;
+  GLint s_bsrc_a = GL_ONE;
+  GLint s_bdst_a = GL_ZERO;
+  GLint s_beq_rgb = GL_FUNC_ADD;
+  GLint s_beq_a = GL_FUNC_ADD;
+  glGetIntegerv(GL_BLEND_SRC_RGB, &s_bsrc_rgb);
+  glGetIntegerv(GL_BLEND_DST_RGB, &s_bdst_rgb);
+  glGetIntegerv(GL_BLEND_SRC_ALPHA, &s_bsrc_a);
+  glGetIntegerv(GL_BLEND_DST_ALPHA, &s_bdst_a);
+  glGetIntegerv(GL_BLEND_EQUATION_RGB, &s_beq_rgb);
+  glGetIntegerv(GL_BLEND_EQUATION_ALPHA, &s_beq_a);
+
+  struct AttribState {
+    GLint enabled;
+    GLint size;
+    GLint type;
+    GLint normalized;
+    GLint stride;
+    GLint buffer;
+    void* pointer;
+  };
+  const std::array<GLint, 2> locs = {a_pos_, a_uv_};
+  std::array<AttribState, 2> sa{};
+  for (size_t i = 0; i < locs.size(); ++i) {
+    const auto loc = static_cast<GLuint>(locs[i]);
+    glGetVertexAttribiv(loc, GL_VERTEX_ATTRIB_ARRAY_ENABLED, &sa[i].enabled);
+    glGetVertexAttribiv(loc, GL_VERTEX_ATTRIB_ARRAY_SIZE, &sa[i].size);
+    glGetVertexAttribiv(loc, GL_VERTEX_ATTRIB_ARRAY_TYPE, &sa[i].type);
+    glGetVertexAttribiv(loc, GL_VERTEX_ATTRIB_ARRAY_NORMALIZED,
+                        &sa[i].normalized);
+    glGetVertexAttribiv(loc, GL_VERTEX_ATTRIB_ARRAY_STRIDE, &sa[i].stride);
+    glGetVertexAttribiv(loc, GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING,
+                        &sa[i].buffer);
+    glGetVertexAttribPointerv(loc, GL_VERTEX_ATTRIB_ARRAY_POINTER,
+                              &sa[i].pointer);
+  }
+
+  // --- our draw ---
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glViewport(0, 0, static_cast<GLsizei>(fb_w), static_cast<GLsizei>(fb_h));
+  glDisable(GL_SCISSOR_TEST);
+  glDisable(GL_DEPTH_TEST);
+  glDisable(GL_CULL_FACE);
+  glDisable(GL_STENCIL_TEST);
+  glEnable(GL_BLEND);
+  glBlendEquation(GL_FUNC_ADD);
+  glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);  // premultiplied "over"
+
+  glUseProgram(program_);
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, texture_);
+  glUniform1i(u_tex_, 0);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);  // client-array vertex pointers
+  glEnableVertexAttribArray(static_cast<GLuint>(a_pos_));
+  glEnableVertexAttribArray(static_cast<GLuint>(a_uv_));
+  glVertexAttribPointer(static_cast<GLuint>(a_pos_), 2, GL_FLOAT, GL_FALSE,
+                        4 * sizeof(float), verts.data());
+  glVertexAttribPointer(static_cast<GLuint>(a_uv_), 2, GL_FLOAT, GL_FALSE,
+                        4 * sizeof(float), verts.data() + 2);
+  glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+  // --- restore exactly ---
+  for (size_t i = 0; i < locs.size(); ++i) {
+    const auto loc = static_cast<GLuint>(locs[i]);
+    glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(sa[i].buffer));
+    glVertexAttribPointer(loc, sa[i].size, static_cast<GLenum>(sa[i].type),
+                          static_cast<GLboolean>(sa[i].normalized),
+                          sa[i].stride, sa[i].pointer);
+    if (sa[i].enabled) {
+      glEnableVertexAttribArray(loc);
+    } else {
+      glDisableVertexAttribArray(loc);
+    }
+  }
+  glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(s_array_buf));
+
+  glBlendEquationSeparate(static_cast<GLenum>(s_beq_rgb),
+                          static_cast<GLenum>(s_beq_a));
+  glBlendFuncSeparate(
+      static_cast<GLenum>(s_bsrc_rgb), static_cast<GLenum>(s_bdst_rgb),
+      static_cast<GLenum>(s_bsrc_a), static_cast<GLenum>(s_bdst_a));
+
+  auto set_enable = [](const GLenum cap, const GLboolean on) {
+    if (on != GL_FALSE) {
+      glEnable(cap);
+    } else {
+      glDisable(cap);
+    }
+  };
+  set_enable(GL_BLEND, s_blend);
+  set_enable(GL_SCISSOR_TEST, s_scissor);
+  set_enable(GL_DEPTH_TEST, s_depth);
+  set_enable(GL_CULL_FACE, s_cull);
+  set_enable(GL_STENCIL_TEST, s_stencil);
+
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(s_tex2d));
+  glActiveTexture(static_cast<GLenum>(s_active_tex));
+  glUseProgram(static_cast<GLuint>(s_prog));
+  glBindFramebuffer(GL_FRAMEBUFFER, static_cast<GLuint>(s_fbo));
+  glViewport(s_vp[0], s_vp[1], s_vp[2], s_vp[3]);
+}
+
+void GlCursor::Destroy() {
+  if (texture_ != 0) {
+    glDeleteTextures(1, &texture_);
+    texture_ = 0;
+  }
+  if (program_ != 0) {
+    glDeleteProgram(program_);
+    program_ = 0;
+  }
+  gl_ready_ = false;
+}
+
+}  // namespace homescreen

--- a/shell/backend/drm_kms_egl/gl_cursor.h
+++ b/shell/backend/drm_kms_egl/gl_cursor.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+#include <GLES2/gl2.h>
+
+#include "input/cursor_position_sink.h"
+
+namespace homescreen {
+
+// GL-composited mouse cursor for the drm_kms_egl backend — the fallback used
+// when the display controller exposes no hardware cursor plane (e.g. i.MX
+// LCDIF, which has a single primary plane) or no XCursor theme is available.
+// The sprite is a small embedded arrow (premultiplied ARGB8888, no libxcursor
+// dependency); it is uploaded once as a GLES2 texture and drawn as a blended
+// quad into the window framebuffer (FBO 0) at the end of each Present, on top
+// of the rendered Flutter scene.
+//
+// Threading: SetPosition()/SetVisible() are called from the seat's input
+// thread (position + visibility are atomics). EnsureGl()/Draw()/Destroy() run
+// on the rasterizer thread with the EGL context current — Draw() from the
+// backend's Present() just before eglSwapBuffers, Destroy() from the backend
+// teardown while the context is still current.
+class GlCursor final : public ICursorPositionSink {
+ public:
+  GlCursor();
+  ~GlCursor() override;
+
+  GlCursor(const GlCursor&) = delete;
+  GlCursor& operator=(const GlCursor&) = delete;
+
+  // Input thread. Coordinates are render/viewport pixels; the hotspot (arrow
+  // tip) is subtracted in Draw(). Marks the cursor visible on first motion.
+  void SetPosition(int32_t x, int32_t y) override {
+    x_.store(x, std::memory_order_relaxed);
+    y_.store(y, std::memory_order_relaxed);
+    visible_.store(true, std::memory_order_release);
+  }
+
+  void SetVisible(const bool visible) {
+    visible_.store(visible, std::memory_order_release);
+  }
+
+  // Rasterizer thread, EGL context current, FBO 0 holding the rendered frame.
+  // Composites the cursor over it. No-op until the cursor is visible.
+  void Draw(uint32_t fb_w, uint32_t fb_h);
+
+  // Rasterizer thread, EGL context current. Release GL objects.
+  void Destroy();
+
+ private:
+  bool EnsureGl();
+
+  // Sprite: premultiplied RGBA8888 bytes, row-major, w_ * h_ texels.
+  std::vector<uint8_t> rgba_;
+  uint32_t w_{0};
+  uint32_t h_{0};
+  int32_t hot_x_{0};
+  int32_t hot_y_{0};
+  uint32_t scale_{2};  // integer upscale so a 12x19 arrow is visible at 1080p
+
+  std::atomic<int32_t> x_{0};
+  std::atomic<int32_t> y_{0};
+  std::atomic<bool> visible_{false};
+
+  GLuint program_{0};
+  GLuint texture_{0};
+  GLint a_pos_{-1};
+  GLint a_uv_{-1};
+  GLint u_tex_{-1};
+  bool gl_ready_{false};
+  bool gl_failed_{false};
+};
+
+}  // namespace homescreen

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -124,6 +124,12 @@ void DrmDisplay::SetCursor(homescreen::DrmCursor* cursor) {
   }
 }
 
+void DrmDisplay::SetGlCursor(homescreen::ICursorPositionSink* sink) {
+  if (auto* drm_seat = dynamic_cast<homescreen::DrmSeat*>(seat_.get())) {
+    drm_seat->SetGlCursor(sink);
+  }
+}
+
 void DrmDisplay::SetCursorRotation(const int32_t degrees) {
   if (auto* drm_seat = dynamic_cast<homescreen::DrmSeat*>(seat_.get())) {
     drm_seat->SetCursorRotation(degrees);

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -25,6 +25,7 @@
 
 namespace homescreen {
 class DrmCursor;
+class ICursorPositionSink;
 class DrmSession;
 }  // namespace homescreen
 
@@ -54,6 +55,10 @@ class DrmDisplay final : public IDisplay {
   // the sprite (used during teardown before DrmBackend destroys the
   // DrmCursor it owns).
   void SetCursor(homescreen::DrmCursor* cursor);
+
+  // Forward the composited cursor sink (the EGL backend's GlCursor, used when
+  // there's no HW cursor plane) to the seat. nullptr is safe.
+  void SetGlCursor(homescreen::ICursorPositionSink* sink);
 
   // Forward the scanout rotation to the seat so the HW cursor sprite is
   // transformed from render space into panel space (0|90|180|270).

--- a/shell/input/cursor_position_sink.h
+++ b/shell/input/cursor_position_sink.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace homescreen {
+
+// Minimal sink the DRM seat pushes pointer positions (in render/viewport
+// pixels) to, for a composited cursor that has no hardware plane — e.g. the
+// EGL backend's GlCursor on display controllers (i.MX LCDIF, etc.) that expose
+// only a primary plane. It is a pure-virtual interface so DrmSeat (shared with
+// the Vulkan DRM backend) carries no link dependency on any concrete cursor:
+// a backend that never sets one leaves the seat's pointer null and the call is
+// skipped.
+class ICursorPositionSink {
+ public:
+  virtual ~ICursorPositionSink() = default;
+
+  // Place the cursor hotspot at (x, y) in render/viewport pixels and mark it
+  // visible. Called from the seat's input-dispatch thread.
+  virtual void SetPosition(int32_t x, int32_t y) = 0;
+};
+
+}  // namespace homescreen

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -386,14 +386,33 @@ void DrmSeat::FlushCursorMotion() {
     return;
   }
   cursor_motion_pending_ = false;
+
+  const int rx = static_cast<int>(pointer_x_);
+  const int ry = static_cast<int>(pointer_y_);
+
+  // The GL-composited cursor (fallback for no HW cursor plane) draws into the
+  // render target, so it takes un-rotated render/viewport coordinates — the
+  // display applies any scanout rotation to the whole framebuffer downstream.
+  if (auto* g = gl_cursor_.load(std::memory_order_acquire); g != nullptr) {
+    g->SetPosition(rx, ry);
+    // The composited cursor only repaints on a presented frame, and Flutter
+    // presents only dirty frames — so on an idle UI the cursor would freeze
+    // between the vsync-paced frames the app happens to produce. Nudge the
+    // engine to render so the cursor tracks the pointer. ScheduleFrame is
+    // thread-safe and coalesces to one frame per vsync. (A HW cursor plane,
+    // when present, self-commits and needs no frame — hence composited-only.)
+    if (const auto engine = CurrentEngine(); engine != nullptr) {
+      LibFlutterEngine->ScheduleFrame(engine);
+    }
+  }
+
+#if HAVE_DRM_CURSOR
   if (auto* c = cursor_.load(std::memory_order_acquire); c != nullptr) {
-    // The pointer lives in render (viewport) space; the cursor plane lives in
-    // panel space. For a 90/270 scanout rotation these differ (axes swapped),
-    // so rotate the position by the scanout amount before placing the sprite.
-    // 0/180 leave the extent unchanged. (Flutter pointer events keep the
-    // un-rotated render coords, so hit-testing stays correct.)
-    const int rx = static_cast<int>(pointer_x_);
-    const int ry = static_cast<int>(pointer_y_);
+    // The HW cursor plane lives in panel space. For a 90/270 scanout rotation
+    // that differs from render space (axes swapped), so rotate the position by
+    // the scanout amount before placing the sprite. 0/180 leave the extent
+    // unchanged. (Flutter pointer events keep the un-rotated render coords, so
+    // hit-testing stays correct.)
     int px = rx;
     int py = ry;
     switch (cursor_rotation_) {
@@ -417,6 +436,7 @@ void DrmSeat::FlushCursorMotion() {
     // here in staged mode — the compositor owns the cursor plane.
     c->SetPosition(px, py);
   }
+#endif
 }
 
 void DrmSeat::HandleEvent(const drm::input::InputEvent& ev) {

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -35,6 +35,7 @@
 
 #include <shell/platform/embedder/embedder.h>
 
+#include "input/cursor_position_sink.h"
 #include "input/iseat.h"
 #include "input/key_repeater.h"
 #include "input/xkb_keyboard.h"
@@ -83,6 +84,15 @@ class DrmSeat final : public ISeat {
   // pointed-to DrmCursor is destroyed.
   void SetCursor(DrmCursor* cursor) {
     cursor_.store(cursor, std::memory_order_release);
+  }
+
+  // Set (or clear) a composited cursor sink (the EGL backend's GlCursor), used
+  // when no hardware cursor plane is available. Safe to call from any thread;
+  // the dispatch loop reads via acquire and ignores nullptr. The sink receives
+  // un-rotated render/viewport coordinates (it composites into the render
+  // target; scanout rotation is applied to the whole framebuffer downstream).
+  void SetGlCursor(ICursorPositionSink* sink) {
+    gl_cursor_.store(sink, std::memory_order_release);
   }
 
   // Hot-swap the xkb keymap. Safe to call from any thread; the actual
@@ -246,6 +256,11 @@ class DrmSeat final : public ISeat {
   // forwards motion to it. Atomic because the wiring runs on a
   // different thread than the dispatch loop that reads it.
   std::atomic<DrmCursor*> cursor_{nullptr};
+
+  // Composited cursor fallback (the EGL backend's GlCursor), used when there
+  // is no hardware cursor plane. Owned by the backend; this seat forwards
+  // motion to it. Null whenever a HW cursor is in use or no cursor at all.
+  std::atomic<ICursorPositionSink*> gl_cursor_{nullptr};
 };
 
 }  // namespace homescreen

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -224,6 +224,8 @@ FlutterView::FlutterView(Configuration::Config config,
       drm_display->SetViewportSize(static_cast<int32_t>(drm_backend->width()),
                                    static_cast<int32_t>(drm_backend->height()));
       drm_display->SetCursor(drm_backend->drm_cursor());
+      // Composited cursor fallback (non-null only when no HW cursor plane).
+      drm_display->SetGlCursor(drm_backend->gl_cursor());
     }
   }
 #elif BUILD_BACKEND_DRM_KMS_VULKAN


### PR DESCRIPTION
## Summary

Adds a **GL-composited cursor fallback** for the `drm_kms_egl` backend, used on display controllers that expose no hardware cursor plane (e.g. i.MX LCDIF, which has a single primary plane). Also adds a cross-build script for the Boundary Devices Nitrogen8MM (NXP i.MX8MM), where this was developed and validated.

## GL-composited cursor

Precedence is a **fallback**, not a replacement:
1. HW cursor plane present (+ drm-cxx/libxcursor) → existing `DrmCursor` (self-commits, cheap).
2. No HW cursor plane / no theme / `HAVE_DRM_CURSOR` off → new `GlCursor`.
3. `--disable-cursor` → neither, and no cursor-driven repaints.

`GlCursor` uploads a small embedded ARGB arrow (no libxcursor dependency) as a GLES2 texture and blends it over the rendered frame in `Present()` before `eglSwapBuffers`.

Notable details:
- Wired through a new pure-virtual `ICursorPositionSink` so the shared `DrmSeat` carries no link dependency on the concrete cursor (the Vulkan DRM build leaves it null).
- `Draw()` snapshots and restores **every** GL state it touches, so Skia's GL state cache stays coherent — otherwise the next frame renders wrong (full-field flashing from a left-disabled scissor).
- `DrmSeat` schedules a frame on pointer motion so the composited cursor tracks on an idle UI (mirrors the software backend). Gated on the cursor existing, so `--disable-cursor` triggers zero extra repaints.
- Fixes a latent **no-libxcursor build break**: the `DrmCursor` `unique_ptr` member and `DrmSeat`'s `SetPosition` call are now guarded behind `HAVE_DRM_CURSOR`.

Limitation: with no HW plane, every cursor move re-renders the whole scene, so smoothness is capped by scene frame rate. A future last-frame re-blit could decouple them.

## build_nitrogen8mm.sh

Cross-builds the `drm_kms_egl` backend for i.MX8MM (Vivante GC7000NanoUltra, GLES2/EGL, Yocto `fsl-imx-wayland`). No SDK / no rootfs sync: it reuses the local Yocto build's weston `recipe-sysroot` (already a complete cross dev sysroot) + its `recipe-sysroot-native` poky gcc 13.3, cross-builds static `libdisplay-info >= 0.2.0` (required by drm-cxx, absent from the image) into that sysroot, and emits the toolchain + a sysroot-aware pkg-config wrapper. `--deploy --restart` installs a VT-bound `seatd` unit + a kiosk unit (the image runs no seatd; libseat's logind backend has no seat in a headless service), pins the CPU governor to `performance`, and sets `HOME=/root` (Flutter's path_provider/prefs require it).

## Testing

- drm_kms_egl renders Wonderous on the Nitrogen8MM at 1920x1080@60 (DSI-1).
- GL cursor: visible, mouse-driven, no flashing, tracks on motion — user-confirmed.
- `--disable-cursor` verified to draw no cursor and trigger no motion repaints.
- `build_nitrogen8mm.sh --clean` and `--deploy --restart` validated end-to-end; kiosk service comes up stable on the board.
- clang-tidy + clang-format clean; cross-build links cleanly.