### PR TITLE
third_party: bump wayland-cxx-scanner to ScalePolicy (submodule + host overlay)

### DIFF
--- a/.emb/raspberry-pi.emb.yaml
+++ b/.emb/raspberry-pi.emb.yaml
@@ -65,7 +65,7 @@ cross:
         # Anchored so the trixie targets (no libdisplay-info augment) reuse it.
         - &augment_scanner
           pkg: wayland-cxx-scanner
-          url: https://github.com/jwinarske/wayland-cxx-scanner/archive/d0f2b05cd413ce9e7644ce7c8ea952b36773f444.tar.gz
+          url: https://github.com/jwinarske/wayland-cxx-scanner/archive/596addb0f614eeb5cdfb18bcfccf1ed3810e2188.tar.gz
           build: cmake
           host: true
           defines:

--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -116,14 +116,19 @@ if (TARGET wayland-cxx)
     endif ()
 endif ()
 
-# Silence the compiled scanner exe/lib (native builds only) and align its STL ABI
-# with the main binary on clang/libc++ builds (same fix as drm-cxx).
+# Silence the compiled scanner exe/lib (native builds only). Unlike drm-cxx,
+# do NOT link toolchain::toolchain onto them: the scanner is a standalone
+# codegen tool run *during* this build (not linked into the shell), so its STL
+# ABI need not match the main binary. toolchain::toolchain forces the project's
+# -stdlib=libc++, which made the freshly-built scanner depend on libc++abi.so.1
+# at exec time; on a toolchain that keeps that runtime off the system loader
+# path (flutter_workspace's clang) the tool then fails to start and codegen
+# aborts. Left on the compiler default (libstdc++, whose .so is always on the
+# loader path) the tool runs everywhere. The exe and its static lib stay on the
+# same stdlib because neither links the toolchain target.
 foreach (_tgt wayland-cxx-scanner wayland-cxx-scanner-lib)
     if (TARGET ${_tgt})
         target_compile_options(${_tgt} PRIVATE -w)
-        if (TARGET toolchain)
-            target_link_libraries(${_tgt} PRIVATE toolchain::toolchain)
-        endif ()
     endif ()
 endforeach ()
 


### PR DESCRIPTION
Bumps `wayland-cxx-scanner` to `596addb`, which promotes `ScalePolicy` to
installed framework headers (`include/wl/scale_policy.hpp` +
`scale_policy_vectors.hpp`).

The scanner exists as **two copies that must move in lockstep**, and this PR
bumps both plus the enabling build fix:

1. **`cmake: don't force libc++ on the scanner`** — the codegen tool is
   standalone (run during the build, not linked into the shell), so it needn't
   share the shell's libc++ ABI. It was linking `toolchain::toolchain`, which
   forced `-stdlib=libc++`; the freshly-built native tool then needed
   `libc++abi.so.1` at exec time and failed under flutter_workspace's clang
   (runtime off the loader path). Dropping that link builds it on the on-path
   `libstdc++`.
2. **bump the submodule** `third_party/wayland-cxx-scanner` → `596addb` — the
   framework headers the shell compiles against.
3. **bump the host overlay** in `.emb/raspberry-pi.emb.yaml` → the same commit
   — the host codegen tool cross builds fetch (native builds compile it from
   the submodule). `596addb` switches `proxy_impl` to
   `wl_proxy_add_dispatcher(&Derived::_Dispatch)`, so the generated CProxy
   classes now require a `_Dispatch` only the matching scanner emits. Bumping
   only the submodule left the cross overlay scanner behind → `_Dispatch`
   compile errors. Both pins now agree.

## Validation

Clean clang build with the new submodule: scanner links `libstdc++.so.6` only
(no `libc++abi`), runs, and the full homescreen builds — codegen regenerates
the headers with `_Dispatch`. Cross builds now fetch the matching host scanner
from the bumped overlay.

No shell source consumes the new ScalePolicy headers yet — the fractional-scale
path keeps its own dependency-free reimplementation; this is a version bump so
the pickup is available.
