### PR TITLE
Per-view display: heterogeneous backends + multi-display on one DRM card

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ annotated all-keys file see
 | `[view.output]` | `preload` | `bool` | `false` | `true\|false` | all |
 | `[view.output]` | `serial` | `string` | `(none)` | `EDID serial` | drm |
 | `[view.output]` | `wl_name` | `string` | `(none)` | `e.g. DP-1` | wayland |
+| `[view.engine]` | `merge_render_platform` | `bool` | `false` | `true\|false` | all |
 
 <!-- END CONFIG-REFERENCE -->
 

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -202,3 +202,8 @@
   # Wayland: match this wl_output name (overrides output.name).
   # type=string default=(none) values=e.g. DP-1 applies=wayland
   wl_name =
+
+[view.engine]
+  # Run the engine's raster thread on the platform thread (single-thread native/Dart-FFI aliasing).
+  # type=bool default=false values=true|false applies=all
+  merge_render_platform =

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -99,12 +99,15 @@ META = {
     "output.index": ("(none)", "int", "all", "Deprecated: match the Nth connected output (prefer a name)."),
     "output.preload": ("false", "true|false", "all", "Warm the engine (suspended) at startup even if the output is absent."),
     "output.on_disconnect": ("suspend", "suspend|teardown", "all", "What to do with the view when its output disappears."),
+
+    # [view.engine] — engine threading knobs
+    "engine.merge_render_platform": ("false", "true|false", "all", "Run the engine's raster thread on the platform thread (single-thread native/Dart-FFI aliasing)."),
 }
 
 TABLE_ORDER = [
     "[global]", "[sentry]", "[[view]]", "[view.args]", "[view.shell]",
     "[view.shell.window]", "[view.shell.window.activation_area]",
-    "[view.backend]", "[view.backend.drm]", "[view.output]",
+    "[view.backend]", "[view.backend.drm]", "[view.output]", "[view.engine]",
 ]
 
 
@@ -129,6 +132,8 @@ def classify(key):
         return "[view.backend]", key.rsplit(".", 1)[1]
     if key.startswith("output."):
         return "[view.output]", key.split(".", 1)[1]
+    if key.startswith("engine."):
+        return "[view.engine]", key.rsplit(".", 1)[1]
     return "[[view]]", key
 
 

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -31,6 +31,9 @@ add_executable(${PROJECT_NAME}
         # Backend-agnostic output resolver (pure name/serial matching); the
         # per-backend output providers feed it via the IDisplay seam.
         display/output.cc
+        # Binds each view to an output by name across backends (resolver +
+        # provider); feeds the resolved connector / wl_output to the backend.
+        display/output_manager.cc
         engine.cc
         libflutter_engine.cc
         main.cc

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -171,6 +171,8 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
             backend/drm_kms_egl/gl_cursor.cc
             backend/gl_process_resolver.cc
             display/drm_display.cc
+            display/drm_output_provider.cc
+            display/drm_device_resolver.cc
             display/drm_mode_list.cc
             input/drm_seat.cc
     )
@@ -253,6 +255,8 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN)
             backend/drm_kms_egl/drm_session.cc
             backend/drm_kms_egl/driver_probe.cc
             display/drm_display.cc
+            display/drm_output_provider.cc
+            display/drm_device_resolver.cc
             display/drm_mode_list.cc
             input/drm_seat.cc
     )

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -20,8 +20,10 @@
 #include <csignal>
 #include <cstdlib>
 #include <functional>
+#include <string>
 #include <string_view>
 #include <system_error>
+#include <unordered_map>
 
 #include <unistd.h>
 
@@ -61,27 +63,82 @@ namespace {
 // loop is normally woken on demand by MainLoopWaker.
 constexpr int kIdleHeartbeatMs = 1000;
 
-std::shared_ptr<IDisplay> MakeDisplay(
+// The device-context key for a view: the set of views sharing one display.
+// All Wayland views share the single compositor connection (device-less); each
+// DRM GPU / drm-dumb device is its own context. The output layer (multiple
+// connectors per GPU, multiple wl_outputs per connection) is resolved within a
+// context, not here.
+std::string ContextKey(const backend::BackendRegistry& reg,
+                       const Configuration::Config& config) {
+  const std::string key = ResolveKeyForConfig(reg, config);
+  if (key.rfind("wayland-", 0) == 0) {
+    return "wayland";
+  }
+  return key + "|" + config.view.drm_device.value_or("");
+}
+
+}  // namespace
+
+std::vector<std::shared_ptr<IDisplay>> App::BuildDisplays(
     const std::vector<Configuration::Config>& configs) {
   // App is self-contained: ensure the runtime registry has an active backend
   // (registering the compiled-in backends + resolving from configs on first
-  // use, or respecting one main() set explicitly) before creating its display.
-  // The active descriptor owns the display-creation body that used to live here
-  // as an #if chain (the bodies now live in backend/register_backends.cc).
-  // Fail-fast: a null backend would crash the engine init.
+  // use, or respecting one main() set explicitly) before creating any display.
+  // The active backend backs the first bundle and process-level queries; each
+  // view independently resolves its own backend (ResolveKeyForConfig) below.
   auto& reg = backend::BackendRegistry::Instance();
   if (!EnsureActiveBackend(reg, configs)) {
     spdlog::critical("[App] no usable backend available; aborting");
     std::exit(EXIT_FAILURE);
   }
-  return reg.Active().make_display(configs);
+
+  // Group config indices by device-context, preserving first-seen order so the
+  // primary bundle's display stays first (it backs process-level wiring).
+  std::vector<std::string> order;
+  std::unordered_map<std::string, std::vector<size_t>> groups;
+  for (size_t i = 0; i < configs.size(); ++i) {
+    const std::string ck = ContextKey(reg, configs[i]);
+    auto it = groups.find(ck);
+    if (it == groups.end()) {
+      order.push_back(ck);
+      groups.emplace(ck, std::vector<size_t>{i});
+    } else {
+      it->second.push_back(i);
+    }
+  }
+
+  // Create one display per context from that context's configs (a group
+  // member's backend descriptor owns the creation body), and record each view's
+  // display so FlutterView is placed on the display for its (backend, device).
+  std::vector<std::shared_ptr<IDisplay>> per_config(configs.size());
+  for (const std::string& ck : order) {
+    const std::vector<size_t>& members = groups[ck];
+    std::vector<Configuration::Config> group_configs;
+    group_configs.reserve(members.size());
+    for (const size_t idx : members) {
+      group_configs.push_back(configs[idx]);
+    }
+    const std::string key = ResolveKeyForConfig(reg, group_configs.front());
+    const backend::BackendDescriptor* descriptor = reg.Resolve(key);
+    if (descriptor == nullptr) {
+      spdlog::critical("[App] no backend resolved for context '{}'", ck);
+      std::exit(EXIT_FAILURE);
+    }
+    auto display = descriptor->make_display(group_configs);
+    m_displays.push_back(display);
+    for (const size_t idx : members) {
+      per_config[idx] = display;
+    }
+  }
+  return per_config;
 }
 
-}  // namespace
-
-App::App(const std::vector<Configuration::Config>& configs)
-    : m_displays{MakeDisplay(configs)} {
+App::App(const std::vector<Configuration::Config>& configs) {
   SPDLOG_DEBUG("+App::App");
+  // One display per device-context; view_display[i] is the display config i
+  // runs on (views sharing a context share a display).
+  const std::vector<std::shared_ptr<IDisplay>> view_display =
+      BuildDisplays(configs);
 // AGL Shell needs a Wayland backend — its WaylandWindow / Display
 // usage is meaningless on DRM / software. ENABLE_AGL_SHELL_CLIENT
 // defaults ON regardless of backend, so combine with a Wayland-backend
@@ -94,7 +151,7 @@ App::App(const std::vector<Configuration::Config>& configs)
   size_t index = 0;
   m_views.reserve(configs.size());
   for (auto const& cfg : configs) {
-    auto view = std::make_unique<FlutterView>(cfg, index, m_displays.front());
+    auto view = std::make_unique<FlutterView>(cfg, index, view_display[index]);
     view->Initialize();
     m_views.emplace_back(std::move(view));
     index++;

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -16,6 +16,7 @@
 #include "app.h"
 #include "logging/logging.h"
 
+#include <algorithm>
 #include <csignal>
 #include <cstdlib>
 #include <functional>
@@ -81,7 +82,7 @@ std::shared_ptr<IDisplay> MakeDisplay(
 }  // namespace
 
 App::App(const std::vector<Configuration::Config>& configs)
-    : m_display(MakeDisplay(configs)) {
+    : m_displays{MakeDisplay(configs)} {
   SPDLOG_DEBUG("+App::App");
 // AGL Shell needs a Wayland backend — its WaylandWindow / Display
 // usage is meaningless on DRM / software. ENABLE_AGL_SHELL_CLIENT
@@ -95,7 +96,7 @@ App::App(const std::vector<Configuration::Config>& configs)
   size_t index = 0;
   m_views.reserve(configs.size());
   for (auto const& cfg : configs) {
-    auto view = std::make_unique<FlutterView>(cfg, index, m_display);
+    auto view = std::make_unique<FlutterView>(cfg, index, m_displays.front());
     view->Initialize();
     m_views.emplace_back(std::move(view));
     index++;
@@ -125,8 +126,10 @@ App::App(const std::vector<Configuration::Config>& configs)
   // other shells. Null-check the cast: in a multi-backend binary the active
   // display may be DRM/software (not a Wayland Display).
   if (found_view_with_bg) {
-    if (auto* d = dynamic_cast<Display*>(m_display.get())) {
-      d->ActiveShell().OnClientReady();
+    for (const auto& display : m_displays) {
+      if (auto* d = dynamic_cast<Display*>(display.get())) {
+        d->ActiveShell().OnClientReady();
+      }
     }
   }
 #endif
@@ -139,18 +142,41 @@ App::App(const std::vector<Configuration::Config>& configs)
   // Wire the App-owned shared reactor onto the Wayland connection before it
   // arms its display fd. Multiple connections would each register onto the same
   // primary_ioc_.
-  if (auto* d = dynamic_cast<Display*>(m_display.get())) {
-    d->SetEventLoop(primary_ioc_);
+  for (const auto& display : m_displays) {
+    if (auto* d = dynamic_cast<Display*>(display.get())) {
+      d->SetEventLoop(primary_ioc_);
+    }
   }
 #endif
 
-  m_display->StartEvents();
+  for (const auto& display : m_displays) {
+    display->StartEvents();
+  }
 
   SPDLOG_DEBUG("-App::App");
 }
 
 App::~App() {
-  m_display->StopEvents();
+  for (const auto& display : m_displays) {
+    display->StopEvents();
+  }
+}
+
+bool App::AnyHasRepeatTimer() const {
+  return std::any_of(
+      m_displays.begin(), m_displays.end(),
+      [](const auto& display) { return display->HasRepeatTimer(); });
+}
+
+double App::MaxRefreshRate() const {
+  double hz = 0.0;
+  for (const auto& display : m_displays) {
+    const double r = display->GetMaxRefreshRate();
+    if (r > hz) {
+      hz = r;
+    }
+  }
+  return hz;
 }
 
 int App::Loop() const {
@@ -163,7 +189,7 @@ int App::Loop() const {
     view->RunTasks();
   }
 
-  if (m_display->HasRepeatTimer())
+  if (AnyHasRepeatTimer())
     EventTimer::wait_event();
 
 #if BUILD_WATCHDOG
@@ -178,7 +204,7 @@ int App::Loop() const {
   // pointer event (or shutdown is requested), so it blocks on the waker
   // instead of spinning at the refresh rate — letting the CPU reach deep
   // idle on a static screen.
-  bool needs_periodic = m_display->HasRepeatTimer();
+  bool needs_periodic = AnyHasRepeatTimer();
   for (auto const& view : m_views) {
     if (view->NeedsPeriodicPump()) {
       needs_periodic = true;
@@ -196,7 +222,7 @@ int App::Loop() const {
             std::chrono::steady_clock::now().time_since_epoch())
             .count();
     const auto elapsed = end_time - start_time;
-    const double refresh_hz = m_display->GetMaxRefreshRate();
+    const double refresh_hz = MaxRefreshRate();
     const double frame_time =
         refresh_hz > 0.0 ? 1000.0 / refresh_hz : 1000.0 / 60.0;
     const double remaining = frame_time - static_cast<double>(elapsed);
@@ -223,7 +249,7 @@ int App::Run() {
   // Refresh-rate frame interval (fallback 60 Hz for virtual outputs that
   // advertise refresh=0).
   auto frame_interval = [this]() -> std::chrono::nanoseconds {
-    const double hz = m_display->GetMaxRefreshRate();
+    const double hz = MaxRefreshRate();
     const double ms = hz > 0.0 ? 1000.0 / hz : 1000.0 / 60.0;
     return std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::duration<double, std::milli>(ms));

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -31,14 +31,12 @@
 #include "timer.h"
 #include "view/flutter_view.h"
 
-#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
 #include <chrono>
 
 #include "asio/io_context.hpp"
 #include "asio/posix/stream_descriptor.hpp"
 #include "asio/post.hpp"
 #include "asio/steady_timer.hpp"
-#endif
 
 #include "shutdown_flag.h"
 
@@ -241,9 +239,13 @@ int App::Loop() const {
 }
 
 int App::Run() {
-#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
-  // The shared reactor is owned by App; the Wayland connection(s) already armed
-  // their fds onto it (App ctor: SetEventLoop + StartEvents).
+  // The shared reactor is owned by App and drives every backend. Reactor
+  // backends (Wayland) armed their display fds onto it in the ctor
+  // (SetEventLoop
+  // + StartEvents); self-driving backends (DRM, software) run their own
+  // seat/flip threads, so for them the reactor only services the refresh-rate
+  // pump (periodic RunTasks) and the shutdown/wake eventfd — the same duties
+  // the legacy per-iteration loop carried.
   asio::io_context& ioc = primary_ioc_;
 
   // Refresh-rate frame interval (fallback 60 Hz for virtual outputs that
@@ -347,11 +349,4 @@ int App::Run() {
   waker.cancel(ec);
   waker.release();
   return 0;
-#else
-  int ret = 0;
-  while (running && ret != -1) {
-    ret = Loop();
-  }
-  return ret;
-#endif
 }

--- a/shell/app.h
+++ b/shell/app.h
@@ -67,7 +67,14 @@ class App final {
   int Run();
 
  private:
-  // The displays the App drives. One entry per distinct (backend, device); a
+  // Builds one display per device-context across @p configs, appends the
+  // distinct displays to m_displays, and returns the per-config assignment
+  // (parallel to configs): every view runs on the display for its (backend,
+  // device). A homogeneous config set yields a single shared display.
+  std::vector<std::shared_ptr<IDisplay>> BuildDisplays(
+      const std::vector<Configuration::Config>& configs);
+
+  // The displays the App drives. One entry per distinct device-context; a
   // homogeneous config set yields a single shared display.
   std::vector<std::shared_ptr<IDisplay>> m_displays;
   std::vector<std::unique_ptr<FlutterView>> m_views;

--- a/shell/app.h
+++ b/shell/app.h
@@ -24,10 +24,8 @@
 #include "view/flutter_view.h"
 #include "watchdog.h"
 
-#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
 #include "asio/executor_work_guard.hpp"
 #include "asio/io_context.hpp"
-#endif
 
 class IDisplay;
 
@@ -43,25 +41,28 @@ class App final {
   const App& operator=(const App&) = delete;
 
   /**
-   * @brief One frame in the loop
+   * @brief Service one unit of main-thread work (pump view tasks, pace once).
+   *
+   * Not the production loop — Run() drives the reactor. Retained as a
+   * single-iteration entry point for tests and diagnostics.
+   *
    * @return int
    * @retval Number of dispatched events
-   * @relation
-   * wayland, flutter
+   * @relation flutter
    */
   [[nodiscard]] int Loop() const;
 
   /**
    * @brief Run the application until shutdown is requested.
    *
-   * On the Wayland backend this runs the display reactor (a single asio
-   * io_context) on the calling thread: the Wayland fd, keyboard repeat timerfd
-   * and the shutdown waker are all serviced event-driven, with periodic plugin
-   * pumping paced by a refresh-rate timer only while a view needs it. Other
-   * backends fall back to the Loop()-per-iteration model.
+   * Drives the shared asio reactor (a single io_context) on the calling thread
+   * for every backend: Wayland connections service their {wl-fd, repeat-fd}
+   * event-driven; DRM/software displays self-drive their own threads while the
+   * reactor runs the refresh-rate plugin pump (only while a view needs it) and
+   * the shutdown/wake eventfd.
    *
    * @return 0 on a clean exit, -1 on fatal error.
-   * @relation wayland, flutter
+   * @relation flutter
    */
   int Run();
 
@@ -76,13 +77,13 @@ class App final {
   [[nodiscard]] bool AnyHasRepeatTimer() const;
   [[nodiscard]] double MaxRefreshRate() const;
 
-#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
-  // The single shared reactor (the "primary" io_context). Run() runs it on the
-  // main thread; every Wayland Display connection registers its {wl-fd,
-  // repeat-fd} onto it, so all connections stay single-threaded with no
-  // per-connection strand. The work guard keeps run() alive across idle gaps.
+  // The single shared reactor (the "primary" io_context) that Run() drives on
+  // the main thread for every backend. Each Wayland Display connection
+  // registers its {wl-fd, repeat-fd} onto it (so all connections stay
+  // single-threaded with no per-connection strand); DRM/software displays
+  // self-drive their own threads and only use the reactor's refresh-rate pump +
+  // shutdown waker. The work guard keeps run() alive across idle gaps.
   asio::io_context primary_ioc_;
   asio::executor_work_guard<asio::io_context::executor_type> primary_work_{
       asio::make_work_guard(primary_ioc_)};
-#endif
 };

--- a/shell/app.h
+++ b/shell/app.h
@@ -66,9 +66,15 @@ class App final {
   int Run();
 
  private:
-  std::shared_ptr<IDisplay> m_display;
+  // The displays the App drives. One entry per distinct (backend, device); a
+  // homogeneous config set yields a single shared display.
+  std::vector<std::shared_ptr<IDisplay>> m_displays;
   std::vector<std::unique_ptr<FlutterView>> m_views;
   std::unique_ptr<Watchdog> m_watch_dog;
+
+  // Reductions across the owned displays.
+  [[nodiscard]] bool AnyHasRepeatTimer() const;
+  [[nodiscard]] double MaxRefreshRate() const;
 
 #if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
   // The single shared reactor (the "primary" io_context). Run() runs it on the

--- a/shell/backend/backend_registry.h
+++ b/shell/backend/backend_registry.h
@@ -29,12 +29,6 @@ class Backend;
 
 namespace backend {
 
-// How App drives the backend after construction:
-//   kReactor — App::Run() runs the shared asio reactor on the main thread
-//              (the Wayland backends).
-//   kLegacy  — main spins `while (running) App::Loop()` (DRM and software).
-enum class LoopMode { kReactor, kLegacy };
-
 // One compiled-in backend's runtime identity plus the two factory callables
 // that used to live in the App::MakeDisplay / Backend::Create #if chains. The
 // pair is cohesive: make_backend expects the concrete IDisplay that
@@ -42,7 +36,6 @@ enum class LoopMode { kReactor, kLegacy };
 struct BackendDescriptor {
   std::string key;  // "wayland-egl","wayland-vulkan","drm-kms-egl",
                     // "drm-kms-vulkan","software"
-  LoopMode loop_mode;
 
   // Creates the IDisplay for this backend (the MakeDisplay branch body).
   std::function<std::shared_ptr<IDisplay>(

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -1332,7 +1332,6 @@ void DrmBackend::UnifiedPageFlipHandler(int /*fd*/,
 
 void DrmBackend::SetPlatformTaskRunner(TaskRunner* runner) {
   platform_task_runner_.store(runner, std::memory_order_release);
-  StartFlipMonitor();
 
   // Wire engine+runner into the provider. SetEngine's #210 kick latch drains
   // any baton parked before the runner came up (the engine's first vsync
@@ -1342,68 +1341,28 @@ void DrmBackend::SetPlatformTaskRunner(TaskRunner* runner) {
   vsync_.SetEngine(engine_handle_.load(std::memory_order_acquire), runner);
 }
 
-void DrmBackend::StartFlipMonitor() {
-  if (flip_descriptor_.has_value()) {
-    return;  // already started
-  }
-  auto* runner = platform_task_runner_.load(std::memory_order_acquire);
-  if (runner == nullptr || runner->GetIoContext() == nullptr ||
-      drm_dev_ == nullptr) {
-    return;
-  }
-  // assign() makes asio take ownership of the fd — StopVsyncMonitor must
-  // call release() before reset() so drm_dev_'s close on its own fd
-  // isn't a double-close.
-  flip_descriptor_.emplace(*runner->GetIoContext());
-  flip_descriptor_->assign(drm_dev_->fd());
-  ArmFlipRead();
-  spdlog::info("[DrmBackend] flip monitor armed on fd={}", drm_dev_->fd());
-}
-
 void DrmBackend::StopVsyncMonitor() {
-  if (flip_descriptor_.has_value()) {
-    std::error_code ec;
-    // cancel() wakes the worker thread out of epoll_wait — the pending
-    // async_wait completion fires with operation_aborted, asio's
-    // outstanding-work count drops to zero, and the TaskRunner worker
-    // loop's run_one() can finally return.
-    flip_descriptor_->cancel(ec);
-    // release() detaches the fd so the descriptor's destructor doesn't
-    // close it (drm_dev_ owns the fd lifetime). Takes no args, returns
-    // the native handle which we deliberately discard — drm_dev_ closes
-    // it later.
-    (void)flip_descriptor_->release();
-    flip_descriptor_.reset();
-  }
   platform_task_runner_.store(nullptr, std::memory_order_release);
 
   // Drop any parked baton, clear engine/runner, and log the IVI_VSYNC_PROFILE
-  // session summary. Any page-flip event drained below then finds the provider
-  // cleared and no-ops its DeliverVsync — correct, we're tearing down.
+  // session summary. Any page-flip event the reader drains after this finds the
+  // provider cleared and no-ops its DeliverVsync — correct, we're tearing down.
   vsync_.Stop();
 
-  // Synchronously drain any in-flight PAGE_FLIP_EVENT. Without this,
-  // ~DrmCompositor → WaitForPendingFlip spins forever: the async flip
-  // monitor was what called drmHandleEvent to clear flip_pending_, and
-  // we just shut it down. The kernel typically fires the event within
-  // one vblank period (~16ms at 60Hz); poll briefly with a margin and
-  // dispatch via the same UnifiedPageFlipHandler the async path used.
-  // If the flag is still set after the poll loop bails (commit was
-  // dropped, session paused, etc.), force-clear it so destructors can
-  // make progress instead of hanging.
-  if (drm_dev_ != nullptr && flip_pending_.load(std::memory_order_acquire)) {
+  // Wait for any in-flight PAGE_FLIP_EVENT to be drained by the card's flip
+  // reader (owned by DrmDisplay, still running through our teardown) so
+  // ~DrmCompositor → WaitForPendingFlip does not spin. The backend must NOT
+  // read the fd itself -- the reader is the single reader for the shared card.
+  // Poll the flag with a one-vblank margin, then force-clear if the kernel
+  // never fired the event (commit dropped, session paused, ...) so destructors
+  // make progress.
+  if (flip_pending_.load(std::memory_order_acquire)) {
     constexpr int kDrainTimeoutMs = 100;
-    constexpr int kPollSliceMs = 10;
+    constexpr int kPollSliceMs = 2;
     int elapsed_ms = 0;
     while (elapsed_ms < kDrainTimeoutMs &&
            flip_pending_.load(std::memory_order_acquire)) {
-      pollfd pfd{drm_dev_->fd(), POLLIN, 0};
-      const int rc = ::poll(&pfd, 1, kPollSliceMs);
-      if (rc > 0 && (pfd.revents & POLLIN)) {
-        DrainFlipEvents();
-      } else if (rc < 0 && errno != EINTR) {
-        break;
-      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(kPollSliceMs));
       elapsed_ms += kPollSliceMs;
     }
     if (flip_pending_.load(std::memory_order_acquire)) {
@@ -1420,47 +1379,6 @@ void DrmBackend::StopVsyncMonitor() {
   }
 }
 
-void DrmBackend::ArmFlipRead() {
-  if (!flip_descriptor_.has_value()) {
-    return;
-  }
-  flip_descriptor_->async_wait(
-      asio::posix::stream_descriptor::wait_read,
-      [this](const std::error_code& ec) {
-        if (ec) {
-          // operation_aborted fires on shutdown/cancellation; quiet path.
-          if (ec != asio::error::operation_aborted) {
-            spdlog::warn("[DrmBackend] flip monitor wait: {}", ec.message());
-          }
-          return;
-        }
-        if (drm_dev_ == nullptr) {
-          return;
-        }
-        DrainFlipEvents();
-        ArmFlipRead();  // re-arm for the next vblank
-      });
-}
-
-void DrmBackend::DrainFlipEvents() const {
-  if (drm_dev_ == nullptr) {
-    return;
-  }
-  // poll(0) + read together under the lock so the read can never block: only
-  // one thread observes POLLIN-then-consumes a given event; a loser's poll(0)
-  // afterwards shows nothing readable and it no-ops. Read-only pollers (the
-  // WaitForPendingFlip diagnostic) need no lock — poll() concurrent with
-  // another thread's read() is safe.
-  const std::lock_guard<std::mutex> lock(drm_event_mutex_);
-  pollfd pfd{drm_dev_->fd(), POLLIN, 0};
-  if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN)) {
-    drmEventContext ctx{};
-    ctx.version = 2;
-    ctx.page_flip_handler = &DrmBackend::UnifiedPageFlipHandler;
-    drmHandleEvent(drm_dev_->fd(), &ctx);
-  }
-}
-
 bool DrmBackend::RasterDrainEnabled() {
   static const bool enabled = []() {
     const char* env = std::getenv("IVI_DRM_RASTER_DRAIN");
@@ -1474,40 +1392,23 @@ bool DrmBackend::RasterDrainEnabled() {
 
 bool DrmBackend::WaitForPendingFlip() const {
   using namespace std::chrono_literals;
-  // When the platform-thread asio monitor is starved (CPU governor downclock,
-  // Dart GC) the rasterizer drains the flip fd itself (DrainFlipEvents,
-  // serialized with the monitor by drm_event_mutex_) rather than sleeping out
-  // the 100ms deadline. On by default; IVI_DRM_RASTER_DRAIN=0 opts out.
-  const bool raster_drain = RasterDrainEnabled();
-  // Bounded wait. On nvidia-drm a flip's PAGE_FLIP_EVENT can go undelivered,
-  // and at teardown the asio monitor that would drain it is already gone — an
-  // unbounded loop then spins forever in hrtimer_nanosleep, hanging Present and
-  // (fatally) ~DrmBackend so the process never exits on SIGTERM. Cap the wait
-  // and proceed; a healthy 60Hz flip clears in ~16ms.
+  // The card's flip reader (DrmDisplay, its own thread) is the single reader of
+  // the shared fd; it drains PAGE_FLIP_EVENTs and clears flip_pending_. We only
+  // wait for the flag -- reading the fd here would race the reader thread.
+  // Bounded wait. On nvidia-drm a flip's PAGE_FLIP_EVENT can go undelivered, so
+  // an unbounded loop would spin forever in hrtimer_nanosleep, hanging Present
+  // and ~DrmBackend so the process never exits on SIGTERM. Cap the wait and
+  // proceed; a healthy 60Hz flip clears in ~16ms.
   constexpr auto kFlipWaitTimeout = 100ms;
   const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
   while (flip_pending_.load(std::memory_order_acquire)) {
-    if (!drm_dev_) {
-      return true;
-    }
-    if (raster_drain) {
-      // Fetch the completion ourselves rather than waiting on the (possibly
-      // starved) platform thread.
-      DrainFlipEvents();
-      if (!flip_pending_.load(std::memory_order_acquire)) {
-        break;
-      }
-    }
     if (std::chrono::steady_clock::now() >= deadline) {
-      // Reached only for a genuinely late/lost flip (e.g. nvidia-drm) — the
-      // raster drain already handles a merely-starved monitor. Proceed; the
-      // bounded wait keeps Present and ~DrmBackend from hanging.
       spdlog::warn(
           "[DrmBackend] WaitForPendingFlip: no flip completion after 100ms; "
           "proceeding (PAGE_FLIP_EVENT likely lost)");
       return true;
     }
-    std::this_thread::sleep_for(raster_drain ? 200us : 500us);
+    std::this_thread::sleep_for(200us);
   }
   return true;
 }

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -156,106 +156,13 @@ DrmBackend* BackendFromState(void* user_data) {
       state->view_controller->engine->GetBackend());
 }
 
-// Refuse to run unless our controlling terminal is the *foreground* VT on
-// the kernel console. Rationale: drmSetMaster can succeed from a non-
-// foreground VT (e.g. a terminal emulator, SSH, or an inactive text VT)
-// when no compositor currently holds master, but the GPU keeps scanning
-// out whatever the foreground VT owns. Atomic commits get silently
-// accepted and no PAGE_FLIP_EVENT ever fires, so PresentLayers stalls on
-// the next flip wait — the "master-acquired but black screen" pathology
-// we kept hitting. Fail fast with an actionable message instead.
-//
-// Returns true if it's safe to proceed, false with a logged error if not.
-// A missing /dev/tty0 (container / headless service) is not fatal —
-// those cases are outside the scope of this check.
-bool VerifyForegroundVt(const std::string& drm_device) {
-  const int tty0 = ::open("/dev/tty0", O_RDONLY | O_CLOEXEC);
-  if (tty0 < 0) {
-    spdlog::warn(
-        "[DrmBackend] open(/dev/tty0): {} — skipping foreground-VT check",
-        std::strerror(errno));
-    return true;
-  }
-  struct vt_stat vtstat{};
-  const bool got_state = ::ioctl(tty0, VT_GETSTATE, &vtstat) == 0;
-  const int vt_errno = errno;
-  ::close(tty0);
-  if (!got_state) {
-    spdlog::warn("[DrmBackend] VT_GETSTATE: {} — skipping foreground-VT check",
-                 std::strerror(vt_errno));
-    return true;
-  }
-  const unsigned int active_vt = vtstat.v_active;
-
-  // open("/dev/tty") redirects to the process's controlling terminal, so
-  // calling open() against the special inode is the only way to acquire
-  // an fd that *targets* the ctty rather than the /dev/tty special device
-  // itself. ENXIO from open() means the process has no ctty at all (e.g.
-  // a daemon without setsid + TIOCSCTTY).
-  const int ctl_fd = ::open("/dev/tty", O_RDONLY | O_CLOEXEC | O_NOCTTY);
-  if (ctl_fd < 0) {
-    spdlog::error(
-        "[DrmBackend] no controlling terminal (open /dev/tty: {}). Cannot "
-        "drive {} without a foreground VT — switch to the active console "
-        "(tty{}) and rerun.",
-        std::strerror(errno), drm_device, active_vt);
-    return false;
-  }
-  // fstat() of the resulting fd does NOT return the underlying tty's
-  // device numbers — it returns /dev/tty's own (5, 0) inode metadata on
-  // every Linux kernel from 4.x onward. The earlier version of this
-  // check believed fstat would resolve through; in practice it
-  // mis-rejected every legitimate kernel-VT ctty too, including
-  // systemd-launched services attached via TTYPath=/dev/tty1. TIOCGDEV
-  // is the canonical ioctl for retrieving the actual tty device number
-  // from a /dev/tty fd; available since Linux 2.6.18.
-  unsigned int dev = 0;
-  const int ioctl_rc = ::ioctl(ctl_fd, TIOCGDEV, &dev);
-  const int ioctl_errno = errno;
-  ::close(ctl_fd);
-  if (ioctl_rc != 0) {
-    spdlog::error(
-        "[DrmBackend] TIOCGDEV(/dev/tty): {}. Cannot drive {} without "
-        "a foreground VT — switch to the active console (tty{}) and rerun.",
-        std::strerror(ioctl_errno), drm_device, active_vt);
-    return false;
-  }
-
-  // TTY_MAJOR is 4 on Linux; /dev/ttyN lives at (4, N). Terminal emulators
-  // and SSH sessions give /dev/tty a pts major (136+), which is precisely
-  // the case we want to refuse.
-  constexpr unsigned int kTtyMajor = 4;
-  const unsigned int ctl_major = major(static_cast<dev_t>(dev));
-  const unsigned int ctl_minor = minor(static_cast<dev_t>(dev));
-  if (ctl_major != kTtyMajor) {
-    spdlog::error(
-        "[DrmBackend] controlling terminal is not a kernel VT "
-        "(major={}, minor={}) — you're running from a terminal emulator or "
-        "SSH. Active VT is tty{}. Switch to tty{} (Ctrl+Alt+F{}) and rerun, "
-        "or `sudo systemctl isolate multi-user.target` first. Refusing to "
-        "drive {}.",
-        ctl_major, ctl_minor, active_vt, active_vt, active_vt, drm_device);
-    return false;
-  }
-  if (ctl_minor != active_vt) {
-    spdlog::error(
-        "[DrmBackend] controlling VT is tty{} but foreground VT is tty{} — "
-        "scanout goes to the foreground. Switch to tty{} (Ctrl+Alt+F{}) and "
-        "rerun. Refusing to drive {}.",
-        ctl_minor, active_vt, ctl_minor, ctl_minor, drm_device);
-    return false;
-  }
-  spdlog::info("[DrmBackend] foreground VT check: on tty{} (active)",
-               active_vt);
-  return true;
-}
-
 }  // namespace
 
-std::unique_ptr<DrmBackend> DrmBackend::Create(
-    const DrmConfig& cfg,
-    homescreen::DrmSession* session) {
+std::unique_ptr<DrmBackend> DrmBackend::Create(const DrmConfig& cfg,
+                                               homescreen::DrmSession* session,
+                                               drm::Device* shared_device) {
   std::unique_ptr<DrmBackend> backend(new DrmBackend(cfg, session));
+  backend->drm_dev_ = shared_device;
   if (!backend->InitDrm()) {
     return nullptr;
   }
@@ -513,83 +420,19 @@ DrmBackend::~DrmBackend() {
     gbm_device_destroy(gbm_device_);
   }
 
-  // Release DRM master so whoever takes over next (fbcon, getty, the
-  // greeter coming back up) can drive the display. Must happen last,
-  // after all our atomic work is done — drm::Device's destructor closes
-  // the fd, which also drops master, but being explicit keeps the log
-  // honest.
-  if (drm_master_ && drm_dev_) {
-    drmDropMaster(drm_dev_->fd());
-    drm_master_ = false;
-  }
-  // drm_dev_ destructor closes the fd automatically.
+  // The shared card + master are owned by DrmDisplay (the device-context),
+  // which outlives this backend and drops master / closes the fd on its own
+  // teardown. The backend holds only a non-owning pointer.
 }
 
 bool DrmBackend::InitDrm() {
-  if (session_ != nullptr) {
-    // libseat path: the seat provider (logind/seatd/builtin) owns VT
-    // activation and master handoff. Skip the foreground-VT check
-    // (logind activates us only when the VT is ours) and drmSetMaster
-    // (libseat_open_device returns a master-capable fd while we hold
-    // the seat). The seat provider also releases the session cleanly
-    // on socket drop (SIGKILL included), restoring TTY state externally.
-    const int fd = session_->TakeDevice(cfg_.drm_device);
-    if (fd < 0) {
-      spdlog::error("[DrmBackend] session take_device({}): failed",
-                    cfg_.drm_device);
-      return false;
-    }
-    drm_dev_.emplace(drm::Device::from_fd(fd));
-    spdlog::info("[DrmBackend] opened {} via libseat (fd={})", cfg_.drm_device,
-                 fd);
-  } else {
-    // Fallback path: no seat backend available (or --drm-no-seat). Refuse
-    // up-front if we're not on the active VT — prevents the "master
-    // acquired, commits return success, but scanout stays on the other VT"
-    // trap where drmSetMaster succeeds but PAGE_FLIP_EVENT never fires.
-    // --drm-no-seat opts out of this guard: the operator has taken
-    // responsibility for the display (e.g. headless / SSH with nothing else
-    // holding master), where there is no foreground kernel VT to be on.
-    if (cfg_.no_seat) {
-      spdlog::warn(
-          "[DrmBackend] --drm-no-seat: skipping the foreground-VT guard on "
-          "{}. If the screen stays black, another DRM master holds the "
-          "device or scanout is owned by a different VT.",
-          cfg_.drm_device);
-    } else if (!VerifyForegroundVt(cfg_.drm_device)) {
-      return false;
-    }
-
-    auto dev = drm::Device::open(cfg_.drm_device);
-    if (!dev) {
-      spdlog::error("[DrmBackend] open({}): {}", cfg_.drm_device,
-                    dev.error().message());
-      return false;
-    }
-    drm_dev_.emplace(std::move(*dev));
-
-    // Acquire DRM master. Required for modeset/atomic commits. Atomic
-    // writes from a non-master fd are silently accepted by some drivers
-    // (amdgpu in particular) as no-ops — the commit returns success, but
-    // nothing actually changes on screen, which is exactly the "blank
-    // panel, no PAGE_FLIP_EVENT" pathology. Refuse to run in that state.
-    if (drmSetMaster(drm_dev_->fd()) != 0) {
-      if (const int err = errno;
-          err == EBUSY || err == EACCES || err == EPERM) {
-        spdlog::error(
-            "[DrmBackend] cannot acquire DRM master on {} ({}). Another "
-            "display server (gdm / gnome-shell / sddm / Xorg / a Wayland "
-            "compositor) is already holding the device. Stop it or run from "
-            "a bare TTY (e.g. `sudo systemctl isolate multi-user.target`).",
-            cfg_.drm_device, std::strerror(err));
-      } else {
-        spdlog::error("[DrmBackend] drmSetMaster({}): {}", cfg_.drm_device,
-                      std::strerror(err));
-      }
-      return false;
-    }
-    drm_master_ = true;
-    spdlog::info("[DrmBackend] DRM master on {}", cfg_.drm_device);
+  // The card is opened and held at master by the device-context
+  // (DrmDisplay::SharedDevice); Create stored the non-owning pointer. The
+  // backend neither opens the device nor takes master -- one card, one master,
+  // shared by every view that scans out to it.
+  if (drm_dev_ == nullptr) {
+    spdlog::error("[DrmBackend] no shared DRM device provided");
+    return false;
   }
 
   if (drmSetClientCap(drm_dev_->fd(), DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1) !=
@@ -1505,7 +1348,7 @@ void DrmBackend::StartFlipMonitor() {
   }
   auto* runner = platform_task_runner_.load(std::memory_order_acquire);
   if (runner == nullptr || runner->GetIoContext() == nullptr ||
-      !drm_dev_.has_value()) {
+      drm_dev_ == nullptr) {
     return;
   }
   // assign() makes asio take ownership of the fd — StopVsyncMonitor must
@@ -1548,7 +1391,7 @@ void DrmBackend::StopVsyncMonitor() {
   // If the flag is still set after the poll loop bails (commit was
   // dropped, session paused, etc.), force-clear it so destructors can
   // make progress instead of hanging.
-  if (drm_dev_.has_value() && flip_pending_.load(std::memory_order_acquire)) {
+  if (drm_dev_ != nullptr && flip_pending_.load(std::memory_order_acquire)) {
     constexpr int kDrainTimeoutMs = 100;
     constexpr int kPollSliceMs = 10;
     int elapsed_ms = 0;
@@ -1591,7 +1434,7 @@ void DrmBackend::ArmFlipRead() {
           }
           return;
         }
-        if (!drm_dev_.has_value()) {
+        if (drm_dev_ == nullptr) {
           return;
         }
         DrainFlipEvents();
@@ -1600,7 +1443,7 @@ void DrmBackend::ArmFlipRead() {
 }
 
 void DrmBackend::DrainFlipEvents() const {
-  if (!drm_dev_.has_value()) {
+  if (drm_dev_ == nullptr) {
     return;
   }
   // poll(0) + read together under the lock so the read can never block: only

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -160,9 +160,11 @@ DrmBackend* BackendFromState(void* user_data) {
 
 std::unique_ptr<DrmBackend> DrmBackend::Create(const DrmConfig& cfg,
                                                homescreen::DrmSession* session,
-                                               drm::Device* shared_device) {
+                                               drm::Device* shared_device,
+                                               DrmDisplay* display) {
   std::unique_ptr<DrmBackend> backend(new DrmBackend(cfg, session));
   backend->drm_dev_ = shared_device;
+  backend->drm_display_ = display;
   if (!backend->InitDrm()) {
     return nullptr;
   }

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -38,6 +38,7 @@
 #include "vsync/ivsync_provider.h"
 
 class DrmCompositor;
+class DrmDisplay;
 class TaskRunner;
 namespace homescreen {
 class DrmCapture;
@@ -154,9 +155,16 @@ class DrmBackend : public Backend {
   // @p shared_device is the card opened + held at master by the device-context
   // (DrmDisplay::SharedDevice); the backend scans out through it without taking
   // master itself. It is non-owning and must outlive the backend.
+  // @p display is the device-context; the compositor uses it to reserve/exclude
+  // planes so co-tenant views on the same card don't collide on a shared
+  // overlay. Non-owning; outlives the backend.
   static std::unique_ptr<DrmBackend> Create(const DrmConfig& cfg,
                                             homescreen::DrmSession* session,
-                                            drm::Device* shared_device);
+                                            drm::Device* shared_device,
+                                            DrmDisplay* display);
+
+  // The device-context this backend scans out through (plane reservation).
+  [[nodiscard]] DrmDisplay* display() const { return drm_display_; }
   ~DrmBackend() override;
 
   DrmBackend(const DrmBackend&) = delete;
@@ -304,6 +312,9 @@ class DrmBackend : public Backend {
 
   DrmConfig cfg_;
   homescreen::DrmSession* session_ = nullptr;
+  // Device-context (non-owning). Used for cross-view plane reservation on the
+  // shared card.
+  DrmDisplay* drm_display_ = nullptr;
 
   // The shared card (opened + held at master by DrmDisplay::SharedDevice).
   // Non-owning: the device-context owns it and outlives this backend, so the

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -229,6 +229,20 @@ class DrmBackend : public Backend {
   // asio work, so run_one() never returns even after work_.reset()).
   void StopVsyncMonitor() override;
 
+  // Unified PAGE_FLIP_EVENT dispatcher (drmModeEventContext.page_flip_handler
+  // signature). The card's flip-reader thread (owned by DrmDisplay) registers
+  // this as the handler; user_data is always a DrmBackend*, so a single reader
+  // on the shared fd routes each flip to the backend that committed it. Clears
+  // that backend's flip_pending_ and returns its vsync baton (DeliverVsync
+  // marshals OnVsync onto the platform runner, so running on the reader thread
+  // is safe). Public so DrmDisplay can register it without depending on this
+  // (EGL-only) type.
+  static void UnifiedPageFlipHandler(int fd,
+                                     unsigned int sequence,
+                                     unsigned int tv_sec,
+                                     unsigned int tv_usec,
+                                     void* user_data);
+
   // Session lifecycle hooks, called from DrmSession's dispatch thread by
   // the libseat trampoline. OnSessionPaused gates the compositor's
   // Present paths and lets the rasterizer drop any flip it had pending;
@@ -273,30 +287,11 @@ class DrmBackend : public Backend {
   bool SetInitialMode();
   uint32_t AddFb(gbm_bo* bo) const;
   bool WaitForPendingFlip() const;
-  // Drain any readable PAGE_FLIP_EVENT on the drm fd (poll(0)+drmHandleEvent),
-  // serialized by drm_event_mutex_ so the rasterizer thread and the asio flip
-  // monitor never read the fd concurrently. The poll+read run under the lock so
-  // the read can't block: only one thread consumes a given event. Used by both
-  // the asio monitor and (when IVI_DRM_RASTER_DRAIN=1) WaitForPendingFlip.
-  void DrainFlipEvents() const;
   // True unless IVI_DRM_RASTER_DRAIN=0 — the single source of truth for the
   // raster-thread drain decision, shared by WaitForPendingFlip (both backend
   // and compositor) and the nvidia-drm cursor-staging heuristic. Cached on
   // first call.
   [[nodiscard]] static bool RasterDrainEnabled();
-  // Unified PAGE_FLIP_EVENT dispatcher. Registered as the
-  // drmEventContext.page_flip_handler from the asio flip monitor; the
-  // user_data is always a DrmBackend* (compositor commits also pass
-  // `backend_` instead of `this`, so the dispatcher can branch on
-  // compositor_->planes_active() to route the per-frame state work to
-  // the right place). Returning a pending vsync baton happens here
-  // too — we're already on the platform task runner thread, so
-  // OnVsync can be called directly without re-posting.
-  static void UnifiedPageFlipHandler(int fd,
-                                     unsigned int sequence,
-                                     unsigned int tv_sec,
-                                     unsigned int tv_usec,
-                                     void* user_data);
   // Per-flip-complete work for the legacy (non-compositor) path:
   // promote pending→current, drmModeRmFB the previous scanout, clear
   // flip_pending_, record frame stats. Called by UnifiedPageFlipHandler
@@ -306,12 +301,6 @@ class DrmBackend : public Backend {
   // FlutterDesktopEngineState user_data back to this backend + the
   // engine handle, then forwards to SetVsyncBaton.
   static void VsyncTrampoline(void* user_data, intptr_t baton);
-  // Bind the drm fd to the platform task runner's io_context and
-  // arm the first async_wait for POLLIN. Re-armed inside the
-  // completion handler so flip events keep flowing without rasterizer
-  // involvement.
-  void StartFlipMonitor();
-  void ArmFlipRead();
 
   DrmConfig cfg_;
   homescreen::DrmSession* session_ = nullptr;
@@ -349,14 +338,6 @@ class DrmBackend : public Backend {
   // next flip in Present) don't race. Same justification on the
   // compositor's mirror.
   std::atomic<bool> flip_pending_{false};
-
-  // Serializes drmHandleEvent() between the asio flip monitor (platform task
-  // runner thread) and WaitForPendingFlip()'s opt-in raster-thread drain, so
-  // the two never read the drm fd concurrently. Mutable: DrainFlipEvents() is
-  // const (called from the const WaitForPendingFlip). INVARIANT: nothing
-  // reachable from UnifiedPageFlipHandler may take this lock — the handler runs
-  // under it (inside drmHandleEvent), so re-locking would self-deadlock.
-  mutable std::mutex drm_event_mutex_;
 
   // Set by OnSessionPaused / cleared by OnSessionResumed (libseat VT switch).
   // While paused, scanout is revoked and page flips never complete, so GBM
@@ -404,11 +385,6 @@ class DrmBackend : public Backend {
   // back to the FlutterEngineRun thread. nullptr until FlutterView
   // wires it after Engine::Run; PostOnVsync no-ops in that window.
   std::atomic<TaskRunner*> platform_task_runner_{nullptr};
-  // asio-managed drm fd reader. Bound to the platform task runner's
-  // io_context in SetPlatformTaskRunner; async_wait(POLLIN) re-arms
-  // itself after every drmHandleEvent so PAGE_FLIP_EVENTs are drained
-  // independently of the rasterizer's Present cadence.
-  std::optional<asio::posix::stream_descriptor> flip_descriptor_;
 
   // Frame stats — only active when cfg_.debug_backend is set. Accessed
   // from the rasterizer thread only (Present / PageFlipHandler), so no

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -151,8 +151,12 @@ class DrmBackend : public Backend {
   // master handoff on VT switch so both are skipped. The caller retains
   // ownership of the session; it must
   // outlive the backend.
+  // @p shared_device is the card opened + held at master by the device-context
+  // (DrmDisplay::SharedDevice); the backend scans out through it without taking
+  // master itself. It is non-owning and must outlive the backend.
   static std::unique_ptr<DrmBackend> Create(const DrmConfig& cfg,
-                                            homescreen::DrmSession* session);
+                                            homescreen::DrmSession* session,
+                                            drm::Device* shared_device);
   ~DrmBackend() override;
 
   DrmBackend(const DrmBackend&) = delete;
@@ -312,10 +316,10 @@ class DrmBackend : public Backend {
   DrmConfig cfg_;
   homescreen::DrmSession* session_ = nullptr;
 
-  // DRM — drm::Device is RAII (closes fd on destruction), unless
-  // constructed via Device::from_fd (libseat-owned fd path).
-  std::optional<drm::Device> drm_dev_{};
-  bool drm_master_ = false;  // true after a successful drmSetMaster
+  // The shared card (opened + held at master by DrmDisplay::SharedDevice).
+  // Non-owning: the device-context owns it and outlives this backend, so the
+  // backend neither takes master nor closes the fd.
+  drm::Device* drm_dev_ = nullptr;
   uint32_t connector_id_ = 0;
   uint32_t crtc_id_ = 0;
   uint32_t crtc_index_ = 0;

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -43,6 +43,7 @@
 #include "backend/drm_kms_egl/driver_probe.h"
 #include "backend/drm_kms_egl/drm_backend.h"
 #include "backend/drm_kms_egl/drm_cursor.h"
+#include "display/drm_display.h"
 #if USE_DRM_SCENE
 #include "backend/drm_kms_egl/scene_layer_source_gl.h"
 #endif
@@ -508,6 +509,16 @@ bool DrmCompositor::InitFramedMode() {
   const uint32_t comp_format = backend_->resolved().primary_format;
   const uint64_t want_overlay_zpos = primary_zpos_ + 1;
 
+  // Overlay planes on a card can be valid for several CRTCs, so a co-tenant
+  // view may already own the first one. Skip planes the device-context reports
+  // reserved so two views on one card don't collide on a shared overlay.
+  const std::vector<uint32_t> reserved =
+      backend_->display() != nullptr ? backend_->display()->ReservedPlanes()
+                                     : std::vector<uint32_t>{};
+  const auto is_reserved = [&reserved](uint32_t id) {
+    return std::find(reserved.begin(), reserved.end(), id) != reserved.end();
+  };
+
   for (const auto* p : plane_registry_->for_crtc(backend_->crtc_index())) {
     if (p->type == drm::planes::DRMPlaneType::PRIMARY &&
         framed_primary_id_ == 0) {
@@ -516,7 +527,7 @@ bool DrmCompositor::InitFramedMode() {
     }
     if (p->type == drm::planes::DRMPlaneType::OVERLAY &&
         framed_overlay_id_ == 0) {
-      if (!p->supports_format(comp_format)) {
+      if (!p->supports_format(comp_format) || is_reserved(p->id)) {
         continue;
       }
       // Clamp to the advertised zpos range. When the overlay zpos is
@@ -540,6 +551,12 @@ bool DrmCompositor::InitFramedMode() {
         "CRTC {} (primary={}, overlay={})",
         backend_->crtc_id(), framed_primary_id_, framed_overlay_id_);
     return false;
+  }
+
+  // Claim these planes so the next view on this card excludes them.
+  if (backend_->display() != nullptr) {
+    backend_->display()->ReservePlanes(
+        {framed_primary_id_, framed_overlay_id_});
   }
 
   // Cache property IDs for both planes so PresentFramed can build the
@@ -1378,12 +1395,22 @@ bool DrmCompositor::PresentFramed(const FlutterLayer** layers,
   }
 
   // Disable every other non-cursor plane on this CRTC so the commit
-  // doesn't inherit stale FB/CRTC/zpos from fbcon or a prior session.
+  // doesn't inherit stale FB/CRTC/zpos from fbcon or a prior session --
+  // except planes another view on this card owns. Shared overlays are valid
+  // for our CRTC too, so disabling one would blank the co-tenant view. Checked
+  // at commit (both views have reserved by steady state; a co-tenant that has
+  // not reserved yet is not scanning out, so disabling it is harmless).
+  const std::vector<uint32_t> reserved =
+      backend_->display() != nullptr ? backend_->display()->ReservedPlanes()
+                                     : std::vector<uint32_t>{};
   for (const auto* p : plane_registry_->for_crtc(backend_->crtc_index())) {
     if (p->type == drm::planes::DRMPlaneType::CURSOR) {
       continue;
     }
     if (p->id == framed_primary_id_ || p->id == framed_overlay_id_) {
+      continue;
+    }
+    if (std::find(reserved.begin(), reserved.end(), p->id) != reserved.end()) {
       continue;
     }
     if (auto fb_pid = framed_props_.property_id(p->id, "FB_ID")) {

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -926,48 +926,34 @@ void DrmCompositor::OnFlipComplete() {
 }
 
 bool DrmCompositor::WaitForPendingFlip() const {
-  // The asio flip monitor in DrmBackend drains PAGE_FLIP_EVENTs on the
-  // platform task runner thread and clears flip_pending_ via
-  // UnifiedPageFlipHandler → OnFlipComplete. We just wait for it.
-  // Short sleep keeps the rasterizer responsive without burning CPU.
+  // The card's flip reader (owned by DrmDisplay, on its own thread) is the
+  // single reader of the shared fd: it drains PAGE_FLIP_EVENTs and clears
+  // flip_pending_ via UnifiedPageFlipHandler → OnFlipComplete. We only wait for
+  // the flag -- we must NOT read the fd here (a second reader would race the
+  // reader thread). Waiting on the flag is also what makes a merged
+  // raster+platform thread safe: an independent thread delivers the completion,
+  // so blocking here can never deadlock the thread that must drain it.
   using namespace std::chrono_literals;
-  // Bounded wait — see DrmBackend::WaitForPendingFlip. On nvidia-drm a
-  // flip event can be lost; without a cap the destructor's wait spins
-  // forever and the process never exits on SIGTERM. A healthy 60Hz flip
-  // clears in ~16ms so the cap never fires in normal operation.
-  // Mirrors DrmBackend::WaitForPendingFlip for the plane compositor path: when
-  // the platform-thread asio monitor is starved, drain the fd on the rasterizer
-  // thread via the backend's shared, mutex-guarded helper (DrainFlipEvents
-  // routes the event to OnFlipComplete) instead of sleeping out the deadline.
-  // On by default; IVI_DRM_RASTER_DRAIN=0 opts out. Shared decision so the
-  // backend and compositor never disagree.
-  const bool raster_drain = DrmBackend::RasterDrainEnabled();
+  // Bounded wait: on nvidia-drm a flip event can be lost; without a cap the
+  // destructor's wait spins forever and the process never exits on SIGTERM. A
+  // healthy 60Hz flip clears in ~16ms so the cap never fires in normal
+  // operation.
   constexpr auto kFlipWaitTimeout = 100ms;
   const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
   while (flip_pending_.load(std::memory_order_acquire)) {
-    // Session went inactive between submitting the flip and the
-    // kernel firing PAGE_FLIP_EVENT — the event will never come.
-    // OnResume() will clear flip_pending_; bail now so the rasterizer
-    // doesn't spin forever.
+    // Session went inactive between submitting the flip and the kernel firing
+    // PAGE_FLIP_EVENT — the event will never come. OnResume() clears
+    // flip_pending_; bail now so the rasterizer doesn't spin forever.
     if (paused_.load(std::memory_order_acquire)) {
       return false;
     }
-    if (raster_drain) {
-      backend_->DrainFlipEvents();  // clears flip_pending_ via OnFlipComplete
-      if (!flip_pending_.load(std::memory_order_acquire)) {
-        break;
-      }
-    }
     if (std::chrono::steady_clock::now() >= deadline) {
-      // Reached only for a genuinely late/lost flip — the raster drain already
-      // handles a merely-starved monitor. Proceed; the bounded wait keeps the
-      // rasterizer and teardown from hanging.
       spdlog::warn(
           "[DrmCompositor] WaitForPendingFlip: no flip completion after "
           "100ms; proceeding (PAGE_FLIP_EVENT likely lost)");
       return true;
     }
-    std::this_thread::sleep_for(raster_drain ? 200us : 500us);
+    std::this_thread::sleep_for(200us);
   }
   return true;
 }

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -620,8 +620,19 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
          unsigned int /*tv_usec*/, void* /*user_data*/) {};
 
   if (drmSetMaster(state->device.fd()) != 0) {
-    err = std::string("drmSetMaster: ") + std::strerror(errno) +
-          " (run from a free VT / stop the active compositor)";
+    if (const int set_err = errno;
+        set_err == EBUSY || set_err == EACCES || set_err == EPERM) {
+      // Read-only enumeration (DrmOutputProvider / ResolveDrmDevice) succeeds
+      // without master, so a card can resolve here yet refuse master because
+      // another DRM master already holds it.
+      err = std::string("cannot acquire DRM master (") +
+            std::strerror(set_err) +
+            "): another display server (gdm / gnome-shell / sddm / Xorg / a "
+            "Wayland compositor) already holds this card. Stop it or run from "
+            "a bare TTY.";
+    } else {
+      err = std::string("drmSetMaster: ") + std::strerror(set_err);
+    }
     return false;
   }
   state->have_master = true;

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -46,7 +46,8 @@
 #include "display/drm_display.h"
 #endif
 #if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
-#include "display/drm_mode_list.h"  // PrintDrmModes for --drm-list-modes
+#include "display/drm_device_resolver.h"  // ResolveDrmDevice
+#include "display/drm_mode_list.h"        // PrintDrmModes for --drm-list-modes
 #endif
 #if BUILD_BACKEND_SOFTWARE
 #if BUILD_SOFTWARE_SINK_DRM
@@ -83,8 +84,16 @@ std::shared_ptr<IDisplay> MakeDrmDisplay(
   const auto w = configs[0].view.width.value_or(kDefaultViewWidth);
   const auto h = configs[0].view.height.value_or(kDefaultViewHeight);
   const bool no_seat = configs[0].view.drm_no_seat.value_or(false);
+  // Resolve the card once here; the DRM backend reads it back from the display
+  // (device_path()) so both agree. ResolveDrmDevice logs the choice / the
+  // reason it could not pick one.
+  auto device = homescreen::ResolveDrmDevice(configs[0].view.drm_device);
+  if (!device) {
+    std::exit(EXIT_FAILURE);
+  }
   return std::make_shared<DrmDisplay>(static_cast<int32_t>(w),
-                                      static_cast<int32_t>(h), 60.0, no_seat);
+                                      static_cast<int32_t>(h), 60.0,
+                                      std::move(*device), no_seat);
 }
 #endif
 
@@ -218,9 +227,16 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
   // cfg_.width.value_or(mode_.hdisplay), i.e. the native mode. When -f
   // is combined with explicit width/height, -f wins — matches how most
   // CLI tools handle a scalar "use native" flag vs. explicit sizing.
+  // DrmDisplay (built first by App::BuildDisplays) resolved and owns the card;
+  // read it back so the backend and display target the same device. In a DRM
+  // build MakeDrmDisplay always returns a DrmDisplay, so the cast fails only on
+  // programmer error.
+  auto* drm_display = dynamic_cast<DrmDisplay*>(display);
+  assert(drm_display != nullptr);
+
   const bool fullscreen = config.view.fullscreen.value_or(false);
   DrmConfig cfg{
-      config.view.drm_device.value_or("/dev/dri/card1"),
+      drm_display->device_path(),
       fullscreen ? std::optional<uint32_t>{} : config.view.width,
       fullscreen ? std::optional<uint32_t>{} : config.view.height,
       config.debug_backend.value_or(false),
@@ -252,14 +268,9 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
   // also skip the foreground-VT guard on its direct-open path.
   cfg.no_seat = config.view.drm_no_seat.value_or(false);
 
-  // DrmDisplay (constructed by App::MakeDisplay, before us) owns the
-  // process-wide libseat session. Pull the raw pointer — may be null
-  // when no seat backend is available, in which case DrmBackend takes
-  // the legacy direct-open path. In a DRM build, MakeDisplay always
-  // returns a DrmDisplay, so dynamic_cast fails only on programmer
-  // error; assert keeps the invariant loud.
-  auto* drm_display = dynamic_cast<DrmDisplay*>(display);
-  assert(drm_display != nullptr);
+  // drm_display (resolved above) owns the process-wide libseat session — it may
+  // be null when no seat backend is available, in which case DrmBackend takes
+  // the legacy direct-open path.
   m_backend = DrmBackend::Create(cfg, drm_display->session());
 
   // DrmBackend::Create returns nullptr on any init failure (libseat
@@ -320,9 +331,8 @@ std::shared_ptr<Backend> MakeDrmVulkanBackend(
           ? *config.view.drm_mode
           : std::string{};
   auto vk_backend = VulkanDrmBackend::Create(
-      config.view.drm_device.value_or("/dev/dri/card1"),
-      config.debug_backend.value_or(false), drm_display->session(), drm_mode,
-      config.view.drm_rotation.value_or(0));
+      drm_display->device_path(), config.debug_backend.value_or(false),
+      drm_display->session(), drm_mode, config.view.drm_rotation.value_or(0));
 
   // Create returns nullptr on any init failure (unsupported device, no
   // zero-copy scanout path). Continuing would dereference a null backend in

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -292,6 +292,13 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
     exit(EXIT_FAILURE);
   }
 
+  // Start the card's single PAGE_FLIP_EVENT reader (owned by the device-context
+  // so it outlives every backend on the card). The dispatcher routes each flip
+  // to the committing backend by user_data, so N views on one card share one
+  // reader. Idempotent across backends on the same card.
+  drm_display->SetFlipHandler(&DrmBackend::UnifiedPageFlipHandler);
+  drm_display->StartFlipReader();
+
   // Wire the HW cursor (if Create succeeded in opening one) to the
   // seat dispatch thread so pointer events move the on-screen sprite.
   // The pointer stays valid for the FlutterView's lifetime — both

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -429,24 +429,23 @@ static int SoftwareListModes(const std::string& device) {
 
 void RegisterCompiledBackends(backend::BackendRegistry& registry) {
 #if BUILD_BACKEND_WAYLAND_EGL
-  registry.Register({"wayland-egl", backend::LoopMode::kReactor,
-                     MakeWaylandDisplay, MakeWaylandEglBackend, nullptr});
+  registry.Register(
+      {"wayland-egl", MakeWaylandDisplay, MakeWaylandEglBackend, nullptr});
 #endif
 #if BUILD_BACKEND_WAYLAND_VULKAN
-  registry.Register({"wayland-vulkan", backend::LoopMode::kReactor,
-                     MakeWaylandDisplay, MakeWaylandVulkanBackend, nullptr});
+  registry.Register({"wayland-vulkan", MakeWaylandDisplay,
+                     MakeWaylandVulkanBackend, nullptr});
 #endif
 #if BUILD_BACKEND_DRM_KMS_EGL
-  registry.Register({"drm-kms-egl", backend::LoopMode::kLegacy, MakeDrmDisplay,
-                     MakeDrmEglBackend, DrmListModes});
+  registry.Register(
+      {"drm-kms-egl", MakeDrmDisplay, MakeDrmEglBackend, DrmListModes});
 #endif
 #if BUILD_BACKEND_DRM_KMS_VULKAN
-  registry.Register({"drm-kms-vulkan", backend::LoopMode::kLegacy,
-                     MakeDrmDisplay, MakeDrmVulkanBackend, DrmListModes});
+  registry.Register(
+      {"drm-kms-vulkan", MakeDrmDisplay, MakeDrmVulkanBackend, DrmListModes});
 #endif
 #if BUILD_BACKEND_SOFTWARE
-  registry.Register({"software", backend::LoopMode::kLegacy,
-                     MakeSoftwareDisplay, MakeSoftwareBackend,
+  registry.Register({"software", MakeSoftwareDisplay, MakeSoftwareBackend,
 #if BUILD_SOFTWARE_SINK_DRM
                      SoftwareListModes});
 #else

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -278,7 +278,10 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
   // drm_display (resolved above) owns the process-wide libseat session — it may
   // be null when no seat backend is available, in which case DrmBackend takes
   // the legacy direct-open path.
-  m_backend = DrmBackend::Create(cfg, drm_display->session());
+  // The device-context (DrmDisplay) owns the card open + master; every backend
+  // scanning out to this card shares it. Acquired lazily here on first use.
+  m_backend = DrmBackend::Create(cfg, drm_display->session(),
+                                 drm_display->SharedDevice());
 
   // DrmBackend::Create returns nullptr on any init failure (libseat
   // take_device, drmSetMaster, no usable connector, GBM/EGL setup,

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -29,6 +29,7 @@
 #include "config/common.h"
 #include "configuration/configuration.h"
 #include "display/idisplay.h"
+#include "display/output_manager.h"
 #include "logging/logging.h"
 
 // Independent guards so several backends can be compiled into one binary. The
@@ -246,8 +247,14 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
   // Treat empty TOML/env/CLI string as "unset" — operator-friendly:
   // `drm_connector = ""` in TOML shouldn't force a strict empty-name
   // match against zero connectors.
-  if (config.view.drm_connector.has_value() &&
-      !config.view.drm_connector->empty()) {
+  // [view.output] (validated against the card's live connectors via the output
+  // provider) selects the connector; fall back to the raw [view.backend.drm]
+  // connector when no [view.output] match applies.
+  if (auto resolved = homescreen::OutputManager::ResolveForView(
+          config, display, homescreen::BackendFamily::kDrm)) {
+    cfg.connector_name = std::move(resolved);
+  } else if (config.view.drm_connector.has_value() &&
+             !config.view.drm_connector->empty()) {
     cfg.connector_name = config.view.drm_connector;
   }
   if (config.view.drm_mode.has_value() && !config.view.drm_mode->empty()) {

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -478,11 +478,10 @@ static bool WaylandSessionAvailable() {
   return std::filesystem::exists(std::filesystem::path(xdg) / sock, ec);
 }
 
-static std::string ResolveActiveKey(
-    const backend::BackendRegistry& reg,
-    const std::vector<Configuration::Config>& configs) {
+std::string ResolveKeyForConfig(const backend::BackendRegistry& reg,
+                                const Configuration::Config& config) {
   const auto keys = reg.Keys();
-  std::string hint = configs[0].view.backend.value_or("");
+  std::string hint = config.view.backend.value_or("");
 
   // An exact registry key (the bundle's [view] backend, or --backend) selects
   // that backend directly -- the primary runtime-selection path.
@@ -562,7 +561,7 @@ bool EnsureActiveBackend(backend::BackendRegistry& registry,
   if (registry.Keys().empty()) {
     RegisterCompiledBackends(registry);
   }
-  const std::string key = ResolveActiveKey(registry, configs);
+  const std::string key = ResolveKeyForConfig(registry, configs[0]);
   const backend::BackendDescriptor* active = registry.Resolve(key);
   if (active == nullptr) {
     std::string available;
@@ -577,22 +576,11 @@ bool EnsureActiveBackend(backend::BackendRegistry& registry,
     return false;
   }
 
-  // One process drives one backend (a single display) today, so the active
-  // backend comes from the first bundle. Per-bundle backend selection isn't
-  // independently honored yet -- warn if a later bundle asks for a different,
-  // valid backend so the ignored request isn't silent.
-  for (size_t i = 1; i < configs.size(); ++i) {
-    const auto& want = configs[i].view.backend;
-    if (want.has_value() && !want->empty() && *want != key &&
-        registry.Resolve(*want) != nullptr) {
-      spdlog::warn(
-          "[backend] bundle {} requests backend '{}', but the process uses "
-          "'{}' "
-          "(per-bundle backend selection is not yet supported)",
-          i, *want, key);
-    }
-  }
-
+  // The "active" backend is the process-wide default: it backs the first
+  // bundle and answers process-level queries (e.g. --drm-list-modes). Each view
+  // independently resolves its own backend via ResolveKeyForConfig when its
+  // display and Backend are built, so a later bundle naming a different backend
+  // is honored rather than coerced onto this one.
   registry.SetActive(active);
   return true;
 }

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -281,7 +281,7 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
   // The device-context (DrmDisplay) owns the card open + master; every backend
   // scanning out to this card shares it. Acquired lazily here on first use.
   m_backend = DrmBackend::Create(cfg, drm_display->session(),
-                                 drm_display->SharedDevice());
+                                 drm_display->SharedDevice(), drm_display);
 
   // DrmBackend::Create returns nullptr on any init failure (libseat
   // take_device, drmSetMaster, no usable connector, GBM/EGL setup,

--- a/shell/backend/register_backends.h
+++ b/shell/backend/register_backends.h
@@ -35,3 +35,15 @@ void RegisterCompiledBackends(backend::BackendRegistry& registry);
 [[nodiscard]] bool EnsureActiveBackend(
     backend::BackendRegistry& registry,
     const std::vector<Configuration::Config>& configs);
+
+// Resolves the backend registry key for a single view @p config: an exact
+// [view] backend / --backend key when it names a compiled-in backend, else the
+// sole compiled backend, else an environment heuristic (a live Wayland session
+// -> wayland-*, otherwise KMS-direct -> drm-kms-* / software), honoring the
+// legacy egl/vulkan renderer hint within the chosen family. Returns an empty
+// string when nothing resolves. This is the per-view counterpart to the
+// process-wide active backend: App uses it to place each view on the right
+// device-context display, and FlutterView to build that view's Backend.
+[[nodiscard]] std::string ResolveKeyForConfig(
+    const backend::BackendRegistry& registry,
+    const Configuration::Config& config);

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -149,6 +149,13 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
     instance.view.fullscreen = v->at_path("fullscreen").value<bool>().value();
   }
 
+  // [view.engine] — engine threading knobs. merge_render_platform runs the
+  // raster thread on the platform thread (one task-runner identifier for both).
+  if (v->at_path("engine.merge_render_platform").is_boolean()) {
+    instance.view.merge_render_platform =
+        v->at_path("engine.merge_render_platform").value<bool>().value();
+  }
+
   // [view.shell] — shell selector + shell-specific knobs (AGL window role /
   // activation area; ivi surface id).
   if (v->at_path("shell.type").is_string()) {

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -57,6 +57,13 @@ class Configuration {
       std::optional<uint32_t> ivi_surface_id;
       std::optional<std::string> drm_device;
 
+      // [view.engine] merge_render_platform: run the engine's raster thread on
+      // the platform thread (one FlutterCustomTaskRunners identifier for both).
+      // Gives native/Dart-FFI code single-thread aliasing; the present path
+      // must be merge-agnostic (non-blocking on the platform thread). Off by
+      // default.
+      std::optional<bool> merge_render_platform;
+
       // DRM backend knobs — all strings so Configuration stays decoupled
       // from the DRM headers. Valid values:
       //   drm_connector             : "<TypeName>-<id>" (e.g. "eDP-1",

--- a/shell/display/drm_device_resolver.cc
+++ b/shell/display/drm_device_resolver.cc
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "display/drm_device_resolver.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <system_error>
+#include <vector>
+
+#include <drm_mode.h>  // DRM_MODE_CONNECTOR_VIRTUAL
+
+#include <drm-cxx/core/device.hpp>
+#include <drm-cxx/display/mode_list.hpp>
+
+#include "logging/logging.h"
+
+namespace homescreen {
+namespace {
+
+// A probed card node and what it exposes, retained for the failure diagnostic.
+struct CardProbe {
+  std::string path;
+  bool has_connected_real = false;  // a connected, non-virtual connector
+  std::string summary;              // "DP-1(connected) HDMI-A-1(disconnected)"
+};
+
+CardProbe ProbeCard(const std::string& path) {
+  CardProbe probe;
+  probe.path = path;
+
+  auto dev = drm::Device::open(path);
+  if (!dev) {
+    probe.summary = "open failed: " + dev.error().message();
+    return probe;
+  }
+  auto connectors = drm::display::query_connector_modes(*dev);
+  if (!connectors) {
+    probe.summary = "query failed: " + connectors.error().message();
+    return probe;
+  }
+
+  std::string summary;
+  for (const auto& connector : *connectors) {
+    const bool is_virtual =
+        connector.connector_type == DRM_MODE_CONNECTOR_VIRTUAL;
+    if (connector.connected && !is_virtual) {
+      probe.has_connected_real = true;
+    }
+    if (!summary.empty()) {
+      summary += ' ';
+    }
+    summary += connector.name();
+    summary += connector.connected ? "(connected)" : "(disconnected)";
+  }
+  probe.summary = summary.empty() ? "no connectors" : summary;
+  return probe;
+}
+
+// The /dev/dri/cardN primary nodes that exist, sorted. Excludes renderD*/
+// controlD* (no KMS) -- only "card" + digits.
+std::vector<std::string> ListCardNodes() {
+  std::vector<std::string> cards;
+  std::error_code ec;
+  const std::filesystem::path dri{"/dev/dri"};
+  for (std::filesystem::directory_iterator it{dri, ec}, end; !ec && it != end;
+       it.increment(ec)) {
+    const std::string name = it->path().filename().string();
+    if (name.size() > 4 && name.rfind("card", 0) == 0 &&
+        name.find_first_not_of("0123456789", 4) == std::string::npos) {
+      cards.push_back(it->path().string());
+    }
+  }
+  std::sort(cards.begin(), cards.end());
+  return cards;
+}
+
+}  // namespace
+
+std::optional<std::string> ResolveDrmDevice(
+    const std::optional<std::string>& explicit_device) {
+  // 1. Explicit selection wins, verbatim -- no probing.
+  if (explicit_device.has_value() && !explicit_device->empty()) {
+    return *explicit_device;
+  }
+
+  // 2. Look at the card nodes that actually exist (never assume card0/card1).
+  const std::vector<std::string> cards = ListCardNodes();
+  if (cards.empty()) {
+    spdlog::critical("[drm] no /dev/dri/card* node present");
+    return std::nullopt;
+  }
+
+  // 3. A single card is the only choice -- single-GPU systems (whatever the
+  //    number) and headless vkms/CI.
+  if (cards.size() == 1) {
+    spdlog::info("[drm] auto-selected the only DRM card present: {}",
+                 cards.front());
+    return cards.front();
+  }
+
+  // 4. Several cards: the first with a connected, non-virtual display, so a
+  //    headless vkms/Virtual node never shadows the real GPU.
+  std::vector<CardProbe> probes;
+  probes.reserve(cards.size());
+  for (const auto& card : cards) {
+    probes.push_back(ProbeCard(card));
+  }
+  for (const auto& probe : probes) {
+    if (probe.has_connected_real) {
+      spdlog::info(
+          "[drm] auto-selected first card with a connected display: {} ({}) -- "
+          "set [view.backend.drm] device / --drm-device to override",
+          probe.path, probe.summary);
+      return probe.path;
+    }
+  }
+
+  // 5. Ambiguous: several cards, none with a connected display. Refuse and
+  //    print the map rather than guess into a black screen.
+  spdlog::critical(
+      "[drm] {} DRM cards present, none with a connected display; select one "
+      "explicitly via --drm-device / [view.backend.drm] device:",
+      cards.size());
+  for (const auto& probe : probes) {
+    spdlog::critical("[drm]   {}: {}", probe.path, probe.summary);
+  }
+  return std::nullopt;
+}
+
+}  // namespace homescreen

--- a/shell/display/drm_device_resolver.h
+++ b/shell/display/drm_device_resolver.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace homescreen {
+
+// Resolve which DRM card to scan out to / enumerate. The card numbering is not
+// stable across systems or boots -- a single-GPU machine may expose only
+// /dev/dri/card0 or only /dev/dri/card1 -- so a fixed default is wrong; this
+// looks at the nodes that actually exist. Precedence:
+//   1. An explicit, non-empty @p explicit_device (TOML / CLI) is returned
+//      verbatim -- the operator's choice is never second-guessed.
+//   2. Exactly one card node present -> that card (the unambiguous single-GPU
+//      and headless-vkms cases), whatever its number, real or virtual.
+//   3. Several cards -> the first with a connected, non-virtual connector, so a
+//      headless vkms/Virtual node never shadows the real GPU.
+//   4. Otherwise (several cards, none with a connected display) -> nullopt,
+//      after logging each card and its connectors. The resolver refuses to
+//      guess into a black screen; the caller fail-fasts and the operator
+//      selects explicitly.
+// The choice and the reasoning are always logged.
+[[nodiscard]] std::optional<std::string> ResolveDrmDevice(
+    const std::optional<std::string>& explicit_device);
+
+}  // namespace homescreen

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -17,6 +17,7 @@
 #include "display/drm_display.h"
 #include "logging/logging.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstring>
 #include <optional>
@@ -360,6 +361,21 @@ void DrmDisplay::StopFlipReader() {
   }
   flip_ioc_.reset();
   flip_reader_running_ = false;
+}
+
+void DrmDisplay::ReservePlanes(const std::vector<uint32_t>& planes) {
+  const std::lock_guard<std::mutex> lock(reserved_planes_mu_);
+  for (const uint32_t id : planes) {
+    if (std::find(reserved_planes_.begin(), reserved_planes_.end(), id) ==
+        reserved_planes_.end()) {
+      reserved_planes_.push_back(id);
+    }
+  }
+}
+
+std::vector<uint32_t> DrmDisplay::ReservedPlanes() const {
+  const std::lock_guard<std::mutex> lock(reserved_planes_mu_);
+  return reserved_planes_;
 }
 
 void DrmDisplay::StartEvents() {

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -60,10 +60,13 @@ drm::input::InputDeviceOpener OpenerFrom(homescreen::DrmSession* session) {
 DrmDisplay::DrmDisplay(int32_t width,
                        int32_t height,
                        double refresh_rate_hz,
+                       std::string device_path,
                        bool no_seat)
     : width_(width),
       height_(height),
       refresh_rate_hz_(refresh_rate_hz),
+      device_path_(std::move(device_path)),
+      output_provider_(device_path_),
       session_(OpenSessionOrLog(no_seat)),
       seat_(std::make_unique<homescreen::DrmSeat>(width,
                                                   height,

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -17,8 +17,19 @@
 #include "display/drm_display.h"
 #include "logging/logging.h"
 
+#include <cerrno>
 #include <cstring>
+#include <optional>
 #include <utility>
+
+#include <fcntl.h>
+#include <linux/vt.h>
+#include <sys/ioctl.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+#include <xf86drm.h>
+
+#include <drm-cxx/core/device.hpp>
 
 #include "backend/drm_kms_egl/drm_session.h"
 #include "cursor_kind.h"
@@ -55,6 +66,97 @@ drm::input::InputDeviceOpener OpenerFrom(homescreen::DrmSession* session) {
   return session->InputOpener();
 }
 
+// Refuse to run unless our controlling terminal is the *foreground* VT on
+// the kernel console. Rationale: drmSetMaster can succeed from a non-
+// foreground VT (e.g. a terminal emulator, SSH, or an inactive text VT)
+// when no compositor currently holds master, but the GPU keeps scanning
+// out whatever the foreground VT owns. Atomic commits get silently
+// accepted and no PAGE_FLIP_EVENT ever fires, so PresentLayers stalls on
+// the next flip wait — the "master-acquired but black screen" pathology
+// we kept hitting. Fail fast with an actionable message instead.
+//
+// Returns true if it's safe to proceed, false with a logged error if not.
+// A missing /dev/tty0 (container / headless service) is not fatal —
+// those cases are outside the scope of this check.
+bool VerifyForegroundVt(const std::string& drm_device) {
+  const int tty0 = ::open("/dev/tty0", O_RDONLY | O_CLOEXEC);
+  if (tty0 < 0) {
+    spdlog::warn(
+        "[DrmDisplay] open(/dev/tty0): {} — skipping foreground-VT check",
+        std::strerror(errno));
+    return true;
+  }
+  struct vt_stat vtstat{};
+  const bool got_state = ::ioctl(tty0, VT_GETSTATE, &vtstat) == 0;
+  const int vt_errno = errno;
+  ::close(tty0);
+  if (!got_state) {
+    spdlog::warn("[DrmDisplay] VT_GETSTATE: {} — skipping foreground-VT check",
+                 std::strerror(vt_errno));
+    return true;
+  }
+  const unsigned int active_vt = vtstat.v_active;
+
+  // open("/dev/tty") redirects to the process's controlling terminal, so
+  // calling open() against the special inode is the only way to acquire
+  // an fd that *targets* the ctty rather than the /dev/tty special device
+  // itself. ENXIO from open() means the process has no ctty at all (e.g.
+  // a daemon without setsid + TIOCSCTTY).
+  const int ctl_fd = ::open("/dev/tty", O_RDONLY | O_CLOEXEC | O_NOCTTY);
+  if (ctl_fd < 0) {
+    spdlog::error(
+        "[DrmDisplay] no controlling terminal (open /dev/tty: {}). Cannot "
+        "drive {} without a foreground VT — switch to the active console "
+        "(tty{}) and rerun.",
+        std::strerror(errno), drm_device, active_vt);
+    return false;
+  }
+  // fstat() of the resulting fd does NOT return the underlying tty's
+  // device numbers — it returns /dev/tty's own (5, 0) inode metadata on
+  // every Linux kernel from 4.x onward. TIOCGDEV is the canonical ioctl
+  // for retrieving the actual tty device number from a /dev/tty fd;
+  // available since Linux 2.6.18.
+  unsigned int dev = 0;
+  const int ioctl_rc = ::ioctl(ctl_fd, TIOCGDEV, &dev);
+  const int ioctl_errno = errno;
+  ::close(ctl_fd);
+  if (ioctl_rc != 0) {
+    spdlog::error(
+        "[DrmDisplay] TIOCGDEV(/dev/tty): {}. Cannot drive {} without "
+        "a foreground VT — switch to the active console (tty{}) and rerun.",
+        std::strerror(ioctl_errno), drm_device, active_vt);
+    return false;
+  }
+
+  // TTY_MAJOR is 4 on Linux; /dev/ttyN lives at (4, N). Terminal emulators
+  // and SSH sessions give /dev/tty a pts major (136+), which is precisely
+  // the case we want to refuse.
+  constexpr unsigned int kTtyMajor = 4;
+  const unsigned int ctl_major = major(static_cast<dev_t>(dev));
+  const unsigned int ctl_minor = minor(static_cast<dev_t>(dev));
+  if (ctl_major != kTtyMajor) {
+    spdlog::error(
+        "[DrmDisplay] controlling terminal is not a kernel VT "
+        "(major={}, minor={}) — you're running from a terminal emulator or "
+        "SSH. Active VT is tty{}. Switch to tty{} (Ctrl+Alt+F{}) and rerun, "
+        "or `sudo systemctl isolate multi-user.target` first. Refusing to "
+        "drive {}.",
+        ctl_major, ctl_minor, active_vt, active_vt, active_vt, drm_device);
+    return false;
+  }
+  if (ctl_minor != active_vt) {
+    spdlog::error(
+        "[DrmDisplay] controlling VT is tty{} but foreground VT is tty{} — "
+        "scanout goes to the foreground. Switch to tty{} (Ctrl+Alt+F{}) and "
+        "rerun. Refusing to drive {}.",
+        ctl_minor, active_vt, ctl_minor, ctl_minor, drm_device);
+    return false;
+  }
+  spdlog::info("[DrmDisplay] foreground VT check: on tty{} (active)",
+               active_vt);
+  return true;
+}
+
 }  // namespace
 
 DrmDisplay::DrmDisplay(int32_t width,
@@ -66,6 +168,7 @@ DrmDisplay::DrmDisplay(int32_t width,
       height_(height),
       refresh_rate_hz_(refresh_rate_hz),
       device_path_(std::move(device_path)),
+      no_seat_(no_seat),
       output_provider_(device_path_),
       session_(OpenSessionOrLog(no_seat)),
       seat_(std::make_unique<homescreen::DrmSeat>(width,
@@ -100,7 +203,80 @@ DrmDisplay::DrmDisplay(int32_t width,
   }
 }
 
-DrmDisplay::~DrmDisplay() = default;
+DrmDisplay::~DrmDisplay() {
+  // Drop master (and let drm_dev_'s destructor close the fd) once the backends
+  // that scanned out through it are gone. This display is shared and destroyed
+  // after them, so master is released last -- whoever takes over next (fbcon,
+  // a getty, the next compositor) inherits a clean device.
+  if (drm_master_ && drm_dev_.has_value()) {
+    drmDropMaster(drm_dev_->fd());
+    drm_master_ = false;
+  }
+}
+
+drm::Device* DrmDisplay::SharedDevice() {
+  if (drm_dev_.has_value()) {
+    return &*drm_dev_;
+  }
+
+  if (session_ != nullptr) {
+    // libseat path: the seat provider (logind/seatd/builtin) owns VT
+    // activation and master handoff; TakeDevice returns a master-capable fd
+    // while we hold the seat. No drmSetMaster, no foreground-VT guard.
+    const int fd = session_->TakeDevice(device_path_);
+    if (fd < 0) {
+      spdlog::error("[DrmDisplay] session take_device({}): failed",
+                    device_path_);
+      return nullptr;
+    }
+    drm_dev_.emplace(drm::Device::from_fd(fd));
+    spdlog::info("[DrmDisplay] opened {} via libseat (fd={})", device_path_,
+                 fd);
+  } else {
+    // Fallback path: no seat backend (or --drm-no-seat). Refuse up-front if we
+    // are not on the active VT, then open + take master directly.
+    if (no_seat_) {
+      spdlog::warn(
+          "[DrmDisplay] --drm-no-seat: skipping the foreground-VT guard on "
+          "{}. If the screen stays black, another DRM master holds the device "
+          "or scanout is owned by a different VT.",
+          device_path_);
+    } else if (!VerifyForegroundVt(device_path_)) {
+      return nullptr;
+    }
+
+    auto dev = drm::Device::open(device_path_);
+    if (!dev) {
+      spdlog::error("[DrmDisplay] open({}): {}", device_path_,
+                    dev.error().message());
+      return nullptr;
+    }
+    drm_dev_.emplace(std::move(*dev));
+
+    // Atomic writes from a non-master fd are silently accepted by some drivers
+    // (amdgpu) as no-ops, which presents as a blank panel with no
+    // PAGE_FLIP_EVENT. Refuse to run without master.
+    if (drmSetMaster(drm_dev_->fd()) != 0) {
+      if (const int err = errno;
+          err == EBUSY || err == EACCES || err == EPERM) {
+        spdlog::error(
+            "[DrmDisplay] cannot acquire DRM master on {} ({}). Another "
+            "display server (gdm / gnome-shell / sddm / Xorg / a Wayland "
+            "compositor) is already holding the device. Stop it or run from a "
+            "bare TTY (e.g. `sudo systemctl isolate multi-user.target`).",
+            device_path_, std::strerror(err));
+      } else {
+        spdlog::error("[DrmDisplay] drmSetMaster({}): {}", device_path_,
+                      std::strerror(err));
+      }
+      drm_dev_.reset();
+      return nullptr;
+    }
+    drm_master_ = true;
+    spdlog::info("[DrmDisplay] DRM master on {}", device_path_);
+  }
+  return &*drm_dev_;
+}
 
 void DrmDisplay::StartEvents() {
   if (seat_) {

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -24,12 +24,16 @@
 
 #include <fcntl.h>
 #include <linux/vt.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/sysmacros.h>
 #include <unistd.h>
 #include <xf86drm.h>
+#include <xf86drmMode.h>
 
 #include <drm-cxx/core/device.hpp>
+
+#include "asio/error.hpp"
 
 #include "backend/drm_kms_egl/drm_session.h"
 #include "cursor_kind.h"
@@ -204,6 +208,9 @@ DrmDisplay::DrmDisplay(int32_t width,
 }
 
 DrmDisplay::~DrmDisplay() {
+  // Stop the per-card flip reader first -- it runs its own thread and holds the
+  // fd via flip_descriptor_, so it must be torn down before the fd is closed.
+  StopFlipReader();
   // Drop master (and let drm_dev_'s destructor close the fd) once the backends
   // that scanned out through it are gone. This display is shared and destroyed
   // after them, so master is released last -- whoever takes over next (fbcon,
@@ -276,6 +283,83 @@ drm::Device* DrmDisplay::SharedDevice() {
     spdlog::info("[DrmDisplay] DRM master on {}", device_path_);
   }
   return &*drm_dev_;
+}
+
+void DrmDisplay::SetFlipHandler(PageFlipHandler handler) {
+  flip_handler_ = handler;
+}
+
+void DrmDisplay::StartFlipReader() {
+  if (flip_reader_running_ || !drm_dev_.has_value() ||
+      flip_handler_ == nullptr) {
+    return;
+  }
+  flip_ioc_ = std::make_unique<asio::io_context>(ASIO_CONCURRENCY_HINT_1);
+  flip_work_.emplace(asio::make_work_guard(*flip_ioc_));
+  flip_descriptor_.emplace(*flip_ioc_);
+  // assign() makes asio own the fd; StopFlipReader releases it before reset so
+  // drm_dev_ (the fd owner) is not double-closed.
+  flip_descriptor_->assign(drm_dev_->fd());
+  ArmFlipRead();
+  flip_thread_ = std::thread([this]() { flip_ioc_->run(); });
+  flip_reader_running_ = true;
+  spdlog::info("[DrmDisplay] flip reader started on fd={}", drm_dev_->fd());
+}
+
+void DrmDisplay::ArmFlipRead() {
+  if (!flip_descriptor_.has_value()) {
+    return;
+  }
+  flip_descriptor_->async_wait(
+      asio::posix::stream_descriptor::wait_read,
+      [this](const std::error_code& ec) {
+        if (ec) {
+          // operation_aborted fires on cancel() at teardown -- quiet path.
+          if (ec != asio::error::operation_aborted) {
+            spdlog::warn("[DrmDisplay] flip reader wait: {}", ec.message());
+          }
+          return;
+        }
+        DrainFlip();
+        ArmFlipRead();  // re-arm for the next vblank
+      });
+}
+
+void DrmDisplay::DrainFlip() {
+  if (!drm_dev_.has_value() || flip_handler_ == nullptr) {
+    return;
+  }
+  // Single reader thread, so no lock: poll(0) then read only if readable. The
+  // handler (user_data == the committing DrmBackend*) routes each flip to its
+  // backend, clears that backend's flip_pending_, and returns its vsync baton.
+  pollfd pfd{drm_dev_->fd(), POLLIN, 0};
+  if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN)) {
+    drmEventContext ctx{};
+    ctx.version = 2;
+    ctx.page_flip_handler = flip_handler_;
+    drmHandleEvent(drm_dev_->fd(), &ctx);
+  }
+}
+
+void DrmDisplay::StopFlipReader() {
+  if (!flip_reader_running_) {
+    return;
+  }
+  if (flip_descriptor_.has_value()) {
+    std::error_code ec;
+    flip_descriptor_->cancel(ec);       // wake the reader out of epoll_wait
+    (void)flip_descriptor_->release();  // detach the fd; drm_dev_ closes it
+    flip_descriptor_.reset();
+  }
+  flip_work_.reset();  // drop the work guard so run() can return
+  if (flip_ioc_) {
+    flip_ioc_->stop();
+  }
+  if (flip_thread_.joinable()) {
+    flip_thread_.join();
+  }
+  flip_ioc_.reset();
+  flip_reader_running_ = false;
 }
 
 void DrmDisplay::StartEvents() {

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
@@ -90,6 +92,13 @@ class DrmDisplay final : public IDisplay {
   // draining flips and dispatching each to its backend off the rasterizer /
   // platform thread. Idempotent; a no-op until SharedDevice + SetFlipHandler.
   void StartFlipReader();
+
+  // Per-card plane coordination: overlay/cursor planes on a card may be valid
+  // for several CRTCs, so independent per-view backends would otherwise pick
+  // the same one and collide. A backend records the planes it owns here; the
+  // next backend on the card excludes them from its own selection.
+  void ReservePlanes(const std::vector<uint32_t>& planes);
+  [[nodiscard]] std::vector<uint32_t> ReservedPlanes() const;
 
   void StartEvents() override;
   void StopEvents() override;
@@ -215,4 +224,10 @@ class DrmDisplay final : public IDisplay {
   std::optional<asio::posix::stream_descriptor> flip_descriptor_;
   std::thread flip_thread_;
   bool flip_reader_running_ = false;
+
+  // Planes claimed by the backends on this card (see ReservePlanes). Guarded
+  // because ReservePlanes/ReservedPlanes could be called from per-view setup
+  // paths on different threads.
+  mutable std::mutex reserved_planes_mu_;
+  std::vector<uint32_t> reserved_planes_;
 };

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -17,8 +17,11 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
+
+#include <drm-cxx/core/device.hpp>
 
 #include "display/drm_output_provider.h"
 #include "display/idisplay.h"
@@ -54,6 +57,15 @@ class DrmDisplay final : public IDisplay {
   [[nodiscard]] homescreen::DrmSession* session() const {
     return session_.get();
   }
+
+  // The card opened once and held master, shared by every backend that scans
+  // out to this device (the device-context owns the master, not the per-view
+  // backend). Acquired lazily on the first call: via the libseat session when
+  // present, else a direct open + drmSetMaster behind the foreground-VT guard
+  // (unless --drm-no-seat). Returns null when the card could not be opened or
+  // master could not be taken (the caller fail-fasts). The pointee outlives the
+  // backends (this display is shared and destroyed after them).
+  [[nodiscard]] drm::Device* SharedDevice();
 
   void StartEvents() override;
   void StopEvents() override;
@@ -134,6 +146,10 @@ class DrmDisplay final : public IDisplay {
   // so it can seed it.
   std::string device_path_;
 
+  // --drm-no-seat: skip the foreground-VT guard on the direct-open path when
+  // SharedDevice() falls back (no libseat session).
+  bool no_seat_;
+
   // Enumerates this card's connectors as outputs (libdrm only, no master).
   homescreen::DrmOutputProvider output_provider_;
 
@@ -150,4 +166,10 @@ class DrmDisplay final : public IDisplay {
   // is there so a Wayland-client + DRM-rendering configuration can swap in
   // a WaylandSeat without changing this class.
   std::unique_ptr<homescreen::ISeat> seat_;
+
+  // The shared card + master (see SharedDevice). Declared last so it is
+  // destroyed first -- master is dropped and the fd closed before the seat and
+  // session tear down. drm::Device is RAII (closes the fd on destruction).
+  std::optional<drm::Device> drm_dev_{};
+  bool drm_master_ = false;  // true after this display took master on drm_dev_
 };

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -19,9 +19,14 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <drm-cxx/core/device.hpp>
+
+#include "asio/executor_work_guard.hpp"
+#include "asio/io_context.hpp"
+#include "asio/posix/stream_descriptor.hpp"
 
 #include "display/drm_output_provider.h"
 #include "display/idisplay.h"
@@ -66,6 +71,25 @@ class DrmDisplay final : public IDisplay {
   // master could not be taken (the caller fail-fasts). The pointee outlives the
   // backends (this display is shared and destroyed after them).
   [[nodiscard]] drm::Device* SharedDevice();
+
+  // drmModeEventContext.page_flip_handler signature. Each backend registers its
+  // dispatcher (DrmBackend::UnifiedPageFlipHandler) here; user_data carries the
+  // committing backend, so a single reader on the shared fd routes every flip.
+  using PageFlipHandler = void (*)(int fd,
+                                   unsigned int sequence,
+                                   unsigned int tv_sec,
+                                   unsigned int tv_usec,
+                                   void* user_data);
+
+  // Register the flip dispatcher (idempotent; all backends on a card share one
+  // dispatcher that routes by user_data). Must be set before StartFlipReader.
+  void SetFlipHandler(PageFlipHandler handler);
+
+  // Start the per-card PAGE_FLIP_EVENT reader: a dedicated thread + io_context
+  // that is the single reader of the shared fd (DRM's one-reader-per-fd rule),
+  // draining flips and dispatching each to its backend off the rasterizer /
+  // platform thread. Idempotent; a no-op until SharedDevice + SetFlipHandler.
+  void StartFlipReader();
 
   void StartEvents() override;
   void StopEvents() override;
@@ -167,9 +191,28 @@ class DrmDisplay final : public IDisplay {
   // a WaylandSeat without changing this class.
   std::unique_ptr<homescreen::ISeat> seat_;
 
+  // Arm the async_wait for the next PAGE_FLIP_EVENT; re-armed after every
+  // drain.
+  void ArmFlipRead();
+  // Drain readable flip events on the reader thread (poll(0)+drmHandleEvent).
+  void DrainFlip();
+  // Stop + join the reader thread and detach the fd (drm_dev_ still owns it).
+  void StopFlipReader();
+
   // The shared card + master (see SharedDevice). Declared last so it is
   // destroyed first -- master is dropped and the fd closed before the seat and
   // session tear down. drm::Device is RAII (closes the fd on destruction).
   std::optional<drm::Device> drm_dev_{};
   bool drm_master_ = false;  // true after this display took master on drm_dev_
+
+  // Per-card PAGE_FLIP_EVENT reader. Its own thread + io_context so it is the
+  // single reader of drm_dev_'s fd. flip_descriptor_ wraps the shared fd and is
+  // released (not closed) on teardown -- drm_dev_ owns the fd.
+  PageFlipHandler flip_handler_ = nullptr;
+  std::unique_ptr<asio::io_context> flip_ioc_;
+  std::optional<asio::executor_work_guard<asio::io_context::executor_type>>
+      flip_work_;
+  std::optional<asio::posix::stream_descriptor> flip_descriptor_;
+  std::thread flip_thread_;
+  bool flip_reader_running_ = false;
 };

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "display/drm_output_provider.h"
 #include "display/idisplay.h"
 #include "input/iseat.h"
 
@@ -32,12 +33,15 @@ class DrmSession;
 
 class DrmDisplay final : public IDisplay {
  public:
+  // @p device_path is the card this display's outputs are enumerated from (its
+  // master domain); it is the same card the backend scans out to.
   // @p no_seat (--drm-no-seat / HOMESCREEN_DRM_NO_SEAT) skips opening a
   // libseat session entirely, forcing the backend's direct-open path. See
   // session().
   DrmDisplay(int32_t width,
              int32_t height,
              double refresh_rate_hz,
+             std::string device_path,
              bool no_seat = false);
   ~DrmDisplay() override;
 
@@ -110,11 +114,28 @@ class DrmDisplay final : public IDisplay {
 
   [[nodiscard]] bool HasRepeatTimer() const override { return false; }
 
+  // The card's connectors, enumerated as outputs (the master domain's output
+  // set). Always non-null for a DRM display.
+  [[nodiscard]] homescreen::IOutputProvider* GetOutputProvider() override {
+    return &output_provider_;
+  }
+
+  // The resolved card this display owns. The backend reads it from here so the
+  // display and its backend always scan out to / enumerate the same device.
+  [[nodiscard]] const std::string& device_path() const { return device_path_; }
+
  private:
   int32_t width_;
   int32_t height_;
   double refresh_rate_hz_;
   FlutterDesktopViewControllerState* view_controller_state_ = nullptr;
+
+  // The resolved card (e.g. "/dev/dri/card1"). Declared before output_provider_
+  // so it can seed it.
+  std::string device_path_;
+
+  // Enumerates this card's connectors as outputs (libdrm only, no master).
+  homescreen::DrmOutputProvider output_provider_;
 
   // Active cursor sprite retargeting sink (set by FlutterView after the
   // backend creates its cursor). Owned by DrmBackend; null when no cursor.

--- a/shell/display/drm_output_provider.cc
+++ b/shell/display/drm_output_provider.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "display/drm_output_provider.h"
+
+#include <utility>
+
+#include <drm-cxx/core/device.hpp>
+#include <drm-cxx/display/mode_list.hpp>
+
+#include "logging/logging.h"
+
+namespace homescreen {
+
+DrmOutputProvider::DrmOutputProvider(std::string device_path)
+    : device_path_(std::move(device_path)) {}
+
+std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
+  std::vector<OutputInfo> outputs;
+
+  auto dev = drm::Device::open(device_path_);
+  if (!dev) {
+    spdlog::warn("[DrmOutputProvider] open('{}'): {}", device_path_,
+                 dev.error().message());
+    return outputs;
+  }
+
+  auto connectors = drm::display::query_connector_modes(*dev);
+  if (!connectors) {
+    spdlog::warn("[DrmOutputProvider] query_connector_modes('{}'): {}",
+                 device_path_, connectors.error().message());
+    return outputs;
+  }
+
+  outputs.reserve(connectors->size());
+  for (const auto& connector : *connectors) {
+    OutputInfo info;
+    info.name = connector.name();
+    info.connected = connector.connected;
+    info.handle = connector.connector_id;
+
+    // Current extent + refresh come from the connector's preferred mode (the
+    // EDID-preferred entry, else the first advertised). EDID make/model/serial
+    // are not read here yet; name is the join key ResolveOutput uses.
+    const drm::ModeInfo* mode = nullptr;
+    for (const auto& candidate : connector.modes) {
+      if (candidate.preferred()) {
+        mode = &candidate;
+        break;
+      }
+    }
+    if (mode == nullptr && !connector.modes.empty()) {
+      mode = &connector.modes.front();
+    }
+    if (mode != nullptr) {
+      info.width_px = static_cast<int32_t>(mode->width());
+      info.height_px = static_cast<int32_t>(mode->height());
+      info.refresh_hz = static_cast<double>(mode->refresh());
+    }
+
+    outputs.push_back(std::move(info));
+  }
+  return outputs;
+}
+
+void DrmOutputProvider::SetOutputListener(IOutputListener* listener) {
+  listener_ = listener;
+}
+
+bool DrmOutputProvider::SupportsHotplug() const {
+  // DRM connectors hotplug, but the udev monitor that would diff the connector
+  // set and drive the listener is not wired here yet -- so outputs are
+  // enumerated on demand and no change callbacks are delivered. This reports
+  // that honestly (per the method contract) until the monitor lands.
+  return false;
+}
+
+}  // namespace homescreen

--- a/shell/display/drm_output_provider.h
+++ b/shell/display/drm_output_provider.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "display/output_provider.h"
+
+namespace homescreen {
+
+// IOutputProvider for a DRM card: enumerates the card's connectors as outputs.
+// The card is a master domain exactly like a Wayland compositor connection --
+// one device, N connectors -- so this is the DRM counterpart of the Wayland
+// provider on Display. Enumeration uses libdrm only (no DRM master, no GL/GBM),
+// so it is safe to call before, and independently of, the backend that scans
+// out: the same connectors the kernel exposes are read directly here and
+// re-exposed to the compositor connection's wl_outputs there.
+class DrmOutputProvider final : public IOutputProvider {
+ public:
+  explicit DrmOutputProvider(std::string device_path);
+  ~DrmOutputProvider() override = default;
+
+  [[nodiscard]] std::vector<OutputInfo> EnumerateOutputs() const override;
+  void SetOutputListener(IOutputListener* listener) override;
+  [[nodiscard]] bool SupportsHotplug() const override;
+
+ private:
+  // The card this provider enumerates (e.g. "/dev/dri/card1").
+  std::string device_path_;
+
+  // Set by SetOutputListener; consumed once the hotplug monitor is wired.
+  IOutputListener* listener_ = nullptr;
+};
+
+}  // namespace homescreen

--- a/shell/display/output_manager.cc
+++ b/shell/display/output_manager.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "display/output_manager.h"
+
+#include <vector>
+
+#include "display/idisplay.h"
+#include "display/output_provider.h"
+#include "logging/logging.h"
+
+namespace homescreen {
+
+std::optional<std::string> OutputManager::ResolveForView(
+    const Configuration::Config& config,
+    IDisplay* display,
+    BackendFamily family) {
+  const OutputMatch& match = config.view.output;
+  if (match.empty()) {
+    // No [view.output] constraint: leave the backend's own default / auto-pick
+    // in place (preserves single-view behavior).
+    return std::nullopt;
+  }
+
+  IOutputProvider* provider =
+      display != nullptr ? display->GetOutputProvider() : nullptr;
+  if (provider == nullptr) {
+    spdlog::warn(
+        "[OutputManager] a view requests a specific output but its display "
+        "exposes no output provider; ignoring the request");
+    return std::nullopt;
+  }
+
+  const std::vector<OutputInfo> outputs = provider->EnumerateOutputs();
+  std::optional<std::string> name = ResolveOutput(match, outputs, family);
+  if (!name.has_value()) {
+    // The requested output is not among the connected ones. The caller keeps
+    // its default; full parking-until-present lands with the hotplug listener.
+    spdlog::warn(
+        "[OutputManager] requested output is not connected (wl_name='{}' "
+        "drm_connector='{}' serial='{}'); falling back to the default output",
+        match.wl_name.value_or("-"), match.drm_connector.value_or("-"),
+        match.edid_serial.value_or("-"));
+    return std::nullopt;
+  }
+
+  spdlog::info("[OutputManager] view bound to output '{}'", *name);
+  return name;
+}
+
+}  // namespace homescreen

--- a/shell/display/output_manager.h
+++ b/shell/display/output_manager.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "configuration/configuration.h"
+#include "display/output.h"
+
+class IDisplay;
+
+namespace homescreen {
+
+// Binds each view to a physical output by name, the same way for every backend:
+// it reads the view's display IOutputProvider, applies the [view.output]
+// OutputMatch through ResolveOutput, and hands back the connector / wl_output
+// name the backend should scan out to. The match logic and the live-output set
+// are the authority -- a Wayland compositor connection and a DRM card are both
+// "one master domain, N named outputs", so the same path drives DRM connector
+// selection and Wayland wl_output targeting.
+class OutputManager {
+ public:
+  // Resolve the output name @p config's view should bind to, from @p display's
+  // current outputs. @p family selects which OutputMatch field is compared
+  // (drm_connector for kDrm, wl_name for kWayland). Returns:
+  //   - the matched output name, when [view.output] names one that is present;
+  //   - nullopt when the view sets no [view.output] constraint (the backend's
+  //     own default / auto-pick stands) or the requested output is absent (the
+  //     caller falls back and the miss is logged).
+  // The decision is logged either way.
+  [[nodiscard]] static std::optional<std::string> ResolveForView(
+      const Configuration::Config& config,
+      IDisplay* display,
+      BackendFamily family);
+};
+
+}  // namespace homescreen

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -110,7 +110,8 @@ Engine::Engine(FlutterView* view,
                const std::vector<const char*>& command_line_args_c,
                const std::vector<const char*>& dart_entrypoint_args_c,
                const std::string& bundle_path,
-               const int32_t accessibility_features)
+               const int32_t accessibility_features,
+               const bool merge_render_platform)
     : m_index(index),
       m_running(false),
       m_backend(view->GetBackend()),
@@ -246,6 +247,24 @@ Engine::Engine(FlutterView* view,
   m_custom_task_runners.struct_size = sizeof(FlutterCustomTaskRunners);
   m_custom_task_runners.platform_task_runner =
       &m_platform_task_runner_description;
+
+  // Optionally run the raster thread on the platform thread: a render task
+  // runner whose identifier matches the platform one makes the engine collapse
+  // them (embedder_thread_host identifier equality), so the rasterizer + GL /
+  // compositor callbacks run on the platform thread. UI and IO stay separate.
+  // The present path must stay non-blocking on the platform thread for this to
+  // be safe (an independent per-card flip reader delivers completion).
+  m_merge_render_platform = merge_render_platform;
+  if (m_merge_render_platform) {
+    constexpr size_t kMergedRunnerId = 1;
+    m_platform_task_runner_description.identifier = kMergedRunnerId;
+    m_render_task_runner_description = m_platform_task_runner_description;
+    m_custom_task_runners.render_task_runner =
+        &m_render_task_runner_description;
+    spdlog::info("({}) engine: raster thread merged onto the platform thread",
+                 m_index);
+  }
+
   // Per-thread priority setter (opt-in via IVI_DRM_RT=1). See
   // EngineThreadPrioritySetter for the mapping rationale.
   m_custom_task_runners.thread_priority_setter = &EngineThreadPrioritySetter;

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -381,7 +381,12 @@ FlutterEngineResult Engine::SetWindowSize(const size_t height,
       .physical_view_inset_bottom = 0,
       .physical_view_inset_left = 0,
       .display_id = 0,  // TODO display index
-      .view_id = static_cast<int64_t>(m_index)};
+      // Each bundle is a discrete engine whose implicit view is id 0. m_index
+      // identifies the view within App, not within this engine -- sending it as
+      // view_id targeted a non-existent view on every engine past the first, so
+      // that engine never scheduled a frame. One engine driving multiple views
+      // (FlutterEngineAddView) would use the real per-view ids here.
+      .view_id = 0};
 
   if (LibFlutterEngine->SendWindowMetricsEvent(m_flutter_engine, &fwme) !=
       kSuccess) {
@@ -416,7 +421,12 @@ FlutterEngineResult Engine::SetPixelRatio(double pixel_ratio) {
       .physical_view_inset_bottom = 0,
       .physical_view_inset_left = 0,
       .display_id = 0,  // TODO display index
-      .view_id = static_cast<int64_t>(m_index)};
+      // Each bundle is a discrete engine whose implicit view is id 0. m_index
+      // identifies the view within App, not within this engine -- sending it as
+      // view_id targeted a non-existent view on every engine past the first, so
+      // that engine never scheduled a frame. One engine driving multiple views
+      // (FlutterEngineAddView) would use the real per-view ids here.
+      .view_id = 0};
 
   const auto result =
       LibFlutterEngine->SendWindowMetricsEvent(m_flutter_engine, &fwme);

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -62,7 +62,8 @@ class Engine {
          const std::vector<const char*>& command_line_args_c,
          const std::vector<const char*>& dart_entrypoint_args_c,
          const std::string& bundle_path,
-         int32_t accessibility_features);
+         int32_t accessibility_features,
+         bool merge_render_platform);
 
   ~Engine();
 
@@ -384,7 +385,15 @@ class Engine {
 
   std::shared_ptr<TaskRunner> m_platform_task_runner;
   FlutterTaskRunnerDescription m_platform_task_runner_description{};
+  // Populated + wired only when m_merge_render_platform: a copy of the platform
+  // description with the same identifier, so the engine runs raster on the
+  // platform thread. Must outlive FlutterEngineRun (custom_task_runners holds
+  // the pointer).
+  FlutterTaskRunnerDescription m_render_task_runner_description{};
   FlutterCustomTaskRunners m_custom_task_runners{};
+
+  // Run the raster thread on the platform thread (see the ctor / config).
+  bool m_merge_render_platform = false;
 
   // Zero-initialized: only assigned for AOT runs (RunsAOTCompiledDartCode()).
   // On a JIT/debug run LoadAotData() never runs, so this must be null —

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -159,20 +159,9 @@ int main(const int argc, char** argv) {
   (void)MainLoopWaker::instance();
   InstallShutdownHandlers();
 
-  // run the application — the active backend's loop mode (resolved by App)
-  // selects the reactor vs legacy dispatch.
-  int ret = 0;
-  auto& reg = backend::BackendRegistry::Instance();
-  if (reg.Active().loop_mode == backend::LoopMode::kReactor) {
-    // Reactor backends (Wayland) run their display reactor on this (main)
-    // thread; Run() blocks until the shutdown signal stops the io_context.
-    ret = app.Run();
-  } else {
-    // Legacy backends (DRM, software) spin the per-iteration loop.
-    while (running && ret != -1) {
-      ret = app.Loop();
-    }
-  }
+  // Run the application: the shared reactor drives every backend on this (main)
+  // thread and blocks until the shutdown signal stops the io_context.
+  const int ret = app.Run();
   (void)ret;
 
   gLogger.reset();

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -22,6 +22,7 @@
 
 #include "app.h"
 #include "backend/backend_registry.h"
+#include "backend/register_backends.h"
 
 // Independent guards so several backends can be compiled into one binary
 // (Backend::Create selects per view at runtime). Header guards make the
@@ -76,16 +77,24 @@ extern void SetUpCommonEngineState(FlutterDesktopEngineState* state,
                                    FlutterView* view);
 
 // The single per-view Backend factory (declared in backend/backend.h).
-// Delegates to the runtime BackendRegistry: the active descriptor's
+// Delegates to the runtime BackendRegistry: the resolved descriptor's
 // make_backend holds the concrete-backend construction + post-creation wiring
 // that used to live here as an #if/#elif chain (now in
-// backend/register_backends.cc). The active descriptor is resolved once in
-// main(), before App is constructed.
+// backend/register_backends.cc). The backend is resolved per view from its own
+// config (ResolveKeyForConfig), so each view runs the renderer its bundle asked
+// for -- matching the device-context display App placed it on.
 std::shared_ptr<Backend> Backend::Create(
     const Configuration::Config& config,
     const std::shared_ptr<IDisplay>& display) {
-  return backend::BackendRegistry::Instance().Active().make_backend(
-      config, display.get());
+  auto& registry = backend::BackendRegistry::Instance();
+  const std::string key = ResolveKeyForConfig(registry, config);
+  const backend::BackendDescriptor* descriptor = registry.Resolve(key);
+  if (descriptor == nullptr) {
+    spdlog::critical("[FlutterView] no backend resolved for view (key='{}')",
+                     key);
+    return nullptr;
+  }
+  return descriptor->make_backend(config, display.get());
 }
 
 FlutterView::FlutterView(Configuration::Config config,

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -288,7 +288,8 @@ void FlutterView::Initialize() {
   m_flutter_engine = std::make_shared<Engine>(
       this, m_index, m_command_line_args_c, m_dart_entrypoint_args_c,
       m_config.view.bundle_path,
-      m_config.view.accessibility_features.value_or(0));
+      m_config.view.accessibility_features.value_or(0),
+      m_config.view.merge_render_platform.value_or(false));
 
   m_state->engine = m_flutter_engine.get();
 


### PR DESCRIPTION
## What

Rearchitects the shell from one process-wide display/backend to **per-view displays**, and makes **multiple views render to multiple outputs on one DRM card** — two discrete Flutter engines driving two connectors, each vsync-locked at 60fps.

## The stack (bottom up)

- **Display container** — App owns N displays (one per device-context) instead of a single display.
- **Shared reactor** — every backend driven from one asio reactor; the loop-mode fork is gone.
- **Per-(backend, device) placement** — each view runs on the display for its own backend + device.
- **Output resolver + provider** — `ResolveOutput` + `IOutputProvider` (Wayland + DRM); `[view.output]` binds a view to a connector / `wl_output` by name; `OutputManager` wires view → connector.
- **Card resolver** — auto-detect the scanout card (no hardcoded `/dev/dri/card1`; respects single-GPU systems that expose only card0 or only card1).
- **Device-context owns the card** — one master per card, shared by every view; a single per-card page-flip reader thread (fixes the shared-fd drain race/hang).
- **`[view.engine] merge_render_platform`** — optionally run the raster thread on the platform thread (single-thread native/Dart-FFI aliasing).
- **Plane coordination** — co-tenant views on one card reserve distinct planes (no shared-overlay collision, no cross-disable).
- **drm-cxx bump** — IN_FORMATS modifier-read fix + EDID identity fields.

## Validated

- **Single-view: behavior-neutral** — 60fps, clean teardown (drm-kms-egl and drm-kms-vulkan).
- **Dual-display: two bundles → HDMI-A-1 + DP-1 on one amdgpu card, each vsync-locked at 60fps, no flicker — visually confirmed.**

Getting there flushed out four distinct bugs: view-1 `EBUSY` at master (→ master-up), the two-reader shared-fd hang (→ per-card reader), window metrics sent to a nonexistent `view_id` on the 2nd engine (→ implicit `view_id` 0), and an overlay-plane collision (→ plane reservation).

## Not in this PR (follow-ups)

- **Multi-display input routing** — the shared seat still binds to the last view, so the pointer lands on one display with the wrong clamp. It needs combined-space routing (pointer across displays, sprite on the display it's over, events to that view) before dual-display is fully usable. The config-driven layout foundation (`[view.output] x`/`y`) is started separately.
- **One engine → N outputs** — `SceneSet` + unified vsync + a multi-view integration test.
- Vulkan-DRM multi-view; Wayland/Vulkan `OutputManager` wiring.

## Scope

DRM-focused; Wayland and software paths are preserved and behavior-neutral. The dual-display path is drm-kms-egl on a single card.