### PR TITLE
shell: harden engine + GL resolver singletons against unsafe teardown and load races

### DIFF
--- a/shell/backend/gl_process_resolver.cc
+++ b/shell/backend/gl_process_resolver.cc
@@ -24,15 +24,9 @@
 
 #include "logging.h"
 
-std::shared_ptr<EglProcessResolver> GlProcessResolver::sInstance = nullptr;
-
-EglProcessResolver::~EglProcessResolver() {
-  for (auto const& item : m_handles) {
-    dlclose(item.first);
-  }
-}
-
 int EglProcessResolver::GetHandle(const std::string& lib, void** out_handle) {
+  *out_handle = nullptr;
+
   const auto handle = dlopen(lib.c_str(), RTLD_LAZY | RTLD_LOCAL);
 #if !defined(NDEBUG)
   if (handle) {
@@ -49,16 +43,13 @@ int EglProcessResolver::GetHandle(const std::string& lib, void** out_handle) {
   return 1;
 }
 
-void EglProcessResolver::Initialize() {
-  void* handle;
-  const std::vector<std::string> libs(kGlSoNames,
-                                      kGlSoNames + std::size(kGlSoNames));
-  for (const auto& name : libs) {
-    GetHandle(name, &handle);
-    if (handle) {
+EglProcessResolver::EglProcessResolver() {
+  for (const auto& name : kGlSoNames) {
+    void* handle = nullptr;
+    if (GetHandle(name, &handle) == 1) {
       m_handles.emplace_back(handle, name);
     } else {
-      spdlog::critical("{}: Library not found", name[0]);
+      spdlog::critical("{}: Library not found", name);
       assert(false);
     }
   }

--- a/shell/backend/gl_process_resolver.h
+++ b/shell/backend/gl_process_resolver.h
@@ -16,27 +16,25 @@
 
 #pragma once
 
-#include <memory>
+#include <string>
 #include <vector>
 
 class EglProcessResolver {
  public:
   static constexpr char kGlSoNames[2UL][15UL] = {{"libGLESv2.so.2"},
                                                  {"libEGL.so.1"}};
-  ~EglProcessResolver();
 
-  /**
-   * @brief Initialize
-   * @return void
-   * @relation
-   * internal
-   */
-  void Initialize();
+  // Non-copyable, non-movable. A copy's destructor would tear down state
+  // it does not own; capture GetInstance() by reference only.
+  EglProcessResolver(const EglProcessResolver&) = delete;
+  EglProcessResolver& operator=(const EglProcessResolver&) = delete;
+  EglProcessResolver(EglProcessResolver&&) = delete;
+  EglProcessResolver& operator=(EglProcessResolver&&) = delete;
 
   /**
    * @brief Get DLL handle
-   * @param[in] lib of library
-   * @param[out] out_handle DLL handle
+   * @param[in] lib name of library
+   * @param[out] out_handle DLL handle; set to nullptr on failure
    * @return int
    * @retval 1 Normal end
    * @retval -1 Abnormal end
@@ -56,6 +54,25 @@ class EglProcessResolver {
   void* process_resolver(const char* name) const;
 
  private:
+  friend class GlProcessResolver;
+
+  /**
+   * @brief Loads the GL client libraries. Runs exactly once, under the
+   *        block-scope static initialization guarantee in
+   *        GlProcessResolver::GetInstance().
+   * @relation
+   * internal
+   */
+  EglProcessResolver();
+
+  /**
+   * Handles are intentionally never dlclose()d. The resolver lives for the
+   * lifetime of the process, and unloading GL client libraries during
+   * static destruction is unsafe: driver worker threads and TLS
+   * destructors may still reference their text segments.
+   */
+  ~EglProcessResolver() = default;
+
   std::vector<std::pair<void*, std::string>> m_handles;
 };
 
@@ -71,15 +88,14 @@ class GlProcessResolver {
    * @retval Instance of the EglProcessResolver class
    * @relation
    * internal
+   *
+   * Thread-safe: initialization of a block-scope variable with static
+   * storage duration is serialized by the implementation
+   * (C++11 [stmt.dcl]p4). Concurrent first callers block until
+   * construction completes; exactly one instance is ever created.
    */
   static EglProcessResolver& GetInstance() {
-    if (!sInstance) {
-      sInstance = std::make_shared<EglProcessResolver>();
-      sInstance->Initialize();
-    }
-    return *sInstance;
+    static EglProcessResolver instance;
+    return instance;
   }
-
- protected:
-  static std::shared_ptr<EglProcessResolver> sInstance;
 };

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -165,7 +165,10 @@ Engine::Engine(FlutterView* view,
     exit(EXIT_FAILURE);
   }
 
-  // override path
+  // Engine selection: a bundle-local engine overrides the system engine.
+  // Overall precedence: preloaded > bundle > linker search (DT_RUNPATH,
+  // LD_LIBRARY_PATH, ld.so.cache). The latter two are selected here; a
+  // preloaded engine is detected inside Load() and wins over both.
   std::filesystem::path engine_file_path(bundle_path);
   engine_file_path /= kBundleEngine;
   if (std::filesystem::exists(engine_file_path)) {
@@ -175,9 +178,14 @@ Engine::Engine(FlutterView* view,
     engine_file_path = kSystemEngine;
   }
 
-  if (!LibFlutterEngine::IsPresent(engine_file_path.c_str())) {
-    spdlog::critical(dlerror());
-    exit(-1);
+  // One-shot per process: the first view binds the engine. Load() fails on
+  // dlopen error, a missing required export, or a prior view having bound a
+  // different path — each cause is already logged at critical/error by the
+  // loader itself.
+  if (!LibFlutterEngine::Load(engine_file_path.c_str())) {
+    spdlog::critical("({}) unable to load flutter engine: {}", m_index,
+                     engine_file_path.c_str());
+    exit(EXIT_FAILURE);
   }
 
   ///

--- a/shell/libflutter_engine.cc
+++ b/shell/libflutter_engine.cc
@@ -16,100 +16,169 @@
 
 #include "libflutter_engine.h"
 
-#include <iostream>
-
 #include <dlfcn.h>
 
+#include <cstdlib>
+#include <mutex>
+#include <string>
+
+#include "logging.h"
 #include "shared_library.h"
 
-LibFlutterEngineExports::LibFlutterEngineExports(void* lib) {
-  if (lib != nullptr) {
-    ShellGetFuncAddress(lib, "FlutterEngineCreateAOTData", &CreateAOTData);
-    ShellGetFuncAddress(lib, "FlutterEngineCollectAOTData", &CollectAOTData);
-    ShellGetFuncAddress(lib, "FlutterEngineRun", &Run);
-    ShellGetFuncAddress(lib, "FlutterEngineShutdown", &Shutdown);
-    ShellGetFuncAddress(lib, "FlutterEngineInitialize", &Initialize);
-    ShellGetFuncAddress(lib, "FlutterEngineDeinitialize", &Deinitialize);
-    ShellGetFuncAddress(lib, "FlutterEngineRunInitialized", &RunInitialized);
-    ShellGetFuncAddress(lib, "FlutterEngineSendWindowMetricsEvent",
-                        &SendWindowMetricsEvent);
-    ShellGetFuncAddress(lib, "FlutterEngineSendPointerEvent",
-                        &SendPointerEvent);
-    ShellGetFuncAddress(lib, "FlutterEngineSendKeyEvent", &SendKeyEvent);
-    ShellGetFuncAddress(lib, "FlutterEngineSendPlatformMessage",
-                        &SendPlatformMessage);
-    ShellGetFuncAddress(lib, "FlutterPlatformMessageCreateResponseHandle",
-                        &PlatformMessageCreateResponseHandle);
-    ShellGetFuncAddress(lib, "FlutterPlatformMessageReleaseResponseHandle",
-                        &PlatformMessageReleaseResponseHandle);
-    ShellGetFuncAddress(lib, "FlutterEngineSendPlatformMessageResponse",
-                        &SendPlatformMessageResponse);
-    ShellGetFuncAddress(lib, "FlutterEngineRegisterExternalTexture",
-                        &RegisterExternalTexture);
-    ShellGetFuncAddress(lib, "FlutterEngineUnregisterExternalTexture",
-                        &UnregisterExternalTexture);
-    ShellGetFuncAddress(lib, "FlutterEngineMarkExternalTextureFrameAvailable",
-                        &MarkExternalTextureFrameAvailable);
-    ShellGetFuncAddress(lib, "FlutterEngineUpdateSemanticsEnabled",
-                        &UpdateSemanticsEnabled);
-    ShellGetFuncAddress(lib, "FlutterEngineUpdateAccessibilityFeatures",
-                        &UpdateAccessibilityFeatures);
-    ShellGetFuncAddress(lib, "FlutterEngineDispatchSemanticsAction",
-                        &DispatchSemanticsAction);
-    ShellGetFuncAddress(lib, "FlutterEngineOnVsync", &OnVsync);
-    ShellGetFuncAddress(lib, "FlutterEngineReloadSystemFonts",
-                        &ReloadSystemFonts);
-    ShellGetFuncAddress(lib, "FlutterEngineTraceEventDurationBegin",
-                        &TraceEventDurationBegin);
-    ShellGetFuncAddress(lib, "FlutterEngineTraceEventDurationEnd",
-                        &TraceEventDurationEnd);
-    ShellGetFuncAddress(lib, "FlutterEngineTraceEventInstant",
-                        &TraceEventInstant);
-    ShellGetFuncAddress(lib, "FlutterEnginePostRenderThreadTask",
-                        &PostRenderThreadTask);
-    ShellGetFuncAddress(lib, "FlutterEngineGetCurrentTime", &GetCurrentTime);
-    ShellGetFuncAddress(lib, "FlutterEngineRunTask", &RunTask);
-    ShellGetFuncAddress(lib, "FlutterEngineUpdateLocales", &UpdateLocales);
-    ShellGetFuncAddress(lib, "FlutterEngineRunsAOTCompiledDartCode",
-                        &RunsAOTCompiledDartCode);
-    ShellGetFuncAddress(lib, "FlutterEnginePostDartObject", &PostDartObject);
-    ShellGetFuncAddress(lib, "FlutterEngineNotifyLowMemoryWarning",
-                        &NotifyLowMemoryWarning);
-    ShellGetFuncAddress(lib, "FlutterEnginePostCallbackOnAllNativeThreads",
-                        &PostCallbackOnAllNativeThreads);
-    ShellGetFuncAddress(lib, "FlutterEngineNotifyDisplayUpdate",
-                        &NotifyDisplayUpdate);
-    ShellGetFuncAddress(lib, "FlutterEngineScheduleFrame", &ScheduleFrame);
-    ShellGetFuncAddress(lib, "FlutterEngineSetNextFrameCallback",
-                        &SetNextFrameCallback);
-    ShellGetFuncAddress(lib, "FlutterEngineAddView", &AddView);
-    ShellGetFuncAddress(lib, "FlutterEngineRemoveView", &RemoveView);
-  }
+namespace {
+
+constexpr char kDefaultSoName[] = "libflutter_engine.so";
+constexpr char kPreloadedSentinel[] = "<preloaded>";
+
+// Backing storage for the export table. Written only inside the
+// call_once body; published to readers via LibFlutterEngine::table_.
+LibFlutterEngineExports g_exports;
+std::once_flag g_load_once;
+std::string g_loaded_path;
+
+/**
+ * Resolve every export from `lib`, which is either a dlopen() handle or
+ * the RTLD_DEFAULT pseudo-handle. RTLD_DEFAULT is ((void*)0) on glibc,
+ * so it must never be null-tested as if it were a real handle — dlsym()
+ * accepts it directly.
+ *
+ * Returns false if any *required* export is missing. AddView/RemoveView
+ * are optional (version-gated) ABI and remain null on older engines.
+ */
+bool PopulateExports(void* lib) {
+  bool ok = true;
+
+  const auto require = [lib, &ok](auto* out, const char* name) {
+    ShellGetFuncAddress(lib, name, out);
+    if (*out == nullptr) {
+      spdlog::critical("libflutter_engine: required export missing: {}", name);
+      ok = false;
+    }
+  };
+  const auto optional = [lib](auto* out, const char* name) {
+    ShellGetFuncAddress(lib, name, out);
+  };
+
+  require(&g_exports.CreateAOTData, "FlutterEngineCreateAOTData");
+  require(&g_exports.CollectAOTData, "FlutterEngineCollectAOTData");
+  require(&g_exports.Run, "FlutterEngineRun");
+  require(&g_exports.Shutdown, "FlutterEngineShutdown");
+  require(&g_exports.Initialize, "FlutterEngineInitialize");
+  require(&g_exports.Deinitialize, "FlutterEngineDeinitialize");
+  require(&g_exports.RunInitialized, "FlutterEngineRunInitialized");
+  require(&g_exports.SendWindowMetricsEvent,
+          "FlutterEngineSendWindowMetricsEvent");
+  require(&g_exports.SendPointerEvent, "FlutterEngineSendPointerEvent");
+  require(&g_exports.SendKeyEvent, "FlutterEngineSendKeyEvent");
+  require(&g_exports.SendPlatformMessage, "FlutterEngineSendPlatformMessage");
+  require(&g_exports.PlatformMessageCreateResponseHandle,
+          "FlutterPlatformMessageCreateResponseHandle");
+  require(&g_exports.PlatformMessageReleaseResponseHandle,
+          "FlutterPlatformMessageReleaseResponseHandle");
+  require(&g_exports.SendPlatformMessageResponse,
+          "FlutterEngineSendPlatformMessageResponse");
+  require(&g_exports.RegisterExternalTexture,
+          "FlutterEngineRegisterExternalTexture");
+  require(&g_exports.UnregisterExternalTexture,
+          "FlutterEngineUnregisterExternalTexture");
+  require(&g_exports.MarkExternalTextureFrameAvailable,
+          "FlutterEngineMarkExternalTextureFrameAvailable");
+  require(&g_exports.UpdateSemanticsEnabled,
+          "FlutterEngineUpdateSemanticsEnabled");
+  require(&g_exports.UpdateAccessibilityFeatures,
+          "FlutterEngineUpdateAccessibilityFeatures");
+  require(&g_exports.DispatchSemanticsAction,
+          "FlutterEngineDispatchSemanticsAction");
+  require(&g_exports.OnVsync, "FlutterEngineOnVsync");
+  require(&g_exports.ReloadSystemFonts, "FlutterEngineReloadSystemFonts");
+  require(&g_exports.TraceEventDurationBegin,
+          "FlutterEngineTraceEventDurationBegin");
+  require(&g_exports.TraceEventDurationEnd,
+          "FlutterEngineTraceEventDurationEnd");
+  require(&g_exports.TraceEventInstant, "FlutterEngineTraceEventInstant");
+  require(&g_exports.PostRenderThreadTask, "FlutterEnginePostRenderThreadTask");
+  require(&g_exports.GetCurrentTime, "FlutterEngineGetCurrentTime");
+  require(&g_exports.RunTask, "FlutterEngineRunTask");
+  require(&g_exports.UpdateLocales, "FlutterEngineUpdateLocales");
+  require(&g_exports.RunsAOTCompiledDartCode,
+          "FlutterEngineRunsAOTCompiledDartCode");
+  require(&g_exports.PostDartObject, "FlutterEnginePostDartObject");
+  require(&g_exports.NotifyLowMemoryWarning,
+          "FlutterEngineNotifyLowMemoryWarning");
+  require(&g_exports.PostCallbackOnAllNativeThreads,
+          "FlutterEnginePostCallbackOnAllNativeThreads");
+  require(&g_exports.NotifyDisplayUpdate, "FlutterEngineNotifyDisplayUpdate");
+  require(&g_exports.ScheduleFrame, "FlutterEngineScheduleFrame");
+  require(&g_exports.SetNextFrameCallback, "FlutterEngineSetNextFrameCallback");
+
+  optional(&g_exports.AddView, "FlutterEngineAddView");
+  optional(&g_exports.RemoveView, "FlutterEngineRemoveView");
+
+  return ok;
 }
 
-LibFlutterEngineExports* LibFlutterEngine::operator->() const {
-  return loadExports(nullptr);
-}
+}  // namespace
 
-LibFlutterEngineExports* LibFlutterEngine::loadExports(
-    const char* library_path = nullptr) {
-  static LibFlutterEngineExports exports = [&] {
-    void* lib;
+std::atomic<const LibFlutterEngineExports*> LibFlutterEngine::table_{nullptr};
 
-    if (ShellGetProcAddress(RTLD_DEFAULT,
-                            "Initialize"))  // Search the global scope
-                                            // for pre-loaded library.
-    {
-      lib = RTLD_DEFAULT;
+bool LibFlutterEngine::Load(const char* library_path) {
+  const std::string requested = library_path ? library_path : kDefaultSoName;
+
+  std::call_once(g_load_once, [&requested] {
+    // A preloaded engine (statically linked into the executable or
+    // LD_PRELOADed) takes precedence over any requested path. Probe the
+    // engine's actual export — a generic symbol name here would
+    // false-positive on unrelated libraries in global scope.
+    void* lib = RTLD_DEFAULT;
+    if (ShellGetProcAddress(RTLD_DEFAULT, "FlutterEngineInitialize") !=
+        nullptr) {
+      g_loaded_path = kPreloadedSentinel;
+      spdlog::info("libflutter_engine: using preloaded engine");
     } else {
-      lib = dlopen(library_path ? library_path : "libflutter_engine.so",
-                   RTLD_LAZY | RTLD_LOCAL);
+      dlerror();  // clear stale error state
+      lib = dlopen(requested.c_str(), RTLD_NOW | RTLD_LOCAL);
+      if (lib == nullptr) {
+        const char* reason = dlerror();
+        spdlog::critical("libflutter_engine: dlopen({}) failed: {}", requested,
+                         reason ? reason : "unknown reason");
+        return;  // table_ stays null; failure is cached for process life
+      }
+      g_loaded_path = requested;
     }
 
-    return LibFlutterEngineExports(lib);
-  }();
+    if (!PopulateExports(lib)) {
+      // Required ABI incomplete: engine .so too old, or the wrong
+      // artifact. Clear any partially populated table. The dlopen
+      // handle is deliberately not dlclose()d.
+      g_exports = {};
+      return;
+    }
 
-  return exports.Initialize ? &exports : nullptr;
+    table_.store(&g_exports, std::memory_order_release);
+  });
+
+  if (table_.load(std::memory_order_acquire) == nullptr) {
+    return false;
+  }
+
+  // The engine is bound once per process. A later request for a
+  // *different* path cannot be honored — fail loudly instead of
+  // silently returning the wrong library's exports.
+  if (g_loaded_path != kPreloadedSentinel && requested != g_loaded_path) {
+    spdlog::error(
+        "libflutter_engine: already loaded from '{}'; ignoring request "
+        "for '{}'",
+        g_loaded_path, requested);
+    return false;
+  }
+
+  return true;
+}
+
+void LibFlutterEngine::FailNotLoaded() {
+  spdlog::critical(
+      "LibFlutterEngine used before a successful Load(); aborting");
+  std::abort();
 }
 
 class LibFlutterEngine LibFlutterEngine;

--- a/shell/libflutter_engine.h
+++ b/shell/libflutter_engine.h
@@ -16,12 +16,11 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "flutter/shell/platform/embedder/embedder.h"
 
 struct LibFlutterEngineExports {
-  LibFlutterEngineExports() = default;
-  explicit LibFlutterEngineExports(void* lib);
-
   FlutterEngineCreateAOTDataFnPtr CreateAOTData = nullptr;
   FlutterEngineCollectAOTDataFnPtr CollectAOTData = nullptr;
   FlutterEngineRunFnPtr Run = nullptr;
@@ -65,23 +64,70 @@ struct LibFlutterEngineExports {
   FlutterEngineNotifyDisplayUpdateFnPtr NotifyDisplayUpdate = nullptr;
   FlutterEngineScheduleFrameFnPtr ScheduleFrame = nullptr;
   FlutterEngineSetNextFrameCallbackFnPtr SetNextFrameCallback = nullptr;
-  // Multi-view. Both are async; the
-  // add/remove callbacks in FlutterAddViewInfo/FlutterRemoveViewInfo report
-  // completion. May be null on an engine .so too old to export them.
+  // Multi-view. Both are async; the add/remove callbacks in
+  // FlutterAddViewInfo/FlutterRemoveViewInfo report completion.
+  // Optional ABI: may be null on an engine .so too old to export them.
+  // Call sites must null-check before use.
   FlutterEngineAddViewFnPtr AddView = nullptr;
   FlutterEngineRemoveViewFnPtr RemoveView = nullptr;
 };
 
 class LibFlutterEngine {
  public:
-  static bool IsPresent(const char* library_path = nullptr) {
-    return loadExports(library_path) != nullptr;
+  /**
+   * @brief One-shot loader. Call from engine bring-up, before any
+   *        operator-> use.
+   * @param[in] library_path path to the engine shared library, or nullptr
+   *            for the default "libflutter_engine.so". A preloaded engine
+   *            (statically linked or LD_PRELOADed, detected via the
+   *            FlutterEngineInitialize export in global scope) takes
+   *            precedence over any path.
+   * @return bool
+   * @retval true  engine loaded and required ABI validated
+   * @retval false dlopen failed, a required export is missing, or a prior
+   *               Load() bound a different library path. The reason is
+   *               logged. Failure is cached for the process lifetime;
+   *               Load() never retries.
+   * @relation
+   * internal
+   *
+   * Thread-safe: the load runs under std::call_once; the export table is
+   * published with release semantics after successful validation.
+   */
+  static bool Load(const char* library_path = nullptr);
+
+  /**
+   * @brief Whether a successful Load() has completed.
+   * @return bool
+   * @relation
+   * internal
+   */
+  static bool IsPresent() {
+    return table_.load(std::memory_order_acquire) != nullptr;
   }
 
-  LibFlutterEngineExports* operator->() const;
+  /**
+   * @brief Access the validated export table.
+   *
+   * Aborts with a critical log if used before a successful Load() —
+   * a diagnosable failure at the boundary instead of a null-pointer
+   * dereference several frames deep.
+   */
+  const LibFlutterEngineExports* operator->() const {
+    const auto* table = table_.load(std::memory_order_acquire);
+    if (table == nullptr) {
+      FailNotLoaded();
+    }
+    return table;
+  }
 
  private:
-  static LibFlutterEngineExports* loadExports(const char* library_path);
+  [[noreturn]] static void FailNotLoaded();
+
+  // Null until Load() succeeds; thereafter points to the immutable,
+  // fully populated export table. Acquire/release pairing makes the
+  // table contents visible to any thread that observes the pointer.
+  static std::atomic<const LibFlutterEngineExports*> table_;
 };
 
-extern LibFlutterEngine LibFlutterEngine;
+extern class LibFlutterEngine LibFlutterEngine;

--- a/test/unit_test/gl_process_resolver-test/test_case_gl_process_resolver.cc
+++ b/test/unit_test/gl_process_resolver-test/test_case_gl_process_resolver.cc
@@ -10,7 +10,7 @@ Initialization Test Summary：Test process_resolver func with valid process name
                 by calling the API via the GetInstance() method.
 ***************************************************************/
 TEST(HomescreenGlProcessResolver, Lv1Normal001) {
-  const auto gl_process = GlProcessResolver::GetInstance();
+  const auto& gl_process = GlProcessResolver::GetInstance();
   const auto process_resolver = gl_process.process_resolver("glGetString");
 
   EXPECT_TRUE(process_resolver != nullptr);
@@ -23,7 +23,7 @@ Initialization Test Summary：Test process_resolver func with invalid process
 name
 ***************************************************************/
 TEST(HomescreenGlProcessResolver, Lv1Abnormal001) {
-  const auto gl_process = GlProcessResolver::GetInstance();
+  const auto& gl_process = GlProcessResolver::GetInstance();
   const auto process_resolver = gl_process.process_resolver("InvalidProcess");
 
   EXPECT_TRUE(process_resolver == nullptr);
@@ -35,7 +35,7 @@ HomescreenGlProcessResolverProcessResolver_Lv1Abnormal002 Use Case Name:
 Initialization Test Summary：Test process_resolver func with null param
 ***************************************************************/
 TEST(HomescreenGlProcessResolver, Lv1Abnormal002) {
-  const auto gl_process = GlProcessResolver::GetInstance();
+  const auto& gl_process = GlProcessResolver::GetInstance();
   const auto process_resolver = gl_process.process_resolver(nullptr);
 
   EXPECT_TRUE(process_resolver == nullptr);
@@ -47,7 +47,7 @@ Use Case Name: Initialization
 Test Summary：Test process_resolver func with valid library name
 ***************************************************************/
 TEST(HomescreenGlProcessResolverGetHandle, Lv1Normal001) {
-  void* handle;
+  void* handle = nullptr;
   const int ret = EglProcessResolver::GetHandle("libEGL.so.1", &handle);
 
   EXPECT_EQ(ret, 1);
@@ -61,8 +61,9 @@ Test Summary：Test process_resolver func with invalid library name
 ***************************************************************/
 
 TEST(HomescreenGlProcessResolverGetHandle, Lv1Abnormal001) {
-  void* handle;
+  void* handle = nullptr;
   const int ret = EglProcessResolver::GetHandle("InvalidLibrary", &handle);
 
   EXPECT_EQ(ret, -1);
+  EXPECT_EQ(handle, nullptr);
 }


### PR DESCRIPTION
## What

Reworks the two process-lifetime singletons behind GL symbol resolution and Flutter engine binding, replacing ad-hoc lazy init with well-defined one-shot loads and explicit ABI validation.

### `libflutter_engine`
- Replace the lazy `loadExports()`/`operator->` pair with an explicit one-shot `Load(path)` that runs under `std::call_once` and publishes an immutable export table via an atomic with acquire/release ordering.
- Split exports into **required** and **optional** (version-gated `AddView`/`RemoveView`); fail `Load()` loudly when a required export is missing instead of silently returning a half-populated table.
- Give preloaded engines (static / `LD_PRELOAD`) precedence, probing the real `FlutterEngineInitialize` export rather than a generic symbol name.
- `dlopen` with `RTLD_NOW`; cache failure for process life (never retry); reject a later request for a *different* path rather than returning the wrong library's exports.
- `operator->` aborts with a diagnostic if used before a successful `Load()`, turning a deep null deref into a boundary failure.

### `gl_process_resolver`
- Convert to a Meyers block-scope static singleton (thread-safe first-use init); load libraries in the constructor and drop `Initialize()`.
- Make `EglProcessResolver` non-copyable/non-movable; hand out `GetInstance()` by reference only.
- Stop `dlclose()`ing GL client handles at static destruction: driver worker threads and TLS destructors may still reference their text segments.
- `GetHandle()` zeroes `*out_handle` up front; fix the critical-log format (`name` vs `name[0]`).

### `engine.cc`
- Adopt `LibFlutterEngine::Load()` and document engine selection precedence (preloaded > bundle > linker search).

### test
- Capture `GetInstance()` by reference and assert `GetHandle()` nulls the out-handle on failure.

## Validation

- **clang-tidy-19** (`--warnings-as-errors`) — clean, no user-code diagnostics.
- **clang-format-19** (`--dry-run -Werror`) — clean.
- **Build** — clean g++ build (host wayland-egl + software + compositor); the changed signatures (`IsPresent()` arity, `GetInstance()` reference return, deleted copy ctor) all link.
- **Runtime smoke-test** — Wonderous JIT bundle on a live Wayland session: `(0) Engine running...`, GL renderer resolved (`radeonsi`, `OpenGL ES 3.2`), `libGLESv2.so.2`/`libEGL.so.1` loaded via the new resolver, app renders and navigates; clean `SIGTERM` at steady state exits 0.

## Notes

- Incidental find during smoke-testing: a pre-existing, timing-dependent teardown SIGSEGV in the Wayland vsync provider's `wp_presentation` feedback cleanup, filed as #287. It is outside this diff (startup-only changes; absent from the crashing stack) and not a regression from this PR.
