### PR TITLE
cursor: route activateSystemCursor through IDisplay (#255)

### DIFF
--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -39,16 +39,6 @@
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #endif
 
-// WaylandWindow's complete type is required for the m_egl_window->
-// ActivateSystemCursor() call in this TU (and for the shared_ptr
-// constructor in the initializer list). flutter_view.h
-// forward-declares WaylandWindow unconditionally so the header
-// compiles without Wayland; the .cc needs the real definition only
-// when Wayland is selected.
-#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
-#include "wayland/window.h"
-#endif
-
 extern void EngineOnFlutterPlatformMessage(
     const FlutterPlatformMessage* engine_message,
     void* user_data);
@@ -123,7 +113,6 @@ Engine::Engine(FlutterView* view,
     : m_index(index),
       m_running(false),
       m_backend(view->GetBackend()),
-      m_egl_window(view->GetWindow()),
       m_view(view),
       m_cache_path(GetFilePath(index)),
       m_prev_height(0),
@@ -674,23 +663,6 @@ FlutterEngineAOTData Engine::LoadAotData(const std::string& bundle_path) const {
     return nullptr;
   }
   return data;
-}
-
-bool Engine::ActivateSystemCursor(const int32_t device,
-                                  const std::string& kind) const {
-  if (!m_egl_window) {
-    return true;
-  }
-#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
-  return m_egl_window->ActivateSystemCursor(device, kind);
-#else
-  // Forward-declaration only on non-Wayland builds; m_egl_window is
-  // always null here, so this branch is unreachable at runtime. The
-  // unused parameter cast keeps the signature stable.
-  (void)device;
-  (void)kind;
-  return true;
-#endif
 }
 
 void Engine::OnFlutterPlatformMessage(

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -37,7 +37,6 @@
 
 class App;
 class Shell;
-class WaylandWindow;
 class FlutterView;
 struct FlutterDesktopEngineState;
 
@@ -295,19 +294,6 @@ class Engine {
   void SendPointerEvents();
 
   /**
-   * @brief Activate system cursor
-   * @param[in] device No use
-   * @param[in] kind Cursor kind
-   * @return bool
-   * @retval true Normal end
-   * @retval false Abnormal end
-   * @relation
-   * wayland
-   */
-  [[nodiscard]] bool ActivateSystemCursor(int32_t device,
-                                          const std::string& kind) const;
-
-  /**
    * @brief Get backend of view
    * @return Shell*
    * @retval Shell pointer
@@ -374,7 +360,6 @@ class Engine {
   bool m_running;
 
   Shell* m_backend;
-  std::shared_ptr<WaylandWindow> m_egl_window;
   FlutterView* m_view;
 
   std::filesystem::path m_assets_path;

--- a/shell/platform/homescreen/mouse_cursor_handler.cc
+++ b/shell/platform/homescreen/mouse_cursor_handler.cc
@@ -17,17 +17,11 @@
 
 #include <flutter/standard_method_codec.h>
 
+#include "display/idisplay.h"
 #include "engine.h"
+#include "view/flutter_view.h"
 
-// Complete WaylandWindow type required at line ~69 for the
-// window->ActivateSystemCursor() call. Forward-decl in flutter_view.h
-// is enough for everything else (GetWindow's return type, the
-// `if (!window)` null check).
-#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
-#include "wayland/window.h"
-#endif
-
-static constexpr char kNoWindowError[] = "Missing window error";
+static constexpr char kNoViewError[] = "Missing view error";
 
 MouseCursorHandler::MouseCursorHandler(flutter::BinaryMessenger* messenger,
                                        FlutterView* view)
@@ -64,29 +58,16 @@ void MouseCursorHandler::HandleMethodCall(
       }
     }
     if (!view_) {
-      result->Error(kNoWindowError, "View is not set.");
+      result->Error(kNoViewError, "View is not set.");
       return;
     }
-    auto window = view_->GetWindow();
-    if (!window) {
-      // DRM/KMS + software paths have no WaylandWindow; cursor is
-      // handled at the KMS plane level (or not at all). Same
-      // behaviour on non-Wayland builds where GetWindow() is
-      // always null and WaylandWindow is forward-declared only.
-      result->Success(flutter::EncodableValue(true));
-      return;
-    }
-#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
-    auto res = window->ActivateSystemCursor(device, kind);
+    // Route through the backend-agnostic IDisplay: every backend (Wayland
+    // Display, DrmDisplay, SoftwareDisplay) implements ActivateSystemCursor.
+    // The Wayland path used to hop through WaylandWindow, which merely
+    // forwarded to this same display call — going direct drops the
+    // Wayland-only gate so DRM and software receive the cursor kind too.
+    const bool res = view_->GetIDisplay()->ActivateSystemCursor(device, kind);
     result->Success(flutter::EncodableValue(res));
-#else
-    // Unreachable — window is always null without a Wayland backend
-    // (see the early return above). The branch exists only so the
-    // compiler doesn't need WaylandWindow's complete type here.
-    (void)device;
-    (void)kind;
-    result->Success(flutter::EncodableValue(true));
-#endif
   } else {
     result->NotImplemented();
   }

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -139,6 +139,17 @@ class FlutterView {
   [[nodiscard]] Display* GetDisplay() const;
 #endif
 
+  /**
+   * @brief Get the view's display as the backend-agnostic IDisplay.
+   * @return IDisplay* — set at construction (never null); valid on every
+   *         backend (Wayland Display, DrmDisplay, SoftwareDisplay). Use this
+   *         for backend-neutral display calls (e.g. ActivateSystemCursor)
+   *         instead of reaching through a concrete window type.
+   * @relation
+   * internal
+   */
+  [[nodiscard]] IDisplay* GetIDisplay() const { return m_display.get(); }
+
 #ifdef ENABLE_PLUGIN_COMP_SURF
   /**
    * @brief Create a surface ofr a compositor surface plugin


### PR DESCRIPTION
Addresses #255 (part a — the routing). `MouseCursorHandler` reached the
cursor through the concrete `WaylandWindow`, so `activateSystemCursor` only
worked on the Wayland backends; DRM and software short-circuited to a no-op.

## Change
- **`flutter_view.h`**: new `GetIDisplay()` → `IDisplay*` (always valid; the
  backend-neutral display accessor, vs. the Wayland-concrete `GetDisplay()`).
- **`mouse_cursor_handler.cc`**: route `activateSystemCursor` through
  `IDisplay::ActivateSystemCursor`. Every backend's display (Wayland `Display`,
  `DrmDisplay`, `SoftwareDisplay`) already implements it. Drops the
  `WaylandWindow` hop, the `#if BUILD_BACKEND_WAYLAND_*` gate, and the window
  null-check. Behavior-identical on Wayland (`WaylandWindow::ActivateSystemCursor`
  only forwarded to the same display call); DRM/software now reach their own impls.
- **Dead-code removal**: `Engine::ActivateSystemCursor` had no in-tree caller —
  removed it and its now-unused `m_egl_window` member, initializer,
  `wayland/window.h` include, and `WaylandWindow` forward-decl.

Net −51 lines.

## Validation
- Builds: wayland-egl, software, drm-kms-egl (compositor on).
- wayland-egl + flutter_gallery on Mutter renders clean, no regression
  (`wp_cursor_shape_manager_v1` bound, engine + Dart VM up, zero errors).
- clang-tidy-19 clean; clang-format-19 clean.

## Follow-up (part b of #255)
`DrmDisplay`/`SoftwareDisplay::ActivateSystemCursor` are still `return true`
stubs. Making them actually retarget the cursor (DRM cursor plane / composited
`SoftwareCursor`) per Flutter cursor `kind` is the remaining work — tracked in #255.
