### PR TITLE
[keyboard] always send flutter/keyevent; drop ENABLE_LEGACY_KEYBOARD

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -13,19 +13,7 @@ on:
 
 jobs:
   ivi-homescreen:
-    # Stable check-context name (omits the artifact suffix so branch-protection
-    # required-check names stay clean): "ivi-homescreen (ENABLE_LEGACY_KEYBOARD=ON)".
-    name: ivi-homescreen (${{ matrix.flags }})
-    # matrix for build flags. suffix disambiguates the per-leg artifact names
-    # (artifact names must be unique within a run).
-    strategy:
-      matrix:
-        include:
-          - flags: "ENABLE_LEGACY_KEYBOARD=ON"
-            suffix: legacy-on
-          - flags: "ENABLE_LEGACY_KEYBOARD=OFF"
-            suffix: legacy-off
-
+    name: ivi-homescreen
     if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' && always() }}
     runs-on: ubuntu-22.04
     steps:
@@ -55,8 +43,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=Debug \
             -D CMAKE_STAGING_PREFIX=${{github.workspace}}/build/staging/usr/local \
             -D BUILD_NUMBER=${GITHUB_RUN_ID} \
-            -D CMAKE_VERBOSE_MAKEFILE=ON \
-            -D ${{ matrix.flags }}
+            -D CMAKE_VERBOSE_MAKEFILE=ON
 
       - name: Build Debug Package
         working-directory: ${{github.workspace}}/build/debug
@@ -68,21 +55,21 @@ jobs:
       - name: Publish Debug Artifact TGZ
         uses: actions/upload-artifact@v7
         with:
-          name: homescreen-dbg.${{ matrix.suffix }}.Linux.tar.gz.zip
+          name: homescreen-dbg.Linux.tar.gz.zip
           path: |
             build/debug/_packages/homescreen-dbg-*-Linux.tar.gz
 
       - name: Publish Debug Artifact Debian
         uses: actions/upload-artifact@v7
         with:
-          name: homescreen-dbg.${{ matrix.suffix }}.amd64.deb.zip
+          name: homescreen-dbg.amd64.deb.zip
           path: |
             build/debug/_packages/homescreen-dbg*_amd64.*deb
 
       - name: Publish Debug Artifact RPM
         uses: actions/upload-artifact@v7
         with:
-          name: homescreen-dbg.${{ matrix.suffix }}.x86_64.rpm.zip
+          name: homescreen-dbg.x86_64.rpm.zip
           path: |
             build/debug/_packages/homescreen-dbg-*.x86_64.rpm
 
@@ -94,8 +81,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=Release \
             -D CMAKE_STAGING_PREFIX=${{github.workspace}}/build/staging/usr/local \
             -D BUILD_NUMBER=${GITHUB_RUN_ID} \
-            -D CMAKE_VERBOSE_MAKEFILE=ON \
-            -D ${{ matrix.flags }}
+            -D CMAKE_VERBOSE_MAKEFILE=ON
 
       - name: Build Release Package
         working-directory: ${{github.workspace}}/build/release
@@ -114,21 +100,21 @@ jobs:
       - name: Publish Release Artifact TGZ
         uses: actions/upload-artifact@v7
         with:
-          name: homescreen-${{ matrix.suffix }}.Linux.tar.gz.zip
+          name: homescreen-Linux.tar.gz.zip
           path: |
             build/release/_packages/homescreen-*-Linux.tar.gz
 
       - name: Publish Release Artifact Debian
         uses: actions/upload-artifact@v7
         with:
-          name: homescreen-${{ matrix.suffix }}.amd64.deb.zip
+          name: homescreen-amd64.deb.zip
           path: |
             build/release/_packages/homescreen_*_amd64.deb
 
       - name: Publish Release Artifact RPM
         uses: actions/upload-artifact@v7
         with:
-          name: homescreen-${{ matrix.suffix }}.x86_64.rpm.zip
+          name: homescreen-x86_64.rpm.zip
           path: |
             build/release/_packages/homescreen-*.x86_64.rpm
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -269,17 +269,6 @@ if (BUILD_WATCHDOG)
 endif ()
 
 #
-# legacy keyboard support
-#
-option(ENABLE_LEGACY_KEYBOARD "Enable legacy keyboard support" ON)
-if (ENABLE_LEGACY_KEYBOARD)
-    MESSAGE(STATUS "Legacy Keyboard Support .. Enabled")
-    add_compile_definitions(ENABLE_LEGACY_KEYBOARD)
-else ()
-    MESSAGE(STATUS "Legacy Keyboard Support .. Disabled")
-endif ()
-
-#
 # Static linking
 #
 option(ENABLE_STATIC_LINK "Link stdlib with static libs" OFF)

--- a/shell/platform/homescreen/key_event_handler.cc
+++ b/shell/platform/homescreen/key_event_handler.cc
@@ -7,15 +7,12 @@
 #include <string>
 
 #include "asio/post.hpp"
-#include "shell/engine.h"
-#ifdef ENABLE_LEGACY_KEYBOARD
 #include "flutter/shell/platform/common/json_message_codec.h"
-#endif
+#include "shell/engine.h"
 #include "shell/platform/homescreen/key_mapping.h"
 #include "shell/platform/homescreen/text_input_plugin.h"
 #include "shell/task_runner.h"
 
-#ifdef ENABLE_LEGACY_KEYBOARD
 static constexpr char kChannelName[] = "flutter/keyevent";
 
 static constexpr char kKeyCodeKey[] = "keyCode";
@@ -31,7 +28,6 @@ static constexpr char kValueToolkitGtk[] = "gtk";
 
 static constexpr char kKeyUp[] = "keyup";
 static constexpr char kKeyDown[] = "keydown";
-#endif
 
 namespace {
 
@@ -142,16 +138,12 @@ void OnKeyEventResponse(bool handled, void* user_data) {
 
 namespace flutter {
 
-#ifdef ENABLE_LEGACY_KEYBOARD
 KeyEventHandler::KeyEventHandler(flutter::BinaryMessenger* messenger)
     : channel_(
           std::make_unique<flutter::BasicMessageChannel<rapidjson::Document>>(
               messenger,
               kChannelName,
               &flutter::JsonMessageCodec::GetInstance())) {}
-#else
-KeyEventHandler::KeyEventHandler(flutter::BinaryMessenger* /* messenger */) {}
-#endif
 
 KeyEventHandler::~KeyEventHandler() {
   // Signal all in-flight callbacks that this handler is gone.
@@ -298,11 +290,8 @@ void KeyEventHandler::KeyboardHook(const bool released,
     asio::post(
         *eng->GetPlatformTaskRunner()->GetStrandContext(),
         [eng, flutter_event, cb_data, keysym, modifiers, released,
-#ifdef ENABLE_LEGACY_KEYBOARD
          channelPtr = channel_.get(), legacyEventDoc = &legacy_event_doc_,
-         utf32, xkb_scancode,
-#endif
-         clipboard = &clipboard_,
+         utf32, xkb_scancode, clipboard = &clipboard_,
          weak_alive = std::weak_ptr<std::atomic<bool>>(alive_)]() mutable {
           // Bail if the owning KeyEventHandler was destroyed while this
           // post was queued; free cb_data to prevent the leak.
@@ -355,10 +344,13 @@ void KeyEventHandler::KeyboardHook(const bool released,
             OnKeyEventResponse(false, cb_data);
           }
 
-#ifdef ENABLE_LEGACY_KEYBOARD
-          // 2. Send via channel `flutter/keyevent`
-          //    (legacy RawKeyboard path, deprecated from Flutter 3.19)
-          //    Sent after SendKeyEvent to ensure correct ordering.
+          // 2. Send via channel `flutter/keyevent`.
+          //    Sent after SendKeyEvent to ensure correct ordering. This is
+          //    REQUIRED for the modern path too: the framework's
+          //    KeyEventManager only flushes queued (non-synthesized) KeyData to
+          //    HardwareKeyboard when a raw flutter/keyevent message arrives. It
+          //    also drives the legacy RawKeyboard path (deprecated from
+          //    Flutter 3.19).
           // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
           auto* legacyDoc = legacyEventDoc;
           legacyDoc->SetObject();
@@ -378,7 +370,6 @@ void KeyEventHandler::KeyboardHook(const bool released,
               allocator);
 
           channelPtr->Send(*legacyDoc);
-#endif
         });
   }
 }

--- a/shell/platform/homescreen/key_event_handler.h
+++ b/shell/platform/homescreen/key_event_handler.h
@@ -17,11 +17,9 @@
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
 #include "shell/platform/homescreen/keyboard_hook_handler.h"
 
-#ifdef ENABLE_LEGACY_KEYBOARD
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
 #include "rapidjson/document.h"
 #include "rapidjson/rapidjson.h"
-#endif
 
 class Engine;
 
@@ -35,7 +33,10 @@ class TextInputPlugin;
 // Key events are dispatched via both:
 //   1. FlutterEngineSendKeyEvent (embedder API) for HardwareKeyboard/Focus
 //      (primary path).
-//   2. flutter/keyevent channel (legacy RawKeyboard / Shortcuts).
+//   2. flutter/keyevent channel — REQUIRED, not optional: the framework's
+//      KeyEventManager queues the modern KeyData from (1) and only flushes it
+//      to HardwareKeyboard when a raw flutter/keyevent message arrives. It also
+//      drives the legacy RawKeyboard / Shortcuts path.
 //      The channel send is sequenced *after* SendKeyEvent, inside the same
 //      asio post, so the two dispatches always arrive in order.
 class KeyEventHandler final : public KeyboardHookHandler {
@@ -109,14 +110,17 @@ class KeyEventHandler final : public KeyboardHookHandler {
   // TODO: integrate with the system clipboard
   std::string clipboard_;
 
-#ifdef ENABLE_LEGACY_KEYBOARD
-  // The Flutter system channel for key event messages (legacy RawKeyboard).
+  // The Flutter system channel for key event messages (flutter/keyevent).
+  // ALWAYS sent — it is the framework's flush trigger for the modern
+  // HardwareKeyboard path: KeyEventManager queues non-synthesized KeyData
+  // (from FlutterEngineSendKeyEvent) and only dispatches it to HardwareKeyboard
+  // when a raw flutter/keyevent message arrives. Gating this send out silently
+  // dropped all real hardware keys.
   std::unique_ptr<flutter::BasicMessageChannel<rapidjson::Document>> channel_;
-  // Reused document for legacy flutter/keyevent channel sends.
-  // Avoids a fresh allocator-chunk heap allocation per keystroke.
-  // Accessed only from the platform strand.
+  // Reused document for flutter/keyevent channel sends. Avoids a fresh
+  // allocator-chunk heap allocation per keystroke. Accessed only from the
+  // platform strand.
   rapidjson::Document legacy_event_doc_;
-#endif
 };
 
 }  // namespace flutter


### PR DESCRIPTION
## Problem
`ENABLE_LEGACY_KEYBOARD=OFF` silently dropped **all** real hardware keyboard input — on every backend (wayland-egl and software, debug and release). Keys reached the libinput seat and `FlutterEngineSendKeyEvent` returned success, but no `HardwareKeyboard` handler ever fired.

## Root cause
The `flutter/keyevent` channel message is the Flutter framework's **flush trigger for the modern `HardwareKeyboard` path**, not just a legacy nicety. `KeyEventManager.handleKeyData` queues the non-synthesized `KeyData` from `FlutterEngineSendKeyEvent` and only dispatches it to `HardwareKeyboard` once a raw `flutter/keyevent` message arrives (`handleKeyData` → `_keyEventsSinceLastMessage.add`; flushed only in `handleRawKeyMessage`). Gating that send behind `ENABLE_LEGACY_KEYBOARD` meant `OFF` sent only the modern `KeyData`, which was queued and never flushed.

(`hardware_keyboard_test` masked this because it calls `HardwareKeyboard.syncKeyboardState()`, whose *synthesized* events dispatch instantly without a flush — inflating coverage with no real key delivered.)

## Fix
- Un-gate the `flutter/keyevent` send so it is **always** sent. The always-on path is byte-identical to what the default `ON` build already shipped.
- Remove the now-meaningless `ENABLE_LEGACY_KEYBOARD` cmake option. A true "modern-only" build isn't possible in this Flutter version without a framework change (the raw channel is load-bearing for the modern API).
- Collapse the CI `ENABLE_LEGACY_KEYBOARD=ON/OFF` matrix to a single `ivi-homescreen` job.

## Validation
- **Build matrix 12/12**: all 6 backends (wayland-egl/-vulkan, drm-kms-egl/-vulkan, software, headless-egl) × compositor ON/OFF.
- **Runtime smoke 28/30**: `hardware_keyboard_test` on host wayland-egl now covers the full real-key surface (keyDown/Up/Repeat, all modifiers, chord, nav/function/backspace/enter/escape/tab, realEvent). The 2 uncovered modes are inherently hard to exercise (nonAsciiCharacter, synthesizedEvent).
- clang-tidy / clang-format clean.

> ⚠️ Branch-protection note: this renames the required check `ivi-homescreen (ENABLE_LEGACY_KEYBOARD=ON/OFF)` → `ivi-homescreen`; the required-check list needs the corresponding swap.