### PR TITLE
test: add multi_touch_test 10-finger integration app + uinput injector

### DIFF
--- a/test/integration/multi_touch_test/.gitignore
+++ b/test/integration/multi_touch_test/.gitignore
@@ -1,0 +1,20 @@
+# Dart / Flutter build output
+.dart_tool/
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+pubspec.lock
+
+# Homescreen bundle output (`-b` target for the homescreen embedder)
+.desktop-homescreen/
+bundle-*/
+
+# Python injector bytecode
+__pycache__/
+*.pyc
+
+# IDE / editor
+.idea/
+*.iml
+.vscode/

--- a/test/integration/multi_touch_test/README.md
+++ b/test/integration/multi_touch_test/README.md
@@ -1,0 +1,116 @@
+# multi_touch_test
+
+Integration test app for **10-finger multi-touch delivery** against the
+ivi-homescreen embedder, plus a uinput injector that simulates a 10-slot
+MT protocol B touch controller — no hardware needed.
+
+The contract under test is the whole touch path:
+
+```
+kernel evdev (MT slots, SYN_REPORT = one hardware scan)
+  -> libinput TOUCH_DOWN/MOTION/UP + TOUCH_FRAME
+  -> wl_touch.down/motion/up + wl_touch.frame        (Wayland backends)
+     or DrmSeat / SoftwareSeat directly              (drm / software backends)
+  -> FlutterEngineSendPointerEvent (one call per touch frame)
+  -> one PointerDataPacket -> one UI-thread task
+  -> PointerDown/Move/Up/Cancel on a raw Listener
+```
+
+The app uses a full-screen `Listener` — no `GestureDetector`, no gesture
+arena — so the raw stream reaches the checks unmodified.
+
+## Checks
+
+| # | Check | What it validates |
+| --- | --- | --- |
+| C1 | concurrency | ≥ `EXPECT_FINGERS` (10) simultaneous contacts with that many distinct device ids |
+| C2 | legality | per-device phase machine: no down-while-down, no move/up/cancel-while-up. Catches lost transitions and the historical cancel bug (only device 0 cancelled → 9 contacts stuck down → next session violates) |
+| C3 | churn | ≥ `EXPECT_CHURN_IDS` (24) distinct device ids across the run. Compositor/libinput touch ids are unbounded; the pre-fix embedder indexed a fixed `surface_x[10]` array by id — an out-of-bounds write for id ≥ 10 |
+| C4 | frame batch | contacts in one hardware scan arrive with one shared timestamp (the embedder stamps the batch once). Mean move-group size during the synchronized 10-finger drag must be ≥ `EXPECT_BATCH_MEAN` (6.0). An unbatched embedder stamps each contact separately → mean ≈ 1 |
+| C5 | cancel | after a compositor cancel, every down contact receives `PointerCancel` within 500 ms. Advisory until a cancel is observed (trigger one manually via a compositor system gesture) |
+
+`MTT-SUMMARY: {json}` is printed whenever all contacts lift.
+`MULTI_TOUCH_TEST: PASS|FAIL` is printed by the Self-check button, or
+automatically with `--dart-define=SELFCHECK_AFTER_S=<seconds>`.
+
+## Expected results
+
+| Embedder | C1 | C2 | C3 | C4 (mean batch) |
+| --- | --- | --- | --- | --- |
+| pre touch-frame-batching | pass | pass* | **undefined behaviour** (OOB write for id ≥ 10) | **fail** (≈ 1.0) |
+| with touch-frame-batching | pass | pass | pass | pass (≈ 10) |
+
+\* C2 fails pre-fix if a compositor cancel occurs mid-session (only device 0
+was cancelled, at the mouse position).
+
+## Building
+
+```sh
+cd test/integration/multi_touch_test
+flutter pub get
+flutter build bundle \
+    --dart-define=SELFCHECK_AFTER_S=60   # optional, for unattended runs
+```
+
+Point ivi-homescreen at `build/flutter_assets` via `-b`.
+
+## Driving it
+
+### Simulated controller (uinput)
+
+```sh
+pip install evdev
+sudo ./tools/inject_ten_finger.py --width 1920 --height 1080
+```
+
+Needs root (or an `input`-group user with `/dev/uinput` access) and a
+compositor that picks up hotplugged input devices. Adjust `--width/--height`
+to the output resolution so injected coordinates land on the app. Phases:
+
+1. **A** — press fingers 0..9 one per scan, hold (C1)
+2. **B** — synchronized 10-finger drag, 250 scans at 125 Hz (C4)
+3. **C** — staggered lift
+4. **D** — 30 rapid taps; tracking ids grow monotonically past 10 (C3)
+5. **E** — 3× quick full-hand tap
+
+#### Spanned multi-monitor desktops
+
+A nesting compositor (mutter, KWin) maps an unassociated touch device across
+the **whole logical desktop**, so contacts sized to one output scatter onto
+the neighbours — e.g. on a 2560+1280 dual-head only 6 of 10 fingers land on a
+2560-wide fullscreen app. Pass the full span and the app output's offset so
+every contact lands on the app:
+
+```sh
+sudo ./tools/inject_ten_finger.py --width 2560 --height 1440 \
+    --desktop-width 3840 --desktop-height 1440 --output-x 0 --output-y 0
+```
+
+Simpler alternatives: disable the second monitor, or drive the **drm/software
+backend on a VT** (below), where libinput feeds the seat directly and no
+per-output mapping applies — none of these flags are needed there.
+
+### Real hardware
+
+Any ≥ 10-point panel. C3 requires enough finger churn to advance the
+compositor's touch ids past 24 — tap repeatedly. Compositors that reuse the
+lowest free id (Weston, wlroots) will not grow ids by design; use the
+injector (which drives the libinput path with growing tracking ids) or lower
+`EXPECT_CHURN_IDS` for those.
+
+## Why frame batching matters (the "engine interruption" question)
+
+`FlutterEngineSendPointerEvent` turns **each call** into one
+`PointerDataPacket` and posts it as **one task to the UI thread**
+(`Shell::OnPlatformViewDispatchPointerDataPacket` →
+`RunNowAndFlushMessages(ui_task_runner, ...)`). The embedder profile uses
+`DefaultPointerDataDispatcher` — there is no engine-side vsync buffering
+(that's Android-only `SmoothPointerDataDispatcher`), so batching is entirely
+the embedder's job.
+
+Per-contact submission on a 10-finger controller scanning at 250 Hz is
+2 500 UI-thread task posts per second, each interleaving with frame
+production. Batching on the protocol's atomicity boundary
+(`wl_touch.frame` / libinput `TOUCH_FRAME` — everything between two markers
+is one logically-simultaneous hardware scan) reduces that to 250, with one
+lock acquisition, one main-loop wake, and one shared timestamp per scan.

--- a/test/integration/multi_touch_test/analysis_options.yaml
+++ b/test/integration/multi_touch_test/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: false

--- a/test/integration/multi_touch_test/lib/main.dart
+++ b/test/integration/multi_touch_test/lib/main.dart
@@ -1,0 +1,438 @@
+// Integration test app for multi-touch delivery against the ivi-homescreen
+// embedder, sized for a 10-finger touch controller.
+//
+// The contract under test is the embedder's touch path:
+//
+//   wl_touch (or libinput TOUCH_*) -> FlutterEngineSendPointerEvent
+//     -> PointerDataPacket -> framework PointerEvents on a raw Listener
+//
+// No GestureDetector and no gesture arena — a full-screen Listener receives
+// the raw PointerDown/Move/Up/Cancel stream so nothing recognizes, claims,
+// or swallows events before the checks see them.
+//
+// Checks (each flips green the first time it is satisfied; violations are
+// counted and never reset except by the Reset button):
+//
+//   C1 concurrency   Peak simultaneous down contacts >= EXPECT_FINGERS
+//                    (default 10) with that many *distinct* device ids.
+//   C2 legality      Per-device phase machine: down only while up, move/up/
+//                    cancel only while down. A violation here means the
+//                    embedder lost, duplicated, or mis-routed a transition
+//                    (e.g. the historical cancel-only-device-0 bug leaves 9
+//                    contacts stuck down; the next session's down for those
+//                    devices is a down-while-down violation).
+//   C3 churn         Total distinct device ids observed across the run
+//                    >= EXPECT_CHURN_IDS (default 24). Exercises compositor
+//                    touch-id growth beyond any fixed 10-slot array — the
+//                    pre-fix embedder indexed surface_x[id] and wrote out of
+//                    bounds for id >= 10.
+//   C4 frame batch   Events that arrive in one PointerDataPacket from one
+//                    hardware scan share one timestamp (the embedder stamps
+//                    the batch once). During a synchronized N-finger drag the
+//                    mean move-group size (grouped by identical timeStamp)
+//                    should approach N. Threshold EXPECT_BATCH_MEAN (default
+//                    6.0 for a 10-finger drag). An unbatched embedder stamps
+//                    each contact separately -> mean ~1.
+//   C5 cancel        After a compositor cancel (e.g. a system gesture takes
+//                    the touch session), every down contact receives
+//                    PointerCancel — no contact may still be down 500 ms
+//                    after a cancel arrives for any device. Advisory unless
+//                    a cancel is actually observed.
+//
+// A summary JSON line prefixed "MTT-SUMMARY:" is printed whenever all
+// contacts lift, and "MULTI_TOUCH_TEST: PASS|FAIL" whenever the Self-check
+// button is tapped or SELFCHECK_AFTER_S (dart-define) elapses — CI runs
+// scrape either.
+//
+// Drive it with tools/inject_ten_finger.py (uinput, no hardware needed) or a
+// real 10-point panel.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+const int kExpectFingers =
+    int.fromEnvironment('EXPECT_FINGERS', defaultValue: 10);
+const int kExpectChurnIds =
+    int.fromEnvironment('EXPECT_CHURN_IDS', defaultValue: 24);
+// Dart has no double.fromEnvironment; read it as a string and parse.
+const String _kExpectBatchMeanRaw =
+    String.fromEnvironment('EXPECT_BATCH_MEAN', defaultValue: '6.0');
+final double kExpectBatchMean = double.tryParse(_kExpectBatchMeanRaw) ?? 6.0;
+// 0 disables the self-check timer (manual runs).
+const int kSelfCheckAfterS =
+    int.fromEnvironment('SELFCHECK_AFTER_S', defaultValue: 0);
+
+void main() {
+  FlutterError.onError = (FlutterErrorDetails details) {
+    FlutterError.dumpErrorToConsole(details);
+  };
+  runApp(const MultiTouchTestApp());
+}
+
+class MultiTouchTestApp extends StatelessWidget {
+  const MultiTouchTestApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData.dark(useMaterial3: true),
+      home: const TouchProbePage(),
+    );
+  }
+}
+
+/// Everything observed about one embedder device id.
+class DeviceState {
+  bool down = false;
+  Offset last = Offset.zero;
+  int downs = 0;
+  int moves = 0;
+  int ups = 0;
+  int cancels = 0;
+}
+
+class TouchProbePage extends StatefulWidget {
+  const TouchProbePage({super.key});
+
+  @override
+  State<TouchProbePage> createState() => _TouchProbePageState();
+}
+
+class _TouchProbePageState extends State<TouchProbePage> {
+  final Map<int, DeviceState> _devices = <int, DeviceState>{};
+  final Set<int> _everSeenIds = <int>{};
+
+  int _peakSimultaneous = 0;
+  int _peakDistinctAtPeak = 0;
+  int _legalityViolations = 0;
+  final List<String> _violationLog = <String>[];
+
+  // C4: move events grouped by identical timeStamp. A group is closed when a
+  // move with a different timestamp arrives. Only groups observed while >= 2
+  // contacts are down count toward the mean (single-finger motion trivially
+  // batches to 1 and would dilute the metric).
+  Duration? _openGroupTs;
+  int _openGroupSize = 0;
+  int _groupCount = 0;
+  int _groupEventTotal = 0;
+  int _largestGroup = 0;
+
+  // C5: pending cancel deadline — set when any cancel arrives while other
+  // contacts are down; if contacts remain down past it, that's a violation.
+  Timer? _cancelDeadline;
+  bool _cancelObserved = false;
+  int _cancelViolations = 0;
+
+  Timer? _selfCheckTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    if (kSelfCheckAfterS > 0) {
+      _selfCheckTimer =
+          Timer(Duration(seconds: kSelfCheckAfterS), _printVerdict);
+    }
+  }
+
+  @override
+  void dispose() {
+    _selfCheckTimer?.cancel();
+    _cancelDeadline?.cancel();
+    super.dispose();
+  }
+
+  DeviceState _dev(int id) => _devices.putIfAbsent(id, DeviceState.new);
+
+  int get _downCount => _devices.values.where((d) => d.down).length;
+
+  void _violation(String what) {
+    _legalityViolations++;
+    if (_violationLog.length < 50) {
+      _violationLog.add(what);
+    }
+    debugPrint('MTT-VIOLATION: $what');
+  }
+
+  void _closeGroup() {
+    if (_openGroupTs == null) return;
+    _groupCount++;
+    _groupEventTotal += _openGroupSize;
+    if (_openGroupSize > _largestGroup) _largestGroup = _openGroupSize;
+    _openGroupTs = null;
+    _openGroupSize = 0;
+  }
+
+  void _trackGroup(Duration ts) {
+    if (_downCount < 2) {
+      _closeGroup();
+      return;
+    }
+    if (_openGroupTs == ts) {
+      _openGroupSize++;
+    } else {
+      _closeGroup();
+      _openGroupTs = ts;
+      _openGroupSize = 1;
+    }
+  }
+
+  double get _meanBatch =>
+      _groupCount == 0 ? 0 : _groupEventTotal / _groupCount;
+
+  void _onDown(PointerDownEvent e) {
+    final d = _dev(e.device);
+    if (d.down) {
+      _violation('down-while-down device=${e.device}');
+    }
+    d.down = true;
+    d.downs++;
+    d.last = e.position;
+    _everSeenIds.add(e.device);
+    _closeGroup(); // a down interleaved in the stream ends any move group
+
+    final down = _downCount;
+    if (down > _peakSimultaneous) {
+      _peakSimultaneous = down;
+      _peakDistinctAtPeak = _devices.entries
+          .where((en) => en.value.down)
+          .map((en) => en.key)
+          .toSet()
+          .length;
+    }
+    setState(() {});
+  }
+
+  void _onMove(PointerMoveEvent e) {
+    final d = _dev(e.device);
+    if (!d.down) {
+      _violation('move-while-up device=${e.device}');
+    }
+    d.moves++;
+    d.last = e.position;
+    _trackGroup(e.timeStamp);
+    setState(() {});
+  }
+
+  void _onUp(PointerUpEvent e) {
+    final d = _dev(e.device);
+    if (!d.down) {
+      _violation('up-while-up device=${e.device}');
+    }
+    d.down = false;
+    d.ups++;
+    _closeGroup();
+    setState(() {});
+    if (_downCount == 0) _printSummary();
+  }
+
+  void _onCancel(PointerCancelEvent e) {
+    final d = _dev(e.device);
+    if (!d.down) {
+      _violation('cancel-while-up device=${e.device}');
+    }
+    d.down = false;
+    d.cancels++;
+    _cancelObserved = true;
+    _closeGroup();
+
+    // C5: every contact that was down when the compositor cancelled the
+    // session must also be cancelled. Give the rest of the batch 500 ms.
+    _cancelDeadline?.cancel();
+    _cancelDeadline = Timer(const Duration(milliseconds: 500), () {
+      final stuck = _devices.entries
+          .where((en) => en.value.down)
+          .map((en) => en.key)
+          .toList();
+      if (stuck.isNotEmpty) {
+        _cancelViolations += stuck.length;
+        debugPrint('MTT-VIOLATION: contacts still down 500ms after cancel: '
+            '$stuck');
+        setState(() {});
+      }
+    });
+    setState(() {});
+    if (_downCount == 0) _printSummary();
+  }
+
+  // ---- verdict -----------------------------------------------------------
+
+  bool get _c1 =>
+      _peakSimultaneous >= kExpectFingers &&
+      _peakDistinctAtPeak >= kExpectFingers;
+  bool get _c2 => _legalityViolations == 0;
+  bool get _c3 => _everSeenIds.length >= kExpectChurnIds;
+  bool get _c4 => _groupCount > 0 && _meanBatch >= kExpectBatchMean;
+  bool get _c5 => _cancelViolations == 0; // advisory if no cancel observed
+
+  Map<String, dynamic> _summary() => <String, dynamic>{
+        'peak_simultaneous': _peakSimultaneous,
+        'peak_distinct_ids': _peakDistinctAtPeak,
+        'distinct_ids_total': _everSeenIds.length,
+        'legality_violations': _legalityViolations,
+        'move_groups': _groupCount,
+        'mean_batch': double.parse(_meanBatch.toStringAsFixed(2)),
+        'largest_batch': _largestGroup,
+        'cancel_observed': _cancelObserved,
+        'cancel_violations': _cancelViolations,
+        'c1_concurrency': _c1,
+        'c2_legality': _c2,
+        'c3_churn': _c3,
+        'c4_frame_batch': _c4,
+        'c5_cancel': _c5,
+      };
+
+  void _printSummary() {
+    debugPrint('MTT-SUMMARY: ${jsonEncode(_summary())}');
+  }
+
+  void _printVerdict() {
+    _printSummary();
+    final pass = _c1 && _c2 && _c3 && _c4 && _c5;
+    debugPrint('MULTI_TOUCH_TEST: ${pass ? 'PASS' : 'FAIL'}');
+  }
+
+  void _reset() {
+    setState(() {
+      _devices.clear();
+      _everSeenIds.clear();
+      _peakSimultaneous = 0;
+      _peakDistinctAtPeak = 0;
+      _legalityViolations = 0;
+      _violationLog.clear();
+      _openGroupTs = null;
+      _openGroupSize = 0;
+      _groupCount = 0;
+      _groupEventTotal = 0;
+      _largestGroup = 0;
+      _cancelObserved = false;
+      _cancelViolations = 0;
+    });
+  }
+
+  // ---- UI ----------------------------------------------------------------
+
+  Widget _check(String label, bool ok, String detail, {bool advisory = false}) {
+    final color = ok
+        ? Colors.greenAccent
+        : (advisory ? Colors.amberAccent : Colors.redAccent);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(children: [
+        Icon(ok ? Icons.check_circle : Icons.radio_button_unchecked,
+            color: color, size: 18),
+        const SizedBox(width: 8),
+        Expanded(
+            child: Text('$label — $detail',
+                style: TextStyle(color: color, fontSize: 13))),
+      ]),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final active = _devices.entries.where((e) => e.value.down).toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+
+    return Scaffold(
+      body: Listener(
+        behavior: HitTestBehavior.opaque,
+        onPointerDown: _onDown,
+        onPointerMove: _onMove,
+        onPointerUp: _onUp,
+        onPointerCancel: _onCancel,
+        child: Stack(children: [
+          // Contact dots
+          for (final e in active)
+            Positioned(
+              left: e.value.last.dx - 28,
+              top: e.value.last.dy - 28,
+              child: IgnorePointer(
+                child: Container(
+                  width: 56,
+                  height: 56,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Colors.primaries[e.key % Colors.primaries.length]
+                        .withOpacity(0.6),
+                  ),
+                  child: Text('${e.key}',
+                      style: const TextStyle(
+                          fontWeight: FontWeight.bold, fontSize: 16)),
+                ),
+              ),
+            ),
+          // Scoreboard
+          Positioned(
+            left: 12,
+            top: 12,
+            child: IgnorePointer(
+              child: Container(
+                width: 460,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.black.withOpacity(0.65),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                        'down: $_downCount   peak: $_peakSimultaneous '
+                        '(distinct ${_peakDistinctAtPeak})   '
+                        'ids ever: ${_everSeenIds.length}',
+                        style: const TextStyle(
+                            fontSize: 14, fontWeight: FontWeight.bold)),
+                    const Divider(height: 12),
+                    _check(
+                        'C1 concurrency',
+                        _c1,
+                        'peak $_peakSimultaneous/$kExpectFingers, '
+                            'distinct $_peakDistinctAtPeak'),
+                    _check(
+                        'C2 legality', _c2, '$_legalityViolations violations'),
+                    _check('C3 churn', _c3,
+                        '${_everSeenIds.length}/$kExpectChurnIds ids'),
+                    _check(
+                        'C4 frame batch',
+                        _c4,
+                        'mean ${_meanBatch.toStringAsFixed(2)} '
+                            '(>= $kExpectBatchMean), max $_largestGroup, '
+                            '$_groupCount groups'),
+                    _check(
+                        'C5 cancel',
+                        _c5,
+                        _cancelObserved
+                            ? '$_cancelViolations stuck after cancel'
+                            : 'no cancel observed (advisory)',
+                        advisory: !_cancelObserved),
+                    if (_violationLog.isNotEmpty) ...[
+                      const Divider(height: 12),
+                      Text(_violationLog.take(4).join('\n'),
+                          style: const TextStyle(
+                              color: Colors.redAccent, fontSize: 11)),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+          // Buttons (small corner targets; the injector never lands here)
+          Positioned(
+            right: 12,
+            top: 12,
+            child: Column(children: [
+              FilledButton.tonal(
+                  onPressed: _printVerdict, child: const Text('Self-check')),
+              const SizedBox(height: 8),
+              FilledButton.tonal(onPressed: _reset, child: const Text('Reset')),
+            ]),
+          ),
+        ]),
+      ),
+    );
+  }
+}

--- a/test/integration/multi_touch_test/pubspec.yaml
+++ b/test/integration/multi_touch_test/pubspec.yaml
@@ -1,0 +1,21 @@
+name: multi_touch_test
+description: Integration test app for 10-finger multi-touch delivery against the ivi-homescreen embedder.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/test/integration/multi_touch_test/tools/inject_ten_finger.py
+++ b/test/integration/multi_touch_test/tools/inject_ten_finger.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# Simulate a 10-slot multi-touch controller (MT protocol B) via uinput and
+# drive the multi_touch_test scenario phases against a running compositor +
+# ivi-homescreen (or against the drm/software backends, which read libinput
+# directly). Everything the kernel emits between two SYN_REPORTs is one
+# hardware scan; libinput turns that into TOUCH_* events + TOUCH_FRAME, and
+# Wayland compositors into wl_touch.* + wl_touch.frame — so this exercises
+# the embedder's frame-batching boundary exactly like real hardware.
+#
+# Phases:
+#   A  press fingers 0..9 one per frame, hold          -> C1 concurrency
+#   B  synchronized 10-finger drag, N frames           -> C4 frame batching
+#   C  staggered lift, one per frame
+#   D  churn: rapid 1-finger taps, tracking ids grow   -> C3 (>10 ids; the
+#      monotonically past 10                              pre-fix embedder
+#                                                         indexed a 10-slot
+#                                                         array by id -> OOB)
+#   E  3x quick 10-finger tap (down all / frame / up all / frame)
+#
+# Requires: python3-evdev (pip install evdev), and root or an 'input'-group
+# user with /dev/uinput access. Give the compositor ~1s after device creation
+# to pick the node up (udev settle).
+#
+# Usage:
+#   sudo ./inject_ten_finger.py [--width 1920] [--height 1080]
+#                               [--rate 125] [--drag-frames 250]
+#                               [--churn 30] [--settle 1.5]
+#
+# On a spanned multi-monitor desktop a compositor maps an unassociated touch
+# device across the *whole* logical desktop, so contacts sized to one output
+# scatter onto the neighbours. Pass the full span and the target output's
+# offset so every contact lands on the app's output:
+#   sudo ./inject_ten_finger.py --width 2560 --height 1440 \
+#                               --desktop-width 3840 --desktop-height 1440 \
+#                               --output-x 0 --output-y 0
+# (single-output or the drm/software backends need none of these.)
+
+import argparse
+import time
+
+from evdev import UInput, AbsInfo, ecodes as e
+
+SLOTS = 10
+
+
+def make_device(width: int, height: int) -> UInput:
+    cap = {
+        e.EV_KEY: [e.BTN_TOUCH],
+        e.EV_ABS: [
+            (e.ABS_MT_SLOT, AbsInfo(0, 0, SLOTS - 1, 0, 0, 0)),
+            (e.ABS_MT_TRACKING_ID, AbsInfo(0, 0, 65535, 0, 0, 0)),
+            (e.ABS_MT_POSITION_X, AbsInfo(0, 0, width - 1, 0, 0, 0)),
+            (e.ABS_MT_POSITION_Y, AbsInfo(0, 0, height - 1, 0, 0, 0)),
+            (e.ABS_X, AbsInfo(0, 0, width - 1, 0, 0, 0)),
+            (e.ABS_Y, AbsInfo(0, 0, height - 1, 0, 0, 0)),
+        ],
+    }
+    return UInput(cap, name='mtt-ten-finger', version=0x1)
+
+
+class Panel:
+    """Minimal MT protocol B state machine over uinput."""
+
+    def __init__(self, ui: UInput, rate_hz: float,
+                 origin=(0, 0), bounds=None):
+        self.ui = ui
+        self.frame_dt = 1.0 / rate_hz
+        self.next_tracking_id = 0
+        self.slot_tid = [-1] * SLOTS   # -1 == empty
+        self.cur_slot = -1
+        self.down_count = 0
+        # Layout coordinates are in target-output pixel space. origin is that
+        # output's top-left within the logical desktop and bounds is the
+        # desktop extent the device is declared over; _map() offsets a point
+        # onto the target output and clamps it to the desktop. On a spanned
+        # multi-monitor compositor (which maps an unassociated touch device
+        # across the *whole* desktop) this keeps every contact on the app's
+        # output instead of scattering onto the neighbours. Defaults (origin
+        # 0,0 / bounds == output) are a no-op for single-output and the
+        # direct-libinput backends.
+        self.origin = origin
+        self.bounds = bounds  # (max_x, max_y) or None == no clamp
+
+    def _map(self, x: int, y: int):
+        x += self.origin[0]
+        y += self.origin[1]
+        if self.bounds is not None:
+            x = max(0, min(self.bounds[0], x))
+            y = max(0, min(self.bounds[1], y))
+        return x, y
+
+    def _slot(self, s: int):
+        if self.cur_slot != s:
+            self.ui.write(e.EV_ABS, e.ABS_MT_SLOT, s)
+            self.cur_slot = s
+
+    def press(self, s: int, x: int, y: int):
+        assert self.slot_tid[s] < 0, f'slot {s} already down'
+        self._slot(s)
+        tid = self.next_tracking_id
+        self.next_tracking_id += 1
+        self.slot_tid[s] = tid
+        mx, my = self._map(x, y)
+        self.ui.write(e.EV_ABS, e.ABS_MT_TRACKING_ID, tid)
+        self.ui.write(e.EV_ABS, e.ABS_MT_POSITION_X, mx)
+        self.ui.write(e.EV_ABS, e.ABS_MT_POSITION_Y, my)
+        if self.down_count == 0:
+            self.ui.write(e.EV_KEY, e.BTN_TOUCH, 1)
+        self.down_count += 1
+
+    def move(self, s: int, x: int, y: int):
+        assert self.slot_tid[s] >= 0, f'slot {s} not down'
+        self._slot(s)
+        mx, my = self._map(x, y)
+        self.ui.write(e.EV_ABS, e.ABS_MT_POSITION_X, mx)
+        self.ui.write(e.EV_ABS, e.ABS_MT_POSITION_Y, my)
+
+    def lift(self, s: int):
+        assert self.slot_tid[s] >= 0, f'slot {s} not down'
+        self._slot(s)
+        self.ui.write(e.EV_ABS, e.ABS_MT_TRACKING_ID, -1)
+        self.slot_tid[s] = -1
+        self.down_count -= 1
+        if self.down_count == 0:
+            self.ui.write(e.EV_KEY, e.BTN_TOUCH, 0)
+
+    def frame(self):
+        """SYN_REPORT: one hardware scan boundary."""
+        self.ui.syn()
+        time.sleep(self.frame_dt)
+
+
+def finger_home(i: int, w: int, h: int):
+    """Ten spread-out home positions, two rows of five."""
+    col, row = i % 5, i // 5
+    x = int(w * (0.12 + 0.19 * col))
+    y = int(h * (0.35 + 0.30 * row))
+    return x, y
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--width', type=int, default=1920,
+                    help='target output width in px (where the app is '
+                         'fullscreen); the finger layout is sized to this')
+    ap.add_argument('--height', type=int, default=1080,
+                    help='target output height in px')
+    ap.add_argument('--desktop-width', type=int, default=None,
+                    help='full logical desktop span width the compositor maps '
+                         'the touch device across (default: --width). Set to '
+                         'the sum of all monitors so contacts land on the app '
+                         'output rather than scattering across a spanned '
+                         'multi-monitor desktop')
+    ap.add_argument('--desktop-height', type=int, default=None,
+                    help='full logical desktop span height (default: --height)')
+    ap.add_argument('--output-x', type=int, default=0,
+                    help="target output's left edge within the desktop (px); "
+                         'the offset applied to every injected contact')
+    ap.add_argument('--output-y', type=int, default=0,
+                    help="target output's top edge within the desktop (px)")
+    ap.add_argument('--rate', type=float, default=125.0,
+                    help='scan rate in Hz (frames per second)')
+    ap.add_argument('--drag-frames', type=int, default=250)
+    ap.add_argument('--churn', type=int, default=30,
+                    help='number of churn taps in phase D')
+    ap.add_argument('--settle', type=float, default=1.5,
+                    help='seconds to wait after device creation')
+    args = ap.parse_args()
+
+    # Declare the device over the whole desktop so a device coordinate is a
+    # desktop pixel (a spanned compositor maps device fraction across the full
+    # logical desktop); the layout stays in target-output space and Panel
+    # offsets it onto the output at (output-x, output-y).
+    desktop_w = args.desktop_width or args.width
+    desktop_h = args.desktop_height or args.height
+
+    ui = make_device(desktop_w, desktop_h)
+    print(f'created uinput device "mtt-ten-finger" '
+          f'(output {args.width}x{args.height} at +{args.output_x}+'
+          f'{args.output_y} on {desktop_w}x{desktop_h} desktop); settling '
+          f'{args.settle}s ...')
+    time.sleep(args.settle)
+
+    p = Panel(ui, args.rate, origin=(args.output_x, args.output_y),
+              bounds=(desktop_w - 1, desktop_h - 1))
+    w, h = args.width, args.height
+    home = [finger_home(i, w, h) for i in range(SLOTS)]
+
+    # Phase A: press 0..9, one per frame.
+    print('phase A: sequential 10-finger press')
+    for i in range(SLOTS):
+        p.press(i, *home[i])
+        p.frame()
+    for _ in range(10):  # hold
+        p.frame()
+
+    # Phase B: synchronized drag — all ten slots updated inside each frame.
+    # This is the C4 discriminator: a frame-batching embedder delivers these
+    # ten moves as one packet with one shared timestamp.
+    print(f'phase B: synchronized drag, {args.drag_frames} frames')
+    span_x = int(w * 0.06)
+    for f in range(args.drag_frames):
+        t = f / max(args.drag_frames - 1, 1)
+        dx = int(span_x * (2 * t - 1))
+        dy = int(h * 0.05 * (1 if (f // 40) % 2 == 0 else -1) * t)
+        for i in range(SLOTS):
+            x0, y0 = home[i]
+            p.move(i, x0 + dx, max(0, min(h - 1, y0 + dy)))
+        p.frame()
+
+    # Phase C: staggered lift.
+    print('phase C: staggered lift')
+    for i in range(SLOTS):
+        p.lift(i)
+        p.frame()
+
+    # Phase D: churn. Tracking ids grow monotonically, so libinput/compositor
+    # touch ids can exceed any fixed 10-slot bound downstream.
+    print(f'phase D: churn, {args.churn} taps '
+          f'(tracking ids -> {p.next_tracking_id + args.churn})')
+    for k in range(args.churn):
+        x = int(w * 0.5) + (k % 7) * 13
+        y = int(h * 0.5) + (k % 5) * 11
+        p.press(0, x, y)
+        p.frame()
+        p.frame()
+        p.lift(0)
+        p.frame()
+
+    # Phase E: quick full-hand taps — down-all / frame / up-all / frame.
+    print('phase E: 3x 10-finger tap')
+    for _ in range(3):
+        for i in range(SLOTS):
+            p.press(i, *home[i])
+        p.frame()
+        p.frame()
+        for i in range(SLOTS):
+            p.lift(i)
+        p.frame()
+        for _ in range(5):
+            p.frame()
+
+    ui.close()
+    print('done — check the app scoreboard / MTT-SUMMARY lines, or run the '
+          'app with --dart-define=SELFCHECK_AFTER_S=<n> for an automatic '
+          'MULTI_TOUCH_TEST: PASS|FAIL verdict.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Integration-test app + uinput injector for **10-finger multi-touch delivery**
against the ivi-homescreen embedder — exercises the touch path that
`input: batch touch contacts per hardware frame across all seats` batches
(kernel evdev → libinput `TOUCH_FRAME` → wl_touch/DrmSeat/SoftwareSeat →
`FlutterEngineSendPointerEvent` → framework `PointerEvent`s on a raw
`Listener`, no gesture arena).

A full-screen `Listener` runs five checks and prints `MTT-SUMMARY: {json}` on
every all-fingers-up plus a `MULTI_TOUCH_TEST: PASS|FAIL` verdict (Self-check
button or `--dart-define=SELFCHECK_AFTER_S=<n>`) for CI scraping:

| # | Check | Validates |
| --- | --- | --- |
| C1 | concurrency | ≥10 simultaneous contacts, ≥10 distinct device ids |
| C2 | legality | per-device phase machine — no lost/duplicated/mis-routed transitions (catches the cancel-only-device-0 regression) |
| C3 | churn | ≥24 distinct device ids across the run (touch-id growth past the old fixed 10-slot array) |
| C4 | frame batch | contacts of one hardware scan share one timestamp; mean move-group ≥6 during a synchronized 10-finger drag (batched ≈10, unbatched ≈1) |
| C5 | cancel | every down contact gets `PointerCancel` within 500 ms of a compositor cancel (advisory until observed) |

`tools/inject_ten_finger.py` simulates a 10-slot MT protocol B controller via
uinput (sequential press, synchronized 250-frame drag at 125 Hz, staggered
lift, 30-tap churn driving tracking ids past 10, quick full-hand taps) — no
hardware needed.

## Multi-monitor support

A nesting compositor maps an unassociated touch device across the **whole
logical desktop**, so contacts sized to one output scatter onto neighbours
(observed: 6 of 10 fingers on a 2560+1280 dual-head with a 2560-wide
fullscreen app). The injector takes `--desktop-width/--desktop-height` and
`--output-x/--output-y` so it declares the device over the full span and
offsets contacts onto the target output — all 10 land. Defaults are a no-op
for single-output and the drm/software (direct-libinput) backends.

## Testing

- App builds and runs on the host `wayland-egl` backend (engine up, 0
  error/warning lines).
- Injector run through all phases: **C2 legality passed with 0 violations**;
  C1/C3/C4 were confined by the dual-head mapping (6/10 contacts) — the
  motivation for the `--desktop-*` flags added here. Layout math verified
  10/10 on-app with the new mapping.
- `flutter analyze`: no errors/warnings. `py_compile`: clean.

## Notes

- The authoritative C4 (batching) measurement is the **drm/software backend on
  a VT**, where `DrmSeat`/`SoftwareSeat` own the `TOUCH_FRAME` grouping; on a
  nesting Wayland compositor C4 reflects that compositor's touch framing.
