### PR TITLE
third_party/drm-cxx: bump 52b6fab -> 4714edf

### DIFF
--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: recursive
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
@@ -85,7 +85,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          submodules: 'true'
+          submodules: recursive
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/shell/backend/drm_kms_egl/scene_layer_source_vk.h
+++ b/shell/backend/drm_kms_egl/scene_layer_source_vk.h
@@ -92,7 +92,7 @@ class VkBackingStoreLayerSource final : public drm::scene::LayerBufferSource {
     return inner_->acquire();
   }
   void release(drm::scene::AcquiredBuffer acquired) noexcept override {
-    inner_->release(acquired);
+    inner_->release(std::move(acquired));
   }
   [[nodiscard]] drm::scene::BindingModel binding_model()
       const noexcept override {

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -252,7 +252,7 @@ class VkScanoutRing final : public drm::scene::LayerBufferSource {
     return slots_[ready_]->acquire();
   }
   void release(drm::scene::AcquiredBuffer acquired) noexcept override {
-    slots_[last_acquired_]->release(acquired);
+    slots_[last_acquired_]->release(std::move(acquired));
   }
   [[nodiscard]] drm::scene::BindingModel binding_model()
       const noexcept override {


### PR DESCRIPTION
## Summary

Bumps the `third_party/drm-cxx` pin `52b6fab -> 4714edf` (61 merged PRs) and adapts the two affected source sites to its one breaking change.

`drm::scene::AcquiredBuffer` is now **move-only**: it carries a `std::optional<drm::sync::SyncFence>`, and `SyncFence` deletes its copy constructor. The `VkBackingStoreLayerSource` (drm_kms_egl) and `VkScanoutRing` (drm_kms_vulkan) `release()` forwarders copied the buffer into the downstream `release()`, which no longer compiles. They now `std::move` it through — `acquired` is unused after the forward and the downstream `release()` takes it by value, so the move is safe.

Headline additions in the bump (all otherwise API-additive):
- present spine: `ScanoutBackend` + GBM/GL/Vulkan `ScanoutProducer`, buffer_ring, negotiate, scanout_target, driver_profile, mode_list
- frame economy: `FrameEconomy` idle-skip, `FB_DAMAGE_CLIPS`, `IN_FENCE_FD` / `OUT_FENCE_PTR` explicit sync
- software present: `DumbScanoutSink` + format negotiation, RGB565, BeagleBone Black armhf
- composition: `GlCompositor` with opt-in auto-zink (embedded split-GPU)
- `scene::CursorSource`; dma_buf_source_cache
- format-modifier module (`FormatTable` / classify / `rotation_compatible` / `ModifierProbeCache`)
- AMD per-plane color pipeline + `HDR_OUTPUT_METADATA` + async page flip

## Testing

Built all six native backends locally (clang, Debug):

| Backend | Status |
|---|---|
| drm-kms-egl | ✅ |
| drm-kms-vulkan | ✅ |
| wayland-egl | ✅ |
| wayland-vulkan | ✅ |
| software | ✅ |
| headless-egl | ✅ |

Only `drm_kms_egl` and `drm_kms_vulkan` were affected by the bump; the other four are unchanged and confirm no shared-code disturbance. clang-tidy and clang-format clean on the change.
