### PR TITLE
view: scale surfaces to physical pixels (viewport/fractional-scale aware)

### DIFF
--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -28,7 +28,7 @@ if (BUILD_BACKEND_WAYLAND_EGL)
 endif ()
 
 # Protocol XML base — xdg-shell + presentation-time ship with wayland-protocols.
-pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.22)
+pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.20)
 pkg_get_variable(_wlcxx_proto_base wayland-protocols pkgdatadir)
 set(IVI_WL_PROTOCOLS_BASE "${_wlcxx_proto_base}" CACHE INTERNAL "wayland-protocols pkgdatadir")
 
@@ -154,6 +154,21 @@ function(ivi_wayland_protocols target)
     # presentation-time — always (IVsyncProvider); no shipped header -> emit tables.
     wayland_cxx_generate(PROTOCOL "${_pres}" MODE client-header EMIT_INTERFACE_TABLES
         OUTPUT wayland-protocols/presentation_time_client.hpp TARGET ${target})
+
+    # viewporter — always (per-surface scaling; stable since wayland-protocols
+    # 1.4, so present on Dunfell's 1.20). No shipped header -> emit tables.
+    wayland_cxx_generate(PROTOCOL
+        "${IVI_WL_PROTOCOLS_BASE}/stable/viewporter/viewporter.xml"
+        MODE client-header EMIT_INTERFACE_TABLES
+        OUTPUT wayland-protocols/viewporter_client.hpp TARGET ${target})
+
+    # fractional-scale-v1 — always. Vendored: the XML only ships with
+    # wayland-protocols >= 1.31, which Dunfell/Ubuntu-20.04 hosts predate.
+    # Both protocols are gated at runtime on the compositor advertising the
+    # global, so generating unconditionally costs nothing on old stacks.
+    wayland_cxx_generate(PROTOCOL "${_loc}/fractional-scale-v1.xml"
+        MODE client-header EMIT_INTERFACE_TABLES
+        OUTPUT wayland-protocols/fractional_scale_v1_client.hpp TARGET ${target})
 
     # text-input (IME) — the build-selected backend's client header. The
     # wl::ime backend header (<wl/ime/backends/text_input_v{1,3}.hpp>) includes

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -690,12 +690,12 @@ void Engine::CoalesceMouseEvent(const FlutterPointerSignalKind signal,
 #elif ENV32BIT
   e.timestamp = static_cast<size_t>(timestamp & 0xFFFFFFFFULL);
 #endif
-  e.x = x;
-  e.y = y;
+  e.x = x * m_pointer_scale;
+  e.y = y * m_pointer_scale;
   e.device = 0;
   e.signal_kind = signal;
-  e.scroll_delta_x = scroll_delta_x;
-  e.scroll_delta_y = scroll_delta_y;
+  e.scroll_delta_x = scroll_delta_x * m_pointer_scale;
+  e.scroll_delta_y = scroll_delta_y * m_pointer_scale;
   e.device_kind = kFlutterPointerDeviceKindMouse;
   e.buttons = buttons;
   e.pan_x = 0;
@@ -739,8 +739,8 @@ void Engine::CoalesceTouchFrame(const TouchEvent* events, const size_t count) {
 #elif ENV32BIT
     e.timestamp = static_cast<size_t>(timestamp & 0xFFFFFFFFULL);
 #endif
-    e.x = events[i].x;
-    e.y = events[i].y;
+    e.x = events[i].x * m_pointer_scale;
+    e.y = events[i].y * m_pointer_scale;
     e.device = events[i].device;
     e.signal_kind = kFlutterPointerSignalKindNone;
     e.scroll_delta_x = 0.0;

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -135,6 +135,12 @@ class Engine {
    */
   [[nodiscard]] double GetPixelRatio() const { return m_prev_pixel_ratio; };
 
+  // wl_output buffer scale applied to incoming pointer/touch coordinates.
+  // Wayland delivers surface-local (logical) coords; Flutter expects physical
+  // pixels. Only the output scale applies here — the config pixel_ratio part
+  // of m_prev_pixel_ratio is a render scale and would skew hit tests.
+  void SetPointerScale(const double scale) { m_pointer_scale = scale; }
+
   /**
    * @brief Stop the Flutter engine and join all of its threads.
    *
@@ -430,6 +436,7 @@ class Engine {
   size_t m_prev_height;
   size_t m_prev_width;
   double m_prev_pixel_ratio;
+  double m_pointer_scale{1.0};  // see SetPointerScale()
   int32_t m_accessibility_features;
 
   FLUTTER_API_SYMBOL(FlutterEngine) m_flutter_engine;

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -17,6 +17,7 @@
 #include "logging/logging.h"
 
 #include <cassert>
+#include <cmath>
 #include <memory>
 #include <utility>
 
@@ -157,7 +158,7 @@ FlutterView::FlutterView(Configuration::Config config,
         m_config.view.activation_area_x, m_config.view.activation_area_y,
         m_config.view.activation_area_width,
         m_config.view.activation_area_height, m_backend.get(),
-        m_config.view.ivi_surface_id.value_or(0));
+        m_config.view.ivi_surface_id.value_or(0), this);
   }
 #endif
 
@@ -401,12 +402,25 @@ void FlutterView::Initialize() {
     height =
         static_cast<int32_t>(m_config.view.height.value_or(kDefaultViewHeight));
   }
-  display.width = static_cast<size_t>(width);
-  display.height = static_cast<size_t>(height);
-  display.device_pixel_ratio = m_flutter_engine->GetPixelRatio();
+  // DRM/software report native mode dims (already physical, scale 1); a
+  // Wayland window reports logical dims — convert with its surface scale so
+  // Flutter sees the display in physical pixels (issue #150).
+  double scale = 1.0;
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+  if (m_wayland_window) {
+    scale = m_wayland_window->GetScale();
+  }
+#endif
+  display.width = static_cast<size_t>(std::lround(width * scale));
+  display.height = static_cast<size_t>(std::lround(height * scale));
+  display.device_pixel_ratio =
+      m_config.view.pixel_ratio.value_or(kDefaultPixelRatio) * scale;
   LibFlutterEngine->NotifyDisplayUpdate(m_flutter_engine->GetFlutterEngine(),
                                         kFlutterEngineDisplaysUpdateTypeStartup,
                                         &display, 1);
+  spdlog::info("Display metadata: {}x{} logical -> {}x{} px, pixel_ratio={}",
+               width, height, display.width, display.height,
+               display.device_pixel_ratio);
 
   // Update for Binary Messenger
   m_state->engine_state->flutter_engine = m_flutter_engine->GetFlutterEngine();
@@ -474,6 +488,37 @@ void FlutterView::Initialize() {
 #endif
 
   SPDLOG_DEBUG("({}) Engine running...", m_index);
+}
+
+void FlutterView::UpdateDisplayMetadata() const {
+  // Only the Wayland path has a runtime scale source; DRM/software report
+  // native mode dimensions once at startup and never rescale.
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+  if (!m_wayland_window || !m_flutter_engine ||
+      !m_flutter_engine->IsRunning()) {
+    return;
+  }
+  const auto [width, height] = m_wayland_window->GetSize();
+  const double scale = m_wayland_window->GetScale();
+
+  FlutterEngineDisplay display{};
+  display.struct_size = sizeof(FlutterEngineDisplay);
+  display.display_id = 1;
+  display.single_display = true;
+  display.refresh_rate =
+      m_display->GetRefreshRate(m_wayland_window->GetOutputIndex());
+  display.width = static_cast<size_t>(std::lround(width * scale));
+  display.height = static_cast<size_t>(std::lround(height * scale));
+  display.device_pixel_ratio =
+      m_config.view.pixel_ratio.value_or(kDefaultPixelRatio) * scale;
+
+  LibFlutterEngine->NotifyDisplayUpdate(m_flutter_engine->GetFlutterEngine(),
+                                        kFlutterEngineDisplaysUpdateTypeStartup,
+                                        &display, 1);
+  spdlog::debug("Display metadata: {}x{} logical -> {}x{} px, pixel_ratio={}",
+                width, height, display.width, display.height,
+                display.device_pixel_ratio);
+#endif
 }
 
 void FlutterView::RunTasks() {

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -120,6 +120,11 @@ class FlutterView {
    */
   [[nodiscard]] Backend* GetBackend() const { return m_backend.get(); }
 
+  // Re-send FlutterEngineDisplay metadata (physical px + effective pixel
+  // ratio) to a running engine. Called by WaylandWindow::ApplyScale when the
+  // surface scale changes; safe no-op before the engine runs.
+  void UpdateDisplayMetadata() const;
+
   /**
    * @brief Get an index of flutter views
    * @return uint64_t

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -27,6 +27,9 @@
 
 #include "config/common.h"
 
+#include "fractional_scale_v1_client.hpp"
+#include "viewporter_client.hpp"
+
 #include "asio/post.hpp"
 #include "engine.h"
 #include "window.h"
@@ -253,6 +256,21 @@ void Display::HandleGlobal(wl::CRegistry& reg,
         wl_registry_bind(registry, name, &wl_seat_interface,
                          std::min(static_cast<uint32_t>(5), version)));
     wl_seat_add_listener(d->m_seat, &seat_listener, d);
+  } else if (iface ==
+             viewporter::client::wp_viewporter_traits::interface_name) {
+    d->m_viewporter = static_cast<wl_proxy*>(wl_registry_bind(
+        registry, name, &viewporter::client::wp_viewporter_traits::wl_iface(),
+        std::min(viewporter::client::wp_viewporter_traits::version, version)));
+  } else if (iface ==
+             fractional_scale_v1::client::
+                 wp_fractional_scale_manager_v1_traits::interface_name) {
+    d->m_fractional_scale_manager = static_cast<wl_proxy*>(wl_registry_bind(
+        registry, name,
+        &fractional_scale_v1::client::wp_fractional_scale_manager_v1_traits::
+            wl_iface(),
+        std::min(fractional_scale_v1::client::
+                     wp_fractional_scale_manager_v1_traits::version,
+                 version)));
   }
   // zwp_text_input_manager_v3 — recorded for text_input_.Bind() after the
   // startup roundtrip (the per-seat text_input needs m_seat). If the compositor
@@ -326,6 +344,7 @@ void Display::display_handle_done(void* data,
                                   struct wl_output* /* wl_output */) {
   auto* oi = static_cast<output_info_t*>(data);
   oi->done = true;
+  oi->display->NotifyOutputScaleChanged(oi);
   oi->display->EmitOutputDone(oi);
 }
 
@@ -1019,6 +1038,52 @@ void Display::UnregisterWindow(WaylandWindow* window) {
 size_t Display::IndexOfOutput(const output_info_t* oi) const {
   for (size_t i = 0; i < m_all_outputs.size(); ++i) {
     if (m_all_outputs[i].get() == oi) {
+      return i;
+    }
+  }
+  return m_all_outputs.size();
+}
+
+void Display::NotifyOutputScaleChanged(const output_info_t* oi) {
+  const size_t idx = IndexOfOutput(oi);
+  if (idx >= m_all_outputs.size()) {
+    return;
+  }
+  const int32_t scale = GetBufferScale(static_cast<uint32_t>(idx));
+  std::vector<WaylandWindow*> snapshot;
+  {
+    std::lock_guard lock(m_windows_lock);
+    snapshot = m_windows;
+  }
+  for (auto* w : snapshot) {
+    w->OnOutputScaleChanged(idx, scale);
+  }
+}
+
+wl_proxy* Display::CreateViewport(struct wl_surface* surface) const {
+  namespace vp = viewporter::client;
+  if (m_viewporter == nullptr || surface == nullptr) {
+    return nullptr;
+  }
+  return wl_proxy_marshal_constructor(
+      m_viewporter, vp::wp_viewporter_traits::Op::GetViewport,
+      &vp::wp_viewport_traits::wl_iface(), nullptr, surface);
+}
+
+wl_proxy* Display::CreateFractionalScale(struct wl_surface* surface) const {
+  namespace fs = fractional_scale_v1::client;
+  if (m_fractional_scale_manager == nullptr || surface == nullptr) {
+    return nullptr;
+  }
+  return wl_proxy_marshal_constructor(
+      m_fractional_scale_manager,
+      fs::wp_fractional_scale_manager_v1_traits::Op::GetFractionalScale,
+      &fs::wp_fractional_scale_v1_traits::wl_iface(), nullptr, surface);
+}
+
+size_t Display::GetOutputIndexByHandle(struct wl_output* output) const {
+  for (size_t i = 0; i < m_all_outputs.size(); ++i) {
+    if (m_all_outputs[i]->output == output) {
       return i;
     }
   }

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -366,6 +366,26 @@ class Display : public IDisplay,
    */
   [[nodiscard]] int32_t GetBufferScale(uint32_t index) const override;
 
+  // wp_viewporter availability. When true, windows scale via
+  // wp_viewport.set_destination (fractional-capable); otherwise they fall
+  // back to integer wl_surface.set_buffer_scale.
+  [[nodiscard]] bool HasViewporter() const { return m_viewporter != nullptr; }
+
+  // Create a wp_viewport for @p surface, or nullptr when the compositor
+  // does not advertise wp_viewporter.
+  [[nodiscard]] wl_proxy* CreateViewport(struct wl_surface* surface) const;
+
+  // Create a wp_fractional_scale_v1 for @p surface, or nullptr when the
+  // compositor does not advertise wp_fractional_scale_manager_v1. The caller
+  // installs its own listener.
+  [[nodiscard]] wl_proxy* CreateFractionalScale(
+      struct wl_surface* surface) const;
+
+  // Index of the output owning @p output, or OutputCount() if unknown.
+  [[nodiscard]] size_t GetOutputIndexByHandle(struct wl_output* output) const;
+
+  [[nodiscard]] size_t OutputCount() const { return m_all_outputs.size(); }
+
   /**
    * @brief Get a video mode size of a specified index of a view
    * @param[in] index Index of a view
@@ -598,6 +618,10 @@ class Display : public IDisplay,
   // m_output_index matches; the window decides whether to shrink.
   void NotifyOutputResized(const output_info_t* oi);
 
+  // Called from display_handle_done: fans the (possibly changed) output
+  // scale out to registered windows; they early-out if unchanged.
+  void NotifyOutputScaleChanged(const output_info_t* oi);
+
   // Notify the output listener when a wl_output's `done` event closes its
   // event batch: OnOutputAdded the first time, OnOutputChanged after.
   void EmitOutputDone(output_info_t* oi);
@@ -608,6 +632,11 @@ class Display : public IDisplay,
   static homescreen::OutputInfo ToOutputInfo(const output_info_t& oi);
 
   bool m_buffer_scale_enable{};
+
+  // Scaling protocol globals; null when the compositor does not advertise
+  // them (e.g. Westeros advertises neither, old Weston only wp_viewporter).
+  wl_proxy* m_viewporter{};
+  wl_proxy* m_fractional_scale_manager{};
 
   // Tracks whether the compositor advertised a GPU buffer-allocation
   // protocol that Mesa's Vulkan WSI can use. Set from

--- a/shell/wayland/protocols/fractional-scale-v1.xml
+++ b/shell/wayland/protocols/fractional-scale-v1.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="fractional_scale_v1">
+  <copyright>
+    Copyright © 2022 Kenny Levinsen
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for requesting fractional surface scales">
+    This protocol allows a compositor to suggest for surfaces to render at
+    fractional scales.
+
+    A client can submit scaled content by utilizing wp_viewport. This is done by
+    creating a wp_viewport object for the surface and setting the destination
+    rectangle to the surface size before the scale factor is applied.
+
+    The buffer size is calculated by multiplying the surface size by the
+    intended scale.
+
+    The wl_surface buffer scale should remain set to 1.
+
+    If a surface has a surface-local size of 100 px by 50 px and wishes to
+    submit buffers with a scale of 1.5, then a buffer of 150px by 75 px should
+    be used and the wp_viewport destination rectangle should be 100 px by 50 px.
+
+    For toplevel surfaces, the size is rounded halfway away from zero. The
+    rounding algorithm for subsurface position and size is not defined.
+  </description>
+
+  <interface name="wp_fractional_scale_manager_v1" version="1">
+    <description summary="fractional surface scale information">
+      A global interface for requesting surfaces to use fractional scales.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind the fractional surface scale interface">
+        Informs the server that the client will not be using this protocol
+        object anymore. This does not affect any other objects,
+        wp_fractional_scale_v1 objects included.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="fractional_scale_exists" value="0"
+        summary="the surface already has a fractional_scale object associated"/>
+    </enum>
+
+    <request name="get_fractional_scale">
+      <description summary="extend surface interface for scale information">
+        Create an add-on object for the the wl_surface to let the compositor
+        request fractional scales. If the given wl_surface already has a
+        wp_fractional_scale_v1 object associated, the fractional_scale_exists
+        protocol error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_fractional_scale_v1"
+           summary="the new surface scale info interface id"/>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="the surface"/>
+    </request>
+  </interface>
+
+  <interface name="wp_fractional_scale_v1" version="1">
+    <description summary="fractional scale interface to a wl_surface">
+      An additional interface to a wl_surface object which allows the compositor
+      to inform the client of the preferred scale.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove surface scale information for surface">
+        Destroy the fractional scale object. When this object is destroyed,
+        preferred_scale events will no longer be sent.
+      </description>
+    </request>
+
+    <event name="preferred_scale">
+      <description summary="notify of new preferred scale">
+        Notification of a new preferred scale for this surface that the
+        compositor suggests that the client should use.
+
+        The sent scale is the numerator of a fraction with a denominator of 120.
+      </description>
+      <arg name="scale" type="uint" summary="the new preferred scale"/>
+    </event>
+  </interface>
+</protocol>

--- a/shell/wayland/window.cc
+++ b/shell/wayland/window.cc
@@ -17,8 +17,37 @@
 
 #include <utility>
 
+#include <cmath>
+
 #include "display.h"
 #include "engine.h"
+#include "fractional_scale_v1_client.hpp"
+#include "view/flutter_view.h"
+#include "viewporter_client.hpp"
+
+// wp_fractional_scale_v1 listener. Owns the proxy; forwards preferred_scale
+// (in 120ths) to the window as a double. Lives behind a unique_ptr so the
+// generated header stays out of window.h.
+struct WaylandWindow::FractionalScale final
+    : fractional_scale_v1::client::CWpFractionalScaleV1<
+          WaylandWindow::FractionalScale> {
+  explicit FractionalScale(WaylandWindow& window, wl_proxy* proxy)
+      : m_window(window) {
+    _SetProxy(proxy);
+  }
+  ~FractionalScale() override { Destroy(); }
+  FractionalScale(const FractionalScale&) = delete;
+  FractionalScale& operator=(const FractionalScale&) = delete;
+
+  void OnPreferredScale(const uint32_t scale_120ths) override {
+    if (scale_120ths != 0) {
+      m_window.ApplyScale(static_cast<double>(scale_120ths) / 120.0);
+    }
+  }
+
+ private:
+  WaylandWindow& m_window;
+};
 
 WaylandWindow::WaylandWindow(const size_t index,
                              std::shared_ptr<Display> display,
@@ -35,13 +64,15 @@ WaylandWindow::WaylandWindow(const size_t index,
                              const uint32_t activation_area_width,
                              const uint32_t activation_area_height,
                              Backend* backend,
-                             const uint32_t ivi_surface_id)
+                             const uint32_t ivi_surface_id,
+                             FlutterView* view)
     : m_index(index),
       m_display(std::move(display)),
       m_wl_output(output),
       m_output_index(output_index),
       m_flutter_engine(nullptr),
       m_pixel_ratio(pixel_ratio),
+      m_view(view),
       m_backend(backend),
       m_ivi_surface_id(ivi_surface_id),
       m_fullscreen(fullscreen),
@@ -55,6 +86,23 @@ WaylandWindow::WaylandWindow(const size_t index,
 
   m_base_surface = wl_compositor_create_surface(m_display->GetCompositor());
   wl_surface_add_listener(m_base_surface, &m_base_surface_listener, this);
+
+  // Scale plumbing. Prefer wp_fractional_scale_v1 (compositor resolves the
+  // per-surface scale, fractional values possible); its preferred_scale
+  // event arrives after the first commit, so seed with the integer
+  // wl_output scale either way. The viewport (when available) lets the
+  // buffer be any size while the surface keeps its logical size — required
+  // for fractional, and harmless for integer scales.
+  m_viewport = m_display->CreateViewport(m_base_surface);
+  if (auto* fs = m_display->CreateFractionalScale(m_base_surface);
+      fs != nullptr && m_viewport != nullptr) {
+    // Fractional scales are only representable through a viewport; without
+    // wp_viewporter fall back to the integer path.
+    m_fractional_scale = std::make_unique<FractionalScale>(*this, fs);
+  } else if (fs != nullptr) {
+    wl_proxy_destroy(fs);
+  }
+  m_scale = static_cast<double>(m_display->GetBufferScale(m_output_index));
 
   // Assign the surface its role via the active compositor-protocol shell
   // (xdg / agl / ivi / simple).
@@ -126,8 +174,10 @@ WaylandWindow::WaylandWindow(const size_t index,
       m_geometry.height = target_h;
     }
     m_wait_for_configure = false;
-    m_backend->Resize(m_index, m_flutter_engine.get(), m_geometry.width,
-                      m_geometry.height);
+    // Geometry may have changed: refresh the mapping, resize in buffer px.
+    DeclareSurfaceMapping();
+    m_backend->Resize(m_index, m_flutter_engine.get(), PhysWidth(),
+                      PhysHeight());
   };
   cfg.on_close = [this]() { m_running = false; };
 
@@ -193,8 +243,8 @@ WaylandWindow::WaylandWindow(const size_t index,
       continue;
   }
 
-  m_backend->CreateSurface(m_index, m_base_surface, m_geometry.width,
-                           m_geometry.height);
+  DeclareSurfaceMapping();
+  m_backend->CreateSurface(m_index, m_base_surface, PhysWidth(), PhysHeight());
 
   // Register *after* initial geometry has settled so the event-thread
   // OnOutputResized path never observes a partially-constructed window.
@@ -220,29 +270,120 @@ WaylandWindow::~WaylandWindow() {
   // m_shell_surface's destructor.
   m_shell_surface.reset();
 
+  m_fractional_scale.reset();
+  if (m_viewport != nullptr) {
+    wl_proxy_marshal(m_viewport,
+                     viewporter::client::wp_viewport_traits::Op::Destroy);
+    wl_proxy_destroy(m_viewport);
+  }
   wl_surface_destroy(m_base_surface);
 
   SPDLOG_TRACE("({}) - ~WaylandWindow()", m_index);
 }
 
-void WaylandWindow::handle_base_surface_enter(void* data,
-                                              struct wl_surface* /* surface */,
-                                              struct wl_output* /* output */) {
-  auto const* d = static_cast<WaylandWindow*>(data);
+int32_t WaylandWindow::PhysWidth() const {
+  return static_cast<int32_t>(std::lround(m_geometry.width * m_scale));
+}
 
-  const auto buffer_scale = d->m_display->GetBufferScale(d->m_output_index);
+int32_t WaylandWindow::PhysHeight() const {
+  return static_cast<int32_t>(std::lround(m_geometry.height * m_scale));
+}
 
-  const auto result =
-      d->m_flutter_engine->SetPixelRatio(d->m_pixel_ratio * buffer_scale);
-  if (result != kSuccess) {
-    spdlog::error("Failed to set Flutter Engine Pixel Ratio");
+void WaylandWindow::DeclareSurfaceMapping() const {
+  // Tell the compositor how the attached buffer maps onto the surface.
+  // Viewport: buffer of any size presents at the logical size; buffer scale
+  // stays 1 (mixing the two is a protocol footgun). Fallback: integer
+  // buffer scale — the only mapping ancient stacks (Westeros) understand.
+  if (m_viewport != nullptr) {
+    // wp_viewport.set_destination rejects any non-positive dimension with the
+    // fatal bad_value protocol error (disconnecting the whole client). A
+    // zero-size geometry — e.g. view.width/height configured to 0, or an
+    // early call before the first configure — is benign for the fallback
+    // buffer-scale path but would be lethal here, so skip the mapping until
+    // the geometry is valid; the next configure/resize re-declares it.
+    if (m_geometry.width <= 0 || m_geometry.height <= 0) {
+      return;
+    }
+    wl_proxy_marshal(m_viewport,
+                     viewporter::client::wp_viewport_traits::Op::SetDestination,
+                     m_geometry.width, m_geometry.height);
+  } else {
+    wl_surface_set_buffer_scale(
+        m_base_surface,
+        std::max(1, static_cast<int32_t>(std::lround(m_scale))));
   }
 }
 
-void WaylandWindow::handle_base_surface_leave(void* /* data */,
+double WaylandWindow::BestOutputScale() const {
+  int32_t best = m_display->GetBufferScale(m_output_index);
+  for (const uint32_t idx : m_entered_outputs) {
+    best = std::max(best, m_display->GetBufferScale(idx));
+  }
+  return static_cast<double>(std::max(1, best));
+}
+
+void WaylandWindow::ApplyScale(const double scale) {
+  if (scale <= 0.0 || scale == m_scale) {
+    return;
+  }
+  m_scale = scale;
+  spdlog::debug("({}) ApplyScale: {} — {}x{} logical -> {}x{} buffer px",
+                m_index, scale, m_geometry.width, m_geometry.height,
+                PhysWidth(), PhysHeight());
+
+  DeclareSurfaceMapping();
+  if (m_flutter_engine) {
+    m_backend->Resize(m_index, m_flutter_engine.get(), PhysWidth(),
+                      PhysHeight());
+    m_flutter_engine->SetPixelRatio(m_pixel_ratio * m_scale);
+    m_flutter_engine->SetPointerScale(m_scale);
+  }
+  if (m_view != nullptr) {
+    m_view->UpdateDisplayMetadata();
+  }
+}
+
+void WaylandWindow::handle_base_surface_enter(void* data,
                                               struct wl_surface* /* surface */,
-                                              struct wl_output* /* output */) {
-  SPDLOG_TRACE("Leaving output");
+                                              struct wl_output* output) {
+  auto* d = static_cast<WaylandWindow*>(data);
+
+  const size_t idx = d->m_display->GetOutputIndexByHandle(output);
+  if (idx < d->m_display->OutputCount()) {
+    d->m_entered_outputs.insert(static_cast<uint32_t>(idx));
+  }
+  if (!d->m_fractional_scale) {
+    d->ApplyScale(d->BestOutputScale());
+  }
+}
+
+void WaylandWindow::handle_base_surface_leave(void* data,
+                                              struct wl_surface* /* surface */,
+                                              struct wl_output* output) {
+  auto* d = static_cast<WaylandWindow*>(data);
+
+  const size_t idx = d->m_display->GetOutputIndexByHandle(output);
+  if (idx < d->m_display->OutputCount()) {
+    d->m_entered_outputs.erase(static_cast<uint32_t>(idx));
+  }
+  // Empty set (left all known outputs): keep the current scale; the next
+  // enter corrects it.
+  if (!d->m_fractional_scale && !d->m_entered_outputs.empty()) {
+    d->ApplyScale(d->BestOutputScale());
+  }
+}
+
+void WaylandWindow::OnOutputScaleChanged(const size_t output_index,
+                                         const int32_t /* new_scale */) {
+  if (m_fractional_scale) {
+    return;  // fractional source owns the scale
+  }
+  const bool relevant =
+      output_index == m_output_index ||
+      m_entered_outputs.count(static_cast<uint32_t>(output_index)) != 0;
+  if (relevant) {
+    ApplyScale(BestOutputScale());
+  }
 }
 
 const struct wl_surface_listener WaylandWindow::m_base_surface_listener = {
@@ -284,7 +425,8 @@ void WaylandWindow::OnOutputResized(const size_t output_index,
   }
   m_geometry.width = target_w;
   m_geometry.height = target_h;
-  m_backend->Resize(m_index, m_flutter_engine.get(), target_w, target_h);
+  DeclareSurfaceMapping();
+  m_backend->Resize(m_index, m_flutter_engine.get(), PhysWidth(), PhysHeight());
 }
 
 bool WaylandWindow::ActivateSystemCursor(int32_t device,
@@ -295,19 +437,22 @@ bool WaylandWindow::ActivateSystemCursor(int32_t device,
 void WaylandWindow::SetEngine(const std::shared_ptr<Engine>& engine) {
   m_flutter_engine = engine;
   if (m_flutter_engine) {
-    auto result =
-        m_flutter_engine->SetWindowSize(static_cast<size_t>(m_geometry.height),
-                                        static_cast<size_t>(m_geometry.width));
+    // Flutter window metrics are physical (buffer) pixels.
+    auto result = m_flutter_engine->SetWindowSize(
+        static_cast<size_t>(PhysHeight()), static_cast<size_t>(PhysWidth()));
     if (result != kSuccess) {
       spdlog::error("Failed to set Flutter Engine Window Size");
     }
 
-    const auto buffer_scale = m_display->GetBufferScale(m_output_index);
-
-    result = m_flutter_engine->SetPixelRatio(m_pixel_ratio * buffer_scale);
+    result = m_flutter_engine->SetPixelRatio(m_pixel_ratio * m_scale);
     if (result != kSuccess) {
       spdlog::error("Failed to set Flutter Engine Pixel Ratio");
     }
+
+    // Input arrives in surface-local units; only the surface scale converts
+    // it to buffer px — see Engine::SetPointerScale() for why the config
+    // pixel_ratio must not be folded in.
+    m_flutter_engine->SetPointerScale(m_scale);
   }
 }
 

--- a/shell/wayland/window.h
+++ b/shell/wayland/window.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <set>
 #include <string>
 
 #include "backend/backend.h"
@@ -30,9 +31,13 @@
 
 class Backend;
 
+struct wl_proxy;
+
 class Display;
 
 class Engine;
+
+class FlutterView;
 
 class WaylandWindow {
  public:
@@ -63,7 +68,8 @@ class WaylandWindow {
                 uint32_t activation_area_width,
                 uint32_t activation_area_height,
                 Backend* backend,
-                uint32_t ivi_surface_id);
+                uint32_t ivi_surface_id,
+                FlutterView* view = nullptr);
 
   ~WaylandWindow();
 
@@ -127,12 +133,25 @@ class WaylandWindow {
     return std::pair<int32_t, int32_t>{m_geometry.width, m_geometry.height};
   }
 
+  // Effective surface scale: buffer pixels per surface-local (logical) unit.
+  // Fractional when the compositor speaks wp_fractional_scale_v1, otherwise
+  // the integer wl_output scale, otherwise 1.
+  [[nodiscard]] double GetScale() const { return m_scale; }
+
+  [[nodiscard]] uint32_t GetOutputIndex() const { return m_output_index; }
+
   // Called from Display::NotifyOutputResized when wl_output.mode reports
   // new dimensions for output index @p output_index. Runs on the
   // wayland event thread. If this window is bound to that output and
   // its current geometry no longer fits, shrink to the new mode and
   // re-Resize the backend.
   void OnOutputResized(size_t output_index, int32_t new_w, int32_t new_h);
+
+  // Called from Display::NotifyOutputScaleChanged on the wayland event
+  // thread when a wl_output.done batch may have changed an output scale.
+  // Fallback scale source only — ignored while wp_fractional_scale_v1 is
+  // bound for this surface.
+  void OnOutputScaleChanged(size_t output_index, int32_t new_scale);
 
  private:
   size_t m_index;
@@ -141,7 +160,47 @@ class WaylandWindow {
   uint32_t m_output_index;
   std::shared_ptr<Engine> m_flutter_engine;
   double m_pixel_ratio;
+  // Owning FlutterView (non-owning back-pointer; the view owns this window
+  // and outlives it). Used to re-send Flutter display metadata on scale
+  // change. Null in unit-test construction.
+  FlutterView* m_view;
   struct wl_surface* m_base_surface{};
+
+  // --- surface scaling -------------------------------------------------
+  // Current effective scale; buffer size is round(logical * m_scale).
+  double m_scale{1.0};
+  // wp_viewport for m_base_surface (null without wp_viewporter). With a
+  // viewport the buffer scale stays 1 and set_destination declares the
+  // logical size — the fractional-capable path.
+  wl_proxy* m_viewport{};
+  // wp_fractional_scale_v1 listener (null when not advertised). While bound
+  // it is the sole scale source; wl_output scale is ignored.
+  struct FractionalScale;
+  std::unique_ptr<FractionalScale> m_fractional_scale;
+  // Fallback source: outputs the surface currently overlaps
+  // (wl_surface.enter/leave). The applied scale is the max wl_output scale
+  // in this set, so the surface stays sharp on the densest display it
+  // touches instead of flickering as enter events race.
+  std::set<uint32_t> m_entered_outputs;
+
+  // Re-declare the buffer->surface mapping (viewport destination or
+  // integer buffer scale) for the current geometry and scale. Must run
+  // whenever either changes, before the next commit.
+  void DeclareSurfaceMapping() const;
+
+  // Round the current logical geometry to buffer pixels.
+  [[nodiscard]] int32_t PhysWidth() const;
+  [[nodiscard]] int32_t PhysHeight() const;
+
+  // Single entry point for scale changes from any source. Early-outs when
+  // unchanged; otherwise re-declares the surface mapping (viewport
+  // destination or integer buffer scale), resizes the backend to physical
+  // pixels, and pushes pixel-ratio / pointer-scale / display metadata to
+  // the engine and view.
+  void ApplyScale(double scale);
+
+  // Max wl_output scale over m_entered_outputs (m_output_index when empty).
+  [[nodiscard]] double BestOutputScale() const;
   // Non-owning. The backend (Backend) is owned by the FlutterView that created
   // this window and outlives it; the ctor receives a raw Backend*. Storing it
   // in a shared_ptr here would create a SECOND, independent ownership of the


### PR DESCRIPTION
## Summary
 
Flutter currently receives logical surface units in `NotifyDisplayUpdate` and
window metrics, so rendering on any scaled output is wrong-sized or blurry.
This PR reports physical pixels everywhere (fixes #150) and makes the surface
scale a first-class, runtime-tracked property. Clean-room single-commit
replacement for #157, rebuilt against the current shell/output architecture.
 
## How it works
 
Two scale sources, selected at runtime from the registry:
 
1. **`wp_fractional_scale_v1` + `wp_viewport`** (preferred) — the compositor
   resolves the per-surface scale, including fractional desktop settings
   (125%/150%). Buffer maps through `wp_viewport.set_destination` with
   `buffer_scale` left at 1.
2. **Integer `wl_output.scale`** (fallback) — tracked via
   `wl_surface.enter/leave`; the applied scale is the max over all
   currently-entered outputs, so a surface straddling two displays stays sharp
   on the denser one instead of flickering. Re-evaluated when a
   `wl_output.done` batch changes a scale.
 
A third candidate source, `wl_surface.preferred_buffer_scale`
(wl_compositor ≥ v6), was evaluated and deliberately omitted: on the target
compositor matrix it is dead weight. Every compositor that implements
wl_compositor v6 (Mutter, wlroots-based) also implements
wp_fractional_scale_v1, so tier 1 already covers them with a strictly better
(fractional) answer; every compositor without fractional-scale is also stuck
at wl_compositor ≤ v5 — shipping Westons still advertise v5, and Westeros v4 —
so the event never fires there and the wl_output fallback is what actually
runs. A middle tier would add a third code path that no supported compositor
would ever select.
 
Every scale change funnels through `WaylandWindow::ApplyScale()`, which
early-outs when unchanged and otherwise: re-declares the buffer→surface
mapping, resizes the backend to `round(logical × scale)`, updates the engine
pixel ratio (`config ratio × scale`) and pointer scale, and re-sends Flutter
display metadata (`FlutterView::UpdateDisplayMetadata()`).
 
Input: Wayland delivers surface-local coordinates; they're converted to
physical pixels using only the surface scale (`Engine::SetPointerScale`).
Folding in the config `pixel_ratio` would shift hit targets — Flutter already
divides by the full ratio to reach logical space.
 
## Compositor coverage
 
| Path | Compositors |
|---|---|
| fractional + viewport | Mutter, Sway/wlroots, Cage |
| viewport + integer scale | Weston, agl-compositor |
| `set_buffer_scale` (inert, scale=1) | Westeros |
 
## Compatibility
 
- Both protocols are generated unconditionally, gated at runtime on the
  compositor advertising the global.
- `fractional-scale-v1.xml` is vendored (only ships with wayland-protocols
  ≥ 1.31); viewporter comes from pkgdatadir (stable since 1.4).
- wayland-protocols floor lowered 1.22 → 1.20: builds on Yocto Dunfell /
  Ubuntu 20.04 again. Flag if the 1.22 bump was intentional.
- DRM/software backends unaffected — they already report native mode
  dimensions.
 
## Testing
 
- Builds and links clean (wayland-egl backend).
- Needs runtime validation on: a fractional desktop (Sway: verify
  `preferred_scale` → viewport destination → buffer size via
  `WAYLAND_DEBUG=1`), agl-compositor (scale 1, should be behavior-neutral),
  and a scale-2 output for the integer path.