### PR TITLE
[drm_kms_egl] honor cursor_theme config for the HW cursor

### DIFF
--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -304,7 +304,8 @@ std::unique_ptr<DrmBackend> DrmBackend::Create(
   } else {
     backend->cursor_ = homescreen::DrmCursor::Create(
         *backend->drm_dev_, backend->crtc_id_, backend->connector_id_,
-        backend->mode_, backend->fb_w_, backend->fb_h_);
+        backend->mode_, backend->fb_w_, backend->fb_h_,
+        /*rotation_degrees=*/0, backend->cfg_.cursor_theme);
   }
 #if BUILD_COMPOSITOR
   // Decide whether to stage the cursor into the compositor's own atomic commit

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -89,6 +89,13 @@ struct DrmConfig {
   // just no DRM cursor sprite. Equivalent to the IVI_DRM_CURSOR=0 env.
   bool disable_cursor{false};
 
+  // XCursor theme name for the HW cursor sprite (global.cursor_theme). Empty =
+  // drm-cxx Theme::discover()'s default ($XCURSOR_THEME, then "default"). The
+  // Wayland backend already consumes cursor_theme; this carries it to the DRM
+  // hardware cursor so the DRM path honors the same config instead of
+  // auto-discovering whatever theme happens to be first on the search path.
+  std::string cursor_theme{};
+
   // Stage the HW cursor into the compositor's atomic commit instead of
   // letting it self-commit (DrmCursor staged mode). kAuto (the default)
   // resolves per driver in DrmBackend::Create: enabled only on nvidia-drm,

--- a/shell/backend/drm_kms_egl/drm_cursor.cc
+++ b/shell/backend/drm_kms_egl/drm_cursor.cc
@@ -130,13 +130,15 @@ constexpr uint64_t PackPos(const int fb_x, const int fb_y) {
 }
 }  // namespace
 
-std::unique_ptr<DrmCursor> DrmCursor::Create(drm::Device& dev,
-                                             const uint32_t crtc_id,
-                                             const uint32_t connector_id,
-                                             const drmModeModeInfo& mode,
-                                             const uint32_t fb_w,
-                                             const uint32_t fb_h,
-                                             const int rotation_degrees) {
+std::unique_ptr<DrmCursor> DrmCursor::Create(
+    drm::Device& dev,
+    const uint32_t crtc_id,
+    const uint32_t connector_id,
+    const drmModeModeInfo& mode,
+    const uint32_t fb_w,
+    const uint32_t fb_h,
+    const int rotation_degrees,
+    const std::string_view theme_name) {
   if (const char* gate = std::getenv("IVI_DRM_CURSOR");
       gate != nullptr && std::string_view(gate) == "0") {
     spdlog::info("[DrmCursor] disabled via IVI_DRM_CURSOR=0");
@@ -161,7 +163,10 @@ std::unique_ptr<DrmCursor> DrmCursor::Create(drm::Device& dev,
     return nullptr;
   }
 
-  auto cursor = drm::cursor::Cursor::load(*theme, "default", "", sizing.sprite);
+  // theme_name (from global.cursor_theme) selects the XCursor theme; empty
+  // falls back to $XCURSOR_THEME / "default" inside the resolver.
+  auto cursor =
+      drm::cursor::Cursor::load(*theme, "default", theme_name, sizing.sprite);
   if (!cursor) {
     spdlog::warn("[DrmCursor] load 'default': {}; no cursor sprite",
                  cursor.error().message());

--- a/shell/backend/drm_kms_egl/drm_cursor.h
+++ b/shell/backend/drm_kms_egl/drm_cursor.h
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string_view>
 
 #include <xf86drmMode.h>
 
@@ -76,7 +77,8 @@ class DrmCursor {
                                            const drmModeModeInfo& mode,
                                            uint32_t fb_w,
                                            uint32_t fb_h,
-                                           int rotation_degrees = 0);
+                                           int rotation_degrees = 0,
+                                           std::string_view theme_name = {});
 
   DrmCursor(const DrmCursor&) = delete;
   DrmCursor& operator=(const DrmCursor&) = delete;

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -166,6 +166,7 @@ FlutterView::FlutterView(Configuration::Config config,
         m_config.debug_backend.value_or(false),
     };
     cfg.disable_cursor = m_config.disable_cursor.value_or(false);
+    cfg.cursor_theme = m_config.cursor_theme;
     // Treat empty TOML/env/CLI string as "unset" — operator-friendly:
     // `drm_connector = ""` in TOML shouldn't force a strict empty-name
     // match against zero connectors.


### PR DESCRIPTION
## Problem

The DRM hardware cursor (`DrmCursor`) loaded its sprite via drm-cxx
`Theme::discover()` with an **empty preferred-theme**, so it used whatever
XCursor theme the resolver found first (`$XCURSOR_THEME`, then `"default"`,
then first on the search path) — **ignoring homescreen's `global.cursor_theme`
/ `--cursor-theme` config**, which the Wayland backend already honors. On a
stock image this picked an arbitrary theme (e.g. a red `redglass` default on
Rockchip), with no in-app way to change it.

## Fix

Thread `cursor_theme` through `DrmConfig` → `DrmCursor::Create` →
`Cursor::load`'s `preferred_theme` argument, so the DRM cursor honors the same
config the Wayland backend does. An empty value preserves the previous
`discover()` fallback behavior.

5 files, +26/−10:
- `DrmConfig` gains a `cursor_theme` field
- `flutter_view` copies `m_config.cursor_theme` into the DRM config
- `DrmCursor::Create` takes a `theme_name` and passes it as `preferred_theme`

## Testing

On RK3588 (Mali-G610, Mesa/panthor; HW cursor on an atomic-overlay plane):
- `--cursor-theme whiteglass` → **white** cursor with **no `XCURSOR_THEME` env**
  (previously `discover()` gave a red `redglass` cursor) — config-driven, verified.
- `--disable-cursor` → cursor suppressed, **no effect on rendering** (~118 fps
  @1080p120, unchanged).

## Note

A companion follow-up (an embedded fallback cursor sprite so a *themeless*
rootfs still shows a cursor) is **not** a homescreen-only change — it needs a
raw-pixel `drm::cursor::Cursor` factory in drm-cxx (the class is theme-only
today).