### PR TITLE
ci(pios): stream the build output with -v for a full record

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -151,7 +151,9 @@ jobs:
           eval "$(../emb_cli/bootstrap.sh --shellenv)"
           emb --version
           start=$SECONDS
-          emb cross . \
+          # -v streams the toolchain/compile output line-prefixed into the log
+          # (tee'd below) so every build leaves a full record, not just spinners.
+          emb -v cross . \
             --target "${{ matrix.board }}-${{ matrix.pios }}" \
             --build --backend "${{ matrix.backend }}" \
             --no-verify -w /emb | tee /tmp/emb-build.log


### PR DESCRIPTION
Add `-v` to the build-matrix `emb cross` command so the toolchain/compile output streams line-prefixed into the tee'd log — every build leaves a full record instead of just step banners. `-v` is emb's global verbosity flag (stripped by a pre-pass, so its position is free); on failure the streamed tail is still what surfaces. YAML validated.