### PR TITLE
input: batch touch contacts per hardware frame across all seats

### DIFF
--- a/shell/backend/software/input/software_seat.cc
+++ b/shell/backend/software/input/software_seat.cc
@@ -15,6 +15,8 @@
  */
 
 #include "backend/software/input/software_seat.h"
+
+#include "config/common.h"
 #include "logging/logging.h"
 
 #include <fcntl.h>
@@ -289,11 +291,15 @@ void SoftwareSeat::HandleEvent(libinput_event* ev) {
       HandleTouchCancel(libinput_event_get_touch_event(ev));
       break;
     case LIBINPUT_EVENT_TOUCH_FRAME:
+      // Frame marker: everything since the previous marker is one hardware
+      // scan — hand it to the engine as one batch (one strand post, one
+      // FlutterEngineSendPointerEvent, one UI-thread task) instead of one
+      // submission per contact. A 10-finger drag at a 250 Hz scan rate is
+      // 250 posts/s instead of 2500/s.
+      FlushTouchBatch();
+      break;
     default:
-      // TOUCH_FRAME is a batch-boundary marker; we dispatch events as
-      // they arrive, so no accumulation to flush. Falls through into
-      // the default no-op alongside gesture / switch events that
-      // aren't wired yet.
+      // No-op alongside gesture / switch events that aren't wired yet.
       break;
   }
 }
@@ -506,7 +512,8 @@ void SoftwareSeat::HandleTouchDown(libinput_event_touch* t) {
   batch[1].y = s.y;
   batch[1].device = slot;
   batch[1].device_kind = kFlutterPointerDeviceKindTouch;
-  DispatchPointerEvents(batch, 2);
+  QueueTouchEvent(batch[0]);
+  QueueTouchEvent(batch[1]);
 }
 
 void SoftwareSeat::HandleTouchMotion(libinput_event_touch* t) {
@@ -534,7 +541,7 @@ void SoftwareSeat::HandleTouchMotion(libinput_event_touch* t) {
   pe.y = s.y;
   pe.device = slot;
   pe.device_kind = kFlutterPointerDeviceKindTouch;
-  DispatchPointerEvent(pe);
+  QueueTouchEvent(pe);
 }
 
 void SoftwareSeat::HandleTouchUp(libinput_event_touch* t) {
@@ -569,7 +576,8 @@ void SoftwareSeat::HandleTouchUp(libinput_event_touch* t) {
   batch[1].y = s.y;
   batch[1].device = slot;
   batch[1].device_kind = kFlutterPointerDeviceKindTouch;
-  DispatchPointerEvents(batch, 2);
+  QueueTouchEvent(batch[0]);
+  QueueTouchEvent(batch[1]);
 }
 
 void SoftwareSeat::HandleTouchCancel(libinput_event_touch* t) {
@@ -601,7 +609,34 @@ void SoftwareSeat::HandleTouchCancel(libinput_event_touch* t) {
   batch[1].y = s.y;
   batch[1].device = slot;
   batch[1].device_kind = kFlutterPointerDeviceKindTouch;
-  DispatchPointerEvents(batch, 2);
+  QueueTouchEvent(batch[0]);
+  QueueTouchEvent(batch[1]);
+  // Not every stack guarantees a TOUCH_FRAME after cancel; flush now so the
+  // engine's per-device state is terminated promptly.
+  FlushTouchBatch();
+}
+
+void SoftwareSeat::QueueTouchEvent(const FlutterPointerEvent& pe) {
+  touch_batch_.push_back(pe);
+  if (touch_batch_.size() >= static_cast<size_t>(kMaxPointerEvent)) {
+    FlushTouchBatch();
+  }
+}
+
+void SoftwareSeat::FlushTouchBatch() {
+  if (touch_batch_.empty()) {
+    return;
+  }
+  // One timestamp for the whole frame: the contacts in a touch frame are
+  // logically simultaneous (one hardware scan), and a shared timestamp keeps
+  // the framework's pointer resampler from interpolating skew between fingers
+  // that moved together.
+  const uint64_t ts = FlutterTimestampMicros();
+  for (auto& e : touch_batch_) {
+    e.timestamp = ts;
+  }
+  DispatchPointerEvents(touch_batch_.data(), touch_batch_.size());
+  touch_batch_.clear();
 }
 
 SoftwareSeat::EngineRef SoftwareSeat::CurrentEngine() const {

--- a/shell/backend/software/input/software_seat.h
+++ b/shell/backend/software/input/software_seat.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <memory>
 #include <thread>
+#include <vector>
 
 #include <xkbcommon/xkbcommon.h>
 
@@ -92,6 +93,19 @@ class SoftwareSeat final : public ISeat {
   void HandleTouchMotion(libinput_event_touch* t);
   void HandleTouchCancel(libinput_event_touch* t);
 
+  // Hand everything accumulated since the last LIBINPUT_EVENT_TOUCH_FRAME to
+  // the engine as one batch: one shared timestamp, one strand post, one
+  // FlutterEngineSendPointerEvent (= one UI-thread task in the engine) per
+  // hardware scan instead of one per contact. No-op when nothing is pending.
+  void FlushTouchBatch();
+
+  // Append an event to the pending touch frame. The timestamp is stamped for
+  // the whole group in FlushTouchBatch — contacts within one frame are
+  // logically simultaneous. Flushes early as a backstop if the batch would
+  // exceed kMaxPointerEvent (a runaway stream without frame markers must not
+  // grow unbounded).
+  void QueueTouchEvent(const FlutterPointerEvent& pe);
+
   // Dispatch a populated FlutterPointerEvent on the platform task
   // runner's strand. Copies the event by value into the lambda.
   void DispatchPointerEvent(const FlutterPointerEvent& pe);
@@ -150,6 +164,11 @@ class SoftwareSeat final : public ISeat {
     double y{0.0};
   };
   std::array<TouchSlot, kMaxTouchSlots> touch_{};
+
+  // Touch events accumulated since the last LIBINPUT_EVENT_TOUCH_FRAME.
+  // libinput groups the per-slot updates of one hardware scan between frame
+  // markers; see FlushTouchBatch. Touched only on the libinput worker thread.
+  std::vector<FlutterPointerEvent> touch_batch_;
 };
 
 }  // namespace homescreen

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -714,33 +714,51 @@ void Engine::CoalesceTouchEvent(const FlutterPointerPhase phase,
                                 const double x,
                                 const double y,
                                 const int32_t device) {
-  auto timestamp = LibFlutterEngine->GetCurrentTime() / 1000;
+  const TouchEvent e{phase, x, y, device};
+  CoalesceTouchFrame(&e, 1);
+}
+
+void Engine::CoalesceTouchFrame(const TouchEvent* events, const size_t count) {
+  if (events == nullptr || count == 0) {
+    return;
+  }
+
+  // One timestamp for the whole frame: the contacts in a touch frame are
+  // logically simultaneous (wl_touch.frame / libinput TOUCH_FRAME group one
+  // hardware scan), and a shared timestamp keeps the engine's pointer
+  // resampler from interpolating skew between fingers that moved together.
+  const auto timestamp = LibFlutterEngine->GetCurrentTime() / 1000;
+
   std::scoped_lock lock(m_pointer_mutex);
-
-  FlutterPointerEvent e{};
-  e.struct_size = sizeof(FlutterPointerEvent);
-  e.phase = phase;
+  for (size_t i = 0; i < count; ++i) {
+    FlutterPointerEvent e{};
+    e.struct_size = sizeof(FlutterPointerEvent);
+    e.phase = events[i].phase;
 #if ENV64BIT
-  e.timestamp = timestamp;
+    e.timestamp = timestamp;
 #elif ENV32BIT
-  e.timestamp = static_cast<size_t>(timestamp & 0xFFFFFFFFULL);
+    e.timestamp = static_cast<size_t>(timestamp & 0xFFFFFFFFULL);
 #endif
-  e.x = x;
-  e.y = y;
-  e.device = device;
-  e.signal_kind = kFlutterPointerSignalKindNone;
-  e.scroll_delta_x = 0.0;
-  e.scroll_delta_y = 0.0;
-  e.device_kind = kFlutterPointerDeviceKindTouch;
-  e.buttons = 0;
-  e.pan_x = 0;
-  e.pan_y = 0;
-  e.scale = 0;
-  e.rotation = 0;
+    e.x = events[i].x;
+    e.y = events[i].y;
+    e.device = events[i].device;
+    e.signal_kind = kFlutterPointerSignalKindNone;
+    e.scroll_delta_x = 0.0;
+    e.scroll_delta_y = 0.0;
+    e.device_kind = kFlutterPointerDeviceKindTouch;
+    e.buttons = 0;
+    e.pan_x = 0;
+    e.pan_y = 0;
+    e.scale = 0;
+    e.rotation = 0;
 
-  m_pointer_events.emplace_back(e);
+    m_pointer_events.emplace_back(e);
+  }
 
-  // Wake the main loop so it flushes this batch promptly (see above).
+  // Wake the main loop once per frame so it flushes this batch promptly
+  // instead of waiting for its next periodic tick (the loop blocks idle on a
+  // static screen). Per-event wakes on a 10-finger controller would be ten
+  // eventfd writes per hardware scan for one flush.
   MainLoopWaker::instance().Wake();
 }
 

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -313,6 +313,35 @@ class Engine {
                           int32_t device);
 
   /**
+   * @brief One touch contact update within a hardware scan (touch frame)
+   */
+  struct TouchEvent {
+    FlutterPointerPhase phase;
+    double x;
+    double y;
+    int32_t device;
+  };
+
+  /**
+   * @brief Coalesce one complete touch frame (a group of logically
+   * simultaneous per-contact updates, e.g. everything between two
+   * wl_touch.frame events or two libinput TOUCH_FRAME markers).
+   *
+   * The whole group is appended to the pointer queue under a single lock,
+   * stamped with a single timestamp (the contacts moved at the same instant),
+   * and the main loop is woken once — so a 10-finger update costs one wake
+   * and reaches the engine as one FlutterEngineSendPointerEvent batch, i.e.
+   * one UI-thread task post instead of ten.
+   *
+   * @param[in] events First event of the frame
+   * @param[in] count Number of events in the frame
+   * @return void
+   * @relation
+   * flutter
+   */
+  void CoalesceTouchFrame(const TouchEvent* events, size_t count);
+
+  /**
    * @brief Send coalesced Pointer events
    * @return void
    * @relation

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -15,6 +15,8 @@
  */
 
 #include "input/drm_seat.h"
+
+#include "config/common.h"
 #include "logging/logging.h"
 
 #include <fcntl.h>
@@ -1094,8 +1096,23 @@ void DrmSeat::HandlePointerAxis(const drm::input::PointerAxisEvent& ev) const {
   DispatchToRegion(region, &pe, 1);
 }
 
+void DrmSeat::FlushTouchBatch() const {
+  if (touch_batch_.empty() || touch_batch_region_ == nullptr) {
+    touch_batch_.clear();
+    touch_batch_region_ = nullptr;
+    return;
+  }
+  DispatchToRegion(*touch_batch_region_, touch_batch_.data(),
+                   touch_batch_.size());
+  touch_batch_.clear();
+  touch_batch_region_ = nullptr;
+}
+
 void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   if (ev.type == drm::input::TouchEvent::Type::Frame) {
+    // Frame marker: everything since the previous marker is one hardware
+    // scan — hand it to the engine as one batch.
+    FlushTouchBatch();
     return;
   }
   if (regions_.empty()) {
@@ -1194,6 +1211,19 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   pe.device_kind = kFlutterPointerDeviceKindTouch;
   pe.buttons = 0;
 
-  DispatchToRegion(*region, &pe, 1);
+  // Contacts must not straddle regions within one batch (multi-panel setups
+  // route by device); flush the previous region's batch first.
+  if (touch_batch_region_ != nullptr && touch_batch_region_ != region) {
+    FlushTouchBatch();
+  }
+  touch_batch_region_ = region;
+  touch_batch_.push_back(pe);
+
+  // Backstops: cancel ends the session with no guaranteed trailing frame
+  // marker, and a runaway stream without markers must not grow unbounded.
+  if (phase == kCancel ||
+      touch_batch_.size() >= static_cast<size_t>(kMaxPointerEvent)) {
+    FlushTouchBatch();
+  }
 }
 }  // namespace homescreen

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -266,6 +266,17 @@ class DrmSeat final : public ISeat {
   // corner. Touched only from the seat dispatch thread (HandleTouch is const).
   mutable std::unordered_map<int32_t, std::pair<double, double>> touch_pos_;
 
+  // Touch events accumulated since the last TOUCH_FRAME marker, and the
+  // region they route to. libinput groups the per-slot updates of one
+  // hardware scan between frame markers; dispatching the group as one batch
+  // means one strand task and one FlutterEngineSendPointerEvent (= one
+  // UI-thread task post in the engine) per scan, instead of one per contact
+  // — a 10-finger drag at a 250 Hz scan rate is 250 posts/s instead of
+  // 2500/s. Touched only from the seat dispatch thread.
+  mutable std::vector<FlutterPointerEvent> touch_batch_;
+  mutable const ViewRegion* touch_batch_region_ = nullptr;
+  void FlushTouchBatch() const;
+
   // Caller-supplied hook for libinput's privileged device opens. Empty
   // when there's no libseat session (falls back to ::open/::close inside
   // drm::input::Seat).

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -754,6 +754,15 @@ void Display::UpdateTextInputSurrounding(const std::string& utf8,
   });
 }
 
+// All wl_touch handlers run on the wayland event thread, so m_touch needs no
+// locking. down/up/motion only accumulate into m_touch.frame; the batch is
+// handed to the engine on wl_touch.frame — the protocol's atomicity boundary
+// (everything between two frame events is one logically-simultaneous hardware
+// scan). A 10-finger update therefore reaches the engine as one group (one
+// lock, one main-loop wake, one FlutterEngineSendPointerEvent call → one
+// UI-thread task in the engine) instead of ten independent submissions that
+// can be split across flushes mid-scan.
+
 void Display::touch_handle_down(void* data,
                                 struct wl_touch* /* wl_touch */,
                                 uint32_t /* serial */,
@@ -764,16 +773,19 @@ void Display::touch_handle_down(void* data,
                                 wl_fixed_t y_w) {
   auto* d = static_cast<Display*>(data);
 
-  d->m_touch.surface_x[id] = x_w;
-  d->m_touch.surface_y[id] = y_w;
-
-  d->m_active_surface = surface;
-  d->m_touch_engine = d->m_surface_engine_map[surface];
-  if (d->m_touch_engine) {
-    d->m_touch_engine->CoalesceTouchEvent(FlutterPointerPhase::kDown,
-                                          wl_fixed_to_double(x_w),
-                                          wl_fixed_to_double(y_w), id);
+  // Contacts must not straddle engines within one batch: if a new contact
+  // lands on a different surface, flush what belongs to the previous engine
+  // first.
+  Engine* engine = d->m_surface_engine_map[surface];
+  if (engine != d->m_touch_engine) {
+    touch_flush_frame(d);
   }
+  d->m_active_surface = surface;
+  d->m_touch_engine = engine;
+
+  d->m_touch.points[id] = {x_w, y_w};
+  touch_push(d, {FlutterPointerPhase::kDown, wl_fixed_to_double(x_w),
+                 wl_fixed_to_double(y_w), id});
 }
 
 void Display::touch_handle_up(void* data,
@@ -781,13 +793,18 @@ void Display::touch_handle_up(void* data,
                               uint32_t /* serial */,
                               uint32_t /* time */,
                               int32_t id) {
-  const auto* d = static_cast<Display*>(data);
+  auto* d = static_cast<Display*>(data);
 
-  if (d->m_touch_engine) {
-    d->m_touch_engine->CoalesceTouchEvent(
-        kUp, wl_fixed_to_double(d->m_touch.surface_x[id]),
-        wl_fixed_to_double(d->m_touch.surface_y[id]), id);
+  // wl_touch.up carries no coordinates; reuse the contact's last position.
+  // Unknown id (no prior down seen, e.g. attach mid-session) is dropped —
+  // the engine was never told this device went down.
+  const auto it = d->m_touch.points.find(id);
+  if (it == d->m_touch.points.end()) {
+    return;
   }
+  touch_push(d, {kUp, wl_fixed_to_double(it->second.first),
+                 wl_fixed_to_double(it->second.second), id});
+  d->m_touch.points.erase(it);
 }
 
 void Display::touch_handle_motion(void* data,
@@ -798,27 +815,60 @@ void Display::touch_handle_motion(void* data,
                                   wl_fixed_t y_w) {
   auto* d = static_cast<Display*>(data);
 
-  d->m_touch.surface_x[id] = x_w;
-  d->m_touch.surface_y[id] = y_w;
-
-  if (d->m_touch_engine) {
-    d->m_touch_engine->CoalesceTouchEvent(FlutterPointerPhase::kMove,
-                                          wl_fixed_to_double(x_w),
-                                          wl_fixed_to_double(y_w), id);
+  const auto it = d->m_touch.points.find(id);
+  if (it == d->m_touch.points.end()) {
+    return;
   }
+  it->second = {x_w, y_w};
+  touch_push(d, {FlutterPointerPhase::kMove, wl_fixed_to_double(x_w),
+                 wl_fixed_to_double(y_w), id});
 }
 
 void Display::touch_handle_cancel(void* data, struct wl_touch* /* wl_touch */) {
-  const auto* d = static_cast<Display*>(data);
-  if (d->m_touch_engine) {
-    SPDLOG_DEBUG("touch_handle_cancel");
-    d->m_touch_engine->CoalesceTouchEvent(kCancel, d->m_pointer.event.surface_x,
-                                          d->m_pointer.event.surface_y, 0);
+  auto* d = static_cast<Display*>(data);
+  SPDLOG_DEBUG("touch_handle_cancel");
+
+  // The compositor cancelled the whole touch session (e.g. it recognized a
+  // system gesture). Every active contact must be cancelled in the engine —
+  // a contact left in the down phase trips
+  // FML_DCHECK(!state.is_down) in the engine's PointerDataPacketConverter on
+  // the next session's down for that device, and leaks its gesture-arena
+  // entry in the framework. Cancel each contact at its last known position
+  // (the previous code cancelled only device 0, at the *mouse* position).
+  d->m_touch.frame.clear();  // pending updates for this session are moot
+  for (const auto& [id, pos] : d->m_touch.points) {
+    d->m_touch.frame.push_back({kCancel, wl_fixed_to_double(pos.first),
+                                wl_fixed_to_double(pos.second), id});
   }
+  d->m_touch.points.clear();
+  // The protocol does not guarantee a frame event after cancel; flush now.
+  touch_flush_frame(d);
 }
 
-void Display::touch_handle_frame(void* /* data */,
-                                 struct wl_touch* /* wl_touch */) {}
+void Display::touch_handle_frame(void* data, struct wl_touch* /* wl_touch */) {
+  touch_flush_frame(static_cast<Display*>(data));
+}
+
+void Display::touch_flush_frame(Display* d) {
+  if (d->m_touch.frame.empty()) {
+    return;
+  }
+  if (d->m_touch_engine) {
+    d->m_touch_engine->CoalesceTouchFrame(d->m_touch.frame.data(),
+                                          d->m_touch.frame.size());
+  }
+  d->m_touch.frame.clear();
+}
+
+void Display::touch_push(Display* d, const Engine::TouchEvent& ev) {
+  d->m_touch.frame.push_back(ev);
+  // wl_touch.frame is the normal flush boundary, but the protocol can't force
+  // a compositor to send it; cap the batch so a stream without frame markers
+  // can't grow the accumulator unbounded (parity with the drm/software seats).
+  if (d->m_touch.frame.size() >= static_cast<size_t>(kMaxPointerEvent)) {
+    touch_flush_frame(d);
+  }
+}
 
 constexpr wl_touch_listener Display::touch_listener = {
     .down = touch_handle_down,

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -56,10 +56,14 @@
 #include <wl/ime/backend.hpp>
 #include <wl/ime/text_input_receiver.hpp>
 
+#include <unordered_map>
+#include <utility>
+
 #include "config/common.h"
 #include "configuration/configuration.h"
 #include "display/idisplay.h"
 #include "display/output_provider.h"
+#include "engine.h"
 #include "platform/homescreen/flutter_desktop_view_controller_state.h"
 #include "platform/homescreen/key_event_handler.h"
 #include "platform/homescreen/keyboard_hook_handler.h"
@@ -528,8 +532,20 @@ class Display : public IDisplay,
   struct touch_ {
     struct wl_touch* touch;
     struct touch_event event;
-    wl_fixed_t surface_x[kMaxTouchFinger];
-    wl_fixed_t surface_y[kMaxTouchFinger];
+    // Active contacts: wl_touch id -> last surface position. Replaces the
+    // former fixed surface_x/surface_y[kMaxTouchFinger] arrays: compositor
+    // assigned touch ids are only guaranteed unique per session, not bounded
+    // by kMaxTouchFinger, so indexing an array by id was an out-of-bounds
+    // write waiting for an id >= 10 (finger churn on a 10-slot controller,
+    // or any >10-slot panel). The map also lets wl_touch.cancel terminate
+    // every active contact instead of just device 0.
+    std::unordered_map<int32_t, std::pair<wl_fixed_t, wl_fixed_t>> points;
+    // Per-contact updates accumulated since the last wl_touch.frame. The
+    // frame event is the protocol's atomicity boundary: everything between
+    // two frames is one logically-simultaneous hardware scan, so it is
+    // handed to the engine as one batch (one lock, one main-loop wake, one
+    // FlutterEngineSendPointerEvent group).
+    std::vector<Engine::TouchEvent> frame;
     uint32_t state;
     FlutterPointerPhase phase;
   } m_touch{};
@@ -985,6 +1001,31 @@ class Display : public IDisplay,
    * @note Do nothing
    */
   static void touch_handle_frame(void* data, struct wl_touch* wl_touch);
+
+  /**
+   * @brief Hand the touch updates accumulated since the last wl_touch.frame
+   * to the active engine as one batch, then reset the accumulator. No-op
+   * when nothing is pending.
+   * @param[in] d Display instance
+   * @return void
+   * @relation
+   * wayland, flutter
+   */
+  static void touch_flush_frame(Display* d);
+
+  /**
+   * @brief Append one contact update to the pending touch frame, flushing
+   * early if the batch would exceed kMaxPointerEvent. wl_touch.frame is the
+   * normal flush boundary, but a broken or hostile compositor could stream
+   * down/motion without ever sending it; the cap keeps the accumulator from
+   * growing unbounded (parity with the drm/software seats).
+   * @param[in] d Display instance
+   * @param[in] ev Contact update to queue
+   * @return void
+   * @relation
+   * wayland, flutter
+   */
+  static void touch_push(Display* d, const Engine::TouchEvent& ev);
 
   static const wl_touch_listener touch_listener;
 };


### PR DESCRIPTION
## Summary

Touch contacts are now handed to the Flutter engine one batch per hardware scan (the `wl_touch.frame` / libinput `TOUCH_FRAME` atomicity boundary) instead of one submission per contact. A 10-finger update at a 250 Hz scan rate drops from ~2500 UI-thread task posts/s to ~250: one lock, one main-loop wake, one `FlutterEngineSendPointerEvent`, and one shared timestamp per scan (so the framework's pointer resampler doesn't interpolate skew between fingers that moved together).

Applies across all three input paths: Wayland (`display.cc`), `drm_seat`, and `software_seat`, backed by a new `Engine::CoalesceTouchFrame`.

## Correctness fixes bundled in

- **OOB write (Wayland):** `surface_x/surface_y[kMaxTouchFinger]` were indexed by the compositor-assigned touch id. Protocol ids are only unique per session, not bounded by 10, so an id ≥ 10 (finger churn on a 10-slot controller, or any larger panel) wrote out of bounds. Replaced with an id→position map.
- **cancel (Wayland):** `wl_touch.cancel` now cancels *every* active contact at its last known position. Previously only device 0 was canceled, at the *mouse* position — the other contacts stayed down in the engine, tripping `FML_DCHECK(!state.is_down)` in `PointerDataPacketConverter` on the next session and leaking gesture-arena entries.
- **Engine straddle (Wayland):** a contact landing on a different surface/engine flushes the previous engine's batch first, so a batch never straddles engines.
- **Unbounded growth backstop (all seats):** a `kMaxPointerEvent` cap flushes early if an input stream never sends a frame marker, so the accumulator can't grow unbounded. `drm_seat`/`software_seat` also flush on cancel (no guaranteed trailing marker); `drm_seat` also flushes when contacts straddle view regions.

## Testing

- Compiles clean with Software + DRM (EGL/Vulkan) + Wayland backends and `BUILD_COMPOSITOR=ON`.
- `clang-tidy-19` clean (no fixes), `clang-format-19` clean.

## Known limitation

Multi-view touch that straddles two surfaces owned by different engines still routes non-`down` events (`motion`/`up`/`cancel`) to the last-`down` engine. This is a pre-existing niche of the shared touch accumulator, not introduced here; single-engine (the common case) is fully correct.
