### PR TITLE
agl: bring the background view up from config alone

### DIFF
--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -71,7 +71,8 @@
 #cmakedefine01 BUILD_CRASH_HANDLER
 #if BUILD_CRASH_HANDLER
 static constexpr char kSentryEnvDefault[] = "@CMAKE_BUILD_TYPE@";
-static constexpr char kCrashpadBinaryPath[] = "@CRASHPAD_BINARY_DIR@/crashpad_handler";
+static constexpr char kCrashpadBinaryPath[] =
+    "@CRASHPAD_BINARY_DIR@/crashpad_handler";
 #endif
 
 #cmakedefine01 BUILD_ACCESSIBILITY
@@ -137,7 +138,13 @@ constexpr char kSystemIcudtl[] = "share/flutter/icudtl.dat";
 
 // Install path constants
 static constexpr char kApplicationName[] = "@EXE_OUTPUT_NAME@";
-static constexpr char kXdgApplicationDir[] = "." "@EXE_OUTPUT_NAME@";
+// Default Wayland/xdg app_id when [global].app_id is unset. Reverse-DNS so it
+// matches an AGL compositor's per-app config (which keys placement on app_id);
+// distinct from kApplicationName (the binary name, used for install paths).
+static constexpr char kDefaultAppId[] = "com.toyotaconnected.homescreen";
+static constexpr char kXdgApplicationDir[] =
+    "."
+    "@EXE_OUTPUT_NAME@";
 static constexpr char kXdgConfigDir[] = ".config";
 
 // DLT Logging
@@ -194,7 +201,6 @@ static constexpr std::array<EGLint, 27> kEglConfigAttribs = {{
     // clang-format on
 }};
 
-
 static constexpr std::array<EGLint, 13> kEglConfigAttribsFallBack = {{
     // clang-format off
     EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
@@ -209,7 +215,6 @@ static constexpr std::array<EGLint, 13> kEglConfigAttribsFallBack = {{
 }};
 #endif  // IVI_HAVE_EGL
 
-
 // All vkCreate* functions take an optional allocator. For now, we select the
 // default allocator by passing in a null pointer, and we highlight the argument
 // by using the VKALLOC constant.
@@ -218,4 +223,4 @@ constexpr struct VkAllocationCallbacks* VKALLOC = nullptr;
 #cmakedefine01 ENV32BIT
 #cmakedefine01 ENV64BIT
 
-#endif //CONFIG_COMMON_H_
+#endif  // CONFIG_COMMON_H_

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -504,7 +504,12 @@ std::vector<Configuration::Config> Configuration::parse_config(
     get_cli_override(d.bundle_path, cfg, cli_config);
 
     if (cfg.view.window_type.empty()) {
-      cfg.view.window_type = "NORMAL";
+      // The AGL shell requires a real surface role (BG / PANEL_*); NORMAL has
+      // no AGL window-management meaning, so an unset type would never be
+      // shown. Default an AGL view to the background role; every other shell
+      // keeps NORMAL.
+      cfg.view.window_type =
+          (cfg.view.shell.value_or("") == "agl") ? "BG" : "NORMAL";
     }
     if (cfg.view.width == 0) {
       cfg.view.width = kDefaultViewWidth;
@@ -516,7 +521,7 @@ std::vector<Configuration::Config> Configuration::parse_config(
       cfg.view.pixel_ratio = kDefaultPixelRatio;
     }
     if (cfg.app_id.empty()) {
-      cfg.app_id = kApplicationName;
+      cfg.app_id = kDefaultAppId;
     }
 
     // An omitted/zero activation area covers the full view extent. TOML has no

--- a/shell/wayland/window.cc
+++ b/shell/wayland/window.cc
@@ -144,15 +144,23 @@ WaylandWindow::WaylandWindow(const size_t index,
   // follow the first commit. Only AglShell exposes a WindowManager facet.
   if (auto* wm = shell.WindowManager()) {
     switch (m_type) {
-      case WINDOW_BG:
+      case WINDOW_BG: {
         wm->SetBackground(m_base_surface, m_output_index);
-        if (m_activation_area.x || m_activation_area.y ||
-            m_activation_area.width || m_activation_area.height) {
-          wm->SetActivationArea(m_activation_area.x, m_activation_area.y,
-                                m_activation_area.width,
-                                m_activation_area.height, m_output_index);
-        }
+        // The activation area is the region the compositor reserves for app
+        // content on the background; the AGL shell wants it set before `ready`.
+        // An unset (0x0) area defaults to the full view extent so the whole
+        // surface is usable rather than a zero-size region the compositor
+        // ignores.
+        const auto aw = m_activation_area.width != 0
+                            ? m_activation_area.width
+                            : static_cast<uint32_t>(m_geometry.width);
+        const auto ah = m_activation_area.height != 0
+                            ? m_activation_area.height
+                            : static_cast<uint32_t>(m_geometry.height);
+        wm->SetActivationArea(m_activation_area.x, m_activation_area.y, aw, ah,
+                              m_output_index);
         break;
+      }
       case WINDOW_PANEL_TOP:
         wm->SetPanel(m_base_surface, ivi::SurfaceRole::kPanelTop,
                      m_output_index);


### PR DESCRIPTION
Under the AGL shell, a Flutter view configured without an explicit window role never rendered — the compositor showed a black screen. This fixes that so `--shell agl` (or `[view.shell] type = 'agl'`) brings the app up with no extra flags.

## Root cause

The window-role enum is `WINDOW_NORMAL = 0`, and `get_window_type("")` falls back to `WINDOW_NORMAL`. A view with an unset `window_type` therefore became NORMAL, which has no AGL window-management meaning — so the AGL background path (`agl_shell.set_background` + `set_activate_region` + `ready`) was skipped entirely and the surface was never shown.

## Fix

- **Default an unset `window_type` to `BG` under AGL** (`configuration.cc`): when the resolved shell is `agl`, an unset type resolves to the background role; every other shell keeps `NORMAL`. This is the render fix.
- **A background's activation region defaults to the full view extent** when unset (`0x0`) instead of being skipped (`window.cc`) — the AGL shell wants `set_activate_region` set before `ready`.
- **`app_id` defaults to a reverse-DNS id** (`kDefaultAppId` = `com.toyotaconnected.homescreen`, `config_common.h.in`) when unset, so it matches a compositor's per-app config; kept distinct from `kApplicationName` (the binary name used for install paths).

## Validated

On a live agl-compositor: the gallery renders from `--shell agl` alone (visually confirmed). The wire trace shows the full handshake — `set_background` → `set_activate_region(…, 0, 0, 1024, 768)` → `ready`, followed by steady `frame.done` events. Non-AGL shells are unaffected (window_type still defaults to NORMAL). clang-tidy / clang-format-19 clean.