### PR TITLE
[drm_kms_egl] fix teardown hang after VT-switch pause (gbm buffer leak)

### DIFF
--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -1377,6 +1377,7 @@ void DrmBackend::SetVsyncBaton(FLUTTER_API_SYMBOL(FlutterEngine) engine,
 
 void DrmBackend::OnSessionPaused() {
   spdlog::info("[DrmBackend] session paused (VT switch-out)");
+  session_paused_.store(true, std::memory_order_release);
 #if BUILD_COMPOSITOR
   if (compositor_) {
     compositor_->SetPaused(true);
@@ -1401,6 +1402,7 @@ void DrmBackend::OnSessionResumed(const int new_fd) {
         drm_dev_->fd(), new_fd);
   }
   spdlog::info("[DrmBackend] session resumed (VT switch-in, fd={})", new_fd);
+  session_paused_.store(false, std::memory_order_release);
 #if BUILD_COMPOSITOR
   if (compositor_) {
     compositor_->OnResume();
@@ -1715,6 +1717,33 @@ bool DrmBackend::WaitForPendingFlip() const {
 }
 
 bool DrmBackend::Present() {
+  // Session-pause gate (mirrors DrmCompositor::PresentLayers). While the VT is
+  // switched away, scanout is revoked and page flips never complete, so the
+  // gbm_surface's buffers are never released. eglSwapBuffers would then block
+  // forever in gbm_surface_get_free_buffer, wedging the rasterizer thread —
+  // FlutterEngineShutdown can't join it and teardown hangs (SIGKILL). Ack the
+  // frame without touching GL/KMS; OnSessionResumed re-modesets and restarts
+  // the pacer.
+  if (session_paused_.load(std::memory_order_acquire)) {
+    return true;
+  }
+  // Reclaim a buffer orphaned by a flip dropped during a VT-switch pause:
+  // OnSessionPaused clears flip_pending_, but the in-flight flip's buffer stays
+  // locked (its completion event never fires). Release it before swapping, or
+  // each pause cycle leaks a locked buffer until the surface starves and
+  // eglSwapBuffers blocks forever in gbm_surface_get_free_buffer (rasterizer
+  // wedged → teardown SIGKILL). Race-free on the raster thread: flip_pending_
+  // is false here, so the platform flip-handler won't touch pending_bo_; the
+  // acquire-load pairs with OnLegacyFlipComplete's release-store so we never
+  // observe a half-updated pending_bo_.
+  if (!flip_pending_.load(std::memory_order_acquire) && pending_bo_) {
+    if (pending_fb_ != 0 && drm_dev_) {
+      drmModeRmFB(drm_dev_->fd(), pending_fb_);
+      pending_fb_ = 0;
+    }
+    gbm_surface_release_buffer(gbm_surface_, pending_bo_);
+    pending_bo_ = nullptr;
+  }
   MaybeCaptureSnapshot();
   if (!WaitForPendingFlip()) {
     return false;
@@ -1744,6 +1773,16 @@ bool DrmBackend::Present() {
   }
 
   if (!mode_set_) {
+    // A resume re-modesets from this fresh buffer (mode_set_ was cleared in
+    // OnSessionResumed). Release the pre-pause scanout buffer first, or it
+    // leaks when overwritten below — another per-cycle starvation source.
+    // Null at the first-ever modeset, so a no-op there.
+    if (current_fb_ != 0 && drm_dev_) {
+      drmModeRmFB(drm_dev_->fd(), current_fb_);
+    }
+    if (current_bo_) {
+      gbm_surface_release_buffer(gbm_surface_, current_bo_);
+    }
     current_bo_ = next_bo;
     current_fb_ = next_fb;
     if (!SetInitialMode()) {

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -341,6 +341,13 @@ class DrmBackend : public Backend {
   // under it (inside drmHandleEvent), so re-locking would self-deadlock.
   mutable std::mutex drm_event_mutex_;
 
+  // Set by OnSessionPaused / cleared by OnSessionResumed (libseat VT switch).
+  // While paused, scanout is revoked and page flips never complete, so GBM
+  // buffers never free — Present() must skip eglSwapBuffers or it blocks
+  // forever in gbm_surface_get_free_buffer, wedging the rasterizer thread and
+  // hanging teardown. Mirrors DrmCompositor's own paused_ gate.
+  std::atomic<bool> session_paused_{false};
+
   // EGL
   EGLDisplay egl_display_ = EGL_NO_DISPLAY;
   EGLConfig egl_config_ = nullptr;


### PR DESCRIPTION
## Problem

`homescreen` intermittently fails to exit on `SIGTERM` and has to be `SIGKILL`ed (rc137) — observed on amdgpu (user had to `sudo kill -9`) and imx-drm. Long-standing "teardown slowness, not yet diagnosed."

## Root cause

Triggered by **libseat VT-switch / session-pause churn, then SIGTERM** (steady-state teardown is clean). gdb thread backtraces on the hung process:

- **main thread** blocked in `pthread_cond_wait` inside `FlutterEngineDeinitialize`/`Shutdown` — waiting to join the engine threads.
- **rasterizer thread** wedged:
  ```
  gbm_*_surface_get_free_buffer ()   ← waiting for a free GBM buffer (never frees)
  libEGL (eglSwapBuffers)
  DrmBackend::Present()
  ```

Mechanism: a VT-switch pause drops the in-flight page flip (its `PAGE_FLIP_EVENT` never fires), but `DrmBackend::Present` kept the flip's gbm buffer locked and never released it — `OnSessionPaused` clears `flip_pending_` without returning `pending_bo_`, and the resume re-modeset overwrote `current_bo_` without releasing the prior scanout buffer. Each pause cycle leaks a locked buffer until the `gbm_surface` starves; the next `eglSwapBuffers` then blocks **forever** in `gbm_*_surface_get_free_buffer`. `FlutterEngineShutdown` can't join a rasterizer stuck in the driver → teardown hangs. (Deeper than the bounded `WaitForPendingFlip`, which is why that cap never helped.)

## Fix

All on the rasterizer thread, so race-free — `flip_pending_` is false post-pause, so the platform flip-handler is dormant and won't touch the buffers:

1. **Track `session_paused_`** (set in `OnSessionPaused`, cleared in `OnSessionResumed`); `Present()` acks the frame without swapping while paused — mirrors the gate `DrmCompositor::PresentLayers` already has — so no new buffer is locked into a surface whose flips can't complete.
2. **Release the orphaned in-flight buffer** (`pending_bo_`/`pending_fb_`) at the top of `Present` once its flip has been dropped (`!flip_pending_ && pending_bo_`; acquire-load pairs with `OnLegacyFlipComplete`'s release-store).
3. **Release the prior scanout buffer** (`current_bo_`/`current_fb_`) before the resume re-modeset overwrites it.

## Testing

Reproduced reliably on imx-drm (`compositor=gl`) with a VT-switch-then-SIGTERM loop (hung on attempt 1 before the fix). After the fix: **clean teardown 8/8 then 10/10**, full `~DrmBackend` completion, zero `gbm` blocks. The plane-compositor path already had the equivalent pause gate, so this targets the legacy-GL path where the leak lived.