### PR TITLE
wayland: high-resolution input timestamps (zwp_input_timestamps_v1)

### DIFF
--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -155,6 +155,15 @@ function(ivi_wayland_protocols target)
     wayland_cxx_generate(PROTOCOL "${_pres}" MODE client-header EMIT_INTERFACE_TABLES
         OUTPUT wayland-protocols/presentation_time_client.hpp TARGET ${target})
 
+    # input-timestamps — always (ivi::InputTimestamps: high-resolution kernel
+    # timestamps for the pointer/touch → Flutter path; runtime-optional, the
+    # provider no-ops when the compositor doesn't advertise the manager).
+    # No shipped header -> emit tables.
+    wayland_cxx_generate(PROTOCOL
+        "${IVI_WL_PROTOCOLS_BASE}/unstable/input-timestamps/input-timestamps-unstable-v1.xml"
+        MODE client-header EMIT_INTERFACE_TABLES
+        OUTPUT wayland-protocols/input_timestamps_client.hpp TARGET ${target})
+
     # viewporter — always (per-surface scaling; stable since wayland-protocols
     # 1.4, so present on Dunfell's 1.20). No shipped header -> emit tables.
     wayland_cxx_generate(PROTOCOL

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -69,6 +69,8 @@ if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN)
             wayland/shell/shells.cc
             # wp_presentation vsync provider (scanner presentation-time C++).
             vsync/wayland_vsync_provider.cc
+            # zwp_input_timestamps_v1 provider (scanner input-timestamps C++).
+            wayland/input_timestamps.cc
     )
     if (ENABLE_XDG_CLIENT OR ENABLE_AGL_SHELL_CLIENT)
         target_sources(${PROJECT_NAME} PRIVATE wayland/shell/xdg_shell.cc)

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -678,8 +678,15 @@ void Engine::CoalesceMouseEvent(const FlutterPointerSignalKind signal,
                                 const double y,
                                 const double scroll_delta_x,
                                 const double scroll_delta_y,
-                                const int64_t buttons) {
-  auto timestamp = LibFlutterEngine->GetCurrentTime() / 1000;
+                                const int64_t buttons,
+                                const uint64_t timestamp_us) {
+  // 0 = no high-resolution source; stamp with the arrival time (the engine
+  // clock is CLOCK_MONOTONIC, so a caller-supplied kernel input timestamp in
+  // the same domain slots in directly and predates this by the input path's
+  // latency — better data for the framework's velocity tracker/resampler).
+  const auto timestamp = timestamp_us != 0
+                             ? timestamp_us
+                             : LibFlutterEngine->GetCurrentTime() / 1000;
   std::scoped_lock lock(m_pointer_mutex);
 
   FlutterPointerEvent e{};
@@ -718,7 +725,9 @@ void Engine::CoalesceTouchEvent(const FlutterPointerPhase phase,
   CoalesceTouchFrame(&e, 1);
 }
 
-void Engine::CoalesceTouchFrame(const TouchEvent* events, const size_t count) {
+void Engine::CoalesceTouchFrame(const TouchEvent* events,
+                                const size_t count,
+                                const uint64_t timestamp_us) {
   if (events == nullptr || count == 0) {
     return;
   }
@@ -727,7 +736,10 @@ void Engine::CoalesceTouchFrame(const TouchEvent* events, const size_t count) {
   // logically simultaneous (wl_touch.frame / libinput TOUCH_FRAME group one
   // hardware scan), and a shared timestamp keeps the engine's pointer
   // resampler from interpolating skew between fingers that moved together.
-  const auto timestamp = LibFlutterEngine->GetCurrentTime() / 1000;
+  // 0 = no high-resolution source; stamp with the arrival time.
+  const auto timestamp = timestamp_us != 0
+                             ? timestamp_us
+                             : LibFlutterEngine->GetCurrentTime() / 1000;
 
   std::scoped_lock lock(m_pointer_mutex);
   for (size_t i = 0; i < count; ++i) {

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -291,6 +291,11 @@ class Engine {
    * @param[in] scroll_delta_x X offset of the scroll
    * @param[in] scroll_delta_y Y offset of the scroll
    * @param[in] buttons Buttons currently pressed, if any
+   * @param[in] timestamp_us Event timestamp in microseconds in the engine
+   * clock domain (CLOCK_MONOTONIC), e.g. from zwp_input_timestamps_v1. 0 (the
+   * default) stamps the event with the arrival time instead — the historical
+   * behavior, and the fallback whenever no high-resolution source is
+   * available.
    * @return void
    * @relation
    * flutter
@@ -301,7 +306,8 @@ class Engine {
                           double y,
                           double scroll_delta_x,
                           double scroll_delta_y,
-                          int64_t buttons);
+                          int64_t buttons,
+                          uint64_t timestamp_us = 0);
 
   /**
    * @brief Coalesce touch event
@@ -341,11 +347,18 @@ class Engine {
    *
    * @param[in] events First event of the frame
    * @param[in] count Number of events in the frame
+   * @param[in] timestamp_us Shared frame timestamp in microseconds in the
+   * engine clock domain (CLOCK_MONOTONIC), e.g. from
+   * zwp_input_timestamps_v1. 0 (the default) stamps the frame with the
+   * arrival time instead — the historical behavior, and the fallback
+   * whenever no high-resolution source is available.
    * @return void
    * @relation
    * flutter
    */
-  void CoalesceTouchFrame(const TouchEvent* events, size_t count);
+  void CoalesceTouchFrame(const TouchEvent* events,
+                          size_t count,
+                          uint64_t timestamp_us = 0);
 
   /**
    * @brief Send coalesced Pointer events

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -144,6 +144,9 @@ Display::~Display() {
   text_input_.Release();
   // Send wl_keyboard teardown + free the handler's xkb objects/timerfd.
   keyboard_.Reset();
+  // Destroy the zwp_input_timestamps_v1 subscriptions + manager while the
+  // display connection is still alive.
+  input_timestamps_.Reset();
 
   // The shells (xdg/agl/ivi/simple) and the vsync provider own their protocol
   // objects and tear them down in their own destructors.
@@ -278,8 +281,13 @@ void Display::HandleGlobal(wl::CRegistry& reg,
   else if (iface == "zwp_text_input_manager_v3") {
     d->text_input_.Record(name, version);
   }
-  // wp_presentation is owned by the vsync provider.
-  else if (d->m_vsync.TryBindGlobal(registry, name, interface, version)) {
+  // wp_presentation is owned by the vsync provider;
+  // zwp_input_timestamps_manager_v1 by the input-timestamps provider (which
+  // subscribes any devices the seat has already announced). Short-circuit ||:
+  // each global is offered to at most one owner.
+  else if (d->m_vsync.TryBindGlobal(registry, name, interface, version) ||
+           d->input_timestamps_.TryBindGlobal(registry, name, interface,
+                                              version)) {
   }
   // Everything else: offer the global to each compositor-protocol shell
   // (xdg/agl/ivi/simple); the first that claims it wins.
@@ -390,8 +398,12 @@ void Display::seat_handle_capabilities(void* data,
       spdlog::debug("Pointer Present");
       d->m_pointer.wl_pointer = wl_seat_get_pointer(seat);
       wl_pointer_add_listener(d->m_pointer.wl_pointer, &pointer_listener, d);
+      d->input_timestamps_.AttachPointer(d->m_pointer.wl_pointer);
     } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) &&
                d->m_pointer.wl_pointer) {
+      // Detach (destroys the subscription proxy) before releasing the device
+      // it references.
+      d->input_timestamps_.AttachPointer(nullptr);
       wl_pointer_release(d->m_pointer.wl_pointer);
       d->m_pointer.wl_pointer = nullptr;
     }
@@ -422,7 +434,11 @@ void Display::seat_handle_capabilities(void* data,
       d->m_touch.touch = wl_seat_get_touch(seat);
       wl_touch_set_user_data(d->m_touch.touch, d);
       wl_touch_add_listener(d->m_touch.touch, &touch_listener, d);
+      d->input_timestamps_.AttachTouch(d->m_touch.touch);
     } else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && d->m_touch.touch) {
+      // Detach (destroys the subscription proxy) before releasing the device
+      // it references.
+      d->input_timestamps_.AttachTouch(nullptr);
       wl_touch_release(d->m_touch.touch);
       d->m_touch.touch = nullptr;
     }
@@ -487,6 +503,11 @@ void Display::pointer_handle_motion(void* data,
                                     wl_fixed_t sx,
                                     wl_fixed_t sy) {
   auto* d = static_cast<Display*>(data);
+  // Take BEFORE the mask gate: motion carries a wl timestamp, so a
+  // zwp_input_timestamps_v1 stamp may be pending for it. Consuming it even
+  // when the event is dropped keeps a stale stamp from attaching to a later
+  // event.
+  const uint64_t ts_us = d->input_timestamps_.TakePointerTimeUs();
 
   if (!d->m_wayland_event_mask.pointer_motion) {
     d->m_pointer.event.surface_x = wl_fixed_to_double(sx);
@@ -497,7 +518,7 @@ void Display::pointer_handle_motion(void* data,
           pointerButtonStatePressed(&d->m_pointer) ? kMove : kHover;
       d->m_active_engine->CoalesceMouseEvent(
           kFlutterPointerSignalKindNone, phase, d->m_pointer.event.surface_x,
-          d->m_pointer.event.surface_y, 0.0, 0.0, d->m_pointer.buttons);
+          d->m_pointer.event.surface_y, 0.0, 0.0, d->m_pointer.buttons, ts_us);
     }
   }
 }
@@ -509,6 +530,8 @@ void Display::pointer_handle_button(void* data,
                                     uint32_t button,
                                     uint32_t state) {
   auto* d = static_cast<Display*>(data);
+  // Take before the mask gate (see pointer_handle_motion).
+  const uint64_t ts_us = d->input_timestamps_.TakePointerTimeUs();
   if (!d->m_wayland_event_mask.pointer_buttons) {
     d->m_pointer.event.button = button;
     d->m_pointer.event.state = state;
@@ -531,7 +554,7 @@ void Display::pointer_handle_button(void* data,
     if (d->m_active_engine) {
       d->m_active_engine->CoalesceMouseEvent(
           kFlutterPointerSignalKindNone, phase, d->m_pointer.event.surface_x,
-          d->m_pointer.event.surface_y, 0.0, 0.0, d->m_pointer.buttons);
+          d->m_pointer.event.surface_y, 0.0, 0.0, d->m_pointer.buttons, ts_us);
     }
   }
 }
@@ -541,8 +564,10 @@ void Display::pointer_handle_axis(void* data,
                                   uint32_t time,
                                   uint32_t axis,
                                   wl_fixed_t value) {
-  if (auto* d = static_cast<Display*>(data);
-      !d->m_wayland_event_mask.pointer_axis) {
+  auto* d = static_cast<Display*>(data);
+  // Take before the mask gate (see pointer_handle_motion).
+  const uint64_t ts_us = d->input_timestamps_.TakePointerTimeUs();
+  if (!d->m_wayland_event_mask.pointer_axis) {
     d->m_pointer.event.time = time;
     d->m_pointer.event.axes[axis].value = wl_fixed_to_double(value);
 
@@ -551,7 +576,7 @@ void Display::pointer_handle_axis(void* data,
           kFlutterPointerSignalKindScroll, FlutterPointerPhase::kMove,
           d->m_pointer.event.surface_x, d->m_pointer.event.surface_y,
           d->m_pointer.event.axes[1].value, d->m_pointer.event.axes[0].value,
-          d->m_pointer.buttons);
+          d->m_pointer.buttons, ts_us);
     }
   }
 }
@@ -563,10 +588,15 @@ void Display::pointer_handle_axis_source(void* /* data */,
                                          struct wl_pointer* /* wl_pointer */,
                                          uint32_t /* axis_source */) {}
 
-void Display::pointer_handle_axis_stop(void* /* data */,
+void Display::pointer_handle_axis_stop(void* data,
                                        struct wl_pointer* /* wl_pointer */,
                                        uint32_t /* time */,
-                                       uint32_t /* axis */) {}
+                                       uint32_t /* axis */) {
+  // axis_stop carries a wl timestamp, so a high-resolution stamp may be
+  // pending for it even though the event itself is not forwarded; discard it
+  // so it can't attach to the next motion/button/axis.
+  (void)static_cast<Display*>(data)->input_timestamps_.TakePointerTimeUs();
+}
 
 void Display::pointer_handle_axis_discrete(void* /* data */,
                                            struct wl_pointer* /* wl_pointer */,
@@ -791,6 +821,9 @@ void Display::touch_handle_down(void* data,
                                 wl_fixed_t x_w,
                                 wl_fixed_t y_w) {
   auto* d = static_cast<Display*>(data);
+  // Take FIRST: the pending high-res stamp belongs to this event, not to the
+  // frame a possible engine-switch flush below sends out.
+  const uint64_t ts_us = d->input_timestamps_.TakeTouchTimeUs();
 
   // Contacts must not straddle engines within one batch: if a new contact
   // lands on a different surface, flush what belongs to the previous engine
@@ -803,8 +836,10 @@ void Display::touch_handle_down(void* data,
   d->m_touch_engine = engine;
 
   d->m_touch.points[id] = {x_w, y_w};
-  touch_push(d, {FlutterPointerPhase::kDown, wl_fixed_to_double(x_w),
-                 wl_fixed_to_double(y_w), id});
+  touch_push(d,
+             {FlutterPointerPhase::kDown, wl_fixed_to_double(x_w),
+              wl_fixed_to_double(y_w), id},
+             ts_us);
 }
 
 void Display::touch_handle_up(void* data,
@@ -813,6 +848,9 @@ void Display::touch_handle_up(void* data,
                               uint32_t /* time */,
                               int32_t id) {
   auto* d = static_cast<Display*>(data);
+  // Take before the unknown-id early return: up carries a wl timestamp, so a
+  // pending stamp must be consumed even for dropped events.
+  const uint64_t ts_us = d->input_timestamps_.TakeTouchTimeUs();
 
   // wl_touch.up carries no coordinates; reuse the contact's last position.
   // Unknown id (no prior down seen, e.g. attach mid-session) is dropped —
@@ -821,8 +859,10 @@ void Display::touch_handle_up(void* data,
   if (it == d->m_touch.points.end()) {
     return;
   }
-  touch_push(d, {kUp, wl_fixed_to_double(it->second.first),
-                 wl_fixed_to_double(it->second.second), id});
+  touch_push(d,
+             {kUp, wl_fixed_to_double(it->second.first),
+              wl_fixed_to_double(it->second.second), id},
+             ts_us);
   d->m_touch.points.erase(it);
 }
 
@@ -833,14 +873,18 @@ void Display::touch_handle_motion(void* data,
                                   wl_fixed_t x_w,
                                   wl_fixed_t y_w) {
   auto* d = static_cast<Display*>(data);
+  // Take before the unknown-id early return (see touch_handle_up).
+  const uint64_t ts_us = d->input_timestamps_.TakeTouchTimeUs();
 
   const auto it = d->m_touch.points.find(id);
   if (it == d->m_touch.points.end()) {
     return;
   }
   it->second = {x_w, y_w};
-  touch_push(d, {FlutterPointerPhase::kMove, wl_fixed_to_double(x_w),
-                 wl_fixed_to_double(y_w), id});
+  touch_push(d,
+             {FlutterPointerPhase::kMove, wl_fixed_to_double(x_w),
+              wl_fixed_to_double(y_w), id},
+             ts_us);
 }
 
 void Display::touch_handle_cancel(void* data, struct wl_touch* /* wl_touch */) {
@@ -855,6 +899,10 @@ void Display::touch_handle_cancel(void* data, struct wl_touch* /* wl_touch */) {
   // entry in the framework. Cancel each contact at its last known position
   // (the previous code cancelled only device 0, at the *mouse* position).
   d->m_touch.frame.clear();  // pending updates for this session are moot
+  // The synthesized cancels have no hardware moment; drop any latched
+  // high-res stamp so the flush uses arrival time (cancel itself carries no
+  // wl timestamp, so no stamp is pending for it).
+  d->m_touch.frame_time_us = 0;
   for (const auto& [id, pos] : d->m_touch.points) {
     d->m_touch.frame.push_back({kCancel, wl_fixed_to_double(pos.first),
                                 wl_fixed_to_double(pos.second), id});
@@ -874,12 +922,21 @@ void Display::touch_flush_frame(Display* d) {
   }
   if (d->m_touch_engine) {
     d->m_touch_engine->CoalesceTouchFrame(d->m_touch.frame.data(),
-                                          d->m_touch.frame.size());
+                                          d->m_touch.frame.size(),
+                                          d->m_touch.frame_time_us);
   }
   d->m_touch.frame.clear();
+  d->m_touch.frame_time_us = 0;
 }
 
-void Display::touch_push(Display* d, const Engine::TouchEvent& ev) {
+void Display::touch_push(Display* d,
+                         const Engine::TouchEvent& ev,
+                         const uint64_t ts_us) {
+  // Latch the frame's shared stamp from the first contact event that carried
+  // one (contacts in a frame are one hardware scan; see touch_.frame_time_us).
+  if (d->m_touch.frame_time_us == 0) {
+    d->m_touch.frame_time_us = ts_us;
+  }
   d->m_touch.frame.push_back(ev);
   // wl_touch.frame is the normal flush boundary, but the protocol can't force
   // a compositor to send it; cap the batch so a stream without frame markers

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -69,6 +69,7 @@
 #include "platform/homescreen/keyboard_hook_handler.h"
 #include "platform/homescreen/text_input_plugin.h"
 #include "vsync/wayland_vsync_provider.h"
+#include "wayland/input_timestamps.h"
 #include "wayland/shell/wayland_shell.h"
 
 class Engine;
@@ -497,6 +498,13 @@ class Display : public IDisplay,
   // drives FlutterEngineOnVsync from per-commit feedback).
   ivi::WaylandVsyncProvider m_vsync;
 
+  // zwp_input_timestamps_v1 provider (owns the manager global + per-device
+  // subscriptions; hands nanosecond kernel input timestamps to the
+  // pointer/touch handlers as engine-clock microseconds). Runtime-optional:
+  // absent global -> Take*() returns 0 -> arrival-time stamping, the
+  // historical behavior.
+  ivi::InputTimestamps input_timestamps_;
+
   bool m_enable_cursor;
   struct wl_surface* m_cursor_surface{};
   std::string m_cursor_theme_name;
@@ -589,6 +597,12 @@ class Display : public IDisplay,
     // handed to the engine as one batch (one lock, one main-loop wake, one
     // FlutterEngineSendPointerEvent group).
     std::vector<Engine::TouchEvent> frame;
+    // Shared high-resolution timestamp for the pending frame: the first
+    // nonzero zwp_input_timestamps_v1 value taken by a contact event since
+    // the last flush (contacts in one frame are logically simultaneous, and
+    // one shared stamp keeps the engine's resampler from interpolating skew
+    // between fingers). 0 -> no high-res source -> arrival-time stamping.
+    uint64_t frame_time_us;
     uint32_t state;
     FlutterPointerPhase phase;
   } m_touch{};
@@ -1073,11 +1087,16 @@ class Display : public IDisplay,
    * growing unbounded (parity with the drm/software seats).
    * @param[in] d Display instance
    * @param[in] ev Contact update to queue
+   * @param[in] ts_us High-resolution event timestamp in microseconds (engine
+   * clock domain), or 0 when unavailable. The first nonzero value since the
+   * last flush is latched as the frame's shared timestamp.
    * @return void
    * @relation
    * wayland, flutter
    */
-  static void touch_push(Display* d, const Engine::TouchEvent& ev);
+  static void touch_push(Display* d,
+                         const Engine::TouchEvent& ev,
+                         uint64_t ts_us);
 
   static const wl_touch_listener touch_listener;
 };

--- a/shell/wayland/input_timestamps.cc
+++ b/shell/wayland/input_timestamps.cc
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wayland/input_timestamps.h"
+
+#include <algorithm>
+#include <ctime>
+
+#include <wayland-client.h>
+
+#include <wl/client_helpers.hpp>
+#include <wl/proxy_impl.hpp>
+
+#include "logging/logging.h"
+
+namespace ivi {
+
+namespace itc = input_timestamps_unstable_v1::client;
+
+namespace {
+
+// Freshness bound for the clock-domain sanity check. An input timestamp is
+// stamped by the kernel at event receipt, so in the CLOCK_MONOTONIC domain it
+// is always in the recent past; a value outside this window (e.g. a
+// CLOCK_REALTIME epoch value, or garbage) cannot be engine-clock-compatible.
+// Generous enough to absorb scheduling delay and dispatch backlog.
+constexpr uint64_t kMaxAgeUs = 10ull * 1000 * 1000;  // 10 s
+// Small forward slack for rounding at the µs boundary.
+constexpr uint64_t kMaxFutureUs = 1000;  // 1 ms
+
+uint64_t MonotonicNowUs() {
+  timespec ts{};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1'000'000u +
+         static_cast<uint64_t>(ts.tv_nsec) / 1000u;
+}
+
+}  // namespace
+
+bool InputTimestamps::TryBindGlobal(wl_registry* registry,
+                                    const uint32_t name,
+                                    const std::string_view interface,
+                                    const uint32_t version) {
+  if (interface !=
+      itc::zwp_input_timestamps_manager_v1_traits::wl_iface().name) {
+    return false;
+  }
+  const uint32_t bind_ver =
+      std::min(version, itc::zwp_input_timestamps_manager_v1_traits::version);
+  auto* raw = static_cast<wl_proxy*>(wl_registry_bind(
+      registry, name, &itc::zwp_input_timestamps_manager_v1_traits::wl_iface(),
+      bind_ver));
+  if (raw == nullptr) {
+    spdlog::warn("[InputTimestamps] manager bind failed");
+    return true;  // consumed (nobody else wants this global)
+  }
+  // The manager has no events; adopt without a listener.
+  manager_.Attach(raw);
+  spdlog::debug("[InputTimestamps] bound zwp_input_timestamps_manager_v1 v{}",
+                bind_ver);
+  // Registry global order vs. wl_seat.capabilities order is not guaranteed;
+  // subscribe anything the seat already announced.
+  if (pointer_ != nullptr) {
+    AttachPointer(pointer_);
+  }
+  if (touch_ != nullptr) {
+    AttachTouch(touch_);
+  }
+  return true;
+}
+
+void InputTimestamps::AttachPointer(wl_pointer* pointer) {
+  pointer_ = pointer;
+  Subscribe(pointer_sub_, reinterpret_cast<wl_proxy*>(pointer),
+            &pending_pointer_, Kind::kPointer);
+}
+
+void InputTimestamps::AttachTouch(wl_touch* touch) {
+  touch_ = touch;
+  Subscribe(touch_sub_, reinterpret_cast<wl_proxy*>(touch), &pending_touch_,
+            Kind::kTouch);
+}
+
+void InputTimestamps::Subscribe(wl::WlPtr<Subscription>& sub,
+                                wl_proxy* device,
+                                Pending* slot,
+                                const Kind kind) {
+  // Drop any previous subscription first — on device re-create (capability
+  // bounce) the old zwp_input_timestamps_v1 became inert when its input
+  // device was destroyed; on detach this is the whole job.
+  sub.Reset();
+  slot->valid = false;
+  if (device == nullptr || manager_.IsNull()) {
+    return;
+  }
+  // get_*_timestamps(id: new_id, device) — new_id leads ("no"), so plain
+  // wl::construct (the opcode is a compile-time template argument, hence one
+  // call per Kind).
+  wl_proxy* raw =
+      kind == Kind::kPointer
+          ? wl::construct<itc::zwp_input_timestamps_v1_traits,
+                          itc::zwp_input_timestamps_manager_v1_traits::Op::
+                              GetPointerTimestamps>(*manager_.Get(), device)
+          : wl::construct<itc::zwp_input_timestamps_v1_traits,
+                          itc::zwp_input_timestamps_manager_v1_traits::Op::
+                              GetTouchTimestamps>(*manager_.Get(), device);
+  const char* what = kind == Kind::kPointer ? "pointer" : "touch";
+  if (!wl::SetupHandler(sub, raw)) {
+    spdlog::warn("[InputTimestamps] {} subscription failed", what);
+    return;
+  }
+  sub.Get()->slot_ = slot;
+  spdlog::debug("[InputTimestamps] subscribed {} timestamps", what);
+}
+
+uint64_t InputTimestamps::TakePointerTimeUs() {
+  return Take(pending_pointer_);
+}
+
+uint64_t InputTimestamps::TakeTouchTimeUs() {
+  return Take(pending_touch_);
+}
+
+uint64_t InputTimestamps::Take(Pending& pending) {
+  if (!pending.valid) {
+    return 0;
+  }
+  pending.valid = false;
+  // Unsigned multiply may wrap for an absurd (hostile/corrupt) sec value;
+  // wrapping is defined, and any wrapped result lands outside the freshness
+  // window below, so the gate defuses overflow as well as wrong-domain
+  // values.
+  const uint64_t ts_us =
+      pending.sec * 1'000'000u + static_cast<uint64_t>(pending.nsec) / 1000u;
+  // Clock-domain sanity check (see class comment): a CLOCK_MONOTONIC input
+  // timestamp is in the recent past relative to CLOCK_MONOTONIC now.
+  const uint64_t now_us = MonotonicNowUs();
+  if (ts_us > now_us + kMaxFutureUs || ts_us + kMaxAgeUs < now_us) {
+    if (!clock_warned_) {
+      clock_warned_ = true;
+      spdlog::warn(
+          "[InputTimestamps] timestamp {} µs is not CLOCK_MONOTONIC-domain "
+          "(now {} µs); falling back to arrival-time stamping",
+          ts_us, now_us);
+    }
+    return 0;
+  }
+  return ts_us;
+}
+
+void InputTimestamps::Reset() {
+  pointer_sub_.Reset();
+  touch_sub_.Reset();
+  manager_.Reset();
+  pointer_ = nullptr;
+  touch_ = nullptr;
+  pending_pointer_.valid = false;
+  pending_touch_.valid = false;
+}
+
+}  // namespace ivi

--- a/shell/wayland/input_timestamps.h
+++ b/shell/wayland/input_timestamps.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_WAYLAND_INPUT_TIMESTAMPS_H_
+#define SHELL_WAYLAND_INPUT_TIMESTAMPS_H_
+
+#include <cstdint>
+#include <string_view>
+
+#include "input_timestamps_client.hpp"  // generated (input_timestamps_unstable_v1::client)
+
+#include <wl/wl_ptr.hpp>
+
+struct wl_pointer;
+struct wl_registry;
+struct wl_touch;
+
+namespace ivi {
+
+/**
+ * @brief Owns zwp_input_timestamps_manager_v1 and the per-device
+ * zwp_input_timestamps_v1 subscriptions, turning the protocol's
+ * nanosecond-resolution timestamp events into microsecond timestamps for the
+ * pointer/touch → Flutter path.
+ *
+ * Why: wl_pointer/wl_touch carry millisecond-granularity timestamps, which is
+ * poor input for the framework's velocity tracker (fling feel) and pointer
+ * resampler. The protocol delivers a high-resolution timestamp event
+ * immediately BEFORE each input event it qualifies; Display's handlers
+ * consume it via the take-and-clear accessors below and hand it to
+ * Engine::CoalesceMouseEvent / CoalesceTouchFrame.
+ *
+ * Threading: every entry point — TryBindGlobal (registry enumeration),
+ * AttachPointer/AttachTouch (wl_seat.capabilities), the OnTimestamp events,
+ * and the Take*() accessors (wl_pointer/wl_touch handlers) — runs on the
+ * Wayland event thread, so the pending slots need no locking (same contract
+ * as Display::m_touch).
+ *
+ * Runtime-optional: when the compositor never advertises the manager,
+ * everything no-ops and Take*() returns 0, which the engine treats as
+ * "stamp with arrival time" — the historical behavior.
+ *
+ * Clock domain: the protocol guarantees only "the same clock domain as the
+ * associated input event timestamp", which the core protocol leaves
+ * unspecified (every mainstream compositor uses CLOCK_MONOTONIC — the engine
+ * clock). Rather than trust that convention blindly, Take*() sanity-checks
+ * each value against CLOCK_MONOTONIC now and falls back to 0 (arrival-time
+ * stamping) when the value can't be from that domain, logging once.
+ */
+class InputTimestamps {
+ public:
+  InputTimestamps() = default;
+  ~InputTimestamps() { Reset(); }
+
+  InputTimestamps(const InputTimestamps&) = delete;
+  InputTimestamps& operator=(const InputTimestamps&) = delete;
+
+  /// Bind zwp_input_timestamps_manager_v1 if @p interface names it. Called
+  /// from Display's registry loop alongside the vsync provider and shells.
+  /// Subscribes any already-attached devices (registry global order vs.
+  /// wl_seat.capabilities order is not guaranteed). Returns true if consumed.
+  [[nodiscard]] bool TryBindGlobal(wl_registry* registry,
+                                   uint32_t name,
+                                   std::string_view interface,
+                                   uint32_t version);
+
+  /// Track the seat's wl_pointer. nullptr detaches (capability lost). If the
+  /// manager is bound, (re)creates the pointer subscription.
+  void AttachPointer(wl_pointer* pointer);
+
+  /// Track the seat's wl_touch. nullptr detaches (capability lost). If the
+  /// manager is bound, (re)creates the touch subscription.
+  void AttachTouch(wl_touch* touch);
+
+  /// Take-and-clear the pending pointer timestamp: microseconds in the
+  /// engine clock domain (CLOCK_MONOTONIC), or 0 when there is none / the
+  /// clock domain is unusable. The wl_pointer handlers must call this for
+  /// EVERY timestamp-carrying event (motion/button/axis) — even ones they
+  /// drop — so a stale stamp is never applied to a later event.
+  [[nodiscard]] uint64_t TakePointerTimeUs();
+
+  /// Take-and-clear the pending touch timestamp; semantics as above, for the
+  /// wl_touch handlers (down/up/motion).
+  [[nodiscard]] uint64_t TakeTouchTimeUs();
+
+  /// Destroy the subscriptions + manager. Must run before
+  /// wl_display_disconnect (proxy destruction touches the display).
+  void Reset();
+
+ private:
+  // A pending (tv_sec, tv_nsec) captured by an OnTimestamp event, waiting for
+  // the input event it qualifies.
+  struct Pending {
+    uint64_t sec = 0;
+    uint32_t nsec = 0;
+    bool valid = false;
+  };
+
+  // zwp_input_timestamps_v1 event handler; stores into the owner's slot.
+  class Subscription final
+      : public input_timestamps_unstable_v1::client::CZwpInputTimestampsV1<
+            Subscription> {
+   public:
+    void OnTimestamp(uint32_t tv_sec_hi,
+                     uint32_t tv_sec_lo,
+                     uint32_t tv_nsec) override {
+      if (slot_ != nullptr) {
+        slot_->sec = (static_cast<uint64_t>(tv_sec_hi) << 32u) | tv_sec_lo;
+        slot_->nsec = tv_nsec;
+        slot_->valid = true;
+      }
+    }
+
+    Pending* slot_ = nullptr;
+  };
+
+  // zwp_input_timestamps_manager_v1 has no events; concrete type for WlPtr.
+  class Manager final : public input_timestamps_unstable_v1::client::
+                            CZwpInputTimestampsManagerV1<Manager> {};
+
+  // (Re)create / destroy the subscription for one device slot.
+  enum class Kind : uint8_t { kPointer, kTouch };
+  void Subscribe(wl::WlPtr<Subscription>& sub,
+                 wl_proxy* device,
+                 Pending* slot,
+                 Kind kind);
+
+  // Validate + convert a pending value; clears it. 0 when absent or the
+  // clock domain check fails.
+  [[nodiscard]] uint64_t Take(Pending& pending);
+
+  wl::WlPtr<Manager> manager_;
+  wl::WlPtr<Subscription> pointer_sub_;
+  wl::WlPtr<Subscription> touch_sub_;
+
+  // Raw devices as last announced by wl_seat.capabilities; not owned (the
+  // Display owns/releases them). Kept so a manager bound after the
+  // capabilities event can still subscribe.
+  wl_pointer* pointer_ = nullptr;
+  wl_touch* touch_ = nullptr;
+
+  Pending pending_pointer_;
+  Pending pending_touch_;
+
+  // Log the clock-domain fallback once, not per event.
+  bool clock_warned_ = false;
+};
+
+}  // namespace ivi
+
+#endif  // SHELL_WAYLAND_INPUT_TIMESTAMPS_H_


### PR DESCRIPTION
Feed high-resolution kernel input timestamps from `zwp_input_timestamps_v1`
into the pointer/touch → Flutter path, replacing arrival-time stamping.

`wl_pointer`/`wl_touch` carry only millisecond timestamps, and the Wayland
backend was stamping events with arrival time — the input path's dispatch
delay *and its variance* — at coalesce. The framework's velocity tracker
differentiates position against those timestamps, so queue jitter became
fling-velocity noise. `zwp_input_timestamps_v1` delivers a nanosecond,
kernel-stamped timestamp immediately before each qualifying input event.

> Stacked on #275 (`jw/view-scale-physical-pixels`). Review/merge that
> first; this PR's diff is the three commits below and will retarget to
> `v2.0` once #275 lands.

### Commits

- **engine: accept caller-supplied timestamps in the pointer coalesce API** —
  `CoalesceMouseEvent`/`CoalesceTouchFrame` gain a `timestamp_us` parameter
  (engine clock domain, `CLOCK_MONOTONIC`). `0` (the default) preserves
  arrival stamping, so every existing call site is unchanged.
- **wayland: add `ivi::InputTimestamps` (`zwp_input_timestamps_v1` provider)** —
  owns the manager global + per-device subscriptions, converts the protocol's
  ns events to µs, and take-and-clears them for the handlers. Runtime-optional:
  absent global → no-op → arrival stamping. `Take()` validates every value
  against `CLOCK_MONOTONIC` (10 s age / 1 ms future) and degrades with a
  log-once warning, mirroring the vsync provider's `wp_presentation` clock gate;
  the same window defuses unsigned overflow from a hostile `tv_sec`.
- **wayland: stamp pointer/touch events with `zwp_input_timestamps_v1`** —
  wires the provider into `Display`. Every timestamp-carrying handler takes the
  pending stamp unconditionally at the top (before the event-mask gates, before
  the unknown-id early returns, including the non-forwarded `axis_stop`) so a
  stale stamp never attaches to a later event. Touch frames keep their shared
  timestamp (one hardware scan → one stamp); detach happens before
  `wl_*_release` and teardown before `wl_display_disconnect`.

### Runtime-optional / no regression

When the compositor doesn't advertise the manager, `Take*()` returns `0` and
the engine stamps with arrival time — exactly the prior behavior. GNOME/mutter
and tinywl (wlroots reference) both fall in this bucket today.

### Validation (this machine, `build/` Wayland-EGL, clang 18)

- **clang-format-19** clean; **clang-tidy-19** (`--warnings-as-errors`, the CI
  gate) clean on all three changed TUs.
- **Fallback path** — GNOME/mutter and tinywl (neither advertises the manager):
  homescreen ran, engine up, input worked, clean teardown, no `[InputTimestamps]`
  binding.
- **Active path** — nested **Weston 14** (advertises `zwp_input_timestamps_manager_v1`
  v1): `bound … v1` → `subscribed pointer timestamps`; over a `WAYLAND_DEBUG`
  session with pointer motion, **2239** `zwp_input_timestamps_v1.timestamp` events
  were received across 2246 pointer events, **0** clock-domain rejections (every
  stamp passed the `CLOCK_MONOTONIC` gate and reached `CoalesceMouseEvent`), and
  teardown emitted `zwp_input_timestamps_v1.destroy` then
  `..._manager_v1.destroy` before disconnect. No crash or leak.
