### PR TITLE
wayland: resolve a view's output by name through OutputManager

### DIFF
--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -115,6 +115,18 @@ FlutterView::FlutterView(Configuration::Config config,
   // in too; their IDisplay is not a wayland Display, so the cast is null and we
   // skip (those backends render without a WaylandWindow).
   if (auto* wl = dynamic_cast<Display*>(display.get())) {
+    // A [[view.output]] array binds one engine to several outputs, but the
+    // one-engine -> N-outputs present router is drm-kms-egl only (the Wayland
+    // backend has no per-output surface / present_view path). Drive the primary
+    // output here and say so, rather than dropping the rest silently: use one
+    // view per output (a bundle each) on Wayland, or the DRM backend for a
+    // single engine spanning outputs.
+    if (!m_config.view.additional_outputs.empty()) {
+      spdlog::warn(
+          "[FlutterView] additional [[view.output]] entries are ignored: the "
+          "Wayland backend drives one output per view. Use one view/bundle per "
+          "output, or the drm-kms-egl backend for one engine across outputs.");
+    }
     // Pin the view to a physical output by name when [view.output] names one:
     // OutputManager applies the view's OutputMatch through the Display's
     // IOutputProvider (the same resolver the DRM path uses for connectors) and

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -53,6 +53,8 @@
 #include <text_input_plugin.h>
 
 #include "configuration/configuration.h"
+#include "display/output.h"          // homescreen::BackendFamily
+#include "display/output_manager.h"  // homescreen::OutputManager
 #include "engine.h"
 #include "logging.h"
 #include "main_loop_waker.h"
@@ -113,11 +115,29 @@ FlutterView::FlutterView(Configuration::Config config,
   // in too; their IDisplay is not a wayland Display, so the cast is null and we
   // skip (those backends render without a WaylandWindow).
   if (auto* wl = dynamic_cast<Display*>(display.get())) {
+    // Pin the view to a physical output by name when [view.output] names one:
+    // OutputManager applies the view's OutputMatch through the Display's
+    // IOutputProvider (the same resolver the DRM path uses for connectors) and
+    // returns the wl_output name, which maps back to the index a WaylandWindow
+    // targets. Fall back to the explicit wl_output_index when no [view.output]
+    // constraint is set or the named output is not live -- preserving
+    // single-output behavior.
+    uint32_t wl_output_index = m_config.view.wl_output_index.value_or(0);
+    if (const auto resolved = homescreen::OutputManager::ResolveForView(
+            m_config, display.get(), homescreen::BackendFamily::kWayland)) {
+      if (const auto idx = wl->WlOutputIndexForName(*resolved)) {
+        wl_output_index = *idx;
+      } else {
+        spdlog::warn(
+            "[FlutterView] resolved wl_output '{}' is not live; using "
+            "wl_output_index {}",
+            *resolved, wl_output_index);
+      }
+    }
     m_wayland_window = std::make_shared<WaylandWindow>(
         m_index, std::dynamic_pointer_cast<Display>(display),
-        m_config.view.window_type,
-        wl->GetWlOutput(m_config.view.wl_output_index.value_or(0)),
-        m_config.view.wl_output_index.value_or(0), m_config.app_id,
+        m_config.view.window_type, wl->GetWlOutput(wl_output_index),
+        wl_output_index, m_config.app_id,
         m_config.view.fullscreen.value_or(false),
         m_config.view.width.value_or(kDefaultViewWidth),
         m_config.view.height.value_or(kDefaultViewHeight),

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -334,6 +334,29 @@ class Display : public IDisplay,
   }
 
   /**
+   * @brief Index in m_all_outputs of the wl_output with the given name
+   *
+   * Maps a wl_output name resolved by OutputManager::ResolveForView (the
+   * IOutputProvider match against [view.output]) back to the numeric index a
+   * WaylandWindow stores as m_output_index and GetWlOutput() takes. Returns
+   * nullopt when no live output carries that name.
+   *
+   * @param[in] name wl_output v4 name (OutputInfo::name)
+   * @return std::optional<uint32_t>
+   * @relation
+   * wayland, flutter
+   */
+  [[nodiscard]] std::optional<uint32_t> WlOutputIndexForName(
+      const std::string& name) const {
+    for (size_t i = 0; i < m_all_outputs.size(); ++i) {
+      if (m_all_outputs[i] && m_all_outputs[i]->name == name) {
+        return static_cast<uint32_t>(i);
+      }
+    }
+    return std::nullopt;
+  }
+
+  /**
    * @brief Get a buffer scale of a specified index of a view
    * @param[in] index Index of a view
    * @return int32_t


### PR DESCRIPTION
## Summary

Route the Wayland and Wayland-Vulkan backends' per-view **output selection**
through `OutputManager::ResolveForView` — the same resolver the DRM path uses
for connectors. Previously those backends targeted an output only through the
raw numeric `wl_output_index`; now a view's `[view.output]` `OutputMatch` is
resolved against the Wayland `Display`'s `IOutputProvider` to a `wl_output`
name, mapped back to the index the `WaylandWindow` targets
(`Display::WlOutputIndexForName`), with a fallback to `wl_output_index` when no
`[view.output]` is set or the named output is absent.

Both Wayland backends build their `WaylandWindow` through the same `FlutterView`
site, so this covers **wayland-egl and wayland-vulkan**. Behavior-neutral for
bundles with no `[view.output]`.

## Also here

A `[[view.output]]` **array** (one engine → several outputs, "case B") has no
present router on the Wayland backend — that path is drm-kms-egl only. The
extra entries were being dropped silently; this now logs a warning pointing at
one view/bundle per output, or the DRM backend.

## Testing (live, dual-output Wayland session: DP-1 27", HDMI-1 18")

- single view, `[view.output] name = "HDMI-1"` → binds HDMI-1 (index-resolved), fullscreen
- absent name (`HDMI-99`) → warns, falls back to default output
- no `[view.output]` → behavior-neutral, no OutputManager binding
- **two views, two bundles → each binds its own named output** (DP-1 + HDMI-1, both engines run)
- multi-view `[[view.output]]` array on Wayland → primary binds, warning logged for the ignored extra
- full link clean (all backends + `BUILD_COMPOSITOR=ON`); clang-tidy clean; clang-format clean

## Out of scope

- **case-B on Wayland** (one engine spanning N Wayland outputs) — needs the Wayland twin of the DRM present-router stack (`present_view_callback`, per-output surface/swapchain, `FlutterEngineAddView`, frame-callback present path). Tracked in the multi-monitor backlog.
- A pre-existing config-layering bug where `additional_outputs` accumulates across a bundle `config.toml` and a master `--config` rather than the later layer replacing it — fixed separately.
