### PR TITLE
input: per-display pointer routing on a multi-region DRM seat

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ annotated all-keys file see
 | `[view.output]` | `on_disconnect` | `string` | `suspend` | `suspend\|teardown` | all |
 | `[view.output]` | `preload` | `bool` | `false` | `true\|false` | all |
 | `[view.output]` | `serial` | `string` | `(none)` | `EDID serial` | drm |
+| `[view.output]` | `touch_device` | `string` | `(primary)` | `device-name substring` | all |
 | `[view.output]` | `wl_name` | `string` | `(none)` | `e.g. DP-1` | wayland |
 | `[view.output]` | `x` | `int` | `0` | `int (px)` | all |
 | `[view.output]` | `y` | `int` | `0` | `int (px)` | all |

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ annotated all-keys file see
 | `[view.output]` | `preload` | `bool` | `false` | `true\|false` | all |
 | `[view.output]` | `serial` | `string` | `(none)` | `EDID serial` | drm |
 | `[view.output]` | `wl_name` | `string` | `(none)` | `e.g. DP-1` | wayland |
+| `[view.output]` | `x` | `int` | `0` | `int (px)` | all |
+| `[view.output]` | `y` | `int` | `0` | `int (px)` | all |
 | `[view.engine]` | `merge_render_platform` | `bool` | `false` | `true\|false` | all |
 
 <!-- END CONFIG-REFERENCE -->

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -199,6 +199,10 @@
   # type=string default=(none) values=EDID serial applies=drm
   serial =
 
+  # Route touch from this panel (libinput device-name substring) to this view; unset sends touch to the primary view.
+  # type=string default=(primary) values=device-name substring applies=all
+  touch_device =
+
   # Wayland: match this wl_output name (overrides output.name).
   # type=string default=(none) values=e.g. DP-1 applies=wayland
   wl_name =

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -203,6 +203,14 @@
   # type=string default=(none) values=e.g. DP-1 applies=wayland
   wl_name =
 
+  # This display's X position in the combined desktop space (multi-display input layout).
+  # type=int default=0 values=int (px) applies=all
+  x =
+
+  # This display's Y position in the combined desktop space (multi-display input layout).
+  # type=int default=0 values=int (px) applies=all
+  y =
+
 [view.engine]
   # Run the engine's raster thread on the platform thread (single-thread native/Dart-FFI aliasing).
   # type=bool default=false values=true|false applies=all

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -99,6 +99,8 @@ META = {
     "output.index": ("(none)", "int", "all", "Deprecated: match the Nth connected output (prefer a name)."),
     "output.preload": ("false", "true|false", "all", "Warm the engine (suspended) at startup even if the output is absent."),
     "output.on_disconnect": ("suspend", "suspend|teardown", "all", "What to do with the view when its output disappears."),
+    "output.x": ("0", "int (px)", "all", "This display's X position in the combined desktop space (multi-display input layout)."),
+    "output.y": ("0", "int (px)", "all", "This display's Y position in the combined desktop space (multi-display input layout)."),
 
     # [view.engine] — engine threading knobs
     "engine.merge_render_platform": ("false", "true|false", "all", "Run the engine's raster thread on the platform thread (single-thread native/Dart-FFI aliasing)."),

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -101,6 +101,7 @@ META = {
     "output.on_disconnect": ("suspend", "suspend|teardown", "all", "What to do with the view when its output disappears."),
     "output.x": ("0", "int (px)", "all", "This display's X position in the combined desktop space (multi-display input layout)."),
     "output.y": ("0", "int (px)", "all", "This display's Y position in the combined desktop space (multi-display input layout)."),
+    "output.touch_device": ("(primary)", "device-name substring", "all", "Route touch from this panel (libinput device-name substring) to this view; unset sends touch to the primary view."),
 
     # [view.engine] — engine threading knobs
     "engine.merge_render_platform": ("false", "true|false", "all", "Run the engine's raster thread on the platform thread (single-thread native/Dart-FFI aliasing)."),

--- a/shell/backend/drm_kms_egl/drm_cursor.cc
+++ b/shell/backend/drm_kms_egl/drm_cursor.cc
@@ -274,6 +274,27 @@ void DrmCursor::SetStagedMode(const bool enabled) {
   impl_->staged = enabled;
 }
 
+void DrmCursor::Hide() {
+  // In staged mode the compositor drives the plane; a self-commit here would
+  // race it. Multi-display cursor coordination on staged drivers is a separate
+  // pass — no-op for now (the reported case is self-committing amdgpu).
+  if (impl_->staged) {
+    return;
+  }
+  if (auto r = impl_->renderer.hide(); !r) {
+    spdlog::warn("[DrmCursor] hide: {}", r.error().message());
+  }
+}
+
+void DrmCursor::Show() {
+  if (impl_->staged) {
+    return;
+  }
+  if (auto r = impl_->renderer.show(); !r) {
+    spdlog::warn("[DrmCursor] show: {}", r.error().message());
+  }
+}
+
 void DrmCursor::SetPosition(const int fb_x, const int fb_y) {
   if (!impl_->staged) {
     Move(fb_x, fb_y);  // legacy self-commit path (non-staging drivers)

--- a/shell/backend/drm_kms_egl/drm_cursor.h
+++ b/shell/backend/drm_kms_egl/drm_cursor.h
@@ -139,6 +139,15 @@ class DrmCursor final : public ICursorShapeSink {
   // LayerScene to accept the cursor plane in its own commit.
   void CommitPending();
 
+  // Detach / re-attach the sprite from its cursor plane without destroying
+  // state, so a multi-display seat can show exactly one cursor: hide the
+  // sprite on the display the pointer left, show it on the one it entered.
+  // Hide() commits FB_ID/CRTC_ID = 0; Show() re-commits at the last position.
+  // Both are no-ops if already in the requested state, and no-ops in staged
+  // mode (the compositor owns the plane there). Seat dispatch thread only.
+  void Hide();
+  void Show();
+
   // The DRM plane id the cursor is scanned out on (0 on the legacy
   // drmModeSetCursor path, which has no addressable plane). On a CRTC
   // with no dedicated cursor plane the renderer takes an overlay; the

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -318,6 +318,9 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
     // share the card's seat, the pointer routes to the display it is over.
     drm_display->SetRegionLayout(config.view.output.layout_x.value_or(0),
                                  config.view.output.layout_y.value_or(0));
+    if (config.view.output.touch_device.has_value()) {
+      drm_display->SetRegionTouchDevice(*config.view.output.touch_device);
+    }
     drm_display->SetCursor(drm_backend->drm_cursor());
     // Composited cursor fallback (non-null only when no HW cursor plane).
     drm_display->SetGlCursor(drm_backend->gl_cursor());
@@ -376,6 +379,9 @@ std::shared_ptr<Backend> MakeDrmVulkanBackend(
   // the card's seat, the pointer routes to the display it is over.
   drm_display->SetRegionLayout(config.view.output.layout_x.value_or(0),
                                config.view.output.layout_y.value_or(0));
+  if (config.view.output.touch_device.has_value()) {
+    drm_display->SetRegionTouchDevice(*config.view.output.touch_device);
+  }
   drm_display->SetCursor(vk_backend->drm_cursor());
   drm_display->SetCursorShapeSink(vk_backend->drm_cursor());
   drm_display->SetCursorRotation(vk_backend->rotation());

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -314,6 +314,10 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
     // clamp stuck at the config size unless we update it here.
     drm_display->SetViewportSize(static_cast<int32_t>(drm_backend->width()),
                                  static_cast<int32_t>(drm_backend->height()));
+    // Place this view in the combined pointer space so, when several views
+    // share the card's seat, the pointer routes to the display it is over.
+    drm_display->SetRegionLayout(config.view.output.layout_x.value_or(0),
+                                 config.view.output.layout_y.value_or(0));
     drm_display->SetCursor(drm_backend->drm_cursor());
     // Composited cursor fallback (non-null only when no HW cursor plane).
     drm_display->SetGlCursor(drm_backend->gl_cursor());
@@ -368,6 +372,10 @@ std::shared_ptr<Backend> MakeDrmVulkanBackend(
   // order).
   drm_display->SetViewportSize(static_cast<int32_t>(vk_backend->width()),
                                static_cast<int32_t>(vk_backend->height()));
+  // Place this view in the combined pointer space so, when several views share
+  // the card's seat, the pointer routes to the display it is over.
+  drm_display->SetRegionLayout(config.view.output.layout_x.value_or(0),
+                               config.view.output.layout_y.value_or(0));
   drm_display->SetCursor(vk_backend->drm_cursor());
   drm_display->SetCursorShapeSink(vk_backend->drm_cursor());
   drm_display->SetCursorRotation(vk_backend->rotation());

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -118,6 +118,14 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
             ? homescreen::OutputMatch::OnDisconnect::kTeardown
             : homescreen::OutputMatch::OnDisconnect::kSuspend;
   }
+  // Position of this view's display in the combined desktop space
+  // (multi-display input layout).
+  if (v->at_path("output.x").is_integer()) {
+    instance.view.output.layout_x = v->at_path("output.x").value<int32_t>();
+  }
+  if (v->at_path("output.y").is_integer()) {
+    instance.view.output.layout_y = v->at_path("output.y").value<int32_t>();
+  }
   if (v->at_path("width").is_integer()) {
     instance.view.width = v->at_path("width").value<uint32_t>().value();
   }

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -126,6 +126,11 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
   if (v->at_path("output.y").is_integer()) {
     instance.view.output.layout_y = v->at_path("output.y").value<int32_t>();
   }
+  // Touch panel bonded to this view's display (libinput device-name substring).
+  if (v->at_path("output.touch_device").is_string()) {
+    instance.view.output.touch_device =
+        v->at_path("output.touch_device").as_string()->value_or("");
+  }
   if (v->at_path("width").is_integer()) {
     instance.view.width = v->at_path("width").value<uint32_t>().value();
   }

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -445,3 +445,9 @@ void DrmDisplay::SetInputTransforms(const std::vector<std::string>& specs) {
     drm_seat->SetInputTransforms(specs);
   }
 }
+
+void DrmDisplay::SetRegionLayout(const int32_t x, const int32_t y) {
+  if (auto* drm_seat = dynamic_cast<homescreen::DrmSeat*>(seat_.get())) {
+    drm_seat->SetRegionLayout(x, y);
+  }
+}

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -451,3 +451,9 @@ void DrmDisplay::SetRegionLayout(const int32_t x, const int32_t y) {
     drm_seat->SetRegionLayout(x, y);
   }
 }
+
+void DrmDisplay::SetRegionTouchDevice(const std::string& name) {
+  if (auto* drm_seat = dynamic_cast<homescreen::DrmSeat*>(seat_.get())) {
+    drm_seat->SetRegionTouchDevice(name);
+  }
+}

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -136,6 +136,11 @@ class DrmDisplay final : public IDisplay {
   // moves between them as laid out. See DrmSeat::SetRegionLayout.
   void SetRegionLayout(int32_t x, int32_t y);
 
+  // Bind a touch panel (libinput device-name substring) to this view so its
+  // touches route here instead of the primary view. See
+  // DrmSeat::SetRegionTouchDevice.
+  void SetRegionTouchDevice(const std::string& name);
+
   // Update the seat's cursor clamping rectangle to match the actual
   // backend framebuffer size. App::MakeDisplay constructs DrmDisplay
   // with the config's view.width/height (defaults 1024x768) — but

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -130,6 +130,12 @@ class DrmDisplay final : public IDisplay {
   // ("<name>=<rot>[,flip-x][,flip-y]"; see DrmSeat::SetInputTransforms).
   void SetInputTransforms(const std::vector<std::string>& specs);
 
+  // Position this view's render surface in the combined pointer space (from
+  // [view.output] x/y). When several views share this display's seat (multiple
+  // displays on one DRM card), each declares its placement so the pointer
+  // moves between them as laid out. See DrmSeat::SetRegionLayout.
+  void SetRegionLayout(int32_t x, int32_t y);
+
   // Update the seat's cursor clamping rectangle to match the actual
   // backend framebuffer size. App::MakeDisplay constructs DrmDisplay
   // with the config's view.width/height (defaults 1024x768) — but

--- a/shell/display/output.h
+++ b/shell/display/output.h
@@ -74,6 +74,14 @@ struct OutputMatch {
   std::optional<int32_t> layout_x;
   std::optional<int32_t> layout_y;
 
+  // Touch device bonded to this view's display, matched by libinput
+  // device-name substring. A touchscreen reports absolute coordinates in its
+  // own space with no cursor, so unlike a mouse it can't be routed by pointer
+  // position -- this names which panel feeds this view. Unset routes touch to
+  // the primary view (preserving single-display behavior). Not a match field --
+  // excluded from empty().
+  std::optional<std::string> touch_device;
+
   // True when no match field is set: the bundle binds to the primary output
   // immediately (preserves single-view behavior). Layout position is not a
   // match constraint, so it does not affect this.

--- a/shell/display/output.h
+++ b/shell/display/output.h
@@ -66,8 +66,17 @@ struct OutputMatch {
   };
   OnDisconnect on_disconnect = OnDisconnect::kSuspend;
 
+  // Position of this view's display in the combined pointer/desktop space, for
+  // multi-display input routing. Unset = origin (0,0). Only meaningful when
+  // several views share one input seat (multiple displays on one card): the
+  // config declares each display's placement so the pointer moves between them
+  // as laid out. Not a match field -- excluded from empty().
+  std::optional<int32_t> layout_x;
+  std::optional<int32_t> layout_y;
+
   // True when no match field is set: the bundle binds to the primary output
-  // immediately (preserves single-view behavior).
+  // immediately (preserves single-view behavior). Layout position is not a
+  // match constraint, so it does not affect this.
   [[nodiscard]] bool empty() const {
     return !wl_name && !drm_connector && !edid_serial && !index;
   }

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -153,13 +153,12 @@ void InstallBackstop() {
 DrmSeat::DrmSeat(const int32_t viewport_width,
                  const int32_t viewport_height,
                  drm::input::InputDeviceOpener opener)
-    : viewport_w_(viewport_width),
-      viewport_h_(viewport_height),
-      opener_(std::move(opener)) {
-  // Start the pointer in the middle of the viewport so the first hover is
-  // visible before the user moves the mouse.
-  pointer_x_ = viewport_w_ / 2.0;
-  pointer_y_ = viewport_h_ / 2.0;
+    : opener_(std::move(opener)) {
+  // Seed the region-under-construction with the initial viewport. The first
+  // SetViewControllerState commits it as the primary region and centers the
+  // pointer on it.
+  pending_.width = viewport_width;
+  pending_.height = viewport_height;
 }
 
 DrmSeat::~DrmSeat() {
@@ -167,15 +166,143 @@ DrmSeat::~DrmSeat() {
 }
 
 void DrmSeat::SetViewControllerState(FlutterDesktopViewControllerState* state) {
-  state_.store(state, std::memory_order_release);
+  // A null state is the teardown clear; DRM views always register a non-null
+  // controller, so there is nothing to commit for null.
+  if (state == nullptr) {
+    return;
+  }
+  // Commit the region accumulated by the per-view setters (SetViewport,
+  // SetCursor, SetGlCursor, SetCursorRotation, SetRegionLayout) into the
+  // region set, then reset the builder for the next view. Registration runs on
+  // the main thread during view construction, before Start() spawns the
+  // dispatch thread, so no lock is needed.
+  pending_.state = state;
+  // If this region's origin collides with an existing one -- e.g. two bundles
+  // launched without explicit [view.output] x/y, so both defaulted to (0,0) --
+  // tile it to the right of the current set. Otherwise the regions would stack
+  // and only the first would ever be under the pointer. Explicit,
+  // non-overlapping layouts never collide, so they pass through untouched.
+  for (const auto& r : regions_) {
+    if (r.layout_x == pending_.layout_x && r.layout_y == pending_.layout_y) {
+      int32_t right = 0;
+      for (const auto& e : regions_) {
+        right = std::max(right, e.layout_x + e.width);
+      }
+      pending_.layout_x = right;
+      pending_.layout_y = 0;
+      break;
+    }
+  }
+  const bool first = regions_.empty();
+  regions_.push_back(pending_);
+  if (first) {
+    // Center the global pointer on the primary region so the first hover is
+    // visible before the user moves the mouse.
+    const auto& r = regions_.front();
+    pointer_x_ = r.layout_x + r.width / 2.0;
+    pointer_y_ = r.layout_y + r.height / 2.0;
+    active_region_ = 0;
+  }
+  pending_ = ViewRegion{};
 }
 
 FLUTTER_API_SYMBOL(FlutterEngine) DrmSeat::CurrentEngine() const {
-  const auto* state = state_.load(std::memory_order_acquire);
+  if (regions_.empty() || active_region_ >= regions_.size()) {
+    return nullptr;
+  }
+  const auto* state = regions_[active_region_].state;
   if (!state || !state->engine) {
     return nullptr;
   }
   return state->engine->GetFlutterEngine();
+}
+
+void DrmSeat::SetRegionLayout(const int32_t x, const int32_t y) {
+  pending_.layout_x = x;
+  pending_.layout_y = y;
+}
+
+void DrmSeat::ResolveActiveRegion() {
+  if (regions_.empty()) {
+    return;
+  }
+  const auto contains = [](const ViewRegion& r, double x, double y) {
+    return x >= r.layout_x && x < r.layout_x + r.width && y >= r.layout_y &&
+           y < r.layout_y + r.height;
+  };
+  // Fast path: still inside the current region.
+  if (active_region_ < regions_.size() &&
+      contains(regions_[active_region_], pointer_x_, pointer_y_)) {
+    return;
+  }
+  // Crossed into another region?
+  for (size_t i = 0; i < regions_.size(); ++i) {
+    if (contains(regions_[i], pointer_x_, pointer_y_)) {
+      active_region_ = i;
+      return;
+    }
+  }
+  // In a gap or past the outer edge: clamp to the union bounding box, then
+  // re-test so an overshoot at a shared border still lands in the neighbor.
+  int32_t min_x = regions_[0].layout_x;
+  int32_t min_y = regions_[0].layout_y;
+  int32_t max_x = regions_[0].layout_x + regions_[0].width;
+  int32_t max_y = regions_[0].layout_y + regions_[0].height;
+  for (const auto& r : regions_) {
+    min_x = std::min(min_x, r.layout_x);
+    min_y = std::min(min_y, r.layout_y);
+    max_x = std::max(max_x, r.layout_x + r.width);
+    max_y = std::max(max_y, r.layout_y + r.height);
+  }
+  pointer_x_ = std::clamp(pointer_x_, static_cast<double>(min_x),
+                          static_cast<double>(max_x - 1));
+  pointer_y_ = std::clamp(pointer_y_, static_cast<double>(min_y),
+                          static_cast<double>(max_y - 1));
+  for (size_t i = 0; i < regions_.size(); ++i) {
+    if (contains(regions_[i], pointer_x_, pointer_y_)) {
+      active_region_ = i;
+      return;
+    }
+  }
+  // Still in a dead zone (non-contiguous layout with mismatched extents): keep
+  // the pointer inside the current region so it can't get stuck between
+  // displays.
+  const size_t keep = active_region_ < regions_.size() ? active_region_ : 0;
+  const auto& r = regions_[keep];
+  pointer_x_ = std::clamp(pointer_x_, static_cast<double>(r.layout_x),
+                          static_cast<double>(r.layout_x + r.width - 1));
+  pointer_y_ = std::clamp(pointer_y_, static_cast<double>(r.layout_y),
+                          static_cast<double>(r.layout_y + r.height - 1));
+  active_region_ = keep;
+}
+
+bool DrmSeat::RegionsShareEngine(const size_t a, const size_t b) const {
+  if (a >= regions_.size() || b >= regions_.size()) {
+    return false;
+  }
+  const auto* sa = regions_[a].state;
+  const auto* sb = regions_[b].state;
+  return sa != nullptr && sb != nullptr && sa->engine == sb->engine;
+}
+
+void DrmSeat::DispatchToRegion(const ViewRegion& region,
+                               const FlutterPointerEvent* events,
+                               const size_t count) {
+  const auto* s = region.state;
+  if (s == nullptr || s->engine == nullptr) {
+    return;
+  }
+  const auto* runner = s->engine->GetPlatformTaskRunner();
+  auto engine_handle = s->engine->GetFlutterEngine();
+  if (runner == nullptr || engine_handle == nullptr) {
+    return;
+  }
+  std::vector<FlutterPointerEvent> batch(events, events + count);
+  asio::dispatch(*runner->GetStrandContext(),
+                 [engine_handle, batch = std::move(batch)]() {
+                   LibFlutterEngine->SendPointerEvent(
+                       engine_handle, batch.data(), batch.size());
+                 });
 }
 
 bool DrmSeat::Start() {
@@ -382,18 +509,22 @@ void DrmSeat::DispatchLoop() {
 }
 
 void DrmSeat::FlushCursorMotion() {
-  if (!cursor_motion_pending_) {
+  if (!cursor_motion_pending_ || regions_.empty() ||
+      active_region_ >= regions_.size()) {
     return;
   }
   cursor_motion_pending_ = false;
 
-  const int rx = static_cast<int>(pointer_x_);
-  const int ry = static_cast<int>(pointer_y_);
+  // The sprite lives on the display the pointer is over; drive it in that
+  // region's local (render) coordinates.
+  const ViewRegion& region = regions_[active_region_];
+  const int rx = static_cast<int>(pointer_x_ - region.layout_x);
+  const int ry = static_cast<int>(pointer_y_ - region.layout_y);
 
   // The GL-composited cursor (fallback for no HW cursor plane) draws into the
   // render target, so it takes un-rotated render/viewport coordinates — the
   // display applies any scanout rotation to the whole framebuffer downstream.
-  if (auto* g = gl_cursor_.load(std::memory_order_acquire); g != nullptr) {
+  if (auto* g = region.gl_cursor; g != nullptr) {
     g->SetPosition(rx, ry);
     // The composited cursor only repaints on a presented frame, and Flutter
     // presents only dirty frames — so on an idle UI the cursor would freeze
@@ -407,7 +538,25 @@ void DrmSeat::FlushCursorMotion() {
   }
 
 #if HAVE_DRM_CURSOR
-  if (auto* c = cursor_.load(std::memory_order_acquire); c != nullptr) {
+  // The pointer changed displays: hide the sprite on the one it left and show
+  // the one it entered, so exactly one cursor is ever visible. Without this a
+  // fast cross leaves the departed plane committed at its last (mid-screen)
+  // position -- a second, frozen cursor. (The composited gl_cursor fallback
+  // path has the same issue on HW without a cursor plane; hiding it needs a
+  // repaint and is a separate pass.)
+  if (cursor_shown_region_ != active_region_) {
+    if (cursor_shown_region_ != kNoRegion &&
+        cursor_shown_region_ < regions_.size()) {
+      if (auto* prev = regions_[cursor_shown_region_].cursor; prev != nullptr) {
+        prev->Hide();
+      }
+    }
+    if (region.cursor != nullptr) {
+      region.cursor->Show();  // no-op if it was never hidden
+    }
+    cursor_shown_region_ = active_region_;
+  }
+  if (auto* c = region.cursor; c != nullptr) {
     // The HW cursor plane lives in panel space. For a 90/270 scanout rotation
     // that differs from render space (axes swapped), so rotate the position by
     // the scanout amount before placing the sprite. 0/180 leave the extent
@@ -415,17 +564,17 @@ void DrmSeat::FlushCursorMotion() {
     // hit-testing stays correct.)
     int px = rx;
     int py = ry;
-    switch (cursor_rotation_) {
+    switch (region.cursor_rotation) {
       case 90:
         px = ry;
-        py = viewport_w_ - 1 - rx;
+        py = region.width - 1 - rx;
         break;
       case 180:
-        px = viewport_w_ - 1 - rx;
-        py = viewport_h_ - 1 - ry;
+        px = region.width - 1 - rx;
+        py = region.height - 1 - ry;
         break;
       case 270:
-        px = viewport_h_ - 1 - ry;
+        px = region.height - 1 - ry;
         py = rx;
         break;
       default:
@@ -480,12 +629,10 @@ void DrmSeat::SetVtSwitchHandler(VtSwitchHandler handler) {
 }
 
 void DrmSeat::SetViewport(const int32_t width, const int32_t height) {
-  viewport_w_ = width;
-  viewport_h_ = height;
-  // Re-center the cursor so the user starts in a sane place after a
-  // viewport change (typically once, at startup, before Start()).
-  pointer_x_ = viewport_w_ / 2.0;
-  pointer_y_ = viewport_h_ / 2.0;
+  // Sizes the region-under-construction; the pointer is centered on the
+  // primary region when it commits (see SetViewControllerState).
+  pending_.width = width;
+  pending_.height = height;
 }
 
 void DrmSeat::SetInputTransforms(const std::vector<std::string>& specs) {
@@ -684,7 +831,12 @@ void DrmSeat::HandleKeyboard(const drm::input::KeyboardEvent& ev) {
 
 void DrmSeat::DispatchKeyToFlutter(
     const drm::input::KeyboardEvent& resolved) const {
-  auto* s = state_.load(std::memory_order_acquire);
+  // Focus-follows-mouse: the keyboard goes to whichever view the pointer is
+  // over. A single-view seat has one region, so this is the only view.
+  if (regions_.empty() || active_region_ >= regions_.size()) {
+    return;
+  }
+  auto* s = regions_[active_region_].state;
   if (s == nullptr) {
     return;
   }
@@ -701,8 +853,8 @@ void DrmSeat::DispatchKeyToFlutter(
 }
 
 void DrmSeat::HandlePointerMotion(const drm::input::PointerMotionEvent& ev) {
-  if (const auto engine = CurrentEngine(); !engine) {
-    return;
+  if (regions_.empty()) {
+    return;  // no view has committed a region yet
   }
 
   // Apply a per-device delta transform when the source device matches a
@@ -741,10 +893,34 @@ void DrmSeat::HandlePointerMotion(const drm::input::PointerMotionEvent& ev) {
     }
   }
 
-  pointer_x_ =
-      std::clamp(pointer_x_ + dx, 0.0, static_cast<double>(viewport_w_ - 1));
-  pointer_y_ =
-      std::clamp(pointer_y_ + dy, 0.0, static_cast<double>(viewport_h_ - 1));
+  // Accumulate in combined (global) pointer space. The cursor moves freely
+  // across displays -- even during a drag -- so it always tracks the hand;
+  // ResolveActiveRegion clamps it to the display set and picks the region it
+  // is physically over (which drives the sprite).
+  pointer_x_ += dx;
+  pointer_y_ += dy;
+
+  const size_t prev = active_region_;
+  ResolveActiveRegion();
+
+  // Boundary decision during a drag: is the display the pointer is crossing
+  // into part of the SAME engine (single engine spanning monitors -> let the
+  // gesture cross freely) or a DIFFERENT engine (multi-engine -> isolate the
+  // gesture to the origin engine by confining the cursor to its region)?
+  if (grab_active_ && grab_region_ < regions_.size() &&
+      !RegionsShareEngine(active_region_, grab_region_)) {
+    const ViewRegion& g = regions_[grab_region_];
+    pointer_x_ = std::clamp(pointer_x_, static_cast<double>(g.layout_x),
+                            static_cast<double>(g.layout_x + g.width - 1));
+    pointer_y_ = std::clamp(pointer_y_, static_cast<double>(g.layout_y),
+                            static_cast<double>(g.layout_y + g.height - 1));
+    active_region_ = grab_region_;
+    // Known rough edge: the pointer stays pinned at the boundary during the
+    // isolated drag, so if the mouse still carries an acceleration vector when
+    // the button releases, the first free motion overshoots into the neighbor
+    // display (a "bounce"). Damping that residual velocity on release is left
+    // for a later refinement.
+  }
 
   // Defer the cursor commit to FlushCursorMotion (called after the
   // dispatch batch). A blocking atomic cursor flip per libinput event
@@ -752,21 +928,53 @@ void DrmSeat::HandlePointerMotion(const drm::input::PointerMotionEvent& ev) {
   // events/s, well under what a 125–1000Hz mouse delivers.
   cursor_motion_pending_ = true;
 
-  FlutterPointerEvent pe[2];
-  size_t count = 0;
   const auto ts = FlutterTimestampMicros();
 
-  if (!pointer_added_) {
+  // Hover focus only changes when NOT dragging. During an implicit grab the
+  // pointer belongs to the grabbed view even while the cursor is over another
+  // display, so we don't hand focus off. Otherwise the view the pointer left
+  // needs a kRemove (its hover clears) and the one it entered a fresh kAdd.
+  if (!grab_active_ && active_region_ != prev && prev < regions_.size() &&
+      regions_[prev].pointer_added) {
+    ViewRegion& old = regions_[prev];
+    FlutterPointerEvent rm{};
+    rm.struct_size = sizeof(FlutterPointerEvent);
+    rm.phase = kRemove;
+    rm.timestamp = ts;
+    rm.x = pointer_x_ - old.layout_x;
+    rm.y = pointer_y_ - old.layout_y;
+    rm.device = 0;
+    rm.device_kind = kFlutterPointerDeviceKindMouse;
+    rm.buttons = 0;
+    DispatchToRegion(old, &rm, 1);
+    old.pointer_added = false;
+  }
+
+  // Events route to the grabbed view during a drag, else to the view under the
+  // pointer. Coordinates are relative to the target view and may fall outside
+  // its bounds mid-drag -- that is correct for a drag that left the window.
+  const size_t target_idx = (grab_active_ && grab_region_ < regions_.size())
+                                ? grab_region_
+                                : active_region_;
+  ViewRegion& target = regions_[target_idx];
+  const double lx = pointer_x_ - target.layout_x;
+  const double ly = pointer_y_ - target.layout_y;
+
+  FlutterPointerEvent pe[2];
+  size_t count = 0;
+
+  if (!grab_active_ && !target.pointer_added) {
+    // This view's engine must see the pointer device before any move/hover.
     pe[count] = FlutterPointerEvent{};
     pe[count].struct_size = sizeof(FlutterPointerEvent);
     pe[count].phase = kAdd;
     pe[count].timestamp = ts;
-    pe[count].x = pointer_x_;
-    pe[count].y = pointer_y_;
+    pe[count].x = lx;
+    pe[count].y = ly;
     pe[count].device = 0;
     pe[count].device_kind = kFlutterPointerDeviceKindMouse;
     pe[count].buttons = 0;
-    pointer_added_ = true;
+    target.pointer_added = true;
     ++count;
   }
 
@@ -774,33 +982,18 @@ void DrmSeat::HandlePointerMotion(const drm::input::PointerMotionEvent& ev) {
   pe[count].struct_size = sizeof(FlutterPointerEvent);
   pe[count].phase = button_mask_ ? kMove : kHover;
   pe[count].timestamp = ts;
-  pe[count].x = pointer_x_;
-  pe[count].y = pointer_y_;
+  pe[count].x = lx;
+  pe[count].y = ly;
   pe[count].device = 0;
   pe[count].device_kind = kFlutterPointerDeviceKindMouse;
   pe[count].buttons = button_mask_;
   ++count;
 
-  const auto* s = state_.load(std::memory_order_acquire);
-  if (!s || !s->engine) {
-    return;
-  }
-  const auto* runner = s->engine->GetPlatformTaskRunner();
-  if (auto engine_handle = s->engine->GetFlutterEngine();
-      runner && engine_handle) {
-    std::vector events(pe, pe + count);
-    asio::dispatch(*runner->GetStrandContext(),
-                   [engine_handle, events = std::move(events)]() {
-                     LibFlutterEngine->SendPointerEvent(
-                         engine_handle, events.data(), events.size());
-                   });
-  }
+  DispatchToRegion(target, pe, count);
 }
 
 void DrmSeat::HandlePointerButton(const drm::input::PointerButtonEvent& ev) {
-  // CurrentEngine() is only for the null-check; actual dispatch goes via
-  // state_.
-  if (!CurrentEngine()) {
+  if (regions_.empty() || active_region_ >= regions_.size()) {
     return;
   }
 
@@ -815,6 +1008,12 @@ void DrmSeat::HandlePointerButton(const drm::input::PointerButtonEvent& ev) {
     button_mask_ &= ~bit;
   }
 
+  // First button down starts the implicit grab on the view under the pointer.
+  if (prev_mask == 0 && button_mask_ != 0) {
+    grab_active_ = true;
+    grab_region_ = active_region_;
+  }
+
   FlutterPointerPhase phase;
   if (ev.pressed) {
     // A press while another button is already held becomes kMove; kDown is
@@ -824,40 +1023,63 @@ void DrmSeat::HandlePointerButton(const drm::input::PointerButtonEvent& ev) {
     phase = (button_mask_ == 0) ? kUp : kMove;
   }
 
+  // While grabbed, button events (including the release) go to the grabbed
+  // view even if the cursor has drifted onto another display; else to the view
+  // under the pointer. Coordinates are relative to that view.
+  const size_t target_idx = (grab_active_ && grab_region_ < regions_.size())
+                                ? grab_region_
+                                : active_region_;
+  const ViewRegion& region = regions_[target_idx];
   FlutterPointerEvent pe{};
   pe.struct_size = sizeof(FlutterPointerEvent);
   pe.phase = phase;
   pe.timestamp = FlutterTimestampMicros();
-  pe.x = pointer_x_;
-  pe.y = pointer_y_;
+  pe.x = pointer_x_ - region.layout_x;
+  pe.y = pointer_y_ - region.layout_y;
   pe.device = 0;
   pe.device_kind = kFlutterPointerDeviceKindMouse;
   pe.buttons = button_mask_;
 
-  auto* s = state_.load(std::memory_order_acquire);
-  if (!s || !s->engine) {
-    return;
-  }
-  const auto* runner = s->engine->GetPlatformTaskRunner();
-  if (auto engine_handle = s->engine->GetFlutterEngine();
-      runner && engine_handle) {
-    asio::dispatch(*runner->GetStrandContext(), [engine_handle, pe]() {
-      LibFlutterEngine->SendPointerEvent(engine_handle, &pe, 1);
-    });
+  DispatchToRegion(region, &pe, 1);
+
+  // The grab ends when the last button releases. If the cursor drifted onto a
+  // different display during the drag, clear the grabbed view's now-stale hover
+  // so focus (and the next kAdd) can move to the display the pointer sits on.
+  if (button_mask_ == 0 && grab_active_) {
+    if (active_region_ != grab_region_ && grab_region_ < regions_.size() &&
+        regions_[grab_region_].pointer_added) {
+      ViewRegion& g = regions_[grab_region_];
+      FlutterPointerEvent rm{};
+      rm.struct_size = sizeof(FlutterPointerEvent);
+      rm.phase = kRemove;
+      rm.timestamp = FlutterTimestampMicros();
+      rm.x = pointer_x_ - g.layout_x;
+      rm.y = pointer_y_ - g.layout_y;
+      rm.device = 0;
+      rm.device_kind = kFlutterPointerDeviceKindMouse;
+      rm.buttons = 0;
+      DispatchToRegion(g, &rm, 1);
+      g.pointer_added = false;
+    }
+    grab_active_ = false;
   }
 }
 
 void DrmSeat::HandlePointerAxis(const drm::input::PointerAxisEvent& ev) const {
-  if (!CurrentEngine()) {
+  if (regions_.empty() || active_region_ >= regions_.size()) {
     return;
   }
 
+  const size_t target_idx = (grab_active_ && grab_region_ < regions_.size())
+                                ? grab_region_
+                                : active_region_;
+  const ViewRegion& region = regions_[target_idx];
   FlutterPointerEvent pe{};
   pe.struct_size = sizeof(FlutterPointerEvent);
   pe.phase = button_mask_ ? kMove : kHover;
   pe.timestamp = FlutterTimestampMicros();
-  pe.x = pointer_x_;
-  pe.y = pointer_y_;
+  pe.x = pointer_x_ - region.layout_x;
+  pe.y = pointer_y_ - region.layout_y;
   pe.device = 0;
   pe.device_kind = kFlutterPointerDeviceKindMouse;
   pe.buttons = button_mask_;
@@ -865,24 +1087,21 @@ void DrmSeat::HandlePointerAxis(const drm::input::PointerAxisEvent& ev) const {
   pe.scroll_delta_x = ev.horizontal;
   pe.scroll_delta_y = ev.vertical;
 
-  auto* s = state_.load(std::memory_order_acquire);
-  if (!s || !s->engine) {
-    return;
-  }
-  const auto* runner = s->engine->GetPlatformTaskRunner();
-  if (auto engine_handle = s->engine->GetFlutterEngine();
-      runner && engine_handle) {
-    asio::dispatch(*runner->GetStrandContext(), [engine_handle, pe]() {
-      LibFlutterEngine->SendPointerEvent(engine_handle, &pe, 1);
-    });
-  }
+  DispatchToRegion(region, &pe, 1);
 }
 
 void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   if (ev.type == drm::input::TouchEvent::Type::Frame) {
     return;
   }
-  if (!CurrentEngine()) {
+  // Touchscreen-to-display association isn't modeled yet, so touch is routed to
+  // the primary region (index 0). A single-display seat has only that region;
+  // multi-display touch mapping is a follow-up.
+  if (regions_.empty()) {
+    return;
+  }
+  const ViewRegion& region = regions_.front();
+  if (region.state == nullptr || region.state->engine == nullptr) {
     return;
   }
 
@@ -910,11 +1129,11 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   // forward rotation; touch is its inverse).
   const double nx = ev.x;
   const double ny = ev.y;
-  const auto w = static_cast<double>(viewport_w_);
-  const auto h = static_cast<double>(viewport_h_);
+  const auto w = static_cast<double>(region.width);
+  const auto h = static_cast<double>(region.height);
   double fx = nx * w;
   double fy = ny * h;
-  switch (cursor_rotation_) {
+  switch (region.cursor_rotation) {
     case 90:
       fx = (1.0 - ny) * w;
       fy = nx * h;
@@ -955,16 +1174,6 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   pe.device_kind = kFlutterPointerDeviceKindTouch;
   pe.buttons = 0;
 
-  const auto* s = state_.load(std::memory_order_acquire);
-  if (!s || !s->engine) {
-    return;
-  }
-  const auto* runner = s->engine->GetPlatformTaskRunner();
-  if (auto engine_handle = s->engine->GetFlutterEngine();
-      runner && engine_handle) {
-    asio::dispatch(*runner->GetStrandContext(), [engine_handle, pe]() {
-      LibFlutterEngine->SendPointerEvent(engine_handle, &pe, 1);
-    });
-  }
+  DispatchToRegion(region, &pe, 1);
 }
 }  // namespace homescreen

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -222,6 +222,10 @@ void DrmSeat::SetRegionLayout(const int32_t x, const int32_t y) {
   pending_.layout_y = y;
 }
 
+void DrmSeat::SetRegionTouchDevice(std::string name) {
+  pending_.touch_match = std::move(name);
+}
+
 void DrmSeat::ResolveActiveRegion() {
   if (regions_.empty()) {
     return;
@@ -1094,14 +1098,30 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   if (ev.type == drm::input::TouchEvent::Type::Frame) {
     return;
   }
-  // Touchscreen-to-display association isn't modeled yet, so touch is routed to
-  // the primary region (index 0). A single-display seat has only that region;
-  // multi-display touch mapping is a follow-up.
   if (regions_.empty()) {
     return;
   }
-  const ViewRegion& region = regions_.front();
-  if (region.state == nullptr || region.state->engine == nullptr) {
+  // A touchscreen reports absolute coordinates in its own space with no cursor,
+  // so it can't be routed by pointer position like a mouse. Route by device:
+  // the region whose configured touch_match ([view.output] touch_device) is a
+  // substring of this event's libinput device name. With none configured (or no
+  // match) touch falls back to the primary region, preserving single-display
+  // behavior.
+  const ViewRegion* region = nullptr;
+  if (ev.device_name != nullptr) {
+    const std::string_view name(ev.device_name);
+    for (const auto& r : regions_) {
+      if (!r.touch_match.empty() &&
+          name.find(r.touch_match) != std::string_view::npos) {
+        region = &r;
+        break;
+      }
+    }
+  }
+  if (region == nullptr) {
+    region = &regions_.front();
+  }
+  if (region->state == nullptr || region->state->engine == nullptr) {
     return;
   }
 
@@ -1129,11 +1149,11 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   // forward rotation; touch is its inverse).
   const double nx = ev.x;
   const double ny = ev.y;
-  const auto w = static_cast<double>(region.width);
-  const auto h = static_cast<double>(region.height);
+  const auto w = static_cast<double>(region->width);
+  const auto h = static_cast<double>(region->height);
   double fx = nx * w;
   double fy = ny * h;
-  switch (region.cursor_rotation) {
+  switch (region->cursor_rotation) {
     case 90:
       fx = (1.0 - ny) * w;
       fy = nx * h;
@@ -1174,6 +1194,6 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   pe.device_kind = kFlutterPointerDeviceKindTouch;
   pe.buttons = 0;
 
-  DispatchToRegion(region, &pe, 1);
+  DispatchToRegion(*region, &pe, 1);
 }
 }  // namespace homescreen

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -98,6 +98,11 @@ class DrmSeat final : public ISeat {
   // Start(); committed by the next SetViewControllerState.
   void SetRegionLayout(int32_t x, int32_t y);
 
+  // Bind a touch panel (libinput device-name substring) to the view under
+  // construction, so its touches route to this view instead of the primary.
+  // Call before Start(); committed by the next SetViewControllerState.
+  void SetRegionTouchDevice(std::string name);
+
   // Hot-swap the xkb keymap. Safe to call from any thread; the actual
   // reload runs on the dispatch thread on the next poll iteration.
   // Held keys and lock latches are preserved across the swap. On
@@ -172,6 +177,10 @@ class DrmSeat final : public ISeat {
     DrmCursor* cursor = nullptr;  // HW cursor plane (this CRTC)
     ICursorPositionSink* gl_cursor = nullptr;  // composited fallback
     bool pointer_added = false;
+    // libinput device-name substring of the touch panel bonded to this view's
+    // display; empty when none is configured. Touch is absolute (no cursor), so
+    // it routes by device, not by pointer position.
+    std::string touch_match;
   };
 
   void DispatchLoop();

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -78,22 +78,25 @@ class DrmSeat final : public ISeat {
   void SetViewControllerState(
       FlutterDesktopViewControllerState* state) override;
 
-  // Set (or clear) the DRM hardware cursor this seat moves. Safe to
-  // call from any thread; the dispatch loop reads via acquire and
-  // ignores nullptr. Caller must clear (pass nullptr) before the
-  // pointed-to DrmCursor is destroyed.
-  void SetCursor(DrmCursor* cursor) {
-    cursor_.store(cursor, std::memory_order_release);
-  }
+  // Set the DRM hardware cursor for the view under construction (the region
+  // committed by the next SetViewControllerState). Call before Start(); region
+  // registration is single-threaded during view construction, which completes
+  // before the dispatch thread starts.
+  void SetCursor(DrmCursor* cursor) { pending_.cursor = cursor; }
 
-  // Set (or clear) a composited cursor sink (the EGL backend's GlCursor), used
-  // when no hardware cursor plane is available. Safe to call from any thread;
-  // the dispatch loop reads via acquire and ignores nullptr. The sink receives
-  // un-rotated render/viewport coordinates (it composites into the render
-  // target; scanout rotation is applied to the whole framebuffer downstream).
-  void SetGlCursor(ICursorPositionSink* sink) {
-    gl_cursor_.store(sink, std::memory_order_release);
-  }
+  // Set the composited cursor sink (the EGL backend's GlCursor) for the view
+  // under construction, used when no hardware cursor plane is available. Call
+  // before Start(). The sink receives un-rotated render/viewport coordinates
+  // (it composites into the render target; scanout rotation is applied to the
+  // whole framebuffer downstream).
+  void SetGlCursor(ICursorPositionSink* sink) { pending_.gl_cursor = sink; }
+
+  // Position of the view under construction in the combined pointer space
+  // (from [view.output] x/y). Multiple views sharing one seat (several
+  // displays on one DRM card) each declare where their render surface sits so
+  // the pointer moves between them as laid out. Defaults to (0,0). Call before
+  // Start(); committed by the next SetViewControllerState.
+  void SetRegionLayout(int32_t x, int32_t y);
 
   // Hot-swap the xkb keymap. Safe to call from any thread; the actual
   // reload runs on the dispatch thread on the next poll iteration.
@@ -126,12 +129,13 @@ class DrmSeat final : public ISeat {
   void OnSessionPaused();
   void OnSessionResumed();
 
-  // Update the cursor clamping rectangle. Called by FlutterView after
-  // DrmBackend::Create resolves the actual framebuffer dimensions
-  // (which can differ from the config's view.width/height when `-f`
-  // promoted the FB to the full mode). Must be called before Start()
-  // so the dispatch thread sees the final values without atomics; the
-  // dispatch thread's pointer math reads these once on the hot path.
+  // Set the render extent of the view under construction. Called after
+  // DrmBackend::Create resolves the actual framebuffer dimensions (which can
+  // differ from the config's view.width/height when `-f` promoted the FB to
+  // the full mode). Sizes the region's rectangle in combined pointer space.
+  // Must be called before Start() (region registration is single-threaded and
+  // completes before the dispatch thread starts); the pointer math reads it on
+  // the hot path.
   void SetViewport(int32_t width, int32_t height);
 
   // Scanout rotation in degrees (0|90|180|270). The pointer accumulates in
@@ -139,7 +143,9 @@ class DrmSeat final : public ISeat {
   // — but the HW cursor plane lives in panel space, so FlushCursorMotion
   // rotates the position by this amount before placing the sprite. Touch is
   // unaffected (the digitizer already tracks the panel). Set before Start().
-  void SetCursorRotation(int32_t degrees) { cursor_rotation_ = degrees; }
+  void SetCursorRotation(int32_t degrees) {
+    pending_.cursor_rotation = degrees;
+  }
 
   // Per-device relative-pointer transforms. Each spec is
   // "<device-name-substring>=<rot>[,flip-x][,flip-y]" (rot = 0|90|180|270). A
@@ -150,6 +156,24 @@ class DrmSeat final : public ISeat {
   void SetInputTransforms(const std::vector<std::string>& specs);
 
  private:
+  // A rendered view occupying a rectangle of the combined pointer space. One
+  // per Flutter view sharing this seat (multiple displays on one DRM card).
+  // The pointer accumulates in combined space; the region under it receives
+  // events in its own local (render) coordinates and owns the sprite that
+  // tracks it. pointer_added tracks whether this view's engine has seen the
+  // pointer device yet -- each engine needs its own kAdd before kMove/kHover.
+  struct ViewRegion {
+    FlutterDesktopViewControllerState* state = nullptr;
+    int32_t layout_x = 0;  // top-left in combined pointer space
+    int32_t layout_y = 0;
+    int32_t width = 0;            // render/viewport extent
+    int32_t height = 0;           // render/viewport extent
+    int32_t cursor_rotation = 0;  // scanout rotation for the sprite (0|90|…)
+    DrmCursor* cursor = nullptr;  // HW cursor plane (this CRTC)
+    ICursorPositionSink* gl_cursor = nullptr;  // composited fallback
+    bool pointer_added = false;
+  };
+
   void DispatchLoop();
   void ApplyPendingKeymap();
   // If pointer motion accumulated during the previous dispatch batch,
@@ -172,15 +196,53 @@ class DrmSeat final : public ISeat {
 
   [[nodiscard]] FLUTTER_API_SYMBOL(FlutterEngine) CurrentEngine() const;
 
-  // Mutable so FlutterView can rewrite them in SetViewport after
-  // DrmBackend::Create has resolved the actual framebuffer size
-  // (e.g. when `-f` promoted the FB to the full mode). Read on the
-  // dispatch thread; SetViewport runs on the main thread before
-  // Start() is called, so no atomic needed.
-  int32_t viewport_w_;
-  int32_t viewport_h_;
-  // Scanout rotation (0|90|180|270) applied to the cursor sprite position only.
-  int32_t cursor_rotation_ = 0;
+  // Resolve which region the (global) pointer is over after a motion delta,
+  // clamping it back into the region set if the delta pushed it into a gap or
+  // past the outer edge. Updates active_region_ and pointer_x_/pointer_y_.
+  // No-op when regions_ is empty.
+  void ResolveActiveRegion();
+  // True when two regions are views of the same Flutter engine (one engine
+  // spanning multiple displays). A drag may cross freely between such regions
+  // as one continuous gesture; a drag between regions of DIFFERENT engines is
+  // confined to the origin engine (engine isolation).
+  [[nodiscard]] bool RegionsShareEngine(size_t a, size_t b) const;
+  // Marshal a batch of pointer events to a region's engine on its platform
+  // strand. No-op if the region has no live engine yet. Static: it works
+  // entirely off the region and the events, touching no seat state.
+  static void DispatchToRegion(const ViewRegion& region,
+                               const FlutterPointerEvent* events,
+                               size_t count);
+
+  // Committed view regions, built by the per-view Set* setters before Start()
+  // and read-only on the dispatch thread thereafter (registration is
+  // single-threaded during view construction, which completes before
+  // StartEvents() spawns the dispatch thread). Index 0 is the primary/first
+  // view. A single-view seat has exactly one region at (0,0), so behavior is
+  // unchanged from before the multi-region rework.
+  std::vector<ViewRegion> regions_;
+  // The region currently under the pointer; index into regions_. Updated by
+  // HandlePointerMotion, read by the button/axis/cursor/keyboard paths.
+  size_t active_region_ = 0;
+  // Implicit pointer grab: on the first button-down the view under the pointer
+  // captures the pointer until every button releases, so a drag keeps routing
+  // to that view even if the cursor wanders onto another display. The cursor
+  // itself still follows the hand across displays (no clamp), so releasing the
+  // button never snaps the pointer -- it is already where the hand is.
+  bool grab_active_ = false;
+  size_t grab_region_ = 0;
+  // The region whose HW cursor sprite is currently shown. When the active
+  // region changes, FlushCursorMotion hides this one's sprite and shows the
+  // new one's, so exactly one cursor is visible across the displays. Starts at
+  // kNoRegion (nothing shown yet).
+  static constexpr size_t kNoRegion = static_cast<size_t>(-1);
+  // [[maybe_unused]]: only read/written under HAVE_DRM_CURSOR (the sprite
+  // hide/show path); a build of drm-cxx without the cursor leaves it dormant.
+  [[maybe_unused]] size_t cursor_shown_region_ = kNoRegion;
+  // Region under construction: the per-view setters (SetViewport, SetCursor,
+  // SetGlCursor, SetCursorRotation, SetRegionLayout) accumulate here, and
+  // SetViewControllerState commits it into regions_ and resets it for the next
+  // view.
+  ViewRegion pending_;
   // Per-device relative-pointer delta transforms (see SetInputTransforms).
   // Matched by device-name substring in HandlePointerMotion; first match wins.
   struct PointerTransform {
@@ -194,8 +256,6 @@ class DrmSeat final : public ISeat {
   // libinput delivers with no coordinates) reuses it instead of snapping to a
   // corner. Touched only from the seat dispatch thread (HandleTouch is const).
   mutable std::unordered_map<int32_t, std::pair<double, double>> touch_pos_;
-
-  std::atomic<FlutterDesktopViewControllerState*> state_{nullptr};
 
   // Caller-supplied hook for libinput's privileged device opens. Empty
   // when there's no libseat session (falls back to ::open/::close inside
@@ -242,25 +302,16 @@ class DrmSeat final : public ISeat {
   int tty_fd_ = -1;
   int saved_kb_mode_ = 0;
 
-  // Accessed only from the dispatch thread.
+  // Accessed only from the dispatch thread. pointer_x_/pointer_y_ are in
+  // combined (global) pointer space -- ResolveActiveRegion maps them to a
+  // region and its local render coordinates.
   double pointer_x_ = 0.0;
   double pointer_y_ = 0.0;
   int64_t button_mask_ = 0;
-  bool pointer_added_ = false;
   // Set by HandlePointerMotion, cleared by FlushCursorMotion. Lets the
   // dispatch loop coalesce a batch of motion events into one cursor
   // commit at the end of seat_->dispatch().
   bool cursor_motion_pending_ = false;
-
-  // KMS hardware cursor target. Owned by DrmBackend; this seat just
-  // forwards motion to it. Atomic because the wiring runs on a
-  // different thread than the dispatch loop that reads it.
-  std::atomic<DrmCursor*> cursor_{nullptr};
-
-  // Composited cursor fallback (the EGL backend's GlCursor), used when there
-  // is no hardware cursor plane. Owned by the backend; this seat forwards
-  // motion to it. Null whenever a HW cursor is in use or no cursor at all.
-  std::atomic<ICursorPositionSink*> gl_cursor_{nullptr};
 };
 
 }  // namespace homescreen


### PR DESCRIPTION
Builds on #263 (per-view display). Makes pointer and touch input work correctly when multiple views drive multiple displays on one DRM card.

## What

Reworks `DrmSeat` from a single view/viewport/cursor to a set of **regions** — one per view sharing the seat, each a rectangle in a combined pointer space. The pointer accumulates in that global space; the region under it receives events in its own **local** coordinates.

- **Per-display pointer routing** — the pointer, its clamp, clicks, scroll, and keyboard all go to the display the cursor is over. Each engine gets its own pointer `kAdd`; keyboard follows the pointer.
- **Single cursor across displays** — `DrmCursor::Hide()`/`Show()` (forwarding to drm-cxx's cursor renderer) hide the sprite on the display the pointer leaves and show it on the one it enters, so exactly one cursor is ever visible. Fixes a frozen second sprite on fast crossings.
- **Engine-scoped drag** — a drag holds an implicit grab on the view where the button went down. At a display boundary the seat decides by engine: **same** engine spanning the displays → the cursor crosses freely as one gesture; **different** engines → the gesture is confined to the origin engine (no leaking across the engine boundary).
- **Per-display touch routing** — touch is absolute and cursor-less, so it can't be routed by pointer position. `[view.output] touch_device` (a libinput device-name substring) binds a touch panel to a view; a touch routes to the matching region, falling back to the primary view when unset/unmatched.
- **Config-driven layout** — `[view.output] x/y` declares where each view's surface sits in the combined space, wired through `DrmDisplay::SetRegionLayout`/`SetRegionTouchDevice` from `register_backends` for both DRM backends. Two views launched without explicit positions auto-tile side by side.

Single-view behavior is unchanged (one region at the origin).

## Validated

Pointer path HW-validated on amdgpu, two discrete engines on one card: gallery on HDMI-A-1 (1280×1440 @ x=0) + image_list on DP-1 (2560×1440 @ x=1280). Confirmed correct per-display routing, correct clamp, single cursor, clicks landing on the right display, and drag isolation between the two engines.

**Touch routing is not yet HW-validated** — the dev rig has no touchscreen. The code path is separate from the pointer path and falls back to primary-view routing when no `touch_device` is configured, so it does not affect the validated pointer behavior; it needs a run on a multi-panel touch rig to prove.

Reliability and security review of the pointer/region diff both came back clean (build/clang-tidy/clang-format-19 green).

## Known follow-ups (not in this PR)

- **Release bounce** — during an isolated (multi-engine) drag the cursor is pinned at the boundary; if the mouse still carries an acceleration vector when the button releases, the first free motion overshoots into the neighbor display. Needs residual-velocity damping / edge resistance. A note is left at the isolation clamp.
- **RemoveRegion** — there is no region-removal path yet; one must land alongside any future per-view hot-teardown (`on_disconnect=teardown`) or a torn-down view's controller-state pointer would dangle in the shared seat.
- Composited GL-cursor hide on the no-HW-cursor-plane path (SoC displays without a cursor plane); the same-engine "cross freely" path exercises only once one engine spans multiple displays (case B).