### PR TITLE
[drm_kms_egl] opt-in raster-thread page-flip drain (IVI_DRM_RASTER_DRAIN)

### DIFF
--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -1594,10 +1594,7 @@ void DrmBackend::StopVsyncMonitor() {
       pollfd pfd{drm_dev_->fd(), POLLIN, 0};
       const int rc = ::poll(&pfd, 1, kPollSliceMs);
       if (rc > 0 && (pfd.revents & POLLIN)) {
-        drmEventContext ctx{};
-        ctx.version = 2;
-        ctx.page_flip_handler = &DrmBackend::UnifiedPageFlipHandler;
-        drmHandleEvent(drm_dev_->fd(), &ctx);
+        DrainFlipEvents();
       } else if (rc < 0 && errno != EINTR) {
         break;
       }
@@ -1634,41 +1631,88 @@ void DrmBackend::ArmFlipRead() {
         if (!drm_dev_.has_value()) {
           return;
         }
-        drmEventContext ctx{};
-        ctx.version = 2;
-        ctx.page_flip_handler = &DrmBackend::UnifiedPageFlipHandler;
-        drmHandleEvent(drm_dev_->fd(), &ctx);
+        DrainFlipEvents();
         ArmFlipRead();  // re-arm for the next vblank
       });
 }
 
+void DrmBackend::DrainFlipEvents() const {
+  if (!drm_dev_.has_value()) {
+    return;
+  }
+  // poll(0) + read together under the lock so the read can never block: only
+  // one thread observes POLLIN-then-consumes a given event; a loser's poll(0)
+  // afterwards shows nothing readable and it no-ops. Read-only pollers (the
+  // WaitForPendingFlip diagnostic) need no lock — poll() concurrent with
+  // another thread's read() is safe.
+  const std::lock_guard<std::mutex> lock(drm_event_mutex_);
+  pollfd pfd{drm_dev_->fd(), POLLIN, 0};
+  if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN)) {
+    drmEventContext ctx{};
+    ctx.version = 2;
+    ctx.page_flip_handler = &DrmBackend::UnifiedPageFlipHandler;
+    drmHandleEvent(drm_dev_->fd(), &ctx);
+  }
+}
+
 bool DrmBackend::WaitForPendingFlip() const {
-  // The asio flip monitor (StartFlipMonitor) drains PAGE_FLIP_EVENTs
-  // on the platform task runner thread and clears flip_pending_ via
-  // UnifiedPageFlipHandler → OnLegacyFlipComplete. We just wait for
-  // it. Short sleep so a 60 Hz frame's ~16ms window has plenty of
-  // resolution but we don't burn the rasterizer CPU.
   using namespace std::chrono_literals;
-  // Bounded wait. On nvidia-drm a flip's PAGE_FLIP_EVENT can go
-  // undelivered, and at teardown the asio monitor that would drain it
-  // is already gone — an unbounded loop then spins forever in
-  // hrtimer_nanosleep, hanging Present and (fatally) ~DrmBackend so the
-  // process never exits on SIGTERM. Cap the wait and proceed; a healthy
-  // 60Hz flip clears in ~16ms so this never fires in normal operation.
-  // Same budget as StopVsyncMonitor's drain.
+  // Opt-in (default off). The asio flip monitor normally drains
+  // PAGE_FLIP_EVENTs on the platform task runner thread; when that thread is
+  // starved (CPU governor downclock, Dart GC), the rasterizer here would sleep
+  // out the whole 100ms deadline even though the event already arrived. With
+  // IVI_DRM_RASTER_DRAIN=1 the rasterizer drains the fd itself instead. Off by
+  // default so behavior on validated platforms is byte-for-byte unchanged; the
+  // diagnostic below reports when turning it on would help.
+  static const bool raster_drain = []() {
+    const char* env = std::getenv("IVI_DRM_RASTER_DRAIN");
+    return env != nullptr && std::string_view(env) == "1";
+  }();
+  // Bounded wait. On nvidia-drm a flip's PAGE_FLIP_EVENT can go undelivered,
+  // and at teardown the asio monitor that would drain it is already gone — an
+  // unbounded loop then spins forever in hrtimer_nanosleep, hanging Present and
+  // (fatally) ~DrmBackend so the process never exits on SIGTERM. Cap the wait
+  // and proceed; a healthy 60Hz flip clears in ~16ms.
   constexpr auto kFlipWaitTimeout = 100ms;
   const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
   while (flip_pending_.load(std::memory_order_acquire)) {
     if (!drm_dev_) {
       return true;
     }
+    if (raster_drain) {
+      // Fetch the completion ourselves rather than waiting on the (possibly
+      // starved) platform thread.
+      DrainFlipEvents();
+      if (!flip_pending_.load(std::memory_order_acquire)) {
+        break;
+      }
+    }
     if (std::chrono::steady_clock::now() >= deadline) {
+      if (!raster_drain) {
+        // Read-only probe: is the completion event sitting readable but
+        // undrained? If so the platform-thread monitor was starved and
+        // IVI_DRM_RASTER_DRAIN=1 would fix it — distinct from a genuinely late
+        // flip (driver / no vblank), where it would not. poll(0) doesn't
+        // read(), so it neither consumes the event nor races the monitor.
+        pollfd pfd{drm_dev_->fd(), POLLIN, 0};
+        if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN) &&
+            flip_pending_.load(std::memory_order_acquire)) {
+          static std::once_flag once;
+          std::call_once(once, []() {
+            spdlog::warn(
+                "[DrmBackend] page-flip event was readable but undrained at "
+                "the 100ms deadline — the flip monitor thread is being starved "
+                "(CPU governor / load). Set IVI_DRM_RASTER_DRAIN=1 to drain it "
+                "on the rasterizer thread.");
+          });
+        }
+      }
       spdlog::warn(
           "[DrmBackend] WaitForPendingFlip: no flip completion after 100ms; "
           "proceeding (PAGE_FLIP_EVENT likely lost)");
       return true;
     }
-    std::this_thread::sleep_for(500us);
+    std::this_thread::sleep_for(raster_drain ? 200us : 500us);
   }
   return true;
 }

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 
@@ -255,6 +256,12 @@ class DrmBackend : public Backend {
   bool SetInitialMode();
   uint32_t AddFb(gbm_bo* bo) const;
   bool WaitForPendingFlip() const;
+  // Drain any readable PAGE_FLIP_EVENT on the drm fd (poll(0)+drmHandleEvent),
+  // serialized by drm_event_mutex_ so the rasterizer thread and the asio flip
+  // monitor never read the fd concurrently. The poll+read run under the lock so
+  // the read can't block: only one thread consumes a given event. Used by both
+  // the asio monitor and (when IVI_DRM_RASTER_DRAIN=1) WaitForPendingFlip.
+  void DrainFlipEvents() const;
   // Unified PAGE_FLIP_EVENT dispatcher. Registered as the
   // drmEventContext.page_flip_handler from the asio flip monitor; the
   // user_data is always a DrmBackend* (compositor commits also pass
@@ -320,6 +327,14 @@ class DrmBackend : public Backend {
   // next flip in Present) don't race. Same justification on the
   // compositor's mirror.
   std::atomic<bool> flip_pending_{false};
+
+  // Serializes drmHandleEvent() between the asio flip monitor (platform task
+  // runner thread) and WaitForPendingFlip()'s opt-in raster-thread drain, so
+  // the two never read the drm fd concurrently. Mutable: DrainFlipEvents() is
+  // const (called from the const WaitForPendingFlip). INVARIANT: nothing
+  // reachable from UnifiedPageFlipHandler may take this lock — the handler runs
+  // under it (inside drmHandleEvent), so re-locking would self-deadlock.
+  mutable std::mutex drm_event_mutex_;
 
   // EGL
   EGLDisplay egl_display_ = EGL_NO_DISPLAY;

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -25,6 +25,8 @@
 #include <cerrno>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
+#include <mutex>
 #include <string_view>
 #include <system_error>
 #include <thread>
@@ -930,6 +932,16 @@ bool DrmCompositor::WaitForPendingFlip() const {
   // flip event can be lost; without a cap the destructor's wait spins
   // forever and the process never exits on SIGTERM. A healthy 60Hz flip
   // clears in ~16ms so the cap never fires in normal operation.
+  // Opt-in (default off), mirrors DrmBackend::WaitForPendingFlip for the plane
+  // compositor path. When the platform-thread asio monitor that drains
+  // PAGE_FLIP_EVENTs is starved (CPU governor downclock, Dart GC), drain the fd
+  // on the rasterizer thread via the backend's shared, mutex-guarded helper
+  // (DrainFlipEvents routes the event to OnFlipComplete) instead of sleeping
+  // out the deadline. Off by default so behavior is unchanged unless asked.
+  static const bool raster_drain = []() {
+    const char* env = std::getenv("IVI_DRM_RASTER_DRAIN");
+    return env != nullptr && std::string_view(env) == "1";
+  }();
   constexpr auto kFlipWaitTimeout = 100ms;
   const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
   while (flip_pending_.load(std::memory_order_acquire)) {
@@ -940,13 +952,36 @@ bool DrmCompositor::WaitForPendingFlip() const {
     if (paused_.load(std::memory_order_acquire)) {
       return false;
     }
+    if (raster_drain) {
+      backend_->DrainFlipEvents();  // clears flip_pending_ via OnFlipComplete
+      if (!flip_pending_.load(std::memory_order_acquire)) {
+        break;
+      }
+    }
     if (std::chrono::steady_clock::now() >= deadline) {
+      if (!raster_drain) {
+        // Read-only probe: event readable but undrained → the monitor was
+        // starved and IVI_DRM_RASTER_DRAIN=1 would fix it (distinct from a
+        // genuinely late flip). poll(0) doesn't read, so no race / no consume.
+        pollfd pfd{backend_->drm_fd(), POLLIN, 0};
+        if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN) &&
+            flip_pending_.load(std::memory_order_acquire)) {
+          static std::once_flag once;
+          std::call_once(once, []() {
+            spdlog::warn(
+                "[DrmCompositor] page-flip event was readable but undrained at "
+                "the 100ms deadline — the flip monitor thread is being starved "
+                "(CPU governor / load). Set IVI_DRM_RASTER_DRAIN=1 to drain it "
+                "on the rasterizer thread.");
+          });
+        }
+      }
       spdlog::warn(
           "[DrmCompositor] WaitForPendingFlip: no flip completion after "
           "100ms; proceeding (PAGE_FLIP_EVENT likely lost)");
       return true;
     }
-    std::this_thread::sleep_for(500us);
+    std::this_thread::sleep_for(raster_drain ? 200us : 500us);
   }
   return true;
 }


### PR DESCRIPTION
## Problem

`WaitForPendingFlip()` (rasterizer thread) relies on the asio flip monitor on the **platform task runner thread** to drain `PAGE_FLIP_EVENT`s and clear `flip_pending_`. When that thread is starved — CPU cpufreq governor downclock (`ondemand`), or a long Dart GC pause — the kernel fires the event but nobody reads it before the 100ms deadline. The rasterizer then logs `PAGE_FLIP_EVENT likely lost` and proceeds while the flip is still in flight, so the next `drmModePageFlip` can `EBUSY` and leak the pending BO.

Root-caused on i.MX8MM: the event is **not** lost — it's sitting readable on the fd, just undrained because the monitor thread didn't get scheduled.

## Fix (opt-in, default off)

`IVI_DRM_RASTER_DRAIN=1` lets the rasterizer drain the fd itself via `DrainFlipEvents()`:
- `poll(0)` + `drmHandleEvent()` **serialized with the asio monitor by `drm_event_mutex_`**. The poll and read run under the lock so the read can never block — only one thread consumes a given event; the loser's `poll(0)` then shows nothing readable.
- The asio monitor and the teardown drain in `StopVsyncMonitor()` route through the same helper, so there's a single guarded drain path.

**Default off → no behavior change on validated platforms.** In the healthy baton-driven flow `flip_pending_` is already false when `Present()` runs, so `WaitForPendingFlip()` returns before touching the lock — zero overhead. The drain only ever runs in the starved case.

## Self-diagnostic

When the flag is **off**, a read-only `poll(0)` probe at the deadline distinguishes a *starved monitor* (event readable but undrained → the flag would help) from a *genuinely late flip* (no event yet → it wouldn't), and logs a one-time, actionable recommendation to set `IVI_DRM_RASTER_DRAIN=1`. `poll(0)` doesn't `read()`, so it neither consumes the event nor races the monitor.

## Reliability / security / performance

- **Security:** none — no new input, the DRM fd is already trusted.
- **Performance:** none on the healthy path (returns before lock/poll); in the starved case it's *lower* latency than the sleep-wait. Single mutex → no lock-ordering deadlock. Invariant documented: nothing reachable from `UnifiedPageFlipHandler` may take `drm_event_mutex_` (the handler runs under it inside `drmHandleEvent`).
- **Reliability:** removes the EBUSY/leaked-BO failure mode behind the give-up.

## Testing

Validated on i.MX8MM (Nitrogen8MM, imx-drm) under the `ondemand` governor:
- flag **off** → `WaitForPendingFlip` warning + the one-time `Set IVI_DRM_RASTER_DRAIN=1` recommendation.
- flag **on** → **0** warnings, renders cleanly, no abort/deadlock.

⚠️ Touches the shared flip path used by the compositor/scene present on amdgpu / rk3588 / msm / vc4, which I could only build- but not run-test here. Recommend a quick sanity check on an amdgpu or RPi target before flipping the default on in a later change.