### PR TITLE
config: replace, don't append, [[view.output]] across config layers

### DIFF
--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -136,6 +136,12 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
   // primary (implicit view / vsync driver), the rest become added views on
   // their own connectors.
   if (const auto node = v->at_path("output"); node.is_array()) {
+    // A later config layer's [[view.output]] replaces the prior layer's extra
+    // outputs, it does not append to them: the bundle's own config.toml is the
+    // base layer and the master --config overrides it, so without clearing here
+    // the two arrays would concatenate (each element past the first
+    // push_backs).
+    instance.view.additional_outputs.clear();
     bool first = true;
     for (auto&& element : *node.as_array()) {
       const auto* t = element.as_table();
@@ -152,6 +158,9 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
       }
     }
   } else if (const auto* t = node.as_table()) {
+    // A single [view.output] in a later layer likewise supersedes any array a
+    // prior layer set — this view binds one output, not that array plus one.
+    instance.view.additional_outputs.clear();
     ParseOutputMatch(*t, instance.view.output);
   }
   if (v->at_path("width").is_integer()) {

--- a/test/unit_test/configuration-test-case/files/GetTomlConfig_OutputArray.toml
+++ b/test/unit_test/configuration-test-case/files/GetTomlConfig_OutputArray.toml
@@ -1,0 +1,16 @@
+# Exercises the [[view.output]] array (one engine -> several outputs): the
+# first entry is the primary binding, the rest are additional_outputs. Applying
+# this file twice to one Config must not concatenate the arrays (a bundle
+# config.toml layered under a master --config).
+[global]
+app_id = 'gallery'
+
+[view]
+width = 1920
+height = 1080
+
+  [[view.output]]
+  name = 'DP-1'
+
+  [[view.output]]
+  name = 'HDMI-1'

--- a/test/unit_test/configuration-test-case/test_case_configuration.cc
+++ b/test/unit_test/configuration-test-case/test_case_configuration.cc
@@ -224,6 +224,35 @@ TEST(HomescreenConfigurationGetTomlConfig, Output) {
 }
 
 /****************************************************************
+Test Case Name.Test Name： HomescreenConfigurationGetTomlConfig_OutputArray
+Use Case Name: Initialization
+Test Summary：A [[view.output]] array binds the first entry as the primary and
+the rest as additional_outputs. Applying the same file twice to one Config (as
+a bundle config.toml layered under a master --config) must replace the extras,
+not concatenate them.
+***************************************************************/
+TEST(HomescreenConfigurationGetTomlConfig, OutputArray) {
+  Configuration::Config config{};
+  std::filesystem::path config_toml_path = kSourceRoot;
+  config_toml_path /= "files/GetTomlConfig_OutputArray.toml";
+
+  Configuration::get_toml_config(config_toml_path.c_str(), config);
+
+  // Primary = first entry; one extra = second entry.
+  EXPECT_EQ("DP-1", config.view.output.wl_name.value_or(""));
+  ASSERT_EQ(1u, config.view.additional_outputs.size());
+  EXPECT_EQ("HDMI-1",
+            config.view.additional_outputs.front().wl_name.value_or(""));
+
+  // Layering a second time (a later config layer) replaces the extras rather
+  // than appending — the count stays 1, it does not grow to 2.
+  Configuration::get_toml_config(config_toml_path.c_str(), config);
+  ASSERT_EQ(1u, config.view.additional_outputs.size());
+  EXPECT_EQ("HDMI-1",
+            config.view.additional_outputs.front().wl_name.value_or(""));
+}
+
+/****************************************************************
 Test Case Name.Test Name： HomescreenConfigurationParseConfig_MultiView
 Use Case Name: Initialization
 Test Summary：A --config master file yields one Config per [[view]], each with


### PR DESCRIPTION
## Summary

`get_view_parameters` overlays configuration layers onto one `Config` — a
bundle's own `config.toml`, then the master `--config`, then CLI flags. The
primary `view.output` was correctly *overwritten* by a later layer, but
`additional_outputs` was only ever `push_back`'d, so a bundle `config.toml`
`[[view.output]]` array and a master `--config` array **concatenated** instead
of the later layer replacing the earlier.

Example: a bundle listing `[A, B]` under a master listing `[A, C]` produced
`additional_outputs = [B, C]` — and the DRM multi-output path would then
`AddOutput` a stale connector.

## Fix

Clear `additional_outputs` whenever a layer supplies `[view.output]` /
`[[view.output]]`, so a later layer fully defines the view's output binding
(matching how the primary already behaves).

## Test

New `HomescreenConfigurationGetTomlConfig.OutputArray`: applying an array config
twice (a base layer + an override layer) keeps `additional_outputs` at one
entry rather than growing to two. Fails without the fix, passes with it.

## Context

Found while validating the Wayland OutputManager wiring (#269): a
`[[view.output]]` config layered a bundle `config.toml` under a master
`--config` and the extra-output count came back doubled.
