### PR TITLE
wayland_vulkan: serialize engine and backend access to the shared VkQueue (#208)

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -91,7 +91,10 @@ set_target_properties(${PROJECT_NAME}
 
 
 if (BUILD_BACKEND_WAYLAND_VULKAN)
-    target_sources(${PROJECT_NAME} PRIVATE backend/wayland_vulkan/wayland_vulkan.cc)
+    target_sources(${PROJECT_NAME} PRIVATE
+            backend/wayland_vulkan/wayland_vulkan.cc
+            backend/wayland_vulkan/vulkan_queue_interposer.cc
+    )
     if (BUILD_COMPOSITOR)
         target_sources(${PROJECT_NAME} PRIVATE
                 backend/wayland_vulkan/vulkan_backing_store.cc

--- a/shell/backend/wayland_vulkan/vulkan_queue_interposer.cc
+++ b/shell/backend/wayland_vulkan/vulkan_queue_interposer.cc
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vulkan_queue_interposer.h"
+
+#include <atomic>
+#include <cstring>
+#include <unordered_map>
+
+namespace wayland_vulkan {
+
+namespace {
+
+// Queue -> guarding mutex. Mutated only at device create/destroy; read on
+// every interposed queue call. The map's own lock is uncontended in
+// steady state (registration is done before the engine runs) and, when it
+// is contended, the callers were about to serialize on the queue mutex
+// anyway.
+std::mutex g_registry_mutex;
+std::unordered_map<VkQueue, std::mutex*>& Registry() {
+  static auto* registry = new std::unordered_map<VkQueue, std::mutex*>();
+  return *registry;
+}
+
+std::mutex* LookupQueueMutex(VkQueue queue) {
+  const std::lock_guard<std::mutex> lock(g_registry_mutex);
+  const auto& registry = Registry();
+  const auto it = registry.find(queue);
+  return it != registry.end() ? it->second : nullptr;
+}
+
+// RAII guard that locks the registered mutex for a queue, or nothing if the
+// queue is unregistered.
+class QueueLock {
+ public:
+  explicit QueueLock(VkQueue queue) : mutex_(LookupQueueMutex(queue)) {
+    if (mutex_ != nullptr) {
+      mutex_->lock();
+    }
+  }
+  ~QueueLock() {
+    if (mutex_ != nullptr) {
+      mutex_->unlock();
+    }
+  }
+  QueueLock(const QueueLock&) = delete;
+  QueueLock& operator=(const QueueLock&) = delete;
+
+ private:
+  std::mutex* mutex_;
+};
+
+// Cached real driver procs. Written while the engine resolves its dispatch
+// tables (FlutterEngineInitialize / first frame), read on every interposed
+// call thereafter. Loader trampolines returned by GIPA/GDPA are valid for
+// any dispatchable child object, so a single process-wide slot per name is
+// sufficient even with multiple backend instances.
+struct RealProcs {
+  std::atomic<PFN_vkQueueSubmit> QueueSubmit{nullptr};
+  std::atomic<PFN_vkQueueSubmit2> QueueSubmit2{nullptr};
+  std::atomic<PFN_vkQueueSubmit2KHR> QueueSubmit2KHR{nullptr};
+  std::atomic<PFN_vkQueueWaitIdle> QueueWaitIdle{nullptr};
+  std::atomic<PFN_vkQueuePresentKHR> QueuePresentKHR{nullptr};
+  std::atomic<PFN_vkQueueBindSparse> QueueBindSparse{nullptr};
+  std::atomic<PFN_vkQueueBeginDebugUtilsLabelEXT> QueueBeginDebugUtilsLabelEXT{
+      nullptr};
+  std::atomic<PFN_vkQueueEndDebugUtilsLabelEXT> QueueEndDebugUtilsLabelEXT{
+      nullptr};
+  std::atomic<PFN_vkQueueInsertDebugUtilsLabelEXT>
+      QueueInsertDebugUtilsLabelEXT{nullptr};
+  std::atomic<PFN_vkGetDeviceProcAddr> GetDeviceProcAddr{nullptr};
+};
+
+RealProcs g_real;
+
+//------------------------------------------------------------------------
+// Locking trampolines. Exact Vulkan signatures; each takes the mutex
+// registered for the queue for the duration of the real call.
+//------------------------------------------------------------------------
+
+VKAPI_ATTR VkResult VKAPI_CALL
+InterposedQueueSubmit(VkQueue queue,
+                      uint32_t submitCount,
+                      const VkSubmitInfo* pSubmits,
+                      VkFence fence) {
+  const QueueLock lock(queue);
+  return g_real.QueueSubmit.load(std::memory_order_relaxed)(queue, submitCount,
+                                                            pSubmits, fence);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+InterposedQueueSubmit2(VkQueue queue,
+                       uint32_t submitCount,
+                       const VkSubmitInfo2* pSubmits,
+                       VkFence fence) {
+  const QueueLock lock(queue);
+  return g_real.QueueSubmit2.load(std::memory_order_relaxed)(queue, submitCount,
+                                                             pSubmits, fence);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+InterposedQueueSubmit2KHR(VkQueue queue,
+                          uint32_t submitCount,
+                          const VkSubmitInfo2* pSubmits,
+                          VkFence fence) {
+  const QueueLock lock(queue);
+  return g_real.QueueSubmit2KHR.load(std::memory_order_relaxed)(
+      queue, submitCount, pSubmits, fence);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL InterposedQueueWaitIdle(VkQueue queue) {
+  const QueueLock lock(queue);
+  return g_real.QueueWaitIdle.load(std::memory_order_relaxed)(queue);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+InterposedQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
+  const QueueLock lock(queue);
+  return g_real.QueuePresentKHR.load(std::memory_order_relaxed)(queue,
+                                                                pPresentInfo);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+InterposedQueueBindSparse(VkQueue queue,
+                          uint32_t bindInfoCount,
+                          const VkBindSparseInfo* pBindInfo,
+                          VkFence fence) {
+  const QueueLock lock(queue);
+  return g_real.QueueBindSparse.load(std::memory_order_relaxed)(
+      queue, bindInfoCount, pBindInfo, fence);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+InterposedQueueBeginDebugUtilsLabelEXT(VkQueue queue,
+                                       const VkDebugUtilsLabelEXT* pLabelInfo) {
+  const QueueLock lock(queue);
+  g_real.QueueBeginDebugUtilsLabelEXT.load(std::memory_order_relaxed)(
+      queue, pLabelInfo);
+}
+
+VKAPI_ATTR void VKAPI_CALL InterposedQueueEndDebugUtilsLabelEXT(VkQueue queue) {
+  const QueueLock lock(queue);
+  g_real.QueueEndDebugUtilsLabelEXT.load(std::memory_order_relaxed)(queue);
+}
+
+VKAPI_ATTR void VKAPI_CALL InterposedQueueInsertDebugUtilsLabelEXT(
+    VkQueue queue,
+    const VkDebugUtilsLabelEXT* pLabelInfo) {
+  const QueueLock lock(queue);
+  g_real.QueueInsertDebugUtilsLabelEXT.load(std::memory_order_relaxed)(
+      queue, pLabelInfo);
+}
+
+//------------------------------------------------------------------------
+// Name -> trampoline dispatch, shared by the instance-level hook and the
+// vkGetDeviceProcAddr shim. `resolve` produces the real proc for `name`
+// from whichever resolver the engine was about to use, so the trampoline
+// always chains to what the engine would otherwise have called.
+//------------------------------------------------------------------------
+
+template <typename Resolver>
+PFN_vkVoidFunction InterposeQueueProc(const char* name,
+                                      const Resolver& resolve) {
+  const auto real = resolve(name);
+  if (real == nullptr) {
+    // Extension not available from this resolver; report that faithfully
+    // rather than handing the engine a trampoline over a null pointer.
+    return nullptr;
+  }
+  if (std::strcmp(name, "vkQueueSubmit") == 0) {
+    g_real.QueueSubmit.store(reinterpret_cast<PFN_vkQueueSubmit>(real),
+                             std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(InterposedQueueSubmit);
+  }
+  if (std::strcmp(name, "vkQueueSubmit2") == 0) {
+    g_real.QueueSubmit2.store(reinterpret_cast<PFN_vkQueueSubmit2>(real),
+                              std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(InterposedQueueSubmit2);
+  }
+  if (std::strcmp(name, "vkQueueSubmit2KHR") == 0) {
+    g_real.QueueSubmit2KHR.store(reinterpret_cast<PFN_vkQueueSubmit2KHR>(real),
+                                 std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(InterposedQueueSubmit2KHR);
+  }
+  if (std::strcmp(name, "vkQueueWaitIdle") == 0) {
+    g_real.QueueWaitIdle.store(reinterpret_cast<PFN_vkQueueWaitIdle>(real),
+                               std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(InterposedQueueWaitIdle);
+  }
+  if (std::strcmp(name, "vkQueuePresentKHR") == 0) {
+    g_real.QueuePresentKHR.store(reinterpret_cast<PFN_vkQueuePresentKHR>(real),
+                                 std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(InterposedQueuePresentKHR);
+  }
+  if (std::strcmp(name, "vkQueueBindSparse") == 0) {
+    g_real.QueueBindSparse.store(reinterpret_cast<PFN_vkQueueBindSparse>(real),
+                                 std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(InterposedQueueBindSparse);
+  }
+  if (std::strcmp(name, "vkQueueBeginDebugUtilsLabelEXT") == 0) {
+    g_real.QueueBeginDebugUtilsLabelEXT.store(
+        reinterpret_cast<PFN_vkQueueBeginDebugUtilsLabelEXT>(real),
+        std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(
+        InterposedQueueBeginDebugUtilsLabelEXT);
+  }
+  if (std::strcmp(name, "vkQueueEndDebugUtilsLabelEXT") == 0) {
+    g_real.QueueEndDebugUtilsLabelEXT.store(
+        reinterpret_cast<PFN_vkQueueEndDebugUtilsLabelEXT>(real),
+        std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(
+        InterposedQueueEndDebugUtilsLabelEXT);
+  }
+  if (std::strcmp(name, "vkQueueInsertDebugUtilsLabelEXT") == 0) {
+    g_real.QueueInsertDebugUtilsLabelEXT.store(
+        reinterpret_cast<PFN_vkQueueInsertDebugUtilsLabelEXT>(real),
+        std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(
+        InterposedQueueInsertDebugUtilsLabelEXT);
+  }
+  return nullptr;
+}
+
+bool IsQueueProcName(const char* name) {
+  return std::strncmp(name, "vkQueue", 7) == 0;
+}
+
+// Shim handed to the engine in place of vkGetDeviceProcAddr. The Skia
+// embedder path (vulkan::VulkanProcTable) resolves all device-level procs
+// through vkGetDeviceProcAddr, which it in turn obtained from the
+// instance-level callback — so intercepting only the instance callback
+// would leave that path unsynchronized.
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL
+InterposedGetDeviceProcAddr(VkDevice device, const char* pName) {
+  const auto real_gdpa =
+      g_real.GetDeviceProcAddr.load(std::memory_order_relaxed);
+  if (pName != nullptr && IsQueueProcName(pName)) {
+    if (auto* proc = InterposeQueueProc(
+            pName, [&](const char* n) { return real_gdpa(device, n); })) {
+      return proc;
+    }
+  }
+  return real_gdpa(device, pName);
+}
+
+}  // namespace
+
+void QueueInterposer::RegisterQueue(VkQueue queue, std::mutex* mutex) {
+  const std::lock_guard<std::mutex> lock(g_registry_mutex);
+  Registry()[queue] = mutex;
+}
+
+void QueueInterposer::UnregisterQueue(VkQueue queue) {
+  const std::lock_guard<std::mutex> lock(g_registry_mutex);
+  Registry().erase(queue);
+}
+
+PFN_vkVoidFunction QueueInterposer::Interpose(VkInstance instance,
+                                              const char* procname,
+                                              PFN_vkGetInstanceProcAddr gipa) {
+  if (procname == nullptr || gipa == nullptr) {
+    return nullptr;
+  }
+  // Impeller initializes its vulkan.hpp dispatcher from the instance-level
+  // callback and resolves device functions through it as loader
+  // trampolines, so queue entry points arrive here directly.
+  if (IsQueueProcName(procname)) {
+    return InterposeQueueProc(procname,
+                              [&](const char* n) { return gipa(instance, n); });
+  }
+  // The Skia VulkanProcTable path resolves device procs via
+  // vkGetDeviceProcAddr; hand it a shim so those resolutions are also
+  // interposed.
+  if (std::strcmp(procname, "vkGetDeviceProcAddr") == 0) {
+    const auto real = reinterpret_cast<PFN_vkGetDeviceProcAddr>(
+        gipa(instance, "vkGetDeviceProcAddr"));
+    if (real == nullptr) {
+      return nullptr;
+    }
+    g_real.GetDeviceProcAddr.store(real, std::memory_order_relaxed);
+    return reinterpret_cast<PFN_vkVoidFunction>(InterposedGetDeviceProcAddr);
+  }
+  return nullptr;
+}
+
+}  // namespace wayland_vulkan

--- a/shell/backend/wayland_vulkan/vulkan_queue_interposer.h
+++ b/shell/backend/wayland_vulkan/vulkan_queue_interposer.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_BACKEND_WAYLAND_VULKAN_VULKAN_QUEUE_INTERPOSER_H_
+#define SHELL_BACKEND_WAYLAND_VULKAN_VULKAN_QUEUE_INTERPOSER_H_
+
+#include <mutex>
+
+#include <vulkan/vulkan.h>
+
+namespace wayland_vulkan {
+
+/**
+ * @brief Serializes host access to a VkQueue shared between the Flutter
+ *        engine and the backend.
+ *
+ * The Vulkan spec requires host access to a VkQueue to be externally
+ * synchronized. On this backend the Flutter raster thread (engine-internal
+ * vkQueueSubmit / vkQueueSubmit2) and the platform thread (present path,
+ * one-shot transfer helpers, swapchain-recreation drains) both use the
+ * single graphics queue handed to the engine via
+ * FlutterVulkanRendererConfig.
+ *
+ * The embedder API designates get_instance_proc_address_callback as the
+ * mechanism for making this safe: the embedder is expected to swap out
+ * vkQueue* entry points for locking variants (see the field documentation
+ * in flutter/shell/platform/embedder/embedder.h and the
+ * EmbedderTest.CanSwapOutVulkanCalls reference test). This class implements
+ * that contract:
+ *
+ *  - RegisterQueue() associates a queue handle with the mutex that already
+ *    guards the backend's own submissions (queue_mutex_), so both sides
+ *    serialize on the same lock.
+ *  - Interpose() recognizes the externally-synchronized vkQueue* entry
+ *    points (and vkGetDeviceProcAddr, so device-level resolution is also
+ *    covered), caches the real driver proc, and returns a trampoline that
+ *    takes the registered mutex for the duration of the call.
+ *
+ * Both engine resolution paths are covered: Impeller resolves every proc
+ * through the instance-level callback (vulkan.hpp dispatcher initialized
+ * with the embedder GIPA), while the Skia VulkanProcTable resolves device
+ * procs through a vkGetDeviceProcAddr that it obtained from the same
+ * callback — which Interpose() shims.
+ *
+ * Calls on a queue that was never registered (or was unregistered) pass
+ * through to the real proc without locking.
+ */
+class QueueInterposer {
+ public:
+  QueueInterposer() = delete;
+
+  /**
+   * @brief Associate a queue with the mutex guarding all host access to it.
+   *
+   * Call once per queue, after vkGetDeviceQueue and before the engine is
+   * handed the queue. The mutex must outlive every submission on the queue;
+   * unregister before it (or the queue's device) is destroyed.
+   */
+  static void RegisterQueue(VkQueue queue, std::mutex* mutex);
+
+  /**
+   * @brief Remove a queue's registration. Safe to call for a queue that was
+   *        never registered.
+   */
+  static void UnregisterQueue(VkQueue queue);
+
+  /**
+   * @brief Interpose a proc-address lookup from the engine.
+   *
+   * If @p procname is a vkQueue* entry point requiring external
+   * synchronization (vkQueueSubmit, vkQueueSubmit2[KHR], vkQueueWaitIdle,
+   * vkQueuePresentKHR, vkQueueBindSparse, vkQueue*DebugUtilsLabelEXT) or
+   * vkGetDeviceProcAddr, resolves the real proc via @p gipa, caches it, and
+   * returns a locking trampoline. Returns nullptr for every other name; the
+   * caller should then fall through to its normal resolution.
+   */
+  static PFN_vkVoidFunction Interpose(VkInstance instance,
+                                      const char* procname,
+                                      PFN_vkGetInstanceProcAddr gipa);
+};
+
+}  // namespace wayland_vulkan
+
+#endif  // SHELL_BACKEND_WAYLAND_VULKAN_VULKAN_QUEUE_INTERPOSER_H_

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -32,6 +32,8 @@
 #include "task_runner.h"
 #include "wayland/display.h"
 
+#include "vulkan_queue_interposer.h"
+
 // The vulkan.hpp dynamic dispatcher needs its storage defined in exactly ONE
 // TU per binary. When the drm-kms-vulkan backend is also compiled in, that
 // backend's device_caps.cc owns the single definition (it must, since the
@@ -198,6 +200,12 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
       d().vkDestroySwapchainKHR(device_, swapchain_, nullptr);
       swapchain_ = VK_NULL_HANDLE;
     }
+    // The engine has been shut down and the queue drained
+    // (vkDeviceWaitIdle above); drop the interposer registration before the
+    // queue's device — and with it the queue handle — goes away. Any
+    // stale-handle call after this point (there should be none) passes
+    // through unlocked rather than dereferencing a dead mutex mapping.
+    wayland_vulkan::QueueInterposer::UnregisterQueue(queue_);
     d().vkDestroyDevice(device_, nullptr);
   }
   if (surface_ != nullptr) {
@@ -568,6 +576,14 @@ void WaylandVulkanBackend::createLogicalDevice() {
       d().vkCreateDevice(physical_device_, &device_info, nullptr, &device_));
 
   d().vkGetDeviceQueue(device_, queue_family_index_, 0, &queue_);
+
+  // GetRenderConfig() hands queue_ to the Flutter engine, whose raster
+  // thread submits on it concurrently with this backend's platform-thread
+  // present/transfer paths. Register the queue so the interposed vkQueue*
+  // entry points handed out by GetInstanceProcAddressCallback serialize the
+  // engine's submissions on the same queue_mutex_ the backend already
+  // takes. See issue #208.
+  wayland_vulkan::QueueInterposer::RegisterQueue(queue_, &queue_mutex_);
 }
 
 bool WaylandVulkanBackend::InitializeSwapChain() {
@@ -995,8 +1011,19 @@ void* WaylandVulkanBackend::GetInstanceProcAddressCallback(
     void* /* user_data */,
     FlutterVulkanInstanceHandle instance,
     const char* procname) {
-  auto* proc =
-      d().vkGetInstanceProcAddr(static_cast<VkInstance>(instance), procname);
+  auto* vk_instance = static_cast<VkInstance>(instance);
+  // Per the embedder API contract (embedder.h,
+  // get_instance_proc_address_callback), swap out vkQueue* entry points for
+  // locking variants: the engine's raster thread and this backend's
+  // present/transfer paths share the single graphics queue, and host access
+  // to a VkQueue must be externally synchronized. Also shims
+  // vkGetDeviceProcAddr so device-level resolution (Skia VulkanProcTable
+  // path) is covered. See issue #208.
+  if (auto* interposed = wayland_vulkan::QueueInterposer::Interpose(
+          vk_instance, procname, d().vkGetInstanceProcAddr)) {
+    return reinterpret_cast<void*>(interposed);
+  }
+  auto* proc = d().vkGetInstanceProcAddr(vk_instance, procname);
   return reinterpret_cast<void*>(proc);
 }
 

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -197,6 +197,9 @@ class WaylandVulkanBackend final : public Backend {
   // callbacks run on the Flutter raster thread while init, swapchain
   // (re)creation and the one-shot blit/transfer helpers can touch the same
   // single queue from the platform thread; serialize every queue op on this.
+  // The Flutter engine's own submissions on queue_ (raster thread) take this
+  // same mutex via the vkQueue* trampolines installed by
+  // GetInstanceProcAddressCallback / QueueInterposer (issue #208).
   mutable std::mutex queue_mutex_{};
 
   bool debugUtilsSupported_{};


### PR DESCRIPTION
Serializes host access to the single `VkQueue` shared between the Flutter
engine (raster thread) and the backend (platform thread) on the Wayland-Vulkan
backend. Fixes the `UNASSIGNED-Threading-MultipleThreads-Write` reported under
`-d` on `vkQueueSubmit` / `vkQueuePresentKHR`.

Fixes #208.

## Approach

The Vulkan spec requires host access to a `VkQueue` to be externally
synchronized. `GetRenderConfig()` hands the engine the backend's own `queue_`,
and the backend's `queue_mutex_` only guards the backend's *own* submissions —
the engine submits directly on the handle with no knowledge of that lock.

The embedder API designates `get_instance_proc_address_callback` as the fix:
embedder.h states the callback should swap out `vkQueue*` entry points for
locking variants (`EmbedderTest.CanSwapOutVulkanCalls` is the reference). This
PR implements that contract via `QueueInterposer`:

- `RegisterQueue(queue_, &queue_mutex_)` maps the queue handle to the mutex the
  backend already holds, so **engine and backend serialize on the same lock**;
- `Interpose()` returns locking trampolines for the externally-synchronized
  `vkQueue*` ops (`vkQueueSubmit`, `vkQueueSubmit2[KHR]`, `vkQueueWaitIdle`,
  `vkQueuePresentKHR`, `vkQueueBindSparse`, the debug-label trio) and shims
  `vkGetDeviceProcAddr` so both engine resolution paths (Impeller via the
  instance GIPA; Skia `VulkanProcTable` via GDPA) are covered.

The backend seeds its own `vulkan.hpp` dispatcher from the real
`vkGetInstanceProcAddr`, so its own present/transfer calls invoke the real
procs and never re-enter the interposer — no recursion on the non-recursive
`queue_mutex_`.

A dedicated present/transfer queue (issue option 1) remains a worthwhile
follow-up to remove raster/present lock contention on `queueCount >= 2`
hardware, but can't be the correctness fix: V3DV and several Mali parts expose
a single graphics queue.

## Validation

Empirical A/B on x86_64 Fedora / AMD RADV (the environment from #208), wonderous
under `--backend wayland-vulkan -d`:

| VUID | baseline | this PR |
| --- | --- | --- |
| `UNASSIGNED-Threading-MultipleThreads-Write` | reproduced (`vkQueueSubmit`, two threads) | **0** |
| `VUID-vkDestroyDevice-device-05137` (pre-existing teardown leak) | 12 | 12 |
| `VUID-vkDestroyImageView-device-parameter` (teardown) | 1 | 1 |

The threading error is eliminated; the app renders and runs hang-free (no
deadlock); the remaining teardown VUIDs are pre-existing and orthogonal.

Lint: `clang-tidy-19` (`--warnings-as-errors`) and `clang-format-19` both clean
on the changed TUs.

## Notes / follow-ups (non-blocking)

- **Single-device assumption.** `g_real` caches one real proc per name
  process-wide. GIPA loader trampolines are device-agnostic, but
  `vkGetDeviceProcAddr` (Skia path) returns device-specific pointers. With one
  `VkDevice` at runtime this is safe; if two Wayland-Vulkan devices ever coexist
  (multi-device multi-view), key the cache by device.
- `g_real` uses relaxed atomics — safe because resolution happens-before the
  raster thread starts; `acquire`/`release` would make that explicit.
- Each interposed op takes `g_registry_mutex` for the map lookup before
  `queue_mutex_`; uncontended after init, but the per-queue `mutex*` could be
  cached to drop it from the hot path.
