### PR TITLE
chore(emb): set cross.package.bin in base manifest

### DIFF
--- a/.emb/base.emb.yaml
+++ b/.emb/base.emb.yaml
@@ -22,6 +22,12 @@ cross:
   # native (`--target local`, the default) build, which uses the host toolchain.
   # Every board target overrides it with its own provider.
   provider: arm-gnu
+  # Embedder binary, relative to each backend build dir. Setting it explicitly
+  # lets --run/--deploy/--deb locate `homescreen` directly instead of scanning
+  # the build tree (which can otherwise hit a CMake compiler-probe binary).
+  package:
+    name: ivi-homescreen
+    bin: shell/homescreen
   defines:
     DISABLE_PLUGINS: 'ON'              # shared by the native build and the boards
   # Native host backend matrix: `emb cross . --build` (no --target) compiles


### PR DESCRIPTION
## What

Sets `cross.package.bin: shell/homescreen` in `.emb/base.emb.yaml` so `emb`'s `--run`/`--deploy`/`--deb` locate the embedder directly instead of scanning the backend build tree (which can otherwise hit a CMake compiler-probe binary under `CMakeFiles/**`).

```yaml
cross:
  provider: arm-gnu
  package:
    name: ivi-homescreen
    bin: shell/homescreen
```

Shared in the base manifest, so every board target inherits it.

## Companion

Pairs with the emb_cli `feat/cross-run-local` change (which also hardens the build-tree binary scan); either can merge first.