### PR TITLE
accessibility: own node strings, prune detached subtrees, extract translator

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -50,7 +50,9 @@ add_executable(${PROJECT_NAME}
 )
 
 if (BUILD_ACCESSIBILITY)
-    target_sources(${PROJECT_NAME} PRIVATE accessibility/accessibility_tree.cc)
+    target_sources(${PROJECT_NAME} PRIVATE
+            accessibility/accessibility_tree.cc
+            accessibility/semantics_translator.cc)
 endif ()
 
 # Wayland-specific TUs:

--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -15,9 +15,11 @@
  */
 
 #include "accessibility_tree.h"
-#include <filesystem>
 
+#include <algorithm>
+#include <filesystem>
 #include <fstream>
+#include <unordered_set>
 
 #include <rapidjson/document.h>
 #include <rapidjson/prettywriter.h>
@@ -26,36 +28,43 @@
 #include "../utils.h"
 #include "logging/logging.h"
 
-void AccessibilityNode::AddChild(const int32_t child_id) {
-  m_children.push_back(child_id);
+AccessibilityNode::AccessibilityNode(const FlutterSemanticsNode2& fl_node) {
+  Update(fl_node);
 }
 
-void AccessibilityNode::UpdateNode(FlutterSemanticsNode2* /* fl_node */) {
-  // Look through all fl_node updates, compare to existing data, update where
-  // necessary
-}
+void AccessibilityNode::Update(const FlutterSemanticsNode2& fl_node) {
+  m_id = fl_node.id;
+  // Own copies of the text fields. The embedder only guarantees these
+  // pointers for the duration of the update callback, and any of them may be
+  // null — constructing std::string from a null pointer is undefined, so
+  // coalesce to empty.
+  m_label = fl_node.label ? fl_node.label : "";
+  m_hint = fl_node.hint ? fl_node.hint : "";
+  m_value = fl_node.value ? fl_node.value : "";
+  m_tooltip = fl_node.tooltip ? fl_node.tooltip : "";
+  m_bounds = fl_node.rect;
+  m_flags = fl_node.flags;
 
-AccessibilityNode::AccessibilityNode(const FlutterSemanticsNode2& fl_node)
-    : m_id(fl_node.id),
-      m_label(fl_node.label),
-      m_hint(fl_node.hint),
-      m_value(fl_node.value),
-      m_tooltip(fl_node.tooltip),
-      m_bounds(fl_node.rect),
-      m_flags(fl_node.flags) {
-  // Determine Role
-  uint8_t node_role;
+  // Role. This inline mapping is a stopgap; the SemanticsTranslator owns the
+  // full role/state/action table.
   if (fl_node.id == 0) {
-    node_role = SEMANTIC_ROLE_WINDOW;
+    m_role = SEMANTIC_ROLE_WINDOW;
   } else if (fl_node.flags & kFlutterSemanticsFlagIsButton) {
-    node_role = SEMANTIC_ROLE_BUTTON;
+    m_role = SEMANTIC_ROLE_BUTTON;
   } else {
-    // TODO: Add more role handling
-    node_role = SEMANTIC_ROLE_UNKNOWN;
+    m_role = SEMANTIC_ROLE_UNKNOWN;
   }
-  m_role = node_role;
 
-  // TODO: Initialize more info from flags and actions
+  // Replace (not append) the children in traversal order, so a reorder or a
+  // removed child is reflected when the node is re-sent.
+  if (fl_node.child_count > 0 &&
+      fl_node.children_in_traversal_order != nullptr) {
+    m_children.assign(fl_node.children_in_traversal_order,
+                      fl_node.children_in_traversal_order +
+                          static_cast<size_t>(fl_node.child_count));
+  } else {
+    m_children.clear();
+  }
 }
 
 AccessibilityTree::AccessibilityTree() : focused_node(0) {}
@@ -63,65 +72,102 @@ AccessibilityTree::~AccessibilityTree() = default;
 
 void AccessibilityTree::HandleFlutterUpdate(
     const FlutterSemanticsUpdate2* update) {
-  if (!IsTreeBuilt()) {
-    // Should be the first time this callback fired, with initial states of all
-    // nodes. Verify node 0 (root node) exists
-    bool root_node_found = false;
-    for (int i = 0; i < static_cast<int>(update->node_count); i++) {
-      if (const FlutterSemanticsNode2* node = update->nodes[i]; node->id == 0) {
-        root_node_found = true;
-      }
-    }
-
-    if (root_node_found) {
-      // Iterate through and create all the nodes
-      for (int i = 0; i < static_cast<int>(update->node_count); i++) {
-        const FlutterSemanticsNode2* node = update->nodes[i];
-        // get_node creates the node if it doesn't already exist (which it
-        // shouldn't)
-        AccessibilityNode* new_node = GetNode(*node);
-        for (int j = 0; j < static_cast<int>(node->child_count); j++) {
-          new_node->AddChild(node->children_in_traversal_order[j]);
-        }
-      }
-      SetTreeBuilt(true);
-      std::filesystem::path dir = Utils::GetConfigHomePath();
-      dir /= "accessibility";
-      std::error_code ec;
-      if (!std::filesystem::exists(dir)) {
-        std::filesystem::create_directories(dir, ec);
-      }
-      const std::string target = (dir / "semantic_tree_init.json").string();
-      // The accessibility directory is derived from the user's environment
-      // (XDG_CONFIG_HOME, or HOME as a fallback). Reject any ".." traversal
-      // segment before opening the file so a crafted environment cannot
-      // redirect the write outside the intended config tree.
-      if (target.find("..") != std::string::npos) {
-        spdlog::error(
-            "Refusing to write accessibility tree dump to '{}': path contains "
-            "a '..' traversal segment",
-            target);
-      } else {
-        DumpTree(target.c_str());
-      }
-#if ENABLE_ACCESSKIT
-      Init_AccessKit();
-#endif
-    }
-  } else {
-    // Tree is built, just provide updates
-    for (int i = 0; i < static_cast<int>(update->node_count); i++) {
-      FlutterSemanticsNode2* node = update->nodes[i];
-      const AccessibilityNode* updated_node = GetNode(*node);
-      if (node->flags & kFlutterSemanticsFlagIsFocused) {
-        SetFocusedNode(updated_node->GetId());
-      }
-      AccessibilityNode::UpdateNode(node);
+  // Upsert every node in this update: create the ones we have not seen and
+  // refresh the rest. Update() replaces fields and children, so stale labels
+  // and detached children never accumulate across successive updates.
+  for (size_t i = 0; i < update->node_count; i++) {
+    const FlutterSemanticsNode2* node = update->nodes[i];
+    AccessibilityNode* mirror = GetNode(*node);
+    mirror->Update(*node);
+    if (node->flags & kFlutterSemanticsFlagIsFocused) {
+      SetFocusedNode(node->id);
     }
   }
 
-  for (int j = 0; j < static_cast<int>(update->custom_action_count); j++) {
+  if (!IsTreeBuilt()) {
+    // The tree is only usable once the root (id 0) has arrived; Flutter sends
+    // it in the first update. Hold off on the initial dump until then.
+    if (node_index.find(0) == node_index.end()) {
+      return;
+    }
+    SetTreeBuilt(true);
+
+    std::filesystem::path dir = Utils::GetConfigHomePath();
+    dir /= "accessibility";
+    std::error_code ec;
+    if (!std::filesystem::exists(dir)) {
+      std::filesystem::create_directories(dir, ec);
+    }
+    const std::string target = (dir / "semantic_tree_init.json").string();
+    // The accessibility directory is derived from the user's environment
+    // (XDG_CONFIG_HOME, or HOME as a fallback). Reject any ".." traversal
+    // segment before opening the file so a crafted environment cannot
+    // redirect the write outside the intended config tree.
+    if (target.find("..") != std::string::npos) {
+      spdlog::error(
+          "Refusing to write accessibility tree dump to '{}': path contains "
+          "a '..' traversal segment",
+          target);
+    } else {
+      DumpTree(target.c_str());
+    }
+#if ENABLE_ACCESSKIT
+    Init_AccessKit();
+#endif
+  }
+
+  // Drop any node no longer reachable from the root: a subtree Flutter
+  // detached is removed from the mirror instead of lingering forever.
+  PruneUnreachable();
+
+  for (size_t j = 0; j < update->custom_action_count; j++) {
     // TODO: handle custom actions
+  }
+}
+
+void AccessibilityTree::PruneUnreachable() {
+  // Mark everything reachable from the root (id 0) via traversal-order
+  // children.
+  std::unordered_set<int32_t> reachable;
+  std::vector<int32_t> stack;
+  if (node_index.find(0) != node_index.end()) {
+    reachable.insert(0);
+    stack.push_back(0);
+  }
+  while (!stack.empty()) {
+    const int32_t id = stack.back();
+    stack.pop_back();
+    const auto it = node_index.find(id);
+    if (it == node_index.end()) {
+      continue;  // referenced by a parent but not (yet) mirrored
+    }
+    const AccessibilityNode* n = it->second;
+    for (uint32_t i = 0; i < n->NumberOfChildren(); i++) {
+      const int32_t child = n->GetChild(static_cast<int32_t>(i));
+      if (child >= 0 && reachable.insert(child).second) {
+        stack.push_back(child);
+      }
+    }
+  }
+
+  // Drop the unreachable nodes from both the index and the owning vector.
+  for (auto it = node_index.begin(); it != node_index.end();) {
+    if (reachable.find(it->first) == reachable.end()) {
+      it = node_index.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  nodes.erase(
+      std::remove_if(nodes.begin(), nodes.end(),
+                     [&reachable](const std::unique_ptr<AccessibilityNode>& n) {
+                       return reachable.find(n->GetId()) == reachable.end();
+                     }),
+      nodes.end());
+
+  // If the focused node was pruned, fall back to the root.
+  if (node_index.find(GetFocusedNode()) == node_index.end()) {
+    SetFocusedNode(0);
   }
 }
 
@@ -132,8 +178,9 @@ AccessibilityNode* AccessibilityTree::GetNode(
     return it->second;
   }
 
-  auto new_node = new AccessibilityNode(fl_node);
-  nodes.emplace_back(new_node);
+  auto owned = std::make_unique<AccessibilityNode>(fl_node);
+  AccessibilityNode* new_node = owned.get();
+  nodes.emplace_back(std::move(owned));
   node_index.emplace(new_node->GetId(), new_node);
   SPDLOG_TRACE("New AccessibilityNode created with ID: {}, number of nodes: {}",
                new_node->GetId(), nodes.size());

--- a/shell/accessibility/accessibility_tree.h
+++ b/shell/accessibility/accessibility_tree.h
@@ -18,6 +18,7 @@
 #define SHELL_ACCESSIBILITY_ACCESSIBILITY_TREE_H_
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -47,26 +48,28 @@ class AccessibilityNode {
   // Returns the ID of the node.
   [[nodiscard]] int32_t GetId() const { return m_id; };
 
-  // Adds a child node ID to the list of children.
-  void AddChild(int32_t child_id);
-
-  // Updates the node with new data from a Flutter semantics node.
-  static void UpdateNode(FlutterSemanticsNode2* fl_node);
+  // Refreshes all fields (label / hint / value / tooltip, bounds, flags, role)
+  // and REPLACES the children list from a Flutter semantics node. Called on
+  // create and on every subsequent update, so stale labels or detached
+  // children never accumulate across updates.
+  void Update(const FlutterSemanticsNode2& fl_node);
 
   // Returns the role of the node.
   [[nodiscard]] uint8_t GetRole() const { return m_role; };
 
-  // Returns the label of the node.
-  [[nodiscard]] const char* GetLabel() const { return m_label; };
+  // Returns the label of the node. Backed by an owned copy, so the pointer
+  // stays valid for the node's lifetime (unlike the embedder's transient
+  // FlutterSemanticsNode2 strings, which live only for the update callback).
+  [[nodiscard]] const char* GetLabel() const { return m_label.c_str(); };
 
   // Returns the hint text of the node.
-  [[nodiscard]] const char* GetHint() const { return m_hint; };
+  [[nodiscard]] const char* GetHint() const { return m_hint.c_str(); };
 
   // Returns the tooltip text of the node.
-  [[nodiscard]] const char* GetTooltip() const { return m_tooltip; };
+  [[nodiscard]] const char* GetTooltip() const { return m_tooltip.c_str(); };
 
   // Returns the value of the node.
-  [[nodiscard]] const char* GetValue() const { return m_value; };
+  [[nodiscard]] const char* GetValue() const { return m_value.c_str(); };
 
   // Returns the bounds of the node.
   [[nodiscard]] FlutterRect GetBounds() const { return m_bounds; };
@@ -86,15 +89,19 @@ class AccessibilityNode {
   }
 
  private:
-  uint8_t m_role;                   // Role of the node.
-  int32_t m_id;                     // ID of the node.
-  const char* m_label;              // Label of the node.
-  const char* m_hint;               // Hint text of the node.
-  const char* m_value;              // Value of the node.
-  const char* m_tooltip;            // Tooltip text of the node.
-  FlutterRect m_bounds;             // Bounds of the node.
-  FlutterSemanticsFlag m_flags;     // Flags associated with the node.
-  std::vector<int32_t> m_children;  // List of child node IDs.
+  // The scalar members are set unconditionally by Update() (called from the
+  // constructor), but carry in-class initializers so the type is never left
+  // with an indeterminate field on any construction path.
+  uint8_t m_role = SEMANTIC_ROLE_UNKNOWN;  // Role of the node.
+  int32_t m_id = -1;                       // ID of the node.
+  std::string m_label;                     // Label of the node (owned copy).
+  std::string m_hint;      // Hint text of the node (owned copy).
+  std::string m_value;     // Value of the node (owned copy).
+  std::string m_tooltip;   // Tooltip text of the node (owned copy).
+  FlutterRect m_bounds{};  // Bounds of the node.
+  FlutterSemanticsFlag m_flags =
+      static_cast<FlutterSemanticsFlag>(0);  // Flags associated with the node.
+  std::vector<int32_t> m_children;           // List of child node IDs.
 };
 
 // Class representing the accessibility tree.
@@ -116,7 +123,7 @@ class AccessibilityTree {
   // If the index is out of bounds, returns nullptr.
   [[nodiscard]] AccessibilityNode* GetNodeByIdx(const int32_t idx) const {
     return (idx >= 0 && static_cast<size_t>(idx) < nodes.size())
-               ? nodes[static_cast<size_t>(idx)]
+               ? nodes[static_cast<size_t>(idx)].get()
                : nullptr;
   }
 
@@ -152,16 +159,22 @@ class AccessibilityTree {
 #endif
 
  private:
+  // Drops nodes no longer reachable from the root (id 0), keeping `nodes` and
+  // `node_index` consistent after a subtree is detached in an update.
+  void PruneUnreachable();
+
   bool tree_built = false;  // Flag indicating if the tree is built.
-  std::vector<AccessibilityNode*> nodes;  // List of nodes in the tree.
+  // Owns the nodes. node_index below holds non-owning raw pointers into these,
+  // so the tree destructs cleanly without a manual delete loop.
+  std::vector<std::unique_ptr<AccessibilityNode>> nodes;
   // Index from node id to node, kept in sync with `nodes` so GetNode() is
   // O(1) instead of a linear scan (semantics updates touch many nodes per
-  // update, which would otherwise be O(n^2)).
+  // update, which would otherwise be O(n^2)). Non-owning.
   std::unordered_map<int32_t, AccessibilityNode*> node_index;
   int32_t focused_node;  // ID of the currently focused node.
 
 #if ENABLE_ACCESSKIT
-  accesskit_unix_adapter* adapter{} {};  // AccessKit adapter for Unix systems.
+  accesskit_unix_adapter* adapter{};  // AccessKit adapter for Unix systems.
 #endif
 };
 

--- a/shell/accessibility/semantics_translator.cc
+++ b/shell/accessibility/semantics_translator.cc
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "semantics_translator.h"
+
+namespace accessibility {
+
+namespace {
+
+bool Has(FlutterSemanticsFlag flags, FlutterSemanticsFlag bit) {
+  return (static_cast<uint32_t>(flags) & static_cast<uint32_t>(bit)) != 0;
+}
+
+bool Has(FlutterSemanticsAction actions, FlutterSemanticsAction bit) {
+  return (static_cast<uint32_t>(actions) & static_cast<uint32_t>(bit)) != 0;
+}
+
+// Role, first-match-wins. The order encodes precedence: a text field that is
+// also focusable is a text input, not a generic container; a checkbox in a
+// mutually-exclusive group is a radio button; etc.
+Role DeriveRole(int32_t id,
+                FlutterSemanticsFlag flags,
+                bool has_label,
+                bool has_children) {
+  if (id == 0) {
+    return Role::kWindow;
+  }
+  if (Has(flags, kFlutterSemanticsFlagIsTextField)) {
+    if (Has(flags, kFlutterSemanticsFlagIsObscured)) {
+      return Role::kPasswordInput;
+    }
+    if (Has(flags, kFlutterSemanticsFlagIsMultiline)) {
+      return Role::kMultilineTextInput;
+    }
+    return Role::kTextInput;
+  }
+  if (Has(flags, kFlutterSemanticsFlagIsSlider)) {
+    return Role::kSlider;
+  }
+  if (Has(flags, kFlutterSemanticsFlagHasToggledState)) {
+    return Role::kSwitch;
+  }
+  if (Has(flags, kFlutterSemanticsFlagHasCheckedState)) {
+    return Has(flags, kFlutterSemanticsFlagIsInMutuallyExclusiveGroup)
+               ? Role::kRadioButton
+               : Role::kCheckBox;
+  }
+  if (Has(flags, kFlutterSemanticsFlagIsButton)) {
+    return Role::kButton;
+  }
+  if (Has(flags, kFlutterSemanticsFlagIsLink)) {
+    return Role::kLink;
+  }
+  if (Has(flags, kFlutterSemanticsFlagIsImage)) {
+    return Role::kImage;
+  }
+  if (Has(flags, kFlutterSemanticsFlagIsHeader)) {
+    return Role::kHeading;
+  }
+  if (Has(flags, kFlutterSemanticsFlagIsKeyboardKey)) {
+    return Role::kButton;  // documented approximation: no AT-SPI keyboard-key
+  }
+  if (Has(flags, kFlutterSemanticsFlagHasImplicitScrolling)) {
+    return Role::kScrollView;
+  }
+  if (Has(flags, kFlutterSemanticsFlagScopesRoute) ||
+      Has(flags, kFlutterSemanticsFlagNamesRoute)) {
+    return Role::kPane;
+  }
+  if (has_label && !has_children) {
+    return Role::kLabel;
+  }
+  return Role::kGenericContainer;
+}
+
+}  // namespace
+
+NodeSpec Translate(int32_t id,
+                   FlutterSemanticsFlag flags,
+                   FlutterSemanticsAction actions,
+                   bool has_label,
+                   bool has_children) {
+  NodeSpec spec;
+  spec.role = DeriveRole(id, flags, has_label, has_children);
+
+  spec.disabled = Has(flags, kFlutterSemanticsFlagHasEnabledState) &&
+                  !Has(flags, kFlutterSemanticsFlagIsEnabled);
+  spec.hidden = Has(flags, kFlutterSemanticsFlagIsHidden);
+  spec.read_only = Has(flags, kFlutterSemanticsFlagIsReadOnly);
+  spec.selected = Has(flags, kFlutterSemanticsFlagIsSelected);
+  spec.expanded = Has(flags, kFlutterSemanticsFlagHasExpandedState) &&
+                  Has(flags, kFlutterSemanticsFlagIsExpanded);
+  spec.checked = Has(flags, kFlutterSemanticsFlagHasCheckedState) &&
+                 Has(flags, kFlutterSemanticsFlagIsChecked);
+  spec.checked_mixed = Has(flags, kFlutterSemanticsFlagIsCheckStateMixed);
+  spec.toggled = Has(flags, kFlutterSemanticsFlagHasToggledState) &&
+                 Has(flags, kFlutterSemanticsFlagIsToggled);
+  spec.live = Has(flags, kFlutterSemanticsFlagIsLiveRegion);
+  spec.focusable = Has(flags, kFlutterSemanticsFlagIsFocusable);
+  spec.focused = Has(flags, kFlutterSemanticsFlagIsFocused);
+
+  spec.action_tap = Has(actions, kFlutterSemanticsActionTap);
+  spec.action_long_press = Has(actions, kFlutterSemanticsActionLongPress);
+  spec.action_increase = Has(actions, kFlutterSemanticsActionIncrease);
+  spec.action_decrease = Has(actions, kFlutterSemanticsActionDecrease);
+  spec.action_scroll_up = Has(actions, kFlutterSemanticsActionScrollUp);
+  spec.action_scroll_down = Has(actions, kFlutterSemanticsActionScrollDown);
+  spec.action_scroll_left = Has(actions, kFlutterSemanticsActionScrollLeft);
+  spec.action_scroll_right = Has(actions, kFlutterSemanticsActionScrollRight);
+  spec.action_show_on_screen =
+      Has(actions, kFlutterSemanticsActionShowOnScreen);
+  spec.action_set_text = Has(actions, kFlutterSemanticsActionSetText);
+  spec.action_focus = Has(actions, kFlutterSemanticsActionFocus);
+
+  return spec;
+}
+
+}  // namespace accessibility

--- a/shell/accessibility/semantics_translator.h
+++ b/shell/accessibility/semantics_translator.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_ACCESSIBILITY_SEMANTICS_TRANSLATOR_H_
+#define SHELL_ACCESSIBILITY_SEMANTICS_TRANSLATOR_H_
+
+#include <cstdint>
+
+#include <shell/platform/embedder/embedder.h>
+
+namespace accessibility {
+
+// Backend-neutral semantic role. Deliberately independent of accesskit_role
+// (a uint8_t enum whose numeric values have shifted across releases): the
+// AccessKit bridge maps this to accesskit_role at the boundary, which keeps
+// this translator free of any accesskit.h dependency and therefore unit-
+// testable in every build configuration.
+enum class Role : uint8_t {
+  kUnknown,
+  kWindow,
+  kButton,
+  kTextInput,
+  kMultilineTextInput,
+  kPasswordInput,
+  kSlider,
+  kSwitch,
+  kCheckBox,
+  kRadioButton,
+  kLink,
+  kImage,
+  kHeading,
+  kScrollView,
+  kPane,
+  kLabel,
+  kGenericContainer,
+};
+
+// The derived, backend-neutral semantic attributes of a node: the pure mapping
+// of a Flutter semantics node's identity, flags, and action bitmask. Text,
+// bounds, and transform stay on the mirror (direct copies, not derived), so
+// this POD carries only what the translation logic computes.
+struct NodeSpec {
+  Role role = Role::kUnknown;
+
+  // States derived from flags.
+  bool disabled = false;       // HasEnabledState && !IsEnabled
+  bool hidden = false;         // IsHidden
+  bool read_only = false;      // IsReadOnly
+  bool selected = false;       // IsSelected
+  bool expanded = false;       // HasExpandedState && IsExpanded
+  bool checked = false;        // HasCheckedState && IsChecked
+  bool checked_mixed = false;  // IsCheckStateMixed
+  bool toggled = false;        // HasToggledState && IsToggled
+  bool live = false;           // IsLiveRegion
+  bool focusable = false;      // IsFocusable
+  bool focused = false;        // IsFocused
+
+  // Actions the AT can invoke, from the action bitmask.
+  bool action_tap = false;
+  bool action_long_press = false;
+  bool action_increase = false;
+  bool action_decrease = false;
+  bool action_scroll_up = false;
+  bool action_scroll_down = false;
+  bool action_scroll_left = false;
+  bool action_scroll_right = false;
+  bool action_show_on_screen = false;
+  bool action_set_text = false;
+  bool action_focus = false;
+};
+
+// Pure translation from a Flutter semantics node's identity + flags + actions
+// to a NodeSpec. `has_label` / `has_children` disambiguate a label-only leaf
+// from a generic container when no stronger role flag matches. Stateless and
+// side-effect free.
+NodeSpec Translate(int32_t id,
+                   FlutterSemanticsFlag flags,
+                   FlutterSemanticsAction actions,
+                   bool has_label,
+                   bool has_children);
+
+}  // namespace accessibility
+
+#endif  // SHELL_ACCESSIBILITY_SEMANTICS_TRANSLATOR_H_

--- a/shell/utils.h
+++ b/shell/utils.h
@@ -106,7 +106,13 @@ class Utils {
    * flutter
    */
   static const char* GetConfigHomePath() {
+    // Resolved once and cached for the process lifetime: the config directory
+    // does not change while running, and re-resolving would strdup() a fresh
+    // copy on every call and leak the previous one.
     static const char* config_home_dir = nullptr;
+    if (config_home_dir != nullptr) {
+      return config_home_dir;
+    }
 
     const auto config_env = getenv("XDG_CONFIG_HOME");
     if (config_env && *config_env) {

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -85,3 +85,10 @@ add_subdirectory(pixel_swizzle-test)
 add_subdirectory(scale_policy-test)
 add_subdirectory(text_input-test)
 #add_subdirectory(texture-test)
+
+# The accessibility sources are only part of the shell target (and therefore of
+# TYPICAL_TEST_SOURCES) when BUILD_ACCESSIBILITY is configured on.
+if (BUILD_ACCESSIBILITY)
+    add_subdirectory(semantics_translator-test)
+    add_subdirectory(accessibility_tree-test)
+endif ()

--- a/test/unit_test/accessibility_tree-test/CMakeLists.txt
+++ b/test/unit_test/accessibility_tree-test/CMakeLists.txt
@@ -1,0 +1,40 @@
+# test-case specific settings
+# when creating new test-case, you need to change here
+set(TESTCASE_NAME "homescreen_accessibility_tree_ut_test_driver")
+set(TESTCASE_CC test_case_accessibility_tree.cc)
+list(REMOVE_ITEM TYPICAL_TEST_DEFINITIONS "ENABLE_PLUGIN_URL_LAUNCHER")
+
+# Basically, the following statements need not be modified
+add_executable(
+        ${TESTCASE_NAME}
+        ${TYPICAL_TEST_SOURCES}
+        ${TESTCASE_CC}
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_compile_definitions(
+        ${TESTCASE_NAME}
+        PRIVATE
+        ${TYPICAL_TEST_DEFINITIONS}
+        TEST_SCRATCH_DIR="${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+target_include_directories(
+        ${TESTCASE_NAME}
+        PRIVATE
+        ${TYPICAL_TEST_INC_DIRS}
+)
+
+target_link_libraries(
+        ${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        ${TYPICAL_TEST_LINK_LIBS}
+        toolchain::toolchain
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
+++ b/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "accessibility/accessibility_tree.h"
+
+namespace {
+
+// Owns the backing storage (label + child ids) that a FlutterSemanticsNode2's
+// pointers reference, so those pointers stay valid for as long as the builder
+// lives. The embedder guarantees the same only for the update callback; the
+// tree must copy, and these tests verify it does.
+struct NodeBuilder {
+  FlutterSemanticsNode2 node{};
+  std::string label;
+  std::vector<int32_t> children;
+
+  NodeBuilder(int32_t id, std::vector<int32_t> kids, std::string lbl) {
+    label = std::move(lbl);
+    children = std::move(kids);
+    node.struct_size = sizeof(FlutterSemanticsNode2);
+    node.id = id;
+    node.flags = static_cast<FlutterSemanticsFlag>(0);
+    node.actions = static_cast<FlutterSemanticsAction>(0);
+    node.label = label.c_str();
+    node.hint = "";
+    node.value = "";
+    node.increased_value = "";
+    node.decreased_value = "";
+    node.tooltip = "";
+    node.child_count = children.size();
+    node.children_in_traversal_order =
+        children.empty() ? nullptr : children.data();
+    node.children_in_hit_test_order = node.children_in_traversal_order;
+  }
+};
+
+// Drives HandleFlutterUpdate from a set of already-built nodes.
+void Apply(AccessibilityTree& tree, std::vector<FlutterSemanticsNode2*> nodes) {
+  FlutterSemanticsUpdate2 update{};
+  update.struct_size = sizeof(FlutterSemanticsUpdate2);
+  update.node_count = nodes.size();
+  update.nodes = nodes.data();
+  update.custom_action_count = 0;
+  update.custom_actions = nullptr;
+  tree.HandleFlutterUpdate(&update);
+}
+
+AccessibilityNode* FindById(const AccessibilityTree& tree, int32_t id) {
+  for (int32_t i = 0; i < tree.NumberOfNodes(); ++i) {
+    AccessibilityNode* n = tree.GetNodeByIdx(i);
+    if (n != nullptr && n->GetId() == id) {
+      return n;
+    }
+  }
+  return nullptr;
+}
+
+// Keep DumpTree's first-build write inside the scratch tree, not the real
+// user config directory.
+class AccessibilityTreeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+#ifdef TEST_SCRATCH_DIR
+    setenv("XDG_CONFIG_HOME", TEST_SCRATCH_DIR, 1);
+#endif
+  }
+};
+
+}  // namespace
+
+// D2: the node owns its text. Reading a label after the embedder's source
+// buffer is freed must be safe (ASan would flag a retained raw pointer).
+TEST_F(AccessibilityTreeTest, LabelSurvivesSourceBufferDestruction) {
+  auto source = std::make_unique<std::string>("Play button");
+  FlutterSemanticsNode2 fl{};
+  fl.struct_size = sizeof(FlutterSemanticsNode2);
+  fl.id = 0;
+  fl.flags = static_cast<FlutterSemanticsFlag>(0);
+  fl.actions = static_cast<FlutterSemanticsAction>(0);
+  fl.label = source->c_str();
+  fl.hint = "";
+  fl.value = "";
+  fl.increased_value = "";
+  fl.decreased_value = "";
+  fl.tooltip = "";
+
+  AccessibilityNode node(fl);
+  source.reset();  // free the embedder-owned buffer
+
+  EXPECT_STREQ(node.GetLabel(), "Play button");
+}
+
+// D2: a null embedder string coalesces to empty rather than being fed to
+// std::string(nullptr) (undefined behavior).
+TEST_F(AccessibilityTreeTest, NullStringsCoalesceToEmpty) {
+  FlutterSemanticsNode2 fl{};
+  fl.struct_size = sizeof(FlutterSemanticsNode2);
+  fl.id = 7;
+  fl.flags = static_cast<FlutterSemanticsFlag>(0);
+  fl.actions = static_cast<FlutterSemanticsAction>(0);
+  fl.label = nullptr;
+  fl.hint = nullptr;
+  fl.value = nullptr;
+  fl.tooltip = nullptr;
+
+  AccessibilityNode node(fl);
+  EXPECT_STREQ(node.GetLabel(), "");
+  EXPECT_STREQ(node.GetHint(), "");
+  EXPECT_STREQ(node.GetValue(), "");
+  EXPECT_STREQ(node.GetTooltip(), "");
+}
+
+// The tree is only usable once the root (id 0) arrives. Before that, an update
+// carrying only non-root nodes leaves the tree unbuilt; pruning is gated behind
+// the first build, so an early orphan is retained (not yet dropped) rather than
+// pruned against a root that does not exist.
+TEST_F(AccessibilityTreeTest, TreeNotBuiltUntilRootArrives) {
+  AccessibilityTree tree;
+  NodeBuilder orphan(5, {}, "orphan");
+  Apply(tree, {&orphan.node});
+  EXPECT_FALSE(tree.IsTreeBuilt());
+  EXPECT_EQ(tree.NumberOfNodes(), 1);
+
+  NodeBuilder root(0, {5}, "root");
+  NodeBuilder child(5, {}, "child");
+  Apply(tree, {&root.node, &child.node});
+  EXPECT_TRUE(tree.IsTreeBuilt());
+  EXPECT_EQ(tree.NumberOfNodes(), 2);
+}
+
+// D5: re-sending a node replaces its fields and children rather than appending.
+TEST_F(AccessibilityTreeTest, UpdateReplacesLabelAndChildren) {
+  AccessibilityTree tree;
+  NodeBuilder root1(0, {1}, "before");
+  NodeBuilder child(1, {}, "child");
+  Apply(tree, {&root1.node, &child.node});
+  ASSERT_EQ(tree.NumberOfNodes(), 2);
+  ASSERT_STREQ(FindById(tree, 0)->GetLabel(), "before");
+  ASSERT_EQ(FindById(tree, 0)->NumberOfChildren(), 1u);
+
+  // Re-send the root with a new label and no children.
+  NodeBuilder root2(0, {}, "after");
+  Apply(tree, {&root2.node});
+  AccessibilityNode* root = FindById(tree, 0);
+  ASSERT_NE(root, nullptr);
+  EXPECT_STREQ(root->GetLabel(), "after");
+  EXPECT_EQ(root->NumberOfChildren(), 0u);
+}
+
+// D7: a subtree Flutter detaches is pruned from both the owning vector and the
+// index, and the focus falls back to the root if the focused node was dropped.
+TEST_F(AccessibilityTreeTest,
+       PruneUnreachableDropsDetachedSubtreeAndResetsFocus) {
+  AccessibilityTree tree;
+  NodeBuilder root1(0, {1}, "root");
+  NodeBuilder child(1, {}, "child");
+  child.node.flags = kFlutterSemanticsFlagIsFocused;
+  Apply(tree, {&root1.node, &child.node});
+  ASSERT_EQ(tree.NumberOfNodes(), 2);
+  ASSERT_EQ(tree.GetFocusedNode(), 1);
+
+  // Detach the child by re-sending the root with no children.
+  NodeBuilder root2(0, {}, "root");
+  Apply(tree, {&root2.node});
+  EXPECT_EQ(tree.NumberOfNodes(), 1);
+  EXPECT_EQ(FindById(tree, 1), nullptr);
+  EXPECT_EQ(tree.GetFocusedNode(), 0);  // focus fell back to root
+}

--- a/test/unit_test/semantics_translator-test/CMakeLists.txt
+++ b/test/unit_test/semantics_translator-test/CMakeLists.txt
@@ -1,0 +1,39 @@
+# test-case specific settings
+# when creating new test-case, you need to change here
+set(TESTCASE_NAME "homescreen_semantics_translator_ut_test_driver")
+set(TESTCASE_CC test_case_semantics_translator.cc)
+list(REMOVE_ITEM TYPICAL_TEST_DEFINITIONS "ENABLE_PLUGIN_URL_LAUNCHER")
+
+# Basically, the following statements need not be modified
+add_executable(
+        ${TESTCASE_NAME}
+        ${TYPICAL_TEST_SOURCES}
+        ${TESTCASE_CC}
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_compile_definitions(
+        ${TESTCASE_NAME}
+        PRIVATE
+        ${TYPICAL_TEST_DEFINITIONS}
+)
+
+target_include_directories(
+        ${TESTCASE_NAME}
+        PRIVATE
+        ${TYPICAL_TEST_INC_DIRS}
+)
+
+target_link_libraries(
+        ${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        ${TYPICAL_TEST_LINK_LIBS}
+        toolchain::toolchain
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/semantics_translator-test/test_case_semantics_translator.cc
+++ b/test/unit_test/semantics_translator-test/test_case_semantics_translator.cc
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+
+#include "gtest/gtest.h"
+
+#include "accessibility/semantics_translator.h"
+
+using accessibility::NodeSpec;
+using accessibility::Role;
+using accessibility::Translate;
+
+namespace {
+
+FlutterSemanticsFlag Flags(uint32_t bits) {
+  return static_cast<FlutterSemanticsFlag>(bits);
+}
+FlutterSemanticsAction Actions(uint32_t bits) {
+  return static_cast<FlutterSemanticsAction>(bits);
+}
+constexpr FlutterSemanticsAction kNoAction =
+    static_cast<FlutterSemanticsAction>(0);
+
+// A non-root (id=1) node with the given flags, no actions, no children/label
+// unless overridden — the common shape for the role/state tables below.
+NodeSpec NonRoot(uint32_t flags,
+                 bool has_label = false,
+                 bool has_children = false) {
+  return Translate(1, Flags(flags), kNoAction, has_label, has_children);
+}
+
+}  // namespace
+
+// ─── Role table (§4.4, first match wins) ───────────────────────────────────
+
+TEST(SemanticsTranslator, RootIsWindowRegardlessOfFlags) {
+  // id 0 wins over any flag.
+  EXPECT_EQ(
+      Translate(0, Flags(kFlutterSemanticsFlagIsButton), kNoAction, false, true)
+          .role,
+      Role::kWindow);
+}
+
+TEST(SemanticsTranslator, TextInputVariants) {
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsTextField).role, Role::kTextInput);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsTextField |
+                    kFlutterSemanticsFlagIsMultiline)
+                .role,
+            Role::kMultilineTextInput);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsTextField |
+                    kFlutterSemanticsFlagIsObscured)
+                .role,
+            Role::kPasswordInput);
+  // Obscured takes precedence over multiline.
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsTextField |
+                    kFlutterSemanticsFlagIsObscured |
+                    kFlutterSemanticsFlagIsMultiline)
+                .role,
+            Role::kPasswordInput);
+}
+
+TEST(SemanticsTranslator, CheckboxVsRadio) {
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagHasCheckedState).role,
+            Role::kCheckBox);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagHasCheckedState |
+                    kFlutterSemanticsFlagIsInMutuallyExclusiveGroup)
+                .role,
+            Role::kRadioButton);
+}
+
+TEST(SemanticsTranslator, SingleFlagRoles) {
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagHasToggledState).role, Role::kSwitch);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsSlider).role, Role::kSlider);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsButton).role, Role::kButton);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsLink).role, Role::kLink);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsImage).role, Role::kImage);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsHeader).role, Role::kHeading);
+  // Keyboard key is a documented approximation to button.
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagIsKeyboardKey).role, Role::kButton);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagHasImplicitScrolling).role,
+            Role::kScrollView);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagScopesRoute).role, Role::kPane);
+  EXPECT_EQ(NonRoot(kFlutterSemanticsFlagNamesRoute).role, Role::kPane);
+}
+
+TEST(SemanticsTranslator, LabelOnlyLeafVsGenericContainer) {
+  EXPECT_EQ(Translate(1, Flags(0), kNoAction, /*has_label=*/true,
+                      /*has_children=*/false)
+                .role,
+            Role::kLabel);
+  // A labelled node with children is a container, not a label.
+  EXPECT_EQ(Translate(1, Flags(0), kNoAction, true, true).role,
+            Role::kGenericContainer);
+  // No label, no distinguishing flag -> generic container.
+  EXPECT_EQ(Translate(1, Flags(0), kNoAction, false, false).role,
+            Role::kGenericContainer);
+}
+
+TEST(SemanticsTranslator, RolePrecedenceTextFieldBeatsButton) {
+  // Both text-field and button set: text field is checked first.
+  EXPECT_EQ(
+      NonRoot(kFlutterSemanticsFlagIsTextField | kFlutterSemanticsFlagIsButton)
+          .role,
+      Role::kTextInput);
+}
+
+// ─── State mapping ──────────────────────────────────────────────────────────
+
+TEST(SemanticsTranslator, Disabled) {
+  EXPECT_FALSE(NonRoot(0).disabled);
+  EXPECT_FALSE(NonRoot(kFlutterSemanticsFlagHasEnabledState |
+                       kFlutterSemanticsFlagIsEnabled)
+                   .disabled);
+  // Has an enabled state and is not enabled -> disabled.
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagHasEnabledState).disabled);
+  // IsEnabled without HasEnabledState is meaningless -> not disabled.
+  EXPECT_FALSE(NonRoot(kFlutterSemanticsFlagIsEnabled).disabled);
+}
+
+TEST(SemanticsTranslator, CheckedToggledTruthTable) {
+  EXPECT_FALSE(NonRoot(kFlutterSemanticsFlagHasCheckedState).checked);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagHasCheckedState |
+                      kFlutterSemanticsFlagIsChecked)
+                  .checked);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagIsCheckStateMixed).checked_mixed);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagHasToggledState |
+                      kFlutterSemanticsFlagIsToggled)
+                  .toggled);
+  EXPECT_FALSE(NonRoot(kFlutterSemanticsFlagHasToggledState).toggled);
+}
+
+TEST(SemanticsTranslator, MiscStates) {
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagIsHidden).hidden);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagIsReadOnly).read_only);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagIsSelected).selected);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagHasExpandedState |
+                      kFlutterSemanticsFlagIsExpanded)
+                  .expanded);
+  EXPECT_FALSE(NonRoot(kFlutterSemanticsFlagHasExpandedState).expanded);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagIsLiveRegion).live);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagIsFocusable).focusable);
+  EXPECT_TRUE(NonRoot(kFlutterSemanticsFlagIsFocused).focused);
+}
+
+// ─── Action bitmask mapping ─────────────────────────────────────────────────
+
+TEST(SemanticsTranslator, ActionsPerBit) {
+  auto a = [](uint32_t bits) {
+    return Translate(1, Flags(0), Actions(bits), false, false);
+  };
+  EXPECT_TRUE(a(kFlutterSemanticsActionTap).action_tap);
+  EXPECT_TRUE(a(kFlutterSemanticsActionLongPress).action_long_press);
+  EXPECT_TRUE(a(kFlutterSemanticsActionIncrease).action_increase);
+  EXPECT_TRUE(a(kFlutterSemanticsActionDecrease).action_decrease);
+  EXPECT_TRUE(a(kFlutterSemanticsActionScrollUp).action_scroll_up);
+  EXPECT_TRUE(a(kFlutterSemanticsActionScrollDown).action_scroll_down);
+  EXPECT_TRUE(a(kFlutterSemanticsActionScrollLeft).action_scroll_left);
+  EXPECT_TRUE(a(kFlutterSemanticsActionScrollRight).action_scroll_right);
+  EXPECT_TRUE(a(kFlutterSemanticsActionShowOnScreen).action_show_on_screen);
+  EXPECT_TRUE(a(kFlutterSemanticsActionSetText).action_set_text);
+  EXPECT_TRUE(a(kFlutterSemanticsActionFocus).action_focus);
+}
+
+TEST(SemanticsTranslator, ActionsCombinedAndUnset) {
+  const NodeSpec s = Translate(
+      1, Flags(0),
+      Actions(kFlutterSemanticsActionTap | kFlutterSemanticsActionIncrease),
+      false, false);
+  EXPECT_TRUE(s.action_tap);
+  EXPECT_TRUE(s.action_increase);
+  EXPECT_FALSE(s.action_decrease);
+  EXPECT_FALSE(s.action_scroll_up);
+}
+
+TEST(SemanticsTranslator, EmptyNodeIsInertGenericContainer) {
+  const NodeSpec s = Translate(1, Flags(0), kNoAction, false, false);
+  EXPECT_EQ(s.role, Role::kGenericContainer);
+  EXPECT_FALSE(s.disabled);
+  EXPECT_FALSE(s.checked);
+  EXPECT_FALSE(s.selected);
+  EXPECT_FALSE(s.action_tap);
+  EXPECT_FALSE(s.focusable);
+}


### PR DESCRIPTION
Hardens the Flutter semantics mirror's memory model and factors the
role/state/action mapping out of the tree into a pure, testable translator.

## Tree memory model
- **Owned strings.** `label`/`hint`/`value`/`tooltip` are now owned
  `std::string` copies. The embedder only guarantees these pointers for the
  duration of the update callback, so retaining them left the getters
  returning into freed memory. Null strings coalesce to empty instead of
  constructing `std::string` from `nullptr` (undefined).
- **Replace, don't accumulate.** Re-sending a node now refreshes all fields
  and *replaces* its children list, so stale labels and detached children no
  longer accumulate across updates.
- **Prune detached subtrees.** Nodes no longer reachable from the root are
  dropped from both the owning vector and the id index after each update; if
  the focused node was pruned, focus falls back to the root.
- **Ownership.** Nodes are held by `unique_ptr` with a non-owning id→node
  index, so the tree destructs without a manual delete loop.

## SemanticsTranslator
- New `(id, flags, actions) -> NodeSpec` translation into a backend-neutral
  `Role` + state/action set. It has no `accesskit` dependency, so it is
  unit-testable in every build configuration; the bridge maps `NodeSpec` to
  `accesskit_role` at the boundary. Replaces the hardcoded inline role stopgap.

## Incidental fixes
- `Utils::GetConfigHomePath()` re-`strdup`'d and leaked its result on every
  call despite a `static` cache pointer — added the missing one-time guard
  (found by LeakSanitizer).
- Delegating `AccessibilityNode` constructor left scalar members flagged by
  clang-tidy `pro-type-member-init` — added in-class initializers.

## Tests
- `semantics_translator-test` (12): role table + precedence, state truth
  tables, per-bit action mapping.
- `accessibility_tree-test` (5): pointer lifetime after the source buffer is
  freed, null coalescing, first-build gate, field/children replacement, prune
  + focus fallback.
- Both gated on `BUILD_ACCESSIBILITY` in the test CMake.

## Verification
- `12 + 5` tests pass, zero leaks / UBSan errors
  (`-DSANITIZE_ADDRESS=ON -DSANITIZE_UNDEFINED=ON`).
- clang-tidy-19 `--warnings-as-errors='*'` clean; clang-format-19
  `--dry-run -Werror` clean.