### PR TITLE
Resolve CodeQL code scanning alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+name: "ivi-homescreen CodeQL config"
+
+# Vendored dependencies live under third_party/ as git submodules. We do not
+# own or modify that code, so it is excluded from analysis; alerts there are
+# upstream concerns, not ours. The CMake build tree is generated output.
+paths-ignore:
+  - third_party
+  - build
+
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/oss-codeql.yml
+++ b/.github/workflows/oss-codeql.yml
@@ -46,12 +46,9 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        queries: +security-and-quality
+        # paths-ignore (third_party submodules, build tree) lives in the config
+        # file so it applies to every run; the query suite is declared there too.
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Configure
       run: |

--- a/shell/backend/wayland_egl/egl.cc
+++ b/shell/backend/wayland_egl/egl.cc
@@ -25,6 +25,14 @@
 
 #include "logging.h"
 
+// Brings up the EGL display for |native_display| and the GLES contexts the
+// renderer needs. The sequence is: initialize the display and bind the GLES
+// API; choose an EGLConfig matching |buffer_size| (falling back to a relaxed
+// attribute set, aborting only if neither matches); create the render,
+// resource, and texture contexts that share resources; then probe the optional
+// damage-region / buffer-age extensions used by the swap path. A failure to
+// create a context leaves the object partially constructed and is logged
+// rather than fatal. |debug| additionally dumps the GLES/EGL attributes.
 Egl::Egl(void* native_display, const int buffer_size, const bool debug)
     : m_buffer_size(buffer_size),
       m_dpy(eglGetDisplay(static_cast<EGLNativeDisplayType>(native_display))) {

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -24,6 +24,11 @@
 #include "cxxopts/include/cxxopts.hpp"
 #include "utils.h"
 
+// Overlays the values found in a parsed TOML document onto |instance|. Each
+// block below maps one TOML key (under the [global], [view], or
+// [window_activation_area] tables) to its Config field, copying it only when
+// the key is present and of the expected type so that unset keys preserve any
+// defaults or command-line values already held by |instance|.
 void Configuration::get_parameters(toml::table* tbl, Config& instance) {
   if (tbl->at_path("global.app_id").is_string()) {
     instance.app_id = tbl->at_path("global.app_id").as_string()->value_or("");

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -277,14 +277,6 @@ Engine::~Engine() {
   m_platform_task_runner.reset();
 }
 
-FlutterEngineResult Engine::RunTask() {
-  if (!m_flutter_engine) {
-    return kSuccess;
-  }
-
-  return kSuccess;
-}
-
 void Engine::Shutdown() {
   if (!m_running) {
     return;  // never started, or already stopped — idempotent

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -131,15 +131,6 @@ class Engine {
   [[maybe_unused]] [[nodiscard]] bool IsRunning() const;
 
   /**
-   * @brief Run flutter tasks
-   * @return FlutterEngineResult
-   * @retval The result of the run flutter tasks
-   * @relation
-   * flutter
-   */
-  FlutterEngineResult RunTask();
-
-  /**
    * @brief Get persistent cache path
    * @param[in] index Index of path (for log)
    * @return std::string

--- a/shell/platform/homescreen/flutter_desktop.cc
+++ b/shell/platform/homescreen/flutter_desktop.cc
@@ -364,9 +364,8 @@ int64_t FlutterDesktopTextureRegistrarRegisterExternalTexture(
       texture_registrar->texture_registry.erase(id);
     }
   } else if (texture_info->type == kFlutterDesktopGpuSurfaceTexture) {
-    auto [struct_size, type, callback, user_data] =
-        texture_info->gpu_surface_config;
-    if (type != kFlutterDesktopGpuSurfaceTypeGlTexture2D) {
+    const auto& gpu_surface_config = texture_info->gpu_surface_config;
+    if (gpu_surface_config.type != kFlutterDesktopGpuSurfaceTypeGlTexture2D) {
       spdlog::error(
           "RegisterExternalTexture: kFlutterDesktopGpuSurfaceTypeGlTexture2D "
           "is only supported at this time");
@@ -375,7 +374,7 @@ int64_t FlutterDesktopTextureRegistrarRegisterExternalTexture(
 
     // get the client defined descriptor
     const auto descriptor =
-        callback(0, 0, texture_info->gpu_surface_config.user_data);
+        gpu_surface_config.callback(0, 0, gpu_surface_config.user_data);
 
     if (!descriptor->handle) {
       spdlog::critical(

--- a/shell/platform/homescreen/logging_handler.h
+++ b/shell/platform/homescreen/logging_handler.h
@@ -25,12 +25,11 @@ class FlutterView;
 
 class LoggingHandler {
  public:
- public:
   explicit LoggingHandler(flutter::BinaryMessenger* messenger,
                           FlutterView* view);
 
  private:
-  // Called when a method is called on |channel_|;
+  // Handles a method invocation received on channel_.
   static void HandleMethodCall(
       const flutter::MethodCall<flutter::EncodableValue>& method_call,
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);

--- a/shell/platform/homescreen/text_input_plugin.cc
+++ b/shell/platform/homescreen/text_input_plugin.cc
@@ -164,6 +164,13 @@ void TextInputPlugin::CharHook(const unsigned int code_point) {
   SendStateUpdate(*active_model_);
 }
 
+// Applies one physical key event from the seat to the active text-input model.
+// It first runs the compose/Unicode state machine (Ctrl+Shift+U hex entry and
+// dead-key composition), then handles editing keys (arrows, Home/End,
+// Backspace, Delete, Enter) with optional Shift-selection and Ctrl
+// word-granularity, and finally inserts printable code points. Only key presses
+// mutate state; key releases return early. Each mutation ends with
+// SendStateUpdate so the Flutter framework sees the new selection and text.
 void TextInputPlugin::KeyboardHook(bool released,
                                    xkb_keysym_t keysym,
                                    uint32_t /* xkb_scancode */,
@@ -518,6 +525,13 @@ void TextInputPlugin::CancelUnicodeInput() {
   compose_base_utf16_ = compose_extent_utf16_ = -1;
 }
 
+// Dispatches calls on the flutter/textinput method channel. TextInput.show and
+// TextInput.hide toggle the (no-op) on-screen keyboard; TextInput.setClient
+// records the connection id and input configuration; TextInput.setEditingState
+// rebuilds active_model_ from the framework's text/selection/composing range;
+// and TextInput.clearClient drops the active connection. Unknown methods are
+// answered with NotImplemented and every handled call sends an empty success
+// reply unless noted otherwise.
 void TextInputPlugin::HandleMethodCall(
     const flutter::MethodCall<rapidjson::Document>& method_call,
     const std::unique_ptr<flutter::MethodResult<rapidjson::Document>>& result) {

--- a/shell/utils.h
+++ b/shell/utils.h
@@ -113,13 +113,39 @@ class Utils {
       auto config_env_raw = std::string(config_env);
       auto clean = trim(config_env_raw, "\"");
       std::filesystem::path path(clean);
-      path /= kXdgConfigDir;
-      path /= kApplicationName;
-      config_home_dir = strdup(path.c_str());
+      // Per the XDG Base Directory spec a relative XDG_CONFIG_HOME "must be
+      // ignored". We also reject any ".." traversal component so a hostile
+      // environment cannot redirect the files we write (engine state, crash
+      // dumps, accessibility tree) outside the intended config directory.
+      if (IsSafeBasePath(path)) {
+        path /= kXdgConfigDir;
+        path /= kApplicationName;
+        config_home_dir = strdup(path.lexically_normal().c_str());
+      } else {
+        config_home_dir = GetHomePath();
+      }
     } else {
       config_home_dir = GetHomePath();
     }
     return config_home_dir;
+  }
+
+  /**
+   * @brief Validate a directory supplied via the environment as a write base
+   * @param[in] p Candidate base path
+   * @return bool
+   * @retval true If p is absolute and contains no ".." traversal component
+   * @retval false Otherwise (path is untrusted and must not be used)
+   * @relation
+   * internal
+   */
+  static bool IsSafeBasePath(const std::filesystem::path& p) {
+    if (!p.is_absolute()) {
+      return false;
+    }
+    return std::none_of(p.begin(), p.end(), [](const std::filesystem::path& e) {
+      return e == "..";
+    });
   }
 
   /**

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -577,8 +577,9 @@ void FlutterView::Initialize() {
 }
 
 void FlutterView::RunTasks() {
-  m_flutter_engine->RunTask();
-
+  // The Flutter platform task runner drains expired engine tasks on its own
+  // asio strand (see TaskRunner::QueueFlutterTask), so there is nothing to pump
+  // for the engine here.
 #ifdef ENABLE_PLUGIN_COMP_SURF
   for (auto const& surface : m_comp_surf) {
     surface.second->RunTask();

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -1212,7 +1212,10 @@ void Display::processAppStatusEvent(const char* app_id,
   } else if (event_type == "terminated") {
     deactivateApp(std::string(app_id));
   } else if (event_type == "deactivated") {
-    // not handled
+    // The AGL shell emits "deactivated" as the counterpart to activation; we
+    // intentionally take no action on it here.
+    spdlog::trace("Ignoring deactivated app status event for app_id {}",
+                  app_id);
   }
 }
 


### PR DESCRIPTION
Resolves all 39 open CodeQL code scanning alerts: 30 in vendored `third_party/` submodules and 9 in `shell/` code.

## CodeQL configuration
- Add `.github/codeql/codeql-config.yml` with `paths-ignore` for `third_party` and `build`, and move the query suite there. Vendored submodules are not ours to patch (changes would be lost on the next bump), so excluding them is the durable resolution. Wired via `config-file:` in `oss-codeql.yml`. Closes the 30 submodule alerts on the next scan.

## shell/ fixes
| Alert | Severity | Fix |
|---|---|---|
| `cpp/path-injection` (accessibility) | high | Harden `Utils::GetConfigHomePath`: a relative or `../`-bearing `XDG_CONFIG_HOME` is rejected (falls back to `$HOME`) and the result is `lexically_normal`-ized. New `IsSafeBasePath` barrier. XDG-spec compliant — a relative `XDG_CONFIG_HOME` must be ignored. |
| `cpp/useless-expression` (flutter_view) | warning | `Engine::RunTask` was a no-op stub (both branches `return kSuccess`); the engine task pump actually runs on the asio strand in `TaskRunner::QueueFlutterTask`. Remove the dead method, its declaration, and the pointless call site. |
| `cpp/unused-local-variable` x2 (flutter_desktop) | note | Replace a structured binding that unpacked unused fields with a `const&` reference. |
| `cpp/empty-if` (display) | note | Log the intentional no-op on the `deactivated` branch. |
| `cpp/commented-out-code` (logging_handler) | note | Reword the misleading doc comment; drop a duplicate `public:`. |
| `cpp/poorly-documented-function` x3 (configuration, egl, text_input) | warning | Document `get_parameters`, the `Egl` constructor, and `KeyboardHook`/`HandleMethodCall`. Each comment verified against the code. |

## Verification
- clang-tidy then clang-format clean on all changed files.
- Built all six backends independently (DRM-EGL, Wayland-EGL, Wayland-Vulkan, DRM-Vulkan, Software, Headless), compositor on and off — all link.
- Ran Wonderous locally on Wayland-EGL (radeonsi, GL ES 3.2): engine launches, app navigates routes, zero errors/asserts/crashes. The working route navigation exercises the platform task runner, confirming the `Engine::RunTask` removal is safe.