### PR TITLE
ci(pios): add a single `pios` gate check for branch protection

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -162,3 +162,24 @@ jobs:
           name: homescreen-${{ matrix.board }}-${{ matrix.pios }}-${{ matrix.backend }}
           path: /emb/.config/flutter_workspace/cross-build-*/build-${{ matrix.backend }}/shell/homescreen
           if-no-files-found: error
+
+  # Single stable status for branch protection: aggregates the publish + build
+  # matrix into one `pios` check, so required-checks don't have to enumerate
+  # every board×os×backend job (which would re-break on any matrix change).
+  # Passes on success or skipped (e.g. the github.com guard); fails if any
+  # publish/build job failed or was cancelled.
+  pios:
+    needs: [publish, build]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Gate on publish + build
+        run: |
+          for r in "${{ needs.publish.result }}" "${{ needs.build.result }}"; do
+            case "$r" in
+              failure|cancelled)
+                echo "pios gate: a required job result was '$r'"; exit 1 ;;
+            esac
+          done
+          echo "pios gate ok: publish=${{ needs.publish.result }} \
+            build=${{ needs.build.result }}"


### PR DESCRIPTION
The new pios workflow emits **28** status contexts (`publish-{bookworm,trixie}` + 26 `build-<board>-<os>-<backend>`). Requiring pios in branch protection by enumerating those is brittle — it goes stale on any matrix change, which is exactly what just happened: the old required job names (`prep-*`, `build-<os>-<backend>`) no longer exist, so they sat permanently "expected" and blocked merges even though all CI was green.

This adds one aggregating **`pios`** job:
- `needs: [publish, build]`, `if: always()`.
- fails iff a publish/build job result is `failure`/`cancelled`; passes on `success`/`skipped` (so the `github.com`-only guard doesn't trip it).

Branch protection can then require the single stable `pios` context instead of the matrix — immune to future board/backend changes.

**Rollout** (admin, done alongside this):
1. ✅ removed the 10 stale required checks (`prep-*`, `build-{bookworm,trixie}-*`) so merges unblock now.
2. merge this PR so the `pios` context starts reporting.
3. add `pios` to v2.0 required checks.