### PR TITLE
ci(pios): install rootless sysroot-extract tools in the build container

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -128,6 +128,17 @@ jobs:
       - name: Fetch emb
         run: git clone --depth 1 "$EMB_REPO" emb_cli
 
+      # emb_cli extracts a sysroot rootlessly when sfdisk (fdisk) and debugfs
+      # (e2fsprogs) are present; without them it falls back to `sudo losetup`,
+      # which a non-privileged container can't run (no loop devices) and which
+      # fails to even spawn here. The build should hit the baked /emb sysroot as
+      # a cache hit and not extract at all, but on a cache miss it re-extracts —
+      # keep that path rootless so it succeeds instead of dying on losetup.
+      - name: Ensure rootless sysroot-extract tools
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends fdisk e2fsprogs
+
       # The image bakes the toolchain + sysroot at /emb, so -w /emb resolves as
       # a pure cache hit (no download/extract). Host build tools (cmake, ninja,
       # meson, wayland-scanner) are baked too; only the augment libs rebuild.


### PR DESCRIPTION
## Summary

The RPi cross-build matrix (`pios` workflow) is red across every board × OS ×
backend — including on `v2.0` mainline. Root cause is **not** a compile error:

```
Unhandled exception:
ProcessException: No such file or directory
  Command: sudo losetup --show -fP /github/home/.cache/emb/tmp/sysroot-base-*.img
```

The `build-*` jobs run in the emb cross container and resolve the sysroot from
the baked `/emb` (expected: a cache hit, no extraction). On a **cache miss** emb
re-extracts the sysroot, and emb_cli only takes its root-free extraction path
when `sfdisk` and `debugfs` are present (`arm_gnu_cross_provider.dart`):

```dart
final rootless = await _hasTool('sfdisk') && await _hasTool('debugfs');
final err = rootless ? _extractImageRootless(...) : _extractImageViaLoopMount(...);
```

The container has neither, so it falls back to `sudo losetup`, which a
non-privileged container can't run (no loop devices) — it fails to spawn at all.

## Fix

Install `fdisk` (provides `sfdisk`) + `e2fsprogs` (provides `debugfs`) in the
build job so emb_cli takes the rootless path. Unblocks the matrix.

## Follow-up (separate, upstream)

The deeper issue is that the build job re-extracts at all — the baked `/emb`
sysroot should resolve as a cache hit. That, plus a clearer emb_cli error when
neither extraction path is available, is being addressed in emb_cli.
