### PR TITLE
[drm_kms_egl] enable IVI_DRM_RASTER_DRAIN by default (+ nvidia-drm cursor self-commit)

### DIFF
--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -1657,16 +1657,17 @@ void DrmBackend::DrainFlipEvents() const {
 
 bool DrmBackend::WaitForPendingFlip() const {
   using namespace std::chrono_literals;
-  // Opt-in (default off). The asio flip monitor normally drains
-  // PAGE_FLIP_EVENTs on the platform task runner thread; when that thread is
-  // starved (CPU governor downclock, Dart GC), the rasterizer here would sleep
-  // out the whole 100ms deadline even though the event already arrived. With
-  // IVI_DRM_RASTER_DRAIN=1 the rasterizer drains the fd itself instead. Off by
-  // default so behavior on validated platforms is byte-for-byte unchanged; the
-  // diagnostic below reports when turning it on would help.
+  // The asio flip monitor normally drains PAGE_FLIP_EVENTs on the platform task
+  // runner thread; when that thread is starved (CPU governor downclock, Dart
+  // GC) the rasterizer would otherwise sleep out the whole 100ms deadline even
+  // though the event already arrived. So the rasterizer drains the fd itself
+  // (DrainFlipEvents, serialized with the monitor by drm_event_mutex_). On by
+  // default — validated across 6 platforms / 5 GPU vendors (no regression, no
+  // deadlock, pause/resume + teardown clean). Set IVI_DRM_RASTER_DRAIN=0 to opt
+  // out (escape hatch).
   static const bool raster_drain = []() {
     const char* env = std::getenv("IVI_DRM_RASTER_DRAIN");
-    return env != nullptr && std::string_view(env) == "1";
+    return env == nullptr || std::string_view(env) != "0";
   }();
   // Bounded wait. On nvidia-drm a flip's PAGE_FLIP_EVENT can go undelivered,
   // and at teardown the asio monitor that would drain it is already gone — an
@@ -1688,25 +1689,9 @@ bool DrmBackend::WaitForPendingFlip() const {
       }
     }
     if (std::chrono::steady_clock::now() >= deadline) {
-      if (!raster_drain) {
-        // Read-only probe: is the completion event sitting readable but
-        // undrained? If so the platform-thread monitor was starved and
-        // IVI_DRM_RASTER_DRAIN=1 would fix it — distinct from a genuinely late
-        // flip (driver / no vblank), where it would not. poll(0) doesn't
-        // read(), so it neither consumes the event nor races the monitor.
-        pollfd pfd{drm_dev_->fd(), POLLIN, 0};
-        if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN) &&
-            flip_pending_.load(std::memory_order_acquire)) {
-          static std::once_flag once;
-          std::call_once(once, []() {
-            spdlog::warn(
-                "[DrmBackend] page-flip event was readable but undrained at "
-                "the 100ms deadline — the flip monitor thread is being starved "
-                "(CPU governor / load). Set IVI_DRM_RASTER_DRAIN=1 to drain it "
-                "on the rasterizer thread.");
-          });
-        }
-      }
+      // Reached only for a genuinely late/lost flip (e.g. nvidia-drm) — the
+      // raster drain already handles a merely-starved monitor. Proceed; the
+      // bounded wait keeps Present and ~DrmBackend from hanging.
       spdlog::warn(
           "[DrmBackend] WaitForPendingFlip: no flip completion after 100ms; "
           "proceeding (PAGE_FLIP_EVENT likely lost)");

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -315,10 +315,18 @@ std::unique_ptr<DrmBackend> DrmBackend::Create(
   // couples cursor motion to Flutter frame production, so the cursor stalls
   // while the UI is idle — the self-committing cursor is smoother. kAuto (the
   // default) therefore stages only on nvidia-drm; yes/no force the choice.
+  //
+  // The raster drain (IVI_DRM_RASTER_DRAIN, on by default) removes the very
+  // PAGE_FLIP_EVENT starvation that made staging necessary on nvidia-drm: the
+  // rasterizer drains the flip itself, so a self-committing cursor no longer
+  // swallows the pending flip. So when the drain is active, kAuto self-commits
+  // on nvidia-drm too (smooth, decoupled cursor — verified on Jetson). With the
+  // drain disabled (=0), kAuto reverts to staging there.
   const bool stage_cursor =
       backend->cfg_.stage_cursor == drm_config::TriState::kYes ||
       (backend->cfg_.stage_cursor == drm_config::TriState::kAuto &&
-       backend->resolved_->driver_name == "nvidia-drm");
+       backend->resolved_->driver_name == "nvidia-drm" &&
+       !RasterDrainEnabled());
   // Either way, reserve the cursor's plane so the scene allocator's
   // disable-unused pass doesn't toggle it off every commit (flicker on
   // motion). plane_id()==0 (legacy cursor path) is a no-op in the
@@ -1655,20 +1663,24 @@ void DrmBackend::DrainFlipEvents() const {
   }
 }
 
-bool DrmBackend::WaitForPendingFlip() const {
-  using namespace std::chrono_literals;
-  // The asio flip monitor normally drains PAGE_FLIP_EVENTs on the platform task
-  // runner thread; when that thread is starved (CPU governor downclock, Dart
-  // GC) the rasterizer would otherwise sleep out the whole 100ms deadline even
-  // though the event already arrived. So the rasterizer drains the fd itself
-  // (DrainFlipEvents, serialized with the monitor by drm_event_mutex_). On by
-  // default — validated across 6 platforms / 5 GPU vendors (no regression, no
-  // deadlock, pause/resume + teardown clean). Set IVI_DRM_RASTER_DRAIN=0 to opt
-  // out (escape hatch).
-  static const bool raster_drain = []() {
+bool DrmBackend::RasterDrainEnabled() {
+  static const bool enabled = []() {
     const char* env = std::getenv("IVI_DRM_RASTER_DRAIN");
+    // On by default — validated across 6 platforms / 5 GPU vendors (no
+    // regression, no deadlock, pause/resume + teardown clean). The only opt-out
+    // is an explicit "0"; anything else (incl. unset) enables it.
     return env == nullptr || std::string_view(env) != "0";
   }();
+  return enabled;
+}
+
+bool DrmBackend::WaitForPendingFlip() const {
+  using namespace std::chrono_literals;
+  // When the platform-thread asio monitor is starved (CPU governor downclock,
+  // Dart GC) the rasterizer drains the flip fd itself (DrainFlipEvents,
+  // serialized with the monitor by drm_event_mutex_) rather than sleeping out
+  // the 100ms deadline. On by default; IVI_DRM_RASTER_DRAIN=0 opts out.
+  const bool raster_drain = RasterDrainEnabled();
   // Bounded wait. On nvidia-drm a flip's PAGE_FLIP_EVENT can go undelivered,
   // and at teardown the asio monitor that would drain it is already gone — an
   // unbounded loop then spins forever in hrtimer_nanosleep, hanging Present and

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -262,6 +262,11 @@ class DrmBackend : public Backend {
   // the read can't block: only one thread consumes a given event. Used by both
   // the asio monitor and (when IVI_DRM_RASTER_DRAIN=1) WaitForPendingFlip.
   void DrainFlipEvents() const;
+  // True unless IVI_DRM_RASTER_DRAIN=0 — the single source of truth for the
+  // raster-thread drain decision, shared by WaitForPendingFlip (both backend
+  // and compositor) and the nvidia-drm cursor-staging heuristic. Cached on
+  // first call.
+  [[nodiscard]] static bool RasterDrainEnabled();
   // Unified PAGE_FLIP_EVENT dispatcher. Registered as the
   // drmEventContext.page_flip_handler from the asio flip monitor; the
   // user_data is always a DrmBackend* (compositor commits also pass

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -932,15 +932,16 @@ bool DrmCompositor::WaitForPendingFlip() const {
   // flip event can be lost; without a cap the destructor's wait spins
   // forever and the process never exits on SIGTERM. A healthy 60Hz flip
   // clears in ~16ms so the cap never fires in normal operation.
-  // Opt-in (default off), mirrors DrmBackend::WaitForPendingFlip for the plane
-  // compositor path. When the platform-thread asio monitor that drains
-  // PAGE_FLIP_EVENTs is starved (CPU governor downclock, Dart GC), drain the fd
-  // on the rasterizer thread via the backend's shared, mutex-guarded helper
-  // (DrainFlipEvents routes the event to OnFlipComplete) instead of sleeping
-  // out the deadline. Off by default so behavior is unchanged unless asked.
+  // Mirrors DrmBackend::WaitForPendingFlip for the plane compositor path. When
+  // the platform-thread asio monitor that drains PAGE_FLIP_EVENTs is starved
+  // (CPU governor downclock, Dart GC), drain the fd on the rasterizer thread
+  // via the backend's shared, mutex-guarded helper (DrainFlipEvents routes the
+  // event to OnFlipComplete) instead of sleeping out the deadline. On by
+  // default (validated across 6 platforms / 5 GPU vendors incl. pause/resume +
+  // teardown); set IVI_DRM_RASTER_DRAIN=0 to opt out.
   static const bool raster_drain = []() {
     const char* env = std::getenv("IVI_DRM_RASTER_DRAIN");
-    return env != nullptr && std::string_view(env) == "1";
+    return env == nullptr || std::string_view(env) != "0";
   }();
   constexpr auto kFlipWaitTimeout = 100ms;
   const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
@@ -959,23 +960,9 @@ bool DrmCompositor::WaitForPendingFlip() const {
       }
     }
     if (std::chrono::steady_clock::now() >= deadline) {
-      if (!raster_drain) {
-        // Read-only probe: event readable but undrained → the monitor was
-        // starved and IVI_DRM_RASTER_DRAIN=1 would fix it (distinct from a
-        // genuinely late flip). poll(0) doesn't read, so no race / no consume.
-        pollfd pfd{backend_->drm_fd(), POLLIN, 0};
-        if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN) &&
-            flip_pending_.load(std::memory_order_acquire)) {
-          static std::once_flag once;
-          std::call_once(once, []() {
-            spdlog::warn(
-                "[DrmCompositor] page-flip event was readable but undrained at "
-                "the 100ms deadline — the flip monitor thread is being starved "
-                "(CPU governor / load). Set IVI_DRM_RASTER_DRAIN=1 to drain it "
-                "on the rasterizer thread.");
-          });
-        }
-      }
+      // Reached only for a genuinely late/lost flip — the raster drain already
+      // handles a merely-starved monitor. Proceed; the bounded wait keeps the
+      // rasterizer and teardown from hanging.
       spdlog::warn(
           "[DrmCompositor] WaitForPendingFlip: no flip completion after "
           "100ms; proceeding (PAGE_FLIP_EVENT likely lost)");

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -932,17 +932,13 @@ bool DrmCompositor::WaitForPendingFlip() const {
   // flip event can be lost; without a cap the destructor's wait spins
   // forever and the process never exits on SIGTERM. A healthy 60Hz flip
   // clears in ~16ms so the cap never fires in normal operation.
-  // Mirrors DrmBackend::WaitForPendingFlip for the plane compositor path. When
-  // the platform-thread asio monitor that drains PAGE_FLIP_EVENTs is starved
-  // (CPU governor downclock, Dart GC), drain the fd on the rasterizer thread
-  // via the backend's shared, mutex-guarded helper (DrainFlipEvents routes the
-  // event to OnFlipComplete) instead of sleeping out the deadline. On by
-  // default (validated across 6 platforms / 5 GPU vendors incl. pause/resume +
-  // teardown); set IVI_DRM_RASTER_DRAIN=0 to opt out.
-  static const bool raster_drain = []() {
-    const char* env = std::getenv("IVI_DRM_RASTER_DRAIN");
-    return env == nullptr || std::string_view(env) != "0";
-  }();
+  // Mirrors DrmBackend::WaitForPendingFlip for the plane compositor path: when
+  // the platform-thread asio monitor is starved, drain the fd on the rasterizer
+  // thread via the backend's shared, mutex-guarded helper (DrainFlipEvents
+  // routes the event to OnFlipComplete) instead of sleeping out the deadline.
+  // On by default; IVI_DRM_RASTER_DRAIN=0 opts out. Shared decision so the
+  // backend and compositor never disagree.
+  const bool raster_drain = DrmBackend::RasterDrainEnabled();
   constexpr auto kFlipWaitTimeout = 100ms;
   const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
   while (flip_pending_.load(std::memory_order_acquire)) {


### PR DESCRIPTION
## Summary

Flip the raster-thread page-flip drain (introduced opt-in in #232) to **on by default**. Not setting the env var now enables it; `IVI_DRM_RASTER_DRAIN=0` is the escape hatch.

```
raster_drain = (env == nullptr) || (env != "0")   // unset → on; "0" → off
```

Applied to both `DrmBackend::WaitForPendingFlip` (GL path) and `DrmCompositor::WaitForPendingFlip` (plane-compositor path). Also drops the now-moot "set `IVI_DRM_RASTER_DRAIN=1`" recommendation diagnostic — it only ran on the flag-off path, which is no longer the default.

## Why now

#232 shipped opt-in to de-risk the new cross-thread fd draining. It's since been validated across **6 platforms / 5 GPU vendors**, and crucially **every** platform exhibited the drain-fixable starvation under its *default* governor with the flag off — so opt-in left the fix unused exactly where it was needed.

| Path | Platform | GPU | Regression (off) | Hang/deadlock (on) | Pause/resume | Teardown vs off |
|---|---|---|---|---|---|---|
| GL (`DrmBackend`) | imx-drm | Vivante | none | none | clean (3/3) | identical (pre-existing rc137) |
| planes (`DrmCompositor`) | amdgpu | AMD | none | none | — | identical (pre-existing rc137) |
| planes | RPi5 vc4 | Broadcom | none | none | — | clean (rc124) |
| planes | rk3588 | Arm Mali | none | none | clean (3/3) | clean (rc124) |
| planes | Uno Q | Qualcomm | none | none | — | clean (rc124) |
| planes | Jetson | **nvidia-drm** | none | **none (no hang)** | — | clean |

- **No regression** with it off; **no deadlock/hang** with it on, including the nvidia-drm lossy-event case (the genuinely-lost event safely falls through the bounded 100 ms deadline — confirmed empirically).
- **Pause/resume** validated on both the GL path (nitrogen8mm) and the plane-compositor path (rk3588) across real VT-switch session-revoke/restore cycles — paused==resumed, rendering resumes, 0 errors.
- **Teardown** is unchanged: exit codes identical flag-off vs on everywhere (the amdgpu/imx-drm SIGKILL is pre-existing slow teardown, not this change).
- **Healthy path has zero overhead** regardless: `WaitForPendingFlip` returns before touching the drain when the flip already completed.

## Rollback

`IVI_DRM_RASTER_DRAIN=0` disables it per-process. The escape hatch stays for one release; once it's proven in the field the flag can be removed and the drain made unconditional.