### PR TITLE
wayland: keyboard via wl::KeyboardHandler on an event-driven asio reactor

### DIFF
--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -32,6 +32,12 @@ pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.22)
 pkg_get_variable(_wlcxx_proto_base wayland-protocols pkgdatadir)
 set(IVI_WL_PROTOCOLS_BASE "${_wlcxx_proto_base}" CACHE INTERNAL "wayland-protocols pkgdatadir")
 
+# Core Wayland protocol XML (wl_seat / wl_keyboard / …) ships with
+# wayland-scanner. The generated wayland_client.hpp backs wl::KeyboardHandler;
+# its core wl_interface tables come from libwayland (no --emit-interface-tables).
+pkg_get_variable(_wlcxx_core_base wayland-scanner pkgdatadir)
+set(IVI_WL_CORE_XML "${_wlcxx_core_base}/wayland.xml" CACHE INTERNAL "core wayland.xml")
+
 # --- Shell client options --------------------------------------------------
 # xdg + agl on by default; ivi + simple are opt-in.
 option(ENABLE_XDG_CLIENT          "Enable XDG shell client"               ON)
@@ -139,6 +145,11 @@ function(ivi_wayland_protocols target)
     set(_pres "${IVI_WL_PROTOCOLS_BASE}/stable/presentation-time/presentation-time.xml")
     set(_bund "${IVI_WL_CXX_SRC}/protocols")
     set(_loc  "${CMAKE_SOURCE_DIR}/shell/wayland/protocols")
+
+    # core wayland — always (wl::KeyboardHandler needs wayland::client::CWlKeyboard);
+    # core wl_interface tables come from libwayland, so do NOT emit tables.
+    wayland_cxx_generate(PROTOCOL "${IVI_WL_CORE_XML}" MODE client-header
+        OUTPUT wayland-protocols/wayland_client.hpp TARGET ${target})
 
     # presentation-time — always (IVsyncProvider); no shipped header -> emit tables.
     wayland_cxx_generate(PROTOCOL "${_pres}" MODE client-header EMIT_INTERFACE_TABLES

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -16,14 +16,33 @@
 #include "app.h"
 #include "logging/logging.h"
 
+#include <csignal>
 #include <cstdlib>
+#include <functional>
 #include <string_view>
+#include <system_error>
+
+#include <unistd.h>
 
 #include "config/common.h"
 
 #include "main_loop_waker.h"
 #include "timer.h"
 #include "view/flutter_view.h"
+
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+#include <chrono>
+
+#include "asio/io_context.hpp"
+#include "asio/posix/stream_descriptor.hpp"
+#include "asio/post.hpp"
+#include "asio/steady_timer.hpp"
+#endif
+
+// Process-wide shutdown flag, owned by main.cc and flipped by the signal
+// handler. The reactor watches the MainLoopWaker eventfd (which the handler
+// writes async-signal-safely) and checks this flag to stop the loop.
+extern volatile sig_atomic_t running;
 
 #if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
 #include "wayland/display.h"
@@ -157,6 +176,15 @@ App::App(const std::vector<Configuration::Config>& configs)
   m_watch_dog = std::make_unique<Watchdog>();
 #endif
 
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+  // Wire the App-owned shared reactor onto the Wayland connection before it
+  // arms its display fd. Multiple connections would each register onto the same
+  // primary_ioc_.
+  if (auto* d = dynamic_cast<Display*>(m_display.get())) {
+    d->SetEventLoop(primary_ioc_);
+  }
+#endif
+
   m_display->StartEvents();
 
   SPDLOG_DEBUG("-App::App");
@@ -225,4 +253,120 @@ int App::Loop() const {
   MainLoopWaker::instance().Wait(timeout_ms);
 
   return 0;
+}
+
+int App::Run() {
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+  // The shared reactor is owned by App; the Wayland connection(s) already armed
+  // their fds onto it (App ctor: SetEventLoop + StartEvents).
+  asio::io_context& ioc = primary_ioc_;
+
+  // Refresh-rate frame interval (fallback 60 Hz for virtual outputs that
+  // advertise refresh=0).
+  auto frame_interval = [this]() -> std::chrono::nanoseconds {
+    const double hz = m_display->GetMaxRefreshRate();
+    const double ms = hz > 0.0 ? 1000.0 / hz : 1000.0 / 60.0;
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double, std::milli>(ms));
+  };
+  auto needs_periodic = [this]() {
+    for (auto const& view : m_views) {
+      if (view->NeedsPeriodicPump()) {
+        return true;
+      }
+    }
+    return false;
+  };
+  // One unit of main-thread work: pump compositor-surface plugins and flush
+  // coalesced pointer events, then pet the watchdog. Frame production itself is
+  // driven by the backend's own vsync source on a separate thread.
+  auto service = [this]() {
+    for (auto const& view : m_views) {
+      view->RunTasks();
+    }
+#if BUILD_WATCHDOG
+    m_watch_dog->pet();
+#endif
+  };
+
+  // Recurring pump timer: re-arms at the refresh rate only while a view needs
+  // periodic servicing; otherwise the reactor idles until the next fd event.
+  asio::steady_timer pump(ioc);
+  bool pump_armed = false;
+  std::function<void(const std::error_code&)> on_pump;
+  std::function<void()> arm_pump = [&]() {
+    if (pump_armed) {
+      return;
+    }
+    pump_armed = true;
+    pump.expires_after(frame_interval());
+    pump.async_wait(on_pump);
+  };
+  on_pump = [&](const std::error_code& ec) {
+    pump_armed = false;
+    if (ec) {
+      return;  // cancelled
+    }
+    service();
+    if (needs_periodic()) {
+      arm_pump();
+    }
+  };
+
+  // Shutdown + on-demand wake: the MainLoopWaker eventfd is written by the
+  // signal handler (shutdown) and by Engine input coalescing / view requests
+  // (a task needs pumping while otherwise idle). Registered non-owning — the
+  // eventfd belongs to the MainLoopWaker singleton, so release() it on exit.
+  asio::posix::stream_descriptor waker(ioc, MainLoopWaker::instance().fd());
+  std::function<void(const std::error_code&)> on_wake;
+  std::function<void()> arm_wake = [&]() {
+    waker.async_wait(asio::posix::stream_descriptor::wait_read, on_wake);
+  };
+  on_wake = [&](const std::error_code& ec) {
+    if (ec) {
+      return;  // cancelled
+    }
+    // Drain the eventfd counter.
+    uint64_t drained = 0;
+    while (::read(waker.native_handle(), &drained, sizeof(drained)) ==
+           static_cast<ssize_t>(sizeof(drained))) {
+    }
+    if (!running) {
+      // App owns the reactor: release the work guard and stop it so run()
+      // returns. Each Display detaches its own fds in StopEvents() / ~Display.
+      primary_work_.reset();
+      primary_ioc_.stop();
+      return;  // do not re-arm
+    }
+    service();
+    if (needs_periodic()) {
+      arm_pump();
+    }
+    arm_wake();
+  };
+
+  // Initial servicing + arm the watches, then block the main thread on the
+  // reactor until shutdown stops it.
+  asio::post(ioc, [&]() {
+    service();
+    if (needs_periodic()) {
+      arm_pump();
+    }
+  });
+  arm_wake();
+
+  primary_ioc_.run();
+
+  // Detach from the shared eventfd so asio does not close it.
+  std::error_code ec;
+  waker.cancel(ec);
+  waker.release();
+  return 0;
+#else
+  int ret = 0;
+  while (running && ret != -1) {
+    ret = Loop();
+  }
+  return ret;
+#endif
 }

--- a/shell/app.h
+++ b/shell/app.h
@@ -19,9 +19,15 @@
 #include <EGL/egl.h>
 #include <memory>
 
+#include "config/common.h"
 #include "configuration/configuration.h"
 #include "view/flutter_view.h"
 #include "watchdog.h"
+
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+#include "asio/executor_work_guard.hpp"
+#include "asio/io_context.hpp"
+#endif
 
 class IDisplay;
 
@@ -45,8 +51,32 @@ class App final {
    */
   [[nodiscard]] int Loop() const;
 
+  /**
+   * @brief Run the application until shutdown is requested.
+   *
+   * On the Wayland backend this runs the display reactor (a single asio
+   * io_context) on the calling thread: the Wayland fd, keyboard repeat timerfd
+   * and the shutdown waker are all serviced event-driven, with periodic plugin
+   * pumping paced by a refresh-rate timer only while a view needs it. Other
+   * backends fall back to the Loop()-per-iteration model.
+   *
+   * @return 0 on a clean exit, -1 on fatal error.
+   * @relation wayland, flutter
+   */
+  int Run();
+
  private:
   std::shared_ptr<IDisplay> m_display;
   std::vector<std::unique_ptr<FlutterView>> m_views;
   std::unique_ptr<Watchdog> m_watch_dog;
+
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+  // The single shared reactor (the "primary" io_context). Run() runs it on the
+  // main thread; every Wayland Display connection registers its {wl-fd,
+  // repeat-fd} onto it, so all connections stay single-threaded with no
+  // per-connection strand. The work guard keeps run() alive across idle gaps.
+  asio::io_context primary_ioc_;
+  asio::executor_work_guard<asio::io_context::executor_type> primary_work_{
+      asio::make_work_guard(primary_ioc_)};
+#endif
 };

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -153,7 +153,7 @@ int main(const int argc, char** argv) {
   }
 #endif
 
-  const App app(configs);
+  App app(configs);
 
   // Construct the waker (publishing its eventfd) before installing the
   // signal handlers, so HandleShutdownSignal's async-signal-safe wake always
@@ -163,9 +163,16 @@ int main(const int argc, char** argv) {
 
   // run the application
   int ret = 0;
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+  // The Wayland backend runs its display reactor on this (main) thread; Run()
+  // blocks until the shutdown signal stops the io_context.
+  ret = app.Run();
+#else
   while (running && ret != -1) {
     ret = app.Loop();
   }
+#endif
+  (void)ret;
 
   gLogger.reset();
 

--- a/shell/main_loop_waker.h
+++ b/shell/main_loop_waker.h
@@ -49,6 +49,11 @@ class MainLoopWaker {
   /// to the (already-created) eventfd; does no allocation or locking.
   static void SignalWake();
 
+  /// The backing eventfd. The Wayland reactor registers it on its io_context
+  /// (as a non-owning descriptor) so a Wake() breaks the loop out of an idle
+  /// block. -1 if the eventfd could not be created.
+  [[nodiscard]] int fd() const { return fd_; }
+
  private:
   MainLoopWaker();
   ~MainLoopWaker();

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -17,20 +17,18 @@
 #include "logging/logging.h"
 
 #include <linux/input-event-codes.h>
-#include <sys/mman.h>
 #include <unistd.h>
 #include <xkbcommon/xkbcommon.h>
 #include <algorithm>
 #include <cerrno>
 #include <cstring>
+#include <system_error>
 #include <utility>
 
 #include "config/common.h"
 
 #include "asio/post.hpp"
 #include "engine.h"
-#include "main_loop_waker.h"
-#include "timer.h"
 #include "window.h"
 
 extern void KeyCallback(FlutterDesktopViewControllerState* view_state,
@@ -39,20 +37,17 @@ extern void KeyCallback(FlutterDesktopViewControllerState* view_state,
                         uint32_t xkb_scancode,
                         uint32_t modifiers);
 
-extern void FocusLostCallback(FlutterDesktopViewControllerState* view_state);
-
 extern void KeymapChangedCallback(FlutterDesktopViewControllerState* view_state,
                                   xkb_keymap* keymap);
+
+extern void FocusLostCallback(FlutterDesktopViewControllerState* view_state);
 
 Display::Display(const bool enable_cursor,
                  const std::string& ignore_wayland_event,
                  std::string cursor_theme_name,
                  const std::vector<Configuration::Config>& configs)
-    : stop_events_flag_(false),
-      event_thread_active_(false),
-      m_enable_cursor(enable_cursor),
-      m_cursor_theme_name(std::move(cursor_theme_name)),
-      m_xkb_context(xkb_context_new(XKB_CONTEXT_NO_FLAGS)) {
+    : m_enable_cursor(enable_cursor),
+      m_cursor_theme_name(std::move(cursor_theme_name)) {
   SPDLOG_TRACE("+ Display()");
 
   wayland_event_mask_update(ignore_wayland_event, m_wayland_event_mask);
@@ -116,6 +111,15 @@ ivi::WaylandShell& Display::ActiveShell() const {
 
 Display::~Display() {
   SPDLOG_TRACE("+ ~Display()");
+
+  // Detach the async descriptors from the fds they were watching. App owns and
+  // has already stopped the shared reactor; both fds are owned elsewhere (the
+  // repeat timerfd by the keyboard handler, the display fd by libwayland), so
+  // release() — never close() — them before the optionals are destroyed.
+  ReleaseRepeatFd();
+  ReleaseWaylandFd();
+  // Send wl_keyboard teardown + free the handler's xkb objects/timerfd.
+  keyboard_.Reset();
 
   // The shells (xdg/agl/ivi/simple) and the vsync provider own their protocol
   // objects and tear them down in their own destructors.
@@ -222,10 +226,6 @@ void Display::registry_handle_global(void* data,
         wl_registry_bind(registry, name, &wl_seat_interface,
                          std::min(static_cast<uint32_t>(5), version)));
     wl_seat_add_listener(d->m_seat, &seat_listener, d);
-
-    d->m_repeat_timer =
-        std::make_shared<EventTimer>(CLOCK_MONOTONIC, keyboard_repeat_func, d);
-    d->m_repeat_timer->set_timerspec(40, 400);
   }
   // wp_presentation is owned by the vsync provider.
   else if (d->m_vsync.TryBindGlobal(registry, name, interface, version)) {
@@ -354,13 +354,21 @@ void Display::seat_handle_capabilities(void* data,
   }
 
   if (!d->m_wayland_event_mask.keyboard) {
-    if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !d->m_keyboard) {
+    if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && d->keyboard_.IsNull()) {
       spdlog::debug("Keyboard Present");
-      d->m_keyboard = wl_seat_get_keyboard(seat);
-      wl_keyboard_add_listener(d->m_keyboard, &keyboard_listener, d);
-    } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) && d->m_keyboard) {
-      wl_keyboard_release(d->m_keyboard);
-      d->m_keyboard = nullptr;
+      // Wrap the raw wl_keyboard in the scanner's CRTP handler (installs its
+      // listener); set the back-pointer and register its repeat timerfd on the
+      // reactor. This runs on the reactor thread during wl dispatch, so OnKey,
+      // the keyboard events and DispatchRepeat all share one thread.
+      wl_keyboard* raw = wl_seat_get_keyboard(seat);
+      if (wl::SetupHandler(d->keyboard_, reinterpret_cast<wl_proxy*>(raw))) {
+        d->keyboard_.Get()->app_ = d;
+        d->ArmRepeatFd();
+      }
+    } else if (!(caps & WL_SEAT_CAPABILITY_KEYBOARD) &&
+               !d->keyboard_.IsNull()) {
+      d->ReleaseRepeatFd();
+      d->keyboard_.Reset();
     }
   }
 
@@ -539,185 +547,49 @@ const wl_pointer_listener Display::pointer_listener = {
 #endif
 };
 
-void Display::keyboard_handle_enter(void* data,
-                                    struct wl_keyboard* /* keyboard */,
-                                    uint32_t /* serial */,
-                                    struct wl_surface* surface,
-                                    struct wl_array* /* keys */) {
-  SPDLOG_TRACE("+ Display::keyboard_handle_enter()");
-  auto* d = static_cast<Display*>(data);
-  d->m_active_surface = surface;
-  d->m_active_engine = d->m_surface_engine_map[surface];
-  SPDLOG_TRACE("- Display::keyboard_handle_enter()");
-}
-
-void Display::keyboard_handle_leave(void* data,
-                                    struct wl_keyboard* /* keyboard */,
-                                    uint32_t /* serial */,
-                                    struct wl_surface* /* surface */) {
-  SPDLOG_TRACE("+ Display::keyboard_handle_leave()");
-  auto* d = static_cast<Display*>(data);
-
-  d->m_repeat_timer->disarm();
-  set_repeat_code(d, XKB_KEY_NoSymbol);
-  SPDLOG_TRACE("- Display::keyboard_handle_leave()");
-  // Post FocusLostCallback onto the platform strand so that all
-  // TextInputPlugin state mutations are serialised with key-event callbacks.
-  if (d->m_view_controller_state) {
-    auto* vcs = d->m_view_controller_state;
-    if (vcs->engine && vcs->engine->GetPlatformTaskRunner()) {
-      asio::post(*vcs->engine->GetPlatformTaskRunner()->GetStrandContext(),
-                 [vcs]() { FocusLostCallback(vcs); });
-    }
-  }
-}
-
-void Display::keyboard_handle_keymap(void* data,
-                                     struct wl_keyboard* /* keyboard */,
-                                     uint32_t /* format */,
-                                     int fd,
-                                     uint32_t size) {
-  auto* d = static_cast<Display*>(data);
-  const auto keymap_string =
-      static_cast<char*>(mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0));
-  xkb_keymap_unref(d->m_keymap);
-  d->m_keymap = xkb_keymap_new_from_string(d->m_xkb_context, keymap_string,
-                                           XKB_KEYMAP_FORMAT_TEXT_V1,
-                                           XKB_KEYMAP_COMPILE_NO_FLAGS);
-  munmap(keymap_string, size);
-  close(fd);
-  // Disarm the repeat timer before swapping xkb_state so that the repeat
-  // callback cannot read the old (about-to-be-freed) xkb_state.
-  d->m_repeat_timer->disarm();
-  set_repeat_code(d, XKB_KEY_NoSymbol);
-  xkb_state_unref(d->m_xkb_state);
-  d->m_xkb_state = xkb_state_new(d->m_keymap);
-  // Post KeymapChangedCallback onto the platform strand.
-  // Refcount the keymap so it stays alive until the lambda fires.
-  if (d->m_view_controller_state && d->m_keymap) {
-    auto* vcs = d->m_view_controller_state;
-    if (vcs->engine && vcs->engine->GetPlatformTaskRunner()) {
-      xkb_keymap_ref(d->m_keymap);
-      auto* km = d->m_keymap;
-      asio::post(*vcs->engine->GetPlatformTaskRunner()->GetStrandContext(),
-                 [vcs, km]() {
-                   KeymapChangedCallback(vcs, km);
-                   xkb_keymap_unref(km);
-                 });
-    }
-  }
-}
-
-void Display::keyboard_handle_key(void* data,
-                                  struct wl_keyboard* /* keyboard */,
-                                  uint32_t /* serial */,
-                                  uint32_t /* time */,
-                                  uint32_t key,
-                                  uint32_t state) {
-  auto* d = static_cast<Display*>(data);
-
-  if (!d->m_xkb_state)
+void Display::OnKey(const wl::KeyEvent& ev) {
+  // Runs on the reactor thread for both real key events and repeat ticks. The
+  // handler already resolved keysym + effective modifiers from its xkb_state;
+  // mirror the old keyboard_handle_key dispatch exactly (evdev → XKB scancode
+  // is ev.key + 8). KeyCallback re-posts onto the engine strand.
+  if (!m_view_controller_state) {
     return;
-
-  //
-  // Important: the scancode from this event is the Linux evdev scancode.
-  // To translate this to an XKB scancode, you must add 8 to the evdev scancode.
-  //
-  uint32_t xkb_scancode = key + 8;
-  //
-  // Gets the single keysym obtained from pressing a particular key in a given
-  // keyboard state. If the key does not have exactly one keysym, returns
-  // XKB_KEY_NoSymbol
-  //
-  xkb_keysym_t keysym = xkb_state_key_get_one_sym(d->m_xkb_state, xkb_scancode);
-  const uint32_t modifiers = d->m_mods_effective;
-
-  if (keysym == XKB_KEY_NoSymbol) {
-    const xkb_keysym_t* key_symbols;
-    const int res =
-        xkb_state_key_get_syms(d->m_xkb_state, xkb_scancode, &key_symbols);
-    if (res == 0) {
-      spdlog::debug("xkb_scancode has no key symbols: 0x{:x}", xkb_scancode);
-      keysym = XKB_KEY_NoSymbol;
-    } else {
-      // only use the first symbol until the use case for two is clarified
-      keysym = key_symbols[0];
-      for (int i = 0; i < res; i++) {
-        spdlog::debug("xkb keysym: 0x{:x}", key_symbols[i]);
-      }
-    }
   }
+  KeyCallback(m_view_controller_state,
+              ev.state == WL_KEYBOARD_KEY_STATE_RELEASED, ev.keysym,
+              ev.key + 8u, ev.modifiers);
+}
 
-  if (d->m_view_controller_state) {
-    KeyCallback(d->m_view_controller_state,
-                state == WL_KEYBOARD_KEY_STATE_RELEASED, keysym, xkb_scancode,
-                modifiers);
+void Display::OnKeymap(xkb_keymap* keymap) {
+  // The handler owns the compiled keymap/xkb_state; we only forward a ref to
+  // the engine. Post KeymapChangedCallback onto the platform strand so the
+  // TextInputPlugin state mutation is serialized with the key-event callbacks;
+  // ref the keymap so it outlives the post.
+  if (!m_view_controller_state || !keymap) {
+    return;
   }
-
-  if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-    if (xkb_keymap_key_repeats(d->m_keymap, xkb_scancode)) {
-      SPDLOG_DEBUG("xkb_keymap_key_repeats: 0x{:x}", xkb_scancode);
-      d->m_keysym_pressed = keysym;
-      set_repeat_code(d, xkb_scancode);
-      d->m_repeat_timer->arm();
-      // Arming happens on the Wayland event thread; the main loop may be
-      // blocked idle (App::Loop now blocks when HasRepeatTimer() is false).
-      // Wake it so it re-evaluates and starts pacing the key-repeat promptly
-      // instead of after the idle heartbeat.
-      MainLoopWaker::instance().Wake();
-    } else {
-      SPDLOG_DEBUG("key does not repeat: 0x{:x}", xkb_scancode);
-    }
-
-  } else if (state == WL_KEYBOARD_KEY_STATE_RELEASED) {
-    if (d->m_repeat_code == xkb_scancode) {
-      d->m_repeat_timer->disarm();
-      set_repeat_code(d, XKB_KEY_NoSymbol);
-    }
+  auto* vcs = m_view_controller_state;
+  if (vcs->engine && vcs->engine->GetPlatformTaskRunner()) {
+    xkb_keymap_ref(keymap);
+    asio::post(*vcs->engine->GetPlatformTaskRunner()->GetStrandContext(),
+               [vcs, keymap]() {
+                 KeymapChangedCallback(vcs, keymap);
+                 xkb_keymap_unref(keymap);
+               });
   }
 }
 
-void Display::keyboard_handle_modifiers(void* data,
-                                        struct wl_keyboard* /* keyboard */,
-                                        uint32_t /* serial */,
-                                        uint32_t mods_depressed,
-                                        uint32_t mods_latched,
-                                        uint32_t mods_locked,
-                                        uint32_t group) {
-  auto* d = static_cast<Display*>(data);
-  xkb_state_update_mask(d->m_xkb_state, mods_depressed, mods_latched,
-                        mods_locked, 0, 0, group);
-  // Cache the effective modifier mask so key and repeat callbacks can
-  // read it without calling xkb_state_serialize_mods themselves.
-  d->m_mods_effective =
-      xkb_state_serialize_mods(d->m_xkb_state, XKB_STATE_MODS_EFFECTIVE);
-}
-
-void Display::keyboard_handle_repeat_info(void* data,
-                                          struct wl_keyboard* /* wl_keyboard */,
-                                          int32_t rate,
-                                          int32_t delay) {
-  const auto d = static_cast<Display*>(data);
-  d->m_repeat_timer->set_timerspec(rate, delay);
-  SPDLOG_DEBUG("[keyboard repeat info] rate: {}, delay: {}", rate, delay);
-}
-
-const wl_keyboard_listener Display::keyboard_listener = {
-    .keymap = keyboard_handle_keymap,
-    .enter = keyboard_handle_enter,
-    .leave = keyboard_handle_leave,
-    .key = keyboard_handle_key,
-    .modifiers = keyboard_handle_modifiers,
-    .repeat_info = keyboard_handle_repeat_info,
-};
-
-void Display::keyboard_repeat_func(void* data) {
-  if (auto d = static_cast<Display*>(data);
-      XKB_KEY_NoSymbol != d->m_repeat_code) {
-    if (d->m_view_controller_state) {
-      KeyCallback(d->m_view_controller_state, false, d->m_keysym_pressed,
-                  d->m_repeat_code, d->m_mods_effective);
-    }
+void Display::OnKeyboardLeave() {
+  // Keyboard focus left the surface. Post FocusLostCallback onto the platform
+  // strand so the TextInputPlugin preedit reset is serialized with the
+  // key-event callbacks. (wl::KeyboardHandler already stopped key-repeat.)
+  if (!m_view_controller_state) {
+    return;
+  }
+  auto* vcs = m_view_controller_state;
+  if (vcs->engine && vcs->engine->GetPlatformTaskRunner()) {
+    asio::post(*vcs->engine->GetPlatformTaskRunner()->GetStrandContext(),
+               [vcs]() { FocusLostCallback(vcs); });
   }
 }
 
@@ -811,32 +683,106 @@ int Display::PollEvents() const {
   return wl_display_dispatch_pending(m_display);
 }
 
-void Display::StartEvents() {
-  if (event_thread_active_)
-    return;
+void Display::ArmWaylandRead() {
+  // Canonical libwayland + reactor integration: prepare a read on the calling
+  // (reactor) thread, flush outbound requests, then wait for the display fd to
+  // become readable. The handler reads + dispatches and re-arms itself, so the
+  // io_context never returns from run() until the descriptor is cancelled.
+  while (wl_display_prepare_read(m_display) != 0) {
+    wl_display_dispatch_pending(m_display);
+  }
+  wl_display_flush(m_display);
 
-  event_thread_ = std::thread([this] {
-    event_thread_active_ = true;
-    while (!stop_events_flag_) {
-      const int count = wl_display_dispatch(m_display);
-      if (count == -1) {
-        spdlog::error("Wayland Dispatch Error: {}", strerror(errno));
-        break;
-      }
-      SPDLOG_TRACE("Wayland Event Count: {}", count);
-    }
-    event_thread_active_ = false;
-  });
+  wl_fd_->async_wait(asio::posix::stream_descriptor::wait_read,
+                     [this](const std::error_code& ec) {
+                       if (ec) {
+                         // Cancelled (teardown) — undo the pending
+                         // prepare_read.
+                         wl_display_cancel_read(m_display);
+                         return;
+                       }
+                       wl_display_read_events(m_display);
+                       wl_display_dispatch_pending(m_display);
+                       ArmWaylandRead();
+                     });
+}
+
+void Display::ArmRepeatFd() {
+  // ioc_ is wired by App after construction; the constructor's seat enumeration
+  // can create the keyboard before then, so defer arming until StartEvents.
+  if (!ioc_ || keyboard_.IsNull()) {
+    return;
+  }
+  const int fd = keyboard_.Get()->GetRepeatFd();
+  if (fd < 0) {
+    return;
+  }
+  // The timerfd is owned by the keyboard handler; the descriptor must not close
+  // it (released in ReleaseRepeatFd). Registered on the App-owned reactor.
+  repeat_fd_.emplace(*ioc_, fd);
+  ArmRepeatWait();
+}
+
+void Display::ArmRepeatWait() {
+  repeat_fd_->async_wait(asio::posix::stream_descriptor::wait_read,
+                         [this](const std::error_code& ec) {
+                           if (ec) {
+                             return;
+                           }
+                           // Re-resolves keysym/modifiers from the handler's
+                           // xkb_state on this (reactor) thread, then re-arms.
+                           if (!keyboard_.IsNull()) {
+                             keyboard_.Get()->DispatchRepeat();
+                           }
+                           ArmRepeatWait();
+                         });
+}
+
+void Display::ReleaseRepeatFd() {
+  if (!repeat_fd_) {
+    return;
+  }
+  std::error_code ec;
+  repeat_fd_->cancel(ec);
+  repeat_fd_->release();  // detach without closing the handler's timerfd
+  repeat_fd_.reset();
+}
+
+void Display::ReleaseWaylandFd() {
+  if (!wl_fd_) {
+    return;
+  }
+  std::error_code ec;
+  wl_fd_->cancel(ec);
+  wl_fd_->release();  // detach without closing libwayland's display fd
+  wl_fd_.reset();
+}
+
+void Display::StartEvents() {
+  if (wl_fd_) {
+    return;  // already armed
+  }
+  // App must have wired the shared reactor first.
+  assert(ioc_ && "Display::SetEventLoop must precede StartEvents");
+  // Registry/seat enumeration already ran (synchronously) in the constructor;
+  // arm the display fd on the App-owned reactor. Construct the descriptor over
+  // the wl fd (libwayland owns it; released in ~Display / StopEvents).
+  wl_fd_.emplace(*ioc_, wl_display_get_fd(m_display));
+  ArmWaylandRead();
+  // A keyboard bound during the constructor's seat enumeration deferred its
+  // repeat-fd arming (no reactor yet); arm it now that ioc_ is wired.
+  if (!keyboard_.IsNull()) {
+    ArmRepeatFd();
+  }
 }
 
 void Display::StopEvents() {
-  if (!event_thread_active_)
-    return;
-
-  stop_events_flag_ = true;
-  if (event_thread_.joinable()) {
-    event_thread_.join();
-  }
+  // App owns and stops the reactor; this connection only detaches its own
+  // descriptors from the (libwayland / handler) fds. Called from ~App after the
+  // reactor has stopped, so no concurrent reactor access — cancel + release
+  // directly (release() never closes the borrowed fds).
+  ReleaseRepeatFd();
+  ReleaseWaylandFd();
 }
 
 void Display::SetEngine(wl_surface* surface, Engine* engine) {

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -22,6 +22,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -30,6 +31,21 @@
 #include <wayland-cursor.h>
 #include <cassert>
 
+#include "asio/io_context.hpp"
+#include "asio/posix/stream_descriptor.hpp"
+
+// Core Wayland C++ proxies (wayland::client::CWlKeyboard) and the header-only
+// CRTP keyboard handler. wayland_client.hpp (generated from wayland.xml) must
+// precede <wl/seat.hpp>, which supplies the wl_seat/wl_keyboard wl_iface()
+// definitions and pulls in <wl/keyboard.hpp> (wl::KeyboardHandler). The order
+// is load-bearing, so keep clang-format from re-sorting it.
+// clang-format off
+#include "wayland_client.hpp"
+#include <wl/seat.hpp>
+#include <wl/client_helpers.hpp>
+#include <wl/wl_ptr.hpp>
+// clang-format on
+
 #include "config/common.h"
 #include "configuration/configuration.h"
 #include "display/idisplay.h"
@@ -37,7 +53,6 @@
 #include "platform/homescreen/key_event_handler.h"
 #include "platform/homescreen/keyboard_hook_handler.h"
 #include "platform/homescreen/text_input_plugin.h"
-#include "timer.h"
 #include "vsync/wayland_vsync_provider.h"
 #include "wayland/shell/wayland_shell.h"
 
@@ -59,15 +74,39 @@ class Display : public IDisplay {
 
   const Display& operator=(const Display&) = delete;
 
-  std::shared_ptr<EventTimer> m_repeat_timer{};
+  // Key repeat is event-driven: wl::KeyboardHandler owns a CLOCK_MONOTONIC
+  // timerfd that is registered on the display reactor (repeat_fd_), so the
+  // main loop never has to pace it. Always false; the interface keeps the
+  // method for the non-Wayland backends whose loop still consults it.
+  [[nodiscard]] bool HasRepeatTimer() const override { return false; }
 
-  [[nodiscard]] bool HasRepeatTimer() const override {
-    // Armed, not merely existing: the repeat timer is created once at keyboard
-    // init and lives for the session, so testing existence would keep App::Loop
-    // pacing at the refresh rate forever. Only an *armed* timer (a key is held)
-    // needs periodic servicing; otherwise the loop may idle.
-    return m_repeat_timer && m_repeat_timer->is_armed();
-  }
+  /**
+   * @brief Register the shared reactor (App-owned primary io_context) this
+   * connection multiplexes its Wayland fd + keyboard repeat timerfd onto. Must
+   * be called before StartEvents(). The reactor is single-threaded, so every
+   * connection's xkb_state stays single-threaded with no per-connection strand.
+   */
+  void SetEventLoop(asio::io_context& ioc) { ioc_ = &ioc; }
+
+  /**
+   * @brief Key-event sink for wl::KeyboardHandler. Runs on the reactor thread;
+   * forwards to KeyCallback (which posts to the engine strand).
+   */
+  void OnKey(const wl::KeyEvent& ev);
+
+  /**
+   * @brief Keymap sink for wl::KeyboardHandler. Posts KeymapChangedCallback
+   * onto the engine platform strand with the keymap ref'd.
+   */
+  void OnKeymap(xkb_keymap* keymap);
+
+  /**
+   * @brief Keyboard-focus-leave sink for wl::KeyboardHandler. Posts
+   * FocusLostCallback onto the engine platform strand so TextInputPlugin
+   * preedit state resets in order with the key-event callbacks. (The handler
+   * stops key-repeat internally; this does not touch repeat.)
+   */
+  void OnKeyboardLeave();
 
   /**
    * @brief Get compositor
@@ -257,9 +296,16 @@ class Display : public IDisplay {
   // along with the rest of the AGL window-management surface.
 
  private:
-  std::thread event_thread_;
-  std::atomic<bool> stop_events_flag_;
-  std::atomic<bool> event_thread_active_;
+  // The shared reactor, owned by App (the primary io_context). This connection
+  // registers its fds onto it; it does not own or run it. Single-threaded, so
+  // the keyboard's xkb_state (read in OnKey / DispatchRepeat) needs no locking.
+  asio::io_context* ioc_{};
+  // Non-owning async descriptors over the Wayland display fd and the keyboard
+  // repeat timerfd. Both fds are owned elsewhere (libwayland / the handler), so
+  // these must release() — never close() — them on teardown.
+  std::optional<asio::posix::stream_descriptor> wl_fd_;
+  std::optional<asio::posix::stream_descriptor> repeat_fd_;
+
   std::shared_ptr<Engine> m_flutter_engine;
 
   struct wl_display* m_display{};
@@ -277,7 +323,38 @@ class Display : public IDisplay {
   struct FlutterDesktopViewControllerState* m_view_controller_state{};
 
   struct wl_seat* m_seat{};
-  struct wl_keyboard* m_keyboard{};
+  // wl_keyboard wrapped in the scanner's CRTP handler: owns its own xkb
+  // context/keymap/state and the repeat timerfd. Bound off the shared wl_seat
+  // in seat_handle_capabilities (pointer + touch stay raw).
+  wl::WlPtr<wl::KeyboardHandler<Display>> keyboard_;
+
+  /**
+   * @brief Arm the Wayland display fd on the reactor (prepare_read / flush /
+   * async_wait, re-arming itself on each readable edge).
+   */
+  void ArmWaylandRead();
+
+  /**
+   * @brief Register the keyboard handler's repeat timerfd on the reactor (after
+   * the keyboard is set up). No-op if the timerfd is unavailable.
+   */
+  void ArmRepeatFd();
+
+  /**
+   * @brief (Re-)arm the wait on the repeat timerfd; on fire, drains it and
+   * dispatches one repeat KeyEvent on the reactor thread.
+   */
+  void ArmRepeatWait();
+
+  /**
+   * @brief Cancel + release (never close) the repeat timerfd descriptor.
+   */
+  void ReleaseRepeatFd();
+
+  /**
+   * @brief Cancel + release (never close) the Wayland display fd descriptor.
+   */
+  void ReleaseWaylandFd();
 
   // Compositor-protocol shells (xdg / agl / ivi / simple), built by
   // WaylandShell::Create in priority order. The active one is the first that
@@ -372,34 +449,6 @@ class Display : public IDisplay {
 
   // for cursor
   struct wl_cursor_theme* m_cursor_theme{};
-
-  struct xkb_context* m_xkb_context;
-  struct xkb_keymap* m_keymap{};
-  struct xkb_state* m_xkb_state{};
-
-  xkb_keysym_t m_keysym_pressed{};
-
-  // Serialized modifier mask cached in keyboard_handle_modifiers so that
-  // keyboard_handle_key and keyboard_repeat_func can read it without calling
-  // xkb_state_serialize_mods on every event.
-  uint32_t m_mods_effective{};
-
-  std::mutex m_lock;
-  uint32_t m_repeat_code{};
-
-  /**
-   * @brief set repeat code
-   * @param[in] display
-   * @param[in] repeat_code a repeat code
-   * @return void
-   * @relation
-   * internal
-   */
-  static inline void set_repeat_code(Display* display,
-                                     const uint32_t repeat_code) {
-    std::lock_guard lock(display->m_lock);
-    display->m_repeat_code = repeat_code;
-  }
 
   std::vector<std::shared_ptr<output_info_t>> m_all_outputs;
 
@@ -766,120 +815,9 @@ class Display : public IDisplay {
 
   static const wl_pointer_listener pointer_listener;
 
-  /**
-   * @brief Set keymap
-   * @param[in,out] data Data of type Display
-   * @param[in] keyboard No use
-   * @param[in] format No use
-   * @param[in] fd File descriptor
-   * @param[in] size Mapping region length
-   * @return void
-   * @relation
-   * wayland
-   */
-  static void keyboard_handle_keymap(void* data,
-                                     struct wl_keyboard* keyboard,
-                                     uint32_t format,
-                                     int fd,
-                                     uint32_t size);
-
-  /**
-   * @brief Keyboard input event
-   * @param[in,out] data Data of type Display
-   * @param[in] keyboard No use
-   * @param[in] serial No use
-   * @param[in] surface Cursor image of keyboard
-   * @param[in] keys No use
-   * @return void
-   * @relation
-   * wayland
-   */
-  static void keyboard_handle_enter(void* data,
-                                    struct wl_keyboard* keyboard,
-                                    uint32_t serial,
-                                    struct wl_surface* surface,
-                                    struct wl_array* keys);
-
-  /**
-   * @brief Keyboard leaves the surface
-   * @param[in,out] data No use
-   * @param[in] keyboard No use
-   * @param[in] serial No use
-   * @param[in] surface No use
-   * @return void
-   * @relation
-   * wayland
-   */
-  static void keyboard_handle_leave(void* data,
-                                    struct wl_keyboard* keyboard,
-                                    uint32_t serial,
-                                    struct wl_surface* surface);
-
-  /**
-   * @brief Key pressed/released
-   * @param[in,out] data Data of type Display
-   * @param[in] keyboard No use
-   * @param[in] serial No use
-   * @param[in] time No use
-   * @param[in] key Key number
-   * @param[in] state Key state released/pressed
-   * @return void
-   * @relation
-   * wayland
-   */
-  static void keyboard_handle_key(void* data,
-                                  struct wl_keyboard* keyboard,
-                                  uint32_t serial,
-                                  uint32_t time,
-                                  uint32_t key,
-                                  uint32_t state);
-
-  /**
-   * @brief Event when the state of the modifier key changes and lock
-   * @param[in,out] data Data of type Display
-   * @param[in] keyboard No use
-   * @param[in] serial No use
-   * @param[in] mods_depressed Flag of modifiers being pushed
-   * @param[in] mods_latched Latched modifiers
-   * @param[in] mods_locked Locked modifiers
-   * @param[in] group Keyboard layout
-   * @return void
-   * @relation
-   * wayland
-   */
-  static void keyboard_handle_modifiers(void* data,
-                                        struct wl_keyboard* keyboard,
-                                        uint32_t serial,
-                                        uint32_t mods_depressed,
-                                        uint32_t mods_latched,
-                                        uint32_t mods_locked,
-                                        uint32_t group);
-
-  /**
-   * @brief Keyboard repeat info
-   * @param[in,out] data No use
-   * @param[in] wl_keyboard No use
-   * @param[in] rate Rate
-   * @param[in] delay Delay
-   * @return void
-   * @relation
-   * wayland
-   */
-  static void keyboard_handle_repeat_info(void* data,
-                                          struct wl_keyboard* wl_keyboard,
-                                          int32_t rate,
-                                          int32_t delay);
-
-  static const wl_keyboard_listener keyboard_listener;
-
-  /**
-   * @brief a callback for key repeat behavior
-   * @param[in] data Data of type Display
-   * @return void
-   * @relation
-   * wayland
-   */
-  static void keyboard_repeat_func(void* data);
+  // The keyboard is no longer a raw wl_keyboard listener: wl::KeyboardHandler
+  // owns the wl_keyboard events, xkb processing and repeat timerfd, calling
+  // back into Display::OnKey / Display::OnKeymap.
 
   /**
    * @brief Touch event down


### PR DESCRIPTION
## Summary
Migrates the Wayland backend's keyboard onto the scanner's `wl::KeyboardHandler<Display>` and makes the Wayland display + keyboard repeat **event-driven on a single asio reactor**, retiring the dedicated `wl_display_dispatch` thread and the `EventTimer`-based key repeat.

## Changes
- **Keyboard**: removes the raw `wl_keyboard` listener, `Display`'s own xkb context/keymap/state, and the `EventTimer` repeat. `wl::KeyboardHandler<Display>` owns the xkb work and a `CLOCK_MONOTONIC` timerfd repeat. `Display` implements `OnKey(const wl::KeyEvent&)` → `KeyCallback`, `OnKeymap(xkb_keymap*)` → `KeymapChangedCallback`, and `OnKeyboardLeave()` → `FocusLostCallback`. **wl_keyboard v10 server-driven repeat** (`state == repeated`) is handled by the scanner handler.
- **Event loop**: `App` owns a single `asio::io_context`; `App::Run()` runs it. The `wl_display` fd (`prepare_read`/`read_events`/`dispatch_pending`) and the keyboard repeat timerfd are registered as `async_wait` descriptors on it, so display dispatch and `DispatchRepeat` run on **one thread** — `xkb_state` is single-threaded with no locking. The descriptors `release()` the borrowed fds (never close libwayland's/the handler's fds). The dedicated event thread is gone; the per-iteration `RunTasks`/watchdog duties move onto a reactor timer that re-arms only while a view needs periodic pumping. Non-Wayland backends keep the legacy `App::Loop()`.
- Bumps `third_party/wayland-cxx-scanner` to include `wl::KeyboardHandler` (timerfd repeat, `KeyEvent` contract, v10 server-repeat) + the optional `OnKeyboardLeave` hook.

## Validation
Hardware-validated end-to-end (Flutter gallery) on **weston** (client-side timerfd repeat) and **mutter/GNOME** (wl_seat v10 server-driven repeat): typing, held-key repeat, modifiers (Shift→uppercase), and focus all work.

## Follow-up
IME / text-input (`zwp_text_input_v3` — on-screen-keyboard popup on focus) is a separate PR; this lands the physical-keyboard path.
