### PR TITLE
[crash-handler] make sentry-config.cmake lookup robust to libdir layout

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -199,20 +199,38 @@ if (BUILD_CRASH_HANDLER)
 
     include(GNUInstallDirs)
 
+    # sentry-native installs its CMake package config under the GNUInstallDirs
+    # libdir of its staging prefix -- typically lib/cmake/sentry, but lib64 on
+    # some distros and a flat cmake/sentry on older layouts. Hardcoding a single
+    # suffix breaks whenever ${CMAKE_INSTALL_LIBDIR} here differs from the one
+    # sentry-native installed with (or is empty because GNUInstallDirs had not
+    # been included yet). Search the likely suffixes under the chosen base so a
+    # libdir mismatch can't break configure.
     if (SENTRY_NATIVE_LIBDIR)
-        if (NOT EXISTS ${SENTRY_NATIVE_LIBDIR}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry/sentry-config.cmake)
-            message(FATAL_ERROR "${SENTRY_NATIVE_LIBDIR}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry/sentry-config.cmake does not exist")
-        else ()
-            message(STATUS "Found libsentry at specified directory: ${SENTRY_NATIVE_LIBDIR}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry/sentry-config.cmake")
-            set(sentry_DIR ${SENTRY_NATIVE_LIBDIR}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry)
-        endif ()
+        set(_sentry_base ${SENTRY_NATIVE_LIBDIR})
     else ()
-        if (EXISTS ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry/sentry-config.cmake)
-            message(STATUS "Found sentry at default location: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry/sentry-config.cmake")
-            set(sentry_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry)
-        else ()
-            message(FATAL_ERROR "Sentry could not be found at ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry/sentry-config.cmake, please set SENTRY_NATIVE_LIBDIR")
+        set(_sentry_base ${CMAKE_INSTALL_PREFIX})
+    endif ()
+
+    set(sentry_DIR "")
+    foreach (_suffix
+            ${CMAKE_INSTALL_LIBDIR}/cmake/sentry
+            lib/cmake/sentry
+            lib64/cmake/sentry
+            cmake/sentry)
+        if (EXISTS ${_sentry_base}/${_suffix}/sentry-config.cmake)
+            set(sentry_DIR ${_sentry_base}/${_suffix})
+            break ()
         endif ()
+    endforeach ()
+
+    if (sentry_DIR)
+        message(STATUS "Found libsentry: ${sentry_DIR}/sentry-config.cmake")
+    else ()
+        message(FATAL_ERROR
+                "sentry-config.cmake not found under ${_sentry_base} "
+                "(searched */cmake/sentry). Set SENTRY_NATIVE_LIBDIR to the "
+                "sentry-native staging prefix.")
     endif ()
 
 


### PR DESCRIPTION
## Summary

Hardens how the crash-handler build locates sentry-native's CMake package config, so a libdir-layout mismatch can no longer break configure.

## Problem

`cmake/options.cmake` looked for sentry-native's package config at a single hardcoded path:

```cmake
${SENTRY_NATIVE_LIBDIR}/${CMAKE_INSTALL_LIBDIR}/cmake/sentry/sentry-config.cmake
```

This breaks when `${CMAKE_INSTALL_LIBDIR}` in this build differs from the libdir sentry-native actually installed with — or is **empty** because `include(GNUInstallDirs)` had not run at that point — which collapses the path to `.../cmake/sentry` and fails configure with:

```
CMake Error at cmake/options.cmake:
  .../sentry-native/build/release/staging/cmake/sentry/sentry-config.cmake does not exist
```

sentry-native installs its config to `staging/lib/cmake/sentry/` (GNUInstallDirs), so the lookup misses it. This is exactly what failed the `crash-handler` CI job on branches whose `options.cmake` predated the GNUInstallDirs change.

## Fix

Search the likely suffixes under the staging base and use the first that exists:

```cmake
foreach (_suffix ${CMAKE_INSTALL_LIBDIR}/cmake/sentry lib/cmake/sentry lib64/cmake/sentry cmake/sentry)
    if (EXISTS ${_sentry_base}/${_suffix}/sentry-config.cmake)
        set(sentry_DIR ${_sentry_base}/${_suffix})
        break ()
    endif ()
endforeach ()
```

Robust to `lib` vs `lib64` vs flat layouts and to GNUInstallDirs ordering.

## Testing

- CMake control-flow + syntax validated with `cmake -P` (negative case → clean not-found; positive `lib/cmake/sentry` layout → found) and a full project reconfigure (parses clean, rc=0).
- The full `crash-handler` job (sentry-native staging build) can't be reproduced locally; relying on CI to exercise it end to end.