### PR TITLE
wayland: drain vsync feedback proxies before wl_display_disconnect (#287)

### DIFF
--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -176,9 +176,17 @@ Display::~Display() {
   // display connection is still alive.
   input_timestamps_.Reset();
 
-  // The shells (xdg/agl/ivi/simple) and the vsync provider own their protocol
-  // objects and tear them down in their own destructors.
+  // The shells (xdg/agl/ivi/simple) own their protocol objects and tear them
+  // down in their own destructors, invoked here while the connection is alive.
   shells_.clear();
+
+  // Drain the vsync provider's in-flight wp_presentation_feedback proxies while
+  // the connection is still up. ~WpFeedbackHandler calls wl_proxy_destroy(),
+  // which walks the wl_display object map that wl_display_disconnect() (below)
+  // frees. The m_vsync member destructor runs AFTER this body — i.e. after
+  // disconnect — so leaving outstanding feedback for it to reap use-after-frees
+  // whenever shutdown races an in-flight frame. Stop() is idempotent. See #287.
+  m_vsync.Stop();
 
   if (m_shm)
     wl_shm_destroy(m_shm);


### PR DESCRIPTION
Fixes #287.

## Root cause

Single-threaded destruction-order **use-after-free** (not the cross-thread race the issue body first hypothesized — the reactor runs on the main thread via `primary_ioc_.run()` and is stopped before teardown).

`~Display()` disconnects the connection in its body:

```cpp
wl_display_flush(m_display);
wl_display_disconnect(m_display);   // frees the wl_display + its object map
```

But `m_vsync` is a **member** (`WaylandVsyncProvider`), so `~WaylandVsyncProvider` runs *after* the `~Display` body — i.e. after disconnect. Its `Stop() → ~WpFeedbackHandler → wl_proxy_destroy()` then walks the already-freed `wl_display` object map, segfaulting in libwayland's `wl_map_insert_at`:

```
wl_map_insert_at (libwayland-client)   <- SIGSEGV
wl_proxy_destroy
ivi::WpFeedbackHandler::~WpFeedbackHandler()
ivi::WaylandVsyncProvider::Stop()
ivi::WaylandVsyncProvider::~WaylandVsyncProvider()
Display::~Display() -> App::~App() -> main
```

It only faults when `feedback_in_flight_` is non-empty at teardown (shutdown mid-frame), which is why it presented as an intermittent, timing-dependent crash — an idle shutdown leaves the vector empty and is clean.

The `wp_presentation` proxy itself is not an offender: `CWpPresentation` / `~CProxyImpl` is `=default` (no `wl_proxy_destroy`) and `PresentationHandler` has no explicit destructor, so it is reaped by `wl_display_disconnect`. The only post-disconnect `wl_proxy_destroy` is in `~WpFeedbackHandler`.

## Fix

Drain the provider explicitly in the `~Display` body, *before* `wl_display_disconnect`, alongside the other protocol-object teardown that already runs pre-disconnect (`shells_.clear()`, `registry_.Reset()`, …). `Stop()` is idempotent, so the later member-destructor `Stop()` becomes a no-op.

## Validation

- **Repro** — 25 s mid-animation shutdown (`timeout -k 5 25 homescreen …` on a live Wayland session with an animating app) reliably dumped core before the fix.
- **After** — same scenario ×3: `timeout` rc 124 (clean SIGTERM, no core), **zero** new core dumps (`coredumpctl` count unchanged), app rendered/navigated normally each run.
- clang-tidy-19 (`--warnings-as-errors`) and clang-format-19 (`--dry-run -Werror`) clean.
