### PR TITLE
Add BUILD_ACCESSIBILITY=ON CI leg; harden a11y dump against path traversal

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -118,6 +118,40 @@ jobs:
           path: |
             build/release/_packages/homescreen-*.x86_64.rpm
 
+  # The accessibility semantics tree is off by default (BUILD_ACCESSIBILITY).
+  # Compile it here so the opt-in path -- the AccessibilityTree subsystem and
+  # its engine/view wiring -- does not bit-rot. No extra dependencies, so this
+  # reuses the lightweight ninja build rather than the workspace action.
+  accessibility:
+    name: accessibility (BUILD_ACCESSIBILITY=ON)
+    if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' && always() }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: 'true'
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install ninja-build \
+          libwayland-dev wayland-protocols libxkbcommon-dev \
+          mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
+
+      - name: Configure (accessibility enabled)
+        run: |
+          cmake -GNinja \
+            -B ${{github.workspace}}/build/accessibility \
+            -D CMAKE_BUILD_TYPE=Debug \
+            -D BUILD_ACCESSIBILITY=ON \
+            -D CMAKE_STAGING_PREFIX=${{github.workspace}}/build/staging/usr/local \
+            -D BUILD_NUMBER=${GITHUB_RUN_ID}
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build/accessibility
+        run: ninja -C . homescreen
+
   # Path-gate the (expensive) crash-handler build: it is a full
   # BUILD_CRASH_HANDLER=ON compile, so it only needs to run when build inputs
   # change. Docs/asset-only PRs skip it. Non-PR events (schedule / release /

--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -91,20 +91,18 @@ void AccessibilityTree::HandleFlutterUpdate(
       if (!std::filesystem::exists(dir)) {
         std::filesystem::create_directories(dir, ec);
       }
-      // Confirm the dump file resolves to a location inside the accessibility
-      // directory before opening it for writing. weakly_canonical collapses any
-      // ".." segments a crafted XDG_CONFIG_HOME might inject, and the prefix
-      // check rejects a target that would escape the intended directory.
-      const std::string base =
-          std::filesystem::weakly_canonical(dir, ec).string();
-      const std::string target =
-          std::filesystem::weakly_canonical(dir / "semantic_tree_init.json", ec)
-              .string();
-      if (!base.empty() && target.rfind(base, 0) == 0) {
-        DumpTree(target.c_str());
+      const std::string target = (dir / "semantic_tree_init.json").string();
+      // The accessibility directory is derived from the user's environment
+      // (XDG_CONFIG_HOME, or HOME as a fallback). Reject any ".." traversal
+      // segment before opening the file so a crafted environment cannot
+      // redirect the write outside the intended config tree.
+      if (target.find("..") != std::string::npos) {
+        spdlog::error(
+            "Refusing to write accessibility tree dump to '{}': path contains "
+            "a '..' traversal segment",
+            target);
       } else {
-        spdlog::error("Refusing to write accessibility tree dump outside {}",
-                      base);
+        DumpTree(target.c_str());
       }
 #if ENABLE_ACCESSKIT
       Init_AccessKit();


### PR DESCRIPTION
Follow-up to #246, which gated the accessibility semantics tree behind `BUILD_ACCESSIBILITY` (default OFF). Two things:

## CI leg
Adds a dedicated `accessibility` job that configures `-DBUILD_ACCESSIBILITY=ON` and compiles the shell, so the opt-in path (the `AccessibilityTree` subsystem and its engine/view wiring) doesn't bit-rot now that it's out of the default build. It needs no extra dependencies, so it uses the lightweight ninja build (not the heavyweight workspace action the crash-handler leg needs).

## Path-injection hardening
The semantic-tree dump directory is derived from the user's environment (`XDG_CONFIG_HOME`, or `HOME` as a fallback). The dump now rejects any `..` traversal segment before opening the file — the barrier pattern CodeQL's `cpp/path-injection` recognizes, placed so it directly dominates the write. A crafted environment can no longer redirect the dump outside the config tree.

Note: CodeQL still scans the default-OFF build, so this code isn't in the scanned binary; the hardening makes the opt-in build genuinely safe rather than relying on the gate alone.

## Verification
- Builds with `BUILD_ACCESSIBILITY` **on and off**; clang-tidy + clang-format clean; workflow YAML validates.
- Ran Wonderous on Wayland-EGL with accessibility **on**: renders, and the dump lands under `XDG_CONFIG_HOME/homescreen/accessibility/semantic_tree_init.json`.
- Negative test: a `HOME` containing `..` is **refused** — `Refusing to write accessibility tree dump … path contains a '..' traversal segment`, no file written.