### PR TITLE
[drm_kms_egl] add --drm-no-seat to bypass libseat

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -62,8 +62,9 @@ std::shared_ptr<IDisplay> MakeDisplay(
   // safe defaults. Backend-side hooks can refine the refresh rate later.
   const auto w = configs[0].view.width.value_or(kDefaultViewWidth);
   const auto h = configs[0].view.height.value_or(kDefaultViewHeight);
+  const bool no_seat = configs[0].view.drm_no_seat.value_or(false);
   return std::make_shared<DrmDisplay>(static_cast<int32_t>(w),
-                                      static_cast<int32_t>(h), 60.0);
+                                      static_cast<int32_t>(h), 60.0, no_seat);
 #elif BUILD_BACKEND_SOFTWARE
   // No compositor, no Wayland, no DRM — just an IDisplay that owns
   // (a) a refresh-rate denominator for App::Loop and (b) an optional

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -537,11 +537,20 @@ bool DrmBackend::InitDrm() {
     spdlog::info("[DrmBackend] opened {} via libseat (fd={})", cfg_.drm_device,
                  fd);
   } else {
-    // Fallback path: no seat backend available. Refuse up-front if we're
-    // not on the active VT — prevents the "master acquired, commits
-    // return success, but scanout stays on the other VT" trap where
-    // drmSetMaster succeeds but PAGE_FLIP_EVENT never fires.
-    if (!VerifyForegroundVt(cfg_.drm_device)) {
+    // Fallback path: no seat backend available (or --drm-no-seat). Refuse
+    // up-front if we're not on the active VT — prevents the "master
+    // acquired, commits return success, but scanout stays on the other VT"
+    // trap where drmSetMaster succeeds but PAGE_FLIP_EVENT never fires.
+    // --drm-no-seat opts out of this guard: the operator has taken
+    // responsibility for the display (e.g. headless / SSH with nothing else
+    // holding master), where there is no foreground kernel VT to be on.
+    if (cfg_.no_seat) {
+      spdlog::warn(
+          "[DrmBackend] --drm-no-seat: skipping the foreground-VT guard on "
+          "{}. If the screen stays black, another DRM master holds the "
+          "device or scanout is owned by a different VT.",
+          cfg_.drm_device);
+    } else if (!VerifyForegroundVt(cfg_.drm_device)) {
       return false;
     }
 

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -129,6 +129,13 @@ struct DrmConfig {
   drm_config::TriState overlay_planes{drm_config::TriState::kAuto};
   drm_config::TriState explicit_sync{drm_config::TriState::kAuto};
   drm_config::TriState async_flip{drm_config::TriState::kAuto};
+
+  // --drm-no-seat: the session is forced null (see DrmDisplay) so InitDrm
+  // takes the direct-open path. This additionally suppresses the
+  // foreground-VT guard there, since the operator has explicitly opted into
+  // driving the device with no seat/VT arbitration (headless/SSH/kiosk).
+  // drmSetMaster is still required and still enforced.
+  bool no_seat{false};
 };
 
 // PrintDrmModes / ConnectorTypeName moved to display/drm_mode_list.h so the

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -18,6 +18,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <string_view>
 
 #include "config/common.h"
 #include "cxxopts/include/cxxopts.hpp"
@@ -128,6 +129,10 @@ void Configuration::get_parameters(toml::table* tbl, Config& instance) {
   if (tbl->at_path("view.drm_stage_cursor").is_string()) {
     instance.view.drm_stage_cursor =
         tbl->at_path("view.drm_stage_cursor").as_string()->value_or("");
+  }
+  if (tbl->at_path("view.drm_no_seat").is_boolean()) {
+    instance.view.drm_no_seat =
+        tbl->at_path("view.drm_no_seat").value<bool>().value();
   }
 
   if (tbl->at_path("window_activation_area.x").is_integer()) {
@@ -253,6 +258,9 @@ void Configuration::get_cli_override(const std::string& bundle_path,
   }
   if (cli.view.drm_stage_cursor.has_value()) {
     instance.view.drm_stage_cursor = cli.view.drm_stage_cursor.value();
+  }
+  if (cli.view.drm_no_seat.has_value()) {
+    instance.view.drm_no_seat = cli.view.drm_no_seat.value();
   }
 }
 
@@ -421,6 +429,11 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
             "drm-stage-cursor",
             "Stage the HW cursor into the compositor commit: auto|yes|no",
             cxxopts::value<std::string>())(
+            "drm-no-seat",
+            "Bypass libseat: open /dev/dri + input directly and self-acquire "
+            "DRM master, skipping the foreground-VT guard (headless/SSH/kiosk "
+            "bring-up; you must ensure nothing else holds the display)",
+            cxxopts::value<bool>())(
             "input-transform",
             "Per-device pointer transform (repeatable): "
             "\"<device-name-substring>=<0|90|180|270>[,flip-x][,flip-y]\"",
@@ -574,6 +587,16 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
                 config.view.drm_async_flip);
     pick_string("drm-stage-cursor", "HOMESCREEN_DRM_STAGE_CURSOR",
                 config.view.drm_stage_cursor);
+
+    // --drm-no-seat (bool flag) / HOMESCREEN_DRM_NO_SEAT (env). CLI wins;
+    // env fills only when the flag is absent. Env is truthy on
+    // 1 / true / yes (case-sensitive); anything else (incl. empty) = unset.
+    if (result.count("drm-no-seat")) {
+      config.view.drm_no_seat = result["drm-no-seat"].as<bool>();
+    } else if (const char* e = std::getenv("HOMESCREEN_DRM_NO_SEAT"); e && *e) {
+      const std::string_view v(e);
+      config.view.drm_no_seat = (v == "1" || v == "true" || v == "yes");
+    }
 
     // drm-rotation is an int (0|90|180|270); CLI wins, then env. Reject any
     // other value so a typo fails loud instead of silently scanning unrotated.

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -80,6 +80,14 @@ class Configuration {
       std::optional<std::string> drm_explicit_sync;
       std::optional<std::string> drm_async_flip;
       std::optional<std::string> drm_stage_cursor;
+      // Bypass libseat entirely (--drm-no-seat / HOMESCREEN_DRM_NO_SEAT): the
+      // DRM backend opens /dev/dri + /dev/input directly via group permissions
+      // and becomes DRM master itself, also skipping the foreground-VT guard.
+      // An opt-in escape hatch for headless / SSH / single-session kiosk
+      // bring-up where no seat manager (logind/seatd) is running and the
+      // operator guarantees nothing else holds the display. Gives up
+      // VT-switch handling and session pause/resume. Unset = false.
+      std::optional<bool> drm_no_seat;
       // Per-device relative-pointer transforms, repeatable:
       //   "<device-name-substring>=<0|90|180|270>[,flip-x][,flip-y]"
       // Rotates a built-in pointer's deltas to a rotated display (e.g. the

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -26,7 +26,15 @@
 
 namespace {
 
-std::unique_ptr<homescreen::DrmSession> OpenSessionOrLog() {
+std::unique_ptr<homescreen::DrmSession> OpenSessionOrLog(bool no_seat) {
+  if (no_seat) {
+    spdlog::warn(
+        "[DrmDisplay] --drm-no-seat: bypassing libseat — the backend opens "
+        "/dev/dri + input directly and self-acquires DRM master, skipping "
+        "the foreground-VT guard. No VT-switch / pause-resume; you are "
+        "responsible for ensuring nothing else holds the display.");
+    return nullptr;
+  }
   auto session = homescreen::DrmSession::Open();
   if (!session) {
     spdlog::info(
@@ -47,11 +55,14 @@ drm::input::InputDeviceOpener OpenerFrom(homescreen::DrmSession* session) {
 
 }  // namespace
 
-DrmDisplay::DrmDisplay(int32_t width, int32_t height, double refresh_rate_hz)
+DrmDisplay::DrmDisplay(int32_t width,
+                       int32_t height,
+                       double refresh_rate_hz,
+                       bool no_seat)
     : width_(width),
       height_(height),
       refresh_rate_hz_(refresh_rate_hz),
-      session_(OpenSessionOrLog()),
+      session_(OpenSessionOrLog(no_seat)),
       seat_(std::make_unique<homescreen::DrmSeat>(width,
                                                   height,
                                                   OpenerFrom(session_.get()))) {

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -31,11 +31,18 @@ class DrmSession;
 
 class DrmDisplay final : public IDisplay {
  public:
-  DrmDisplay(int32_t width, int32_t height, double refresh_rate_hz);
+  // @p no_seat (--drm-no-seat / HOMESCREEN_DRM_NO_SEAT) skips opening a
+  // libseat session entirely, forcing the backend's direct-open path. See
+  // session().
+  DrmDisplay(int32_t width,
+             int32_t height,
+             double refresh_rate_hz,
+             bool no_seat = false);
   ~DrmDisplay() override;
 
   // Process-wide libseat session. Null when no seat backend is available
-  // (no logind/seatd/builtin) or when drm-cxx was built without libseat.
+  // (no logind/seatd/builtin), when drm-cxx was built without libseat, or
+  // when --drm-no-seat forced the direct-open path.
   // DrmBackend consults this to route its DRM device open through the
   // seat; when null, the backend falls back to direct open + the legacy
   // VT/master guards.

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -189,6 +189,9 @@ FlutterView::FlutterView(Configuration::Config config,
     // kAuto (default) resolves per driver in DrmBackend::Create — staging is
     // enabled only on nvidia-drm; yes/no force the choice.
     cfg.stage_cursor = parse_tri(m_config.view.drm_stage_cursor);
+    // --drm-no-seat: DrmDisplay forced the session null; tell DrmBackend to
+    // also skip the foreground-VT guard on its direct-open path.
+    cfg.no_seat = m_config.view.drm_no_seat.value_or(false);
 
     // DrmDisplay (constructed by App::MakeDisplay, before us) owns the
     // process-wide libseat session. Pull the raw pointer — may be null


### PR DESCRIPTION
## Summary

Adds `--drm-no-seat` (also `HOMESCREEN_DRM_NO_SEAT=1`, or `view.drm_no_seat` in the config TOML): an opt-in escape hatch that makes the DRM backends bypass libseat entirely.

## Motivation

The DRM backends acquire their device + input through libseat. Over an SSH session that logind has **not** assigned a seat to, libseat falls back to its builtin backend, which needs root to open `/dev/tty0` for VT management and fails:

```
[libseat error] [common/terminal.c:162] Could not open target tty: Permission denied
[libseat error] [seatd/seat.c:461] Could not open VT for client
```

Running then requires `seatd` or root — even when the user is already in the `video`/`render`/`input` groups and could open the device directly. This is common on headless / SSH / single-session kiosk bring-up (observed on a Radxa Zero 3, RK3566).

## What it does

- `DrmDisplay` skips opening a libseat session, so `DrmBackend` takes its **existing** direct-open path: opens `/dev/dri` + `/dev/input` via group permissions and self-acquires DRM master.
- Because there is no foreground kernel VT to verify in that scenario, the flag also suppresses the foreground-VT guard. `drmSetMaster` is still required and enforced.
- Input falls back to `drm::input::Seat`'s direct `::open` — the same path used today when no libseat backend is available.
- Both `DrmDisplay` and `DrmBackend` log a warning spelling out the contract (no VT-switch / pause-resume; the operator owns the display).
- The Vulkan DRM backend already opens the device directly and tolerates a null session, so forcing the session null covers it with no further change.

This reuses machinery that already existed (the null-session fallback, the empty-opener direct `/dev/input` path); the only genuinely new behavior is the VT-guard opt-out.

## Caveats

- Gives up VT-switch handling and session pause/resume — single-session / kiosk assumption.
- Requires the user be in `video`/`render` (DRM) and `input` (evdev), and that nothing else holds DRM master.

## Testing

- Validated on a Radxa Zero 3 (RK3566 / rockchip) over SSH with **no seatd and no root**: self-acquires master on `/dev/dri/card0`, picks HDMI-A-1, renders Wonderous at ~60 fps (`flip #60…#120 handled`), and takes pointer input — all with no `libseat session active` line in the log.
- Built clean against all five backends (drm-kms-egl, drm-kms-vulkan, software, wayland-egl, wayland-vulkan); no build regression.
- clang-tidy + clang-format clean.