### PR TITLE
cursor: themed shape change across DRM + software backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,12 @@ if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN)
     include(wayland_cxx)
 endif ()
 
+# The software backend resolves XCursor themes via drm-cxx's loader sources
+# built in-tree (no display deps); see cmake/drm_cxx_cursor_load.cmake.
+if (BUILD_BACKEND_SOFTWARE)
+    include(drm_cxx_cursor_load)
+endif ()
+
 configure_file(cmake/config_common.h.in ${PROJECT_BINARY_DIR}/config/common.h)
 
 #

--- a/cmake/drm_cxx_cursor_load.cmake
+++ b/cmake/drm_cxx_cursor_load.cmake
@@ -1,0 +1,48 @@
+#
+# drm_cxx_cursor_load — the drm::cursor loader (Theme + Cursor) built in-tree
+# from the drm-cxx submodule sources, WITHOUT the display stack.
+#
+# This mirrors drm-cxx's own `drm-cxx::cursor-load` target (cursor/theme.cpp +
+# cursor/cursor.cpp + the vendored X11-free xcursor-mini loader) but defines it
+# here so the software backend can resolve XCursor themes and rasterize cursor
+# frames into its own ARGB8888 buffers WITHOUT add_subdirectory(drm-cxx) — which
+# would run drm-cxx's display configure (pkg_check_modules(gbm REQUIRED), libdrm,
+# libdisplay-info, ...) and pull those into the software backend whose whole
+# point is "no GBM / no GL / no extra libraries". The loader links nothing
+# beyond the standard library (header-only span/expected polyfill under C++17).
+#
+
+set(_dcxx "${CMAKE_SOURCE_DIR}/third_party/drm-cxx")
+
+if (NOT EXISTS "${_dcxx}/src/cursor/cursor.cpp")
+    message(STATUS
+        "drm-cxx cursor-load sources missing; software themed cursor disabled")
+    return()
+endif ()
+
+# C is for the vendored .xcursor loader (xcursor_file.c).
+enable_language(C)
+
+add_library(drm_cxx_cursor_load STATIC
+        "${_dcxx}/src/cursor/theme.cpp"
+        "${_dcxx}/src/cursor/cursor.cpp"
+        "${_dcxx}/third_party/xcursor-mini/xcursor_file.c")
+add_library(drm-cxx::cursor-load ALIAS drm_cxx_cursor_load)
+
+set_target_properties(drm_cxx_cursor_load PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_compile_features(drm_cxx_cursor_load PUBLIC cxx_std_17)
+
+# Vendored submodule sources: suppress their warnings under ivi's strict flags.
+target_compile_options(drm_cxx_cursor_load PRIVATE -w)
+
+target_include_directories(drm_cxx_cursor_load
+        PUBLIC
+            # src/ resolves the public "cursor/cursor.hpp" + "detail/..." paths;
+            # the polyfill roots back <tl/expected.hpp> / <tcb/span.hpp> on a
+            # pre-C++20 toolchain (this project is C++17).
+            "${_dcxx}/src"
+            "${_dcxx}/subprojects/tl-expected/include"
+            "${_dcxx}/subprojects/tcb-span/include"
+        PRIVATE
+            # cursor.cpp includes the vendored "xcursor.h".
+            "${_dcxx}/third_party/xcursor-mini")

--- a/cmake/drm_cxx_cursor_load.cmake
+++ b/cmake/drm_cxx_cursor_load.cmake
@@ -20,6 +20,43 @@ if (NOT EXISTS "${_dcxx}/src/cursor/cursor.cpp")
     return()
 endif ()
 
+# The cursor sources include detail/{expected,span}.hpp, which back
+# <tl/expected.hpp> / <tcb/span.hpp> on a pre-C++20 toolchain (this project is
+# C++17). Resolve those polyfills the same way drm-cxx does: prefer a system
+# package (a Yocto recipe / cross sysroot provides them via find_package), else
+# fall back to drm-cxx's checked-out git submodules under third_party/. Never
+# fetch — offline / Yocto builds must not touch the network at configure. If a
+# polyfill is reachable by neither route the submodule simply is not checked out
+# (e.g. a non-recursive clone); disable the themed cursor rather than fail.
+set(_cursor_polyfill_targets "")
+set(_cursor_polyfill_includes "")
+
+find_package(tl-expected CONFIG QUIET)
+if (tl-expected_FOUND)
+    list(APPEND _cursor_polyfill_targets tl::expected)
+elseif (EXISTS "${_dcxx}/third_party/tl-expected/include/tl/expected.hpp")
+    list(APPEND _cursor_polyfill_includes
+        "${_dcxx}/third_party/tl-expected/include")
+else ()
+    message(STATUS
+        "tl-expected unavailable (no system package, drm-cxx submodule not "
+        "checked out); software themed cursor disabled")
+    return()
+endif ()
+
+find_package(tcb-span CONFIG QUIET)
+if (tcb-span_FOUND)
+    list(APPEND _cursor_polyfill_targets tcb::span)
+elseif (EXISTS "${_dcxx}/third_party/tcb-span/include/tcb/span.hpp")
+    list(APPEND _cursor_polyfill_includes
+        "${_dcxx}/third_party/tcb-span/include")
+else ()
+    message(STATUS
+        "tcb-span unavailable (no system package, drm-cxx submodule not "
+        "checked out); software themed cursor disabled")
+    return()
+endif ()
+
 # C is for the vendored .xcursor loader (xcursor_file.c).
 enable_language(C)
 
@@ -37,12 +74,17 @@ target_compile_options(drm_cxx_cursor_load PRIVATE -w)
 
 target_include_directories(drm_cxx_cursor_load
         PUBLIC
-            # src/ resolves the public "cursor/cursor.hpp" + "detail/..." paths;
-            # the polyfill roots back <tl/expected.hpp> / <tcb/span.hpp> on a
-            # pre-C++20 toolchain (this project is C++17).
+            # src/ resolves the public "cursor/cursor.hpp" + "detail/..." paths.
             "${_dcxx}/src"
-            "${_dcxx}/subprojects/tl-expected/include"
-            "${_dcxx}/subprojects/tcb-span/include"
+            # Polyfill include roots (empty when a system package supplies the
+            # imported target below instead).
+            ${_cursor_polyfill_includes}
         PRIVATE
             # cursor.cpp includes the vendored "xcursor.h".
             "${_dcxx}/third_party/xcursor-mini")
+
+# System-provided polyfills carry their own SYSTEM include dirs via the
+# imported target; link them so both this lib and its consumers see the headers.
+if (_cursor_polyfill_targets)
+    target_link_libraries(drm_cxx_cursor_load PUBLIC ${_cursor_polyfill_targets})
+endif ()

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -126,6 +126,13 @@ if (BUILD_BACKEND_SOFTWARE)
         )
         target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::SW_LIBINPUT)
     endif ()
+    # Themed software cursor via the in-tree drm-cxx cursor loader (no display
+    # deps; defined in cmake/drm_cxx_cursor_load.cmake). Absent when the drm-cxx
+    # submodule isn't checked out — the cursor then stays the embedded arrow.
+    if (TARGET drm_cxx_cursor_load)
+        target_link_libraries(${PROJECT_NAME} PRIVATE drm_cxx_cursor_load)
+        target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_SW_CURSOR_THEME=1)
+    endif ()
 endif ()
 
 # Shared libinput keyboard core (xkb translation + key-repeat) used by every

--- a/shell/backend/drm_kms_egl/drm_cursor.cc
+++ b/shell/backend/drm_kms_egl/drm_cursor.cc
@@ -24,6 +24,8 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <mutex>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -119,8 +121,28 @@ struct DrmCursor::Impl {
   std::atomic<uint64_t> desired_pos{0};
   std::atomic<bool> have_pos{false};
 
-  Impl(drm::cursor::Renderer r, int lx, int ly)
-      : renderer(std::move(r)), letterbox_x(lx), letterbox_y(ly) {}
+  // Sprite state. theme + theme_name + sprite_size let SetShape reload a named
+  // cursor at runtime; pending_shape is written under shape_mtx by the platform
+  // thread (SetShape) and consumed by the render thread (ApplyPendingShape).
+  drm::cursor::Theme theme;
+  std::string theme_name;
+  uint32_t sprite_size{0};
+  std::mutex shape_mtx;
+  std::string pending_shape;
+  bool shape_dirty{false};
+
+  Impl(drm::cursor::Renderer r,
+       drm::cursor::Theme t,
+       std::string tn,
+       const uint32_t ss,
+       const int lx,
+       const int ly)
+      : renderer(std::move(r)),
+        letterbox_x(lx),
+        letterbox_y(ly),
+        theme(std::move(t)),
+        theme_name(std::move(tn)),
+        sprite_size(ss) {}
 };
 
 namespace {
@@ -226,8 +248,9 @@ std::unique_ptr<DrmCursor> DrmCursor::Create(
       sizing.sprite, sizing.buffer, PlanePathName(renderer->path()),
       renderer->plane_id(), letterbox_x, letterbox_y);
 
-  return std::unique_ptr<DrmCursor>(new DrmCursor(
-      std::make_unique<Impl>(std::move(*renderer), letterbox_x, letterbox_y)));
+  return std::unique_ptr<DrmCursor>(new DrmCursor(std::make_unique<Impl>(
+      std::move(*renderer), std::move(*theme), std::string(theme_name),
+      sizing.sprite, letterbox_x, letterbox_y)));
 }
 
 DrmCursor::DrmCursor(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
@@ -238,6 +261,7 @@ uint32_t DrmCursor::plane_id() const {
 }
 
 void DrmCursor::Move(const int fb_x, const int fb_y) {
+  ApplyPendingShape();
   const int crtc_x = fb_x + impl_->letterbox_x;
   const int crtc_y = fb_y + impl_->letterbox_y;
   if (auto r = impl_->renderer.move_to(crtc_x, crtc_y); !r) {
@@ -260,6 +284,7 @@ void DrmCursor::SetPosition(const int fb_x, const int fb_y) {
 }
 
 bool DrmCursor::Stage(drm::AtomicRequest& req, bool* const needs_modeset) {
+  ApplyPendingShape();
   if (needs_modeset != nullptr) {
     *needs_modeset = false;
   }
@@ -290,6 +315,40 @@ void DrmCursor::CommitPending() {
   const uint64_t packed = impl_->desired_pos.load(std::memory_order_acquire);
   Move(static_cast<int32_t>(packed >> 32),
        static_cast<int32_t>(packed & 0xffffffffU));
+}
+
+bool DrmCursor::SetShape(const char* const xcursor_name) {
+  if (xcursor_name == nullptr) {
+    // "none": the HW cursor's visibility is gated by pointer motion, not the
+    // sprite, so leave the current sprite in place.
+    return true;
+  }
+  const std::lock_guard<std::mutex> lock(impl_->shape_mtx);
+  impl_->pending_shape.assign(xcursor_name);
+  impl_->shape_dirty = true;
+  return true;
+}
+
+void DrmCursor::ApplyPendingShape() {
+  std::string name;
+  {
+    const std::lock_guard<std::mutex> lock(impl_->shape_mtx);
+    if (!impl_->shape_dirty) {
+      return;
+    }
+    name = impl_->pending_shape;
+    impl_->shape_dirty = false;
+  }
+  auto cursor = drm::cursor::Cursor::load(impl_->theme, name, impl_->theme_name,
+                                          impl_->sprite_size);
+  if (!cursor) {
+    spdlog::warn("[DrmCursor] load '{}': {}; keeping current sprite", name,
+                 cursor.error().message());
+    return;
+  }
+  if (auto r = impl_->renderer.set_cursor(std::move(*cursor)); !r) {
+    spdlog::warn("[DrmCursor] set_cursor '{}': {}", name, r.error().message());
+  }
 }
 
 }  // namespace homescreen

--- a/shell/backend/drm_kms_egl/drm_cursor.h
+++ b/shell/backend/drm_kms_egl/drm_cursor.h
@@ -22,6 +22,8 @@
 
 #include <xf86drmMode.h>
 
+#include "display/icursor_shape_sink.h"
+
 namespace drm {
 class Device;
 class AtomicRequest;
@@ -44,12 +46,15 @@ namespace homescreen {
 // DrmDisplay/DrmSeat are handed a raw pointer for the seat-thread
 // HandlePointerMotion path.
 //
-// Single-thread by ownership: every public method must be called from
-// the seat dispatch thread. The compositor's atomic commits race
-// harmlessly against the cursor's own atomic commits at the kernel
-// boundary (the kernel serializes), but the Renderer itself is not
-// thread-safe.
-class DrmCursor {
+// Single-thread by ownership: Move/SetPosition/Stage/CommitPending must be
+// called from the seat dispatch / raster thread. The compositor's atomic
+// commits race harmlessly against the cursor's own atomic commits at the
+// kernel boundary (the kernel serializes), but the Renderer itself is not
+// thread-safe. SetShape is the exception: it is called from the platform
+// thread (ActivateSystemCursor) and only records the requested shape under a
+// lock; the sprite swap is applied on the render-owning thread at the next
+// Stage()/Move().
+class DrmCursor final : public ICursorShapeSink {
  public:
   // Construct the cursor on the given CRTC for the active mode.
   // `fb_w` / `fb_h` are the framebuffer dimensions the seat clamps the
@@ -82,7 +87,7 @@ class DrmCursor {
 
   DrmCursor(const DrmCursor&) = delete;
   DrmCursor& operator=(const DrmCursor&) = delete;
-  ~DrmCursor();
+  ~DrmCursor() override;
 
   // Move the sprite. Coordinates are in framebuffer space (i.e. the
   // same range the seat clamps pointer events to); the letterbox
@@ -93,6 +98,13 @@ class DrmCursor {
   // ignored — the pointer remains usable in Flutter even if the
   // sprite stalls.
   void Move(int fb_x, int fb_y);
+
+  // ICursorShapeSink: retarget the sprite to an XCursor name (resolved against
+  // the theme picked at Create). Records the request under a lock and returns
+  // true; the actual Cursor::load + Renderer::set_cursor runs on the next
+  // Stage()/Move() (the render-owning thread). A null name is a no-op for the
+  // HW cursor (visibility is gated by pointer motion, not the sprite).
+  bool SetShape(const char* xcursor_name) override;
 
   // Enable staged mode. In staged mode the cursor plane is driven by the
   // compositor via Stage() instead of self-committing — used on drivers
@@ -137,6 +149,10 @@ class DrmCursor {
  private:
   struct Impl;
   std::unique_ptr<Impl> impl_;
+
+  // Apply a pending SetShape() request on the render-owning thread. Called at
+  // the head of Stage()/Move(); no-op when no shape change is queued.
+  void ApplyPendingShape();
 
   explicit DrmCursor(std::unique_ptr<Impl> impl);
 };

--- a/shell/backend/drm_kms_egl/gl_cursor.cc
+++ b/shell/backend/drm_kms_egl/gl_cursor.cc
@@ -18,6 +18,14 @@
 
 #include <array>
 #include <cstring>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#ifdef HAVE_DRM_CURSOR
+#include <drm-cxx/cursor/cursor.hpp>
+#include <drm-cxx/cursor/theme.hpp>
+#endif
 
 #include "logging.h"
 
@@ -103,6 +111,76 @@ GlCursor::GlCursor() : w_(kCursorW), h_(kCursorH) {
 
 GlCursor::~GlCursor() = default;
 
+bool GlCursor::SetShape(const char* const xcursor_name) {
+#ifdef HAVE_DRM_CURSOR
+  if (xcursor_name == nullptr) {
+    SetVisible(false);
+    return true;
+  }
+  // XCURSOR_SIZE convention is 24 logical px; the theme resolver scales to the
+  // nearest available size.
+  constexpr uint32_t kThemeLogicalSize = 24;
+  static auto theme = drm::cursor::Theme::discover();
+  if (!theme) {
+    return false;
+  }
+  auto cursor =
+      drm::cursor::Cursor::load(*theme, xcursor_name, {}, kThemeLogicalSize);
+  if (!cursor) {
+    return false;
+  }
+  const auto& f = cursor->first();
+  // drm::cursor frames are premultiplied ARGB8888 (0xAARRGGBB); the GL texture
+  // wants premultiplied RGBA bytes [R,G,B,A].
+  const auto count = static_cast<size_t>(f.width) * f.height;
+  std::vector<uint8_t> rgba(count * 4);
+  for (size_t i = 0; i < count; ++i) {
+    const uint32_t px = f.pixels[i];
+    rgba[i * 4 + 0] = static_cast<uint8_t>((px >> 16) & 0xFF);
+    rgba[i * 4 + 1] = static_cast<uint8_t>((px >> 8) & 0xFF);
+    rgba[i * 4 + 2] = static_cast<uint8_t>(px & 0xFF);
+    rgba[i * 4 + 3] = static_cast<uint8_t>((px >> 24) & 0xFF);
+  }
+  {
+    const std::lock_guard<std::mutex> lock(shape_mtx_);
+    pending_rgba_ = std::move(rgba);
+    pending_w_ = f.width;
+    pending_h_ = f.height;
+    pending_hot_x_ = f.xhot;
+    pending_hot_y_ = f.yhot;
+    shape_dirty_ = true;
+  }
+  SetVisible(true);
+  return true;
+#else
+  (void)xcursor_name;
+  return false;
+#endif
+}
+
+void GlCursor::ApplyPendingShape() {
+  const std::lock_guard<std::mutex> lock(shape_mtx_);
+  if (!shape_dirty_) {
+    return;
+  }
+  rgba_ = std::move(pending_rgba_);
+  w_ = pending_w_;
+  h_ = pending_h_;
+  hot_x_ = pending_hot_x_;
+  hot_y_ = pending_hot_y_;
+  // Themed cursors are full-size; drop the integer upscale that only exists to
+  // make the tiny embedded fallback arrow visible.
+  scale_ = 1;
+  shape_dirty_ = false;
+  if (texture_ != 0) {
+    glBindTexture(GL_TEXTURE_2D, texture_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, static_cast<GLsizei>(w_),
+                 static_cast<GLsizei>(h_), 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 rgba_.data());
+    glBindTexture(GL_TEXTURE_2D, 0);
+  }
+}
+
 bool GlCursor::EnsureGl() {
   if (gl_ready_) {
     return true;
@@ -178,6 +256,7 @@ void GlCursor::Draw(const uint32_t fb_w, const uint32_t fb_h) {
   if (fb_w == 0 || fb_h == 0 || !EnsureGl()) {
     return;
   }
+  ApplyPendingShape();
 
   const auto fw = static_cast<float>(fb_w);
   const auto fh = static_cast<float>(fb_h);

--- a/shell/backend/drm_kms_egl/gl_cursor.h
+++ b/shell/backend/drm_kms_egl/gl_cursor.h
@@ -18,10 +18,12 @@
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 #include <vector>
 
 #include <GLES2/gl2.h>
 
+#include "display/icursor_shape_sink.h"
 #include "input/cursor_position_sink.h"
 
 namespace homescreen {
@@ -38,8 +40,10 @@ namespace homescreen {
 // thread (position + visibility are atomics). EnsureGl()/Draw()/Destroy() run
 // on the rasterizer thread with the EGL context current — Draw() from the
 // backend's Present() just before eglSwapBuffers, Destroy() from the backend
-// teardown while the context is still current.
-class GlCursor final : public ICursorPositionSink {
+// teardown while the context is still current. SetShape() is called from the
+// platform thread and only records the requested sprite under a lock; the GL
+// texture re-upload happens on the next Draw() (rasterizer thread).
+class GlCursor final : public ICursorPositionSink, public ICursorShapeSink {
  public:
   GlCursor();
   ~GlCursor() override;
@@ -59,6 +63,13 @@ class GlCursor final : public ICursorPositionSink {
     visible_.store(visible, std::memory_order_release);
   }
 
+  // ICursorShapeSink: retarget the sprite to an XCursor name. Loads the named
+  // cursor from the system theme, converts it to RGBA, and queues it under a
+  // lock; the GL texture is re-uploaded on the next Draw(). A null name hides
+  // the cursor. Returns false when no theme is available (HAVE_DRM_CURSOR off)
+  // or the shape couldn't be loaded; the current sprite then stays.
+  bool SetShape(const char* xcursor_name) override;
+
   // Rasterizer thread, EGL context current, FBO 0 holding the rendered frame.
   // Composites the cursor over it. No-op until the cursor is visible.
   void Draw(uint32_t fb_w, uint32_t fb_h);
@@ -69,6 +80,11 @@ class GlCursor final : public ICursorPositionSink {
  private:
   bool EnsureGl();
 
+  // Apply a queued SetShape() on the rasterizer thread (EGL context current):
+  // swap in the pending sprite and re-upload the GL texture. No-op when no
+  // shape change is pending.
+  void ApplyPendingShape();
+
   // Sprite: premultiplied RGBA8888 bytes, row-major, w_ * h_ texels.
   std::vector<uint8_t> rgba_;
   uint32_t w_{0};
@@ -76,6 +92,16 @@ class GlCursor final : public ICursorPositionSink {
   int32_t hot_x_{0};
   int32_t hot_y_{0};
   uint32_t scale_{2};  // integer upscale so a 12x19 arrow is visible at 1080p
+
+  // SetShape() queue. pending_* is filled under shape_mtx_ on the platform
+  // thread; ApplyPendingShape() consumes it on the rasterizer thread.
+  std::mutex shape_mtx_;
+  std::vector<uint8_t> pending_rgba_;
+  uint32_t pending_w_{0};
+  uint32_t pending_h_{0};
+  int32_t pending_hot_x_{0};
+  int32_t pending_hot_y_{0};
+  bool shape_dirty_{false};
 
   std::atomic<int32_t> x_{0};
   std::atomic<int32_t> y_{0};

--- a/shell/backend/software/software_cursor.cc
+++ b/shell/backend/software/software_cursor.cc
@@ -66,6 +66,7 @@ void SoftwareCursor::BlendXRGB(uint8_t* map,
   if (map == nullptr || !visible_.load(std::memory_order_acquire)) {
     return;
   }
+  const std::lock_guard<std::mutex> lock(bitmap_mtx_);
   const int32_t ox = x_.load(std::memory_order_relaxed) - hot_x_;
   const int32_t oy = y_.load(std::memory_order_relaxed) - hot_y_;
 
@@ -98,4 +99,20 @@ void SoftwareCursor::BlendXRGB(uint8_t* map,
       // d[3] (X) left unchanged.
     }
   }
+}
+
+void SoftwareCursor::SetShape(const uint32_t* const argb,
+                              const uint32_t width,
+                              const uint32_t height,
+                              const int32_t hot_x,
+                              const int32_t hot_y) {
+  if (argb == nullptr || width == 0 || height == 0) {
+    return;
+  }
+  const std::lock_guard<std::mutex> lock(bitmap_mtx_);
+  pixels_.assign(argb, argb + static_cast<size_t>(width) * height);
+  width_ = width;
+  height_ = height;
+  hot_x_ = hot_x;
+  hot_y_ = hot_y;
 }

--- a/shell/backend/software/software_cursor.h
+++ b/shell/backend/software/software_cursor.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 #include <vector>
 
 // Software mouse cursor for the CPU/software backend. The dumb-buffer sinks
@@ -25,14 +26,17 @@
 // just composited on top after the swizzle and before the page flip — no
 // save/restore of the pixels under the cursor is needed.
 //
-// The bitmap is a small embedded arrow (premultiplied ARGB8888), so the
-// software backend keeps its "no GBM / no GL / no extra libraries" property —
-// no libxcursor dependency. The hotspot is the arrow tip.
+// The bitmap starts as a small embedded arrow (premultiplied ARGB8888). It can
+// be retargeted to a themed XCursor shape via SetShape() (fed by the in-tree
+// drm-cxx cursor loader, which is X11-free and pulls no GBM/GL/display libs, so
+// the software backend keeps its dep-light property). The hotspot is the
+// sprite's hot point.
 //
 // Threading: SetPosition()/SetVisible() are called from the input thread
 // (SoftwareSeat); BlendXRGB() is called from the rasterizer thread (the sink's
-// Present). Position + visibility are atomics; the bitmap is immutable after
-// construction.
+// Present); SetShape() is called from the platform thread. Position +
+// visibility are atomics; the bitmap (pixels_ + dimensions + hotspot) is
+// guarded by bitmap_mtx_ so SetShape can swap it under the rasterizer's blend.
 class SoftwareCursor {
  public:
   SoftwareCursor();
@@ -49,6 +53,15 @@ class SoftwareCursor {
     visible_.store(visible, std::memory_order_release);
   }
 
+  // Replace the sprite with a new premultiplied-ARGB8888 bitmap (@p argb has
+  // @p width * @p height texels). Thread-safe against BlendXRGB. Used by
+  // SoftwareDisplay::ActivateSystemCursor to apply a themed cursor shape.
+  void SetShape(const uint32_t* argb,
+                uint32_t width,
+                uint32_t height,
+                int32_t hot_x,
+                int32_t hot_y);
+
   [[nodiscard]] bool visible() const {
     return visible_.load(std::memory_order_acquire);
   }
@@ -63,6 +76,8 @@ class SoftwareCursor {
 
  private:
   // Premultiplied ARGB8888 (0xAARRGGBB), row-major, width_ * height_ entries.
+  // Guarded by bitmap_mtx_ (BlendXRGB reads, SetShape writes).
+  mutable std::mutex bitmap_mtx_;
   std::vector<uint32_t> pixels_;
   uint32_t width_{0};
   uint32_t height_{0};

--- a/shell/cursor_kind.h
+++ b/shell/cursor_kind.h
@@ -1,0 +1,87 @@
+// Copyright 2020-2026 Toyota Connected North America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string_view>
+
+namespace homescreen {
+
+// Maps a Flutter SystemMouseCursors `kind` (the string sent over the
+// flutter/mousecursor platform channel) to a freedesktop XCursor name that
+// installed XCursor themes provide. The backend cursor implementations
+// (Wayland wl_cursor theme, DRM drm::cursor::Theme, software drm::cursor) all
+// resolve the returned name against a theme.
+//
+// Returns nullptr for "none" — the caller should hide the cursor — and
+// "default" for any unrecognized kind (themes always ship "default").
+[[nodiscard]] inline const char* CursorKindToXcursorName(
+    const std::string_view kind) {
+  if (kind == "none") {
+    return nullptr;
+  }
+
+  struct Entry {
+    std::string_view kind;
+    const char* name;
+  };
+  // Flutter kind -> XCursor/CSS cursor name. Ordered roughly as in Flutter's
+  // SystemMouseCursors. Names follow the CSS cursor spec, which modern XCursor
+  // themes (Adwaita, breeze, …) ship; older themes fall back via theme
+  // inheritance to the legacy aliases (e.g. ew-resize -> sb_h_double_arrow).
+  static constexpr Entry kMap[] = {
+      {"basic", "default"},
+      {"click", "pointer"},
+      {"forbidden", "not-allowed"},
+      {"wait", "wait"},
+      {"progress", "progress"},
+      {"contextMenu", "context-menu"},
+      {"help", "help"},
+      {"text", "text"},
+      {"verticalText", "vertical-text"},
+      {"cell", "cell"},
+      {"precise", "crosshair"},
+      {"move", "move"},
+      {"grab", "grab"},
+      {"grabbing", "grabbing"},
+      {"noDrop", "no-drop"},
+      {"alias", "alias"},
+      {"copy", "copy"},
+      {"allScroll", "all-scroll"},
+      {"resizeLeftRight", "ew-resize"},
+      {"resizeUpDown", "ns-resize"},
+      {"resizeUpLeftDownRight", "nwse-resize"},
+      {"resizeUpRightDownLeft", "nesw-resize"},
+      {"resizeUp", "n-resize"},
+      {"resizeDown", "s-resize"},
+      {"resizeLeft", "w-resize"},
+      {"resizeRight", "e-resize"},
+      {"resizeUpLeft", "nw-resize"},
+      {"resizeUpRight", "ne-resize"},
+      {"resizeDownLeft", "sw-resize"},
+      {"resizeDownRight", "se-resize"},
+      {"resizeColumn", "col-resize"},
+      {"resizeRow", "row-resize"},
+      {"zoomIn", "zoom-in"},
+      {"zoomOut", "zoom-out"},
+  };
+  for (const auto& e : kMap) {
+    if (e.kind == kind) {
+      return e.name;
+    }
+  }
+  return "default";
+}
+
+}  // namespace homescreen

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -21,6 +21,8 @@
 #include <utility>
 
 #include "backend/drm_kms_egl/drm_session.h"
+#include "cursor_kind.h"
+#include "display/icursor_shape_sink.h"
 #include "input/drm_seat.h"
 #include "logging.h"
 
@@ -145,6 +147,18 @@ void DrmDisplay::SetCursorRotation(const int32_t degrees) {
   if (auto* drm_seat = dynamic_cast<homescreen::DrmSeat*>(seat_.get())) {
     drm_seat->SetCursorRotation(degrees);
   }
+}
+
+void DrmDisplay::SetCursorShapeSink(homescreen::ICursorShapeSink* sink) {
+  shape_sink_ = sink;
+}
+
+bool DrmDisplay::ActivateSystemCursor(const int32_t /*device*/,
+                                      const std::string& kind) const {
+  if (shape_sink_ == nullptr) {
+    return true;
+  }
+  return shape_sink_->SetShape(homescreen::CursorKindToXcursorName(kind));
 }
 
 void DrmDisplay::SetInputTransforms(const std::vector<std::string>& specs) {

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -26,6 +26,7 @@
 namespace homescreen {
 class DrmCursor;
 class ICursorPositionSink;
+class ICursorShapeSink;
 class DrmSession;
 }  // namespace homescreen
 
@@ -67,6 +68,11 @@ class DrmDisplay final : public IDisplay {
   // there's no HW cursor plane) to the seat. nullptr is safe.
   void SetGlCursor(homescreen::ICursorPositionSink* sink);
 
+  // Register the active cursor (HW DrmCursor or GL-composited GlCursor) so
+  // ActivateSystemCursor can retarget its sprite. nullptr disables the
+  // retargeting (e.g. during teardown). The pointee is owned by DrmBackend.
+  void SetCursorShapeSink(homescreen::ICursorShapeSink* sink);
+
   // Forward the scanout rotation to the seat so the HW cursor sprite is
   // transformed from render space into panel space (0|90|180|270).
   void SetCursorRotation(int32_t degrees);
@@ -99,10 +105,8 @@ class DrmDisplay final : public IDisplay {
   }
 
   [[nodiscard]] bool ActivateSystemCursor(
-      int32_t /*device*/,
-      const std::string& /*kind*/) const override {
-    return true;
-  }
+      int32_t device,
+      const std::string& kind) const override;
 
   [[nodiscard]] bool HasRepeatTimer() const override { return false; }
 
@@ -111,6 +115,10 @@ class DrmDisplay final : public IDisplay {
   int32_t height_;
   double refresh_rate_hz_;
   FlutterDesktopViewControllerState* view_controller_state_ = nullptr;
+
+  // Active cursor sprite retargeting sink (set by FlutterView after the
+  // backend creates its cursor). Owned by DrmBackend; null when no cursor.
+  homescreen::ICursorShapeSink* shape_sink_ = nullptr;
 
   // Seat session must outlive seat_ (DrmSeat's libinput_opener captures
   // into the session's internal state). Declare it first so it's

--- a/shell/display/icursor_shape_sink.h
+++ b/shell/display/icursor_shape_sink.h
@@ -1,0 +1,36 @@
+// Copyright 2020-2026 Toyota Connected North America
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace homescreen {
+
+// A backend cursor that can change its sprite to a named XCursor shape. The
+// backend registers the active cursor with its display so
+// IDisplay::ActivateSystemCursor can retarget the live cursor regardless of
+// which concrete cursor (HW plane, GL-composited, software) is in use.
+class ICursorShapeSink {
+ public:
+  virtual ~ICursorShapeSink() = default;
+
+  // Set the cursor sprite to the given XCursor name (resolved against the
+  // active theme), e.g. "default", "pointer", "text". A null name requests
+  // hiding the cursor. Returns false if the shape could not be loaded.
+  //
+  // Called from the platform thread; the actual sprite swap may be deferred to
+  // the backend's render thread, so implementations must be thread-safe.
+  virtual bool SetShape(const char* xcursor_name) = 0;
+};
+
+}  // namespace homescreen

--- a/shell/display/software_display.cc
+++ b/shell/display/software_display.cc
@@ -16,10 +16,18 @@
 
 #include "display/software_display.h"
 
+#include <cstdint>
 #include <utility>
 
 #include "backend/software/input/software_seat.h"
+#include "backend/software/software_cursor.h"
+#include "cursor_kind.h"
 #include "input/iseat.h"
+
+#ifdef HAVE_SW_CURSOR_THEME
+#include "cursor/cursor.hpp"
+#include "cursor/theme.hpp"
+#endif
 
 SoftwareDisplay::SoftwareDisplay(const int32_t width,
                                  const int32_t height,
@@ -48,6 +56,37 @@ void SoftwareDisplay::SetCursor(std::shared_ptr<SoftwareCursor> cursor) {
   if (auto* sw_seat = dynamic_cast<homescreen::SoftwareSeat*>(seat_.get())) {
     sw_seat->SetCursor(cursor_);
   }
+}
+
+bool SoftwareDisplay::ActivateSystemCursor(const int32_t /*device*/,
+                                           const std::string& kind) const {
+  if (!cursor_) {
+    return true;
+  }
+  const char* const name = homescreen::CursorKindToXcursorName(kind);
+  if (name == nullptr) {  // "none" — hide the cursor.
+    cursor_->SetVisible(false);
+    return true;
+  }
+#ifdef HAVE_SW_CURSOR_THEME
+  // XCURSOR_SIZE convention is 24 logical px; the resolver scales to the
+  // nearest available size. The theme is resolved once (process-global).
+  constexpr uint32_t kThemeLogicalSize = 24;
+  static auto theme = drm::cursor::Theme::discover();
+  if (theme) {
+    auto cursor =
+        drm::cursor::Cursor::load(*theme, name, {}, kThemeLogicalSize);
+    if (cursor) {
+      const auto& f = cursor->first();
+      cursor_->SetShape(f.pixels.data(), f.width, f.height, f.xhot, f.yhot);
+      cursor_->SetVisible(true);
+      return true;
+    }
+  }
+#endif
+  // No theme available or shape not found: keep the current sprite visible.
+  cursor_->SetVisible(true);
+  return true;
 }
 
 void SoftwareDisplay::StartEvents() {

--- a/shell/display/software_display.h
+++ b/shell/display/software_display.h
@@ -78,10 +78,8 @@ class SoftwareDisplay final : public IDisplay {
   }
 
   [[nodiscard]] bool ActivateSystemCursor(
-      int32_t /*device*/,
-      const std::string& /*kind*/) const override {
-    return true;
-  }
+      int32_t device,
+      const std::string& kind) const override;
 
   [[nodiscard]] bool HasRepeatTimer() const override { return false; }
 

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -27,9 +27,11 @@
 // drm_display.h include harmless.
 #if BUILD_BACKEND_DRM_KMS_EGL
 #include "backend/drm_kms_egl/drm_backend.h"
+#include "backend/drm_kms_egl/drm_cursor.h"  // DrmCursor -> ICursorShapeSink*
 #include "display/drm_display.h"
 #endif
 #if BUILD_BACKEND_DRM_KMS_VULKAN
+#include "backend/drm_kms_egl/drm_cursor.h"  // DrmCursor -> ICursorShapeSink*
 #include "backend/drm_kms_vulkan/vulkan_drm_backend.h"
 #include "display/drm_display.h"
 #endif
@@ -229,6 +231,9 @@ std::shared_ptr<Shell> Shell::Create(const Configuration::Config& config,
       drm_display->SetCursor(drm_backend->drm_cursor());
       // Composited cursor fallback (non-null only when no HW cursor plane).
       drm_display->SetGlCursor(drm_backend->gl_cursor());
+      // Retarget the cursor sprite on activateSystemCursor. The HW cursor is
+      // the shape sink; null (no HW plane) leaves it a no-op.
+      drm_display->SetCursorShapeSink(drm_backend->drm_cursor());
     }
   }
 #elif BUILD_BACKEND_DRM_KMS_VULKAN
@@ -266,6 +271,7 @@ std::shared_ptr<Shell> Shell::Create(const Configuration::Config& config,
     drm_display->SetViewportSize(static_cast<int32_t>(vk_backend->width()),
                                  static_cast<int32_t>(vk_backend->height()));
     drm_display->SetCursor(vk_backend->drm_cursor());
+    drm_display->SetCursorShapeSink(vk_backend->drm_cursor());
     drm_display->SetCursorRotation(vk_backend->rotation());
     drm_display->SetInputTransforms(config.view.drm_input_transforms);
     m_backend = vk_backend;

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -28,6 +28,7 @@
 #if BUILD_BACKEND_DRM_KMS_EGL
 #include "backend/drm_kms_egl/drm_backend.h"
 #include "backend/drm_kms_egl/drm_cursor.h"  // DrmCursor -> ICursorShapeSink*
+#include "backend/drm_kms_egl/gl_cursor.h"   // GlCursor -> ICursorShapeSink*
 #include "display/drm_display.h"
 #endif
 #if BUILD_BACKEND_DRM_KMS_VULKAN
@@ -231,9 +232,17 @@ std::shared_ptr<Shell> Shell::Create(const Configuration::Config& config,
       drm_display->SetCursor(drm_backend->drm_cursor());
       // Composited cursor fallback (non-null only when no HW cursor plane).
       drm_display->SetGlCursor(drm_backend->gl_cursor());
-      // Retarget the cursor sprite on activateSystemCursor. The HW cursor is
-      // the shape sink; null (no HW plane) leaves it a no-op.
-      drm_display->SetCursorShapeSink(drm_backend->drm_cursor());
+      // Retarget the cursor sprite on activateSystemCursor: the HW cursor when
+      // a cursor plane exists, else the GL-composited fallback. gl_cursor() is
+      // typed as ICursorPositionSink*; cross-cast to the sibling shape-sink
+      // interface (GlCursor implements both).
+      if (auto* hw = drm_backend->drm_cursor()) {
+        drm_display->SetCursorShapeSink(hw);
+      } else {
+        drm_display->SetCursorShapeSink(
+            dynamic_cast<homescreen::ICursorShapeSink*>(
+                drm_backend->gl_cursor()));
+      }
     }
   }
 #elif BUILD_BACKEND_DRM_KMS_VULKAN


### PR DESCRIPTION
Part (b) of #255 — make `activateSystemCursor` actually change the cursor
**shape** on the DRM and software backends (part (a), the `IDisplay` routing,
merged in #256). The Flutter cursor `kind` is mapped to a freedesktop XCursor
name (shared `CursorKindToXcursorName`) and applied to the active cursor.

## What's covered
- **DRM HW cursor** (`DrmCursor`): `SetShape` reloads the named cursor from its
  XCursor theme and hands it to the drm-cxx `Renderer`. The Renderer is
  raster-thread-only, so `SetShape` (platform thread) records the request under
  a lock and the swap is applied on the next `Stage()`/`Move()`, mirroring
  `SetPosition`. Wired for both EGL and Vulkan DRM.
- **DRM GL-fallback cursor** (`GlCursor`, used when there's no HW cursor plane):
  loads the theme shape, converts ARGB→RGBA, re-uploads the GLES2 texture on
  the next `Draw()`. Gated on `HAVE_DRM_CURSOR` (the xcursor CMake check).
- **Software cursor** (`SoftwareCursor`): bitmap becomes swappable under a
  mutex (BlendXRGB reads, `SetShape` writes). Themed bitmaps come from drm-cxx's
  cursor loader built **in-tree as a standalone static lib**
  (`cmake/drm_cxx_cursor_load.cmake`) — *not* `add_subdirectory(drm-cxx)`, so
  the software backend stays gbm/GL/display-free. Verified: the software binary
  links none of libgbm/libdisplay-info/libEGL/libvulkan/libseat.

`ICursorShapeSink` is the small interface the displays use to reach the live
cursor; the backend registers the active one (HW, GL, or software).

## Validation
- Builds on wayland-egl, software, drm-kms-egl, drm-kms-vulkan (compositor on).
- clang-tidy-19 + clang-format-19 clean.
- **Live on real hardware (amdgpu, 1280×1440):** DRM HW cursor and software
  composited cursor both change shape over gallery widgets (arrow → hand over
  tiles, I-beam over text) — user-confirmed on the panel.

## Notes
- The drm-cxx submodule bump for the cursor-load loader sources (drm-cxx #150)
  is included here as commit `eb2b0655` — no external prerequisite.
- GL-fallback isn't exercised on amdgpu (it has a HW cursor plane), but builds,
  is gated, and shares the same theme-load path.



Closes #255
