### PR TITLE
shared: add ihs_shared C-ABI library scaffold for FFI plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,12 @@ include(logging_helpers)
 configure_file(cmake/config_common.h.in ${PROJECT_BINARY_DIR}/config/common.h)
 
 #
+# ihs_shared: C-ABI shared library for out-of-tree FFI plugins (logging,
+# tracing, platform-view negotiation, config). See docs/PLUGIN_ABI.md.
+#
+add_subdirectory(shared)
+
+#
 # libraries
 #
 add_subdirectory(third_party)

--- a/docs/PLUGIN_ABI.md
+++ b/docs/PLUGIN_ABI.md
@@ -1,0 +1,65 @@
+# ivi-homescreen plugin ABI (`ihs_shared`)
+
+`ihs_shared` is the supported binary interface between the ivi-homescreen
+process and out-of-tree Dart FFI plugins. It is delivered as a single shared
+library, `libihs_shared.so`, and covers logging, tracing, platform-view surface
+negotiation, and configuration read-back.
+
+## The boundary is C
+
+Everything a plugin reaches across the `dlopen` boundary is plain C:
+
+- No C++ types, exceptions, or RTTI cross the boundary. Any C++ convenience
+  wrapper is header-only and inline over the C entry points, so the compiled
+  boundary stays a C ABI.
+- Types in the installed headers are fixed-width (`<stdint.h>`) and
+  size (`<stddef.h>`); the headers compile as C11 and parse under `ffigen`.
+- Errors are reported by return code. A thread-local
+  `ihs_last_error_message()` carries a human-readable description for
+  diagnostics. There are no errno-style globals.
+
+## One library, one copy of state
+
+`libihs_shared.so` is shared-only. There is no static variant, by design: a
+static copy linked into the shell and another into a plugin would give the
+process two independent copies of the logging bridge, ring registry, and trace
+sink table. A single shared object with exactly one copy of process state is
+the whole point of the boundary.
+
+The shell links `ihs_shared` and initializes process-wide state (for example,
+starting the logging bridge) before any plugin is loaded. Plugins reach the
+library either transitively (their own native library links it) or directly via
+`DynamicLibrary.open("libihs_shared.so.1")` — the versioned SONAME is the
+documented open string.
+
+## Relationship to the in-tree plugin ABI
+
+`ihs_shared` does **not** replace or duplicate
+`shell/platform/homescreen/public/flutter_homescreen.h` and the
+`FlutterDesktopPluginRegistrar` / messenger surface. That surface remains the
+interface for in-tree and statically registered plugins. `ihs_shared` covers a
+disjoint set of concerns — logging, tracing, platform-view surface
+negotiation, and config read — and does not expose a registrar or a messenger.
+Keeping the two surfaces non-overlapping is deliberate: a texture path or
+dmabuf path duplicated across both would drift into two half-interfaces.
+
+## Versioning
+
+The library exposes a single ABI version, `IHS_SHARED_ABI_VERSION`, a `uint32`
+laid out as `(major << 16) | minor`:
+
+- **Additive** changes (new entry points, new trailing struct fields guarded by
+  a leading `struct_size`) bump the **minor** version. A plugin built against an
+  older minor keeps working against a newer library by construction.
+- **Breaking** changes bump the **major** version and the library `SOVERSION`.
+
+The entry point is `ihs_get_api(uint32_t requested_abi)`. It returns a table
+valid for the process lifetime, or `NULL` if the requested **major** version is
+not the one this library provides — so a plugin newer than the shell fails
+cleanly at load rather than mismatching a struct layout at runtime. Every table
+and sub-table begins with a `size_t struct_size` field, following the Flutter
+embedder convention already used throughout the shell.
+
+A sub-table pointer in `IhsApi` is `NULL` when that capability is not present in
+the running build. A consumer must treat a null sub-table as "capability
+absent" rather than assuming it is always available.

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -63,6 +63,11 @@ excludes = (
     os.path.join(root, "shell", "platform", "homescreen", "public") + os.sep,
 )
 
+roots = (
+    os.path.join(root, "shell") + os.sep,
+    os.path.join(root, "shared") + os.sep,
+)
+
 seen = set()
 for entry in entries:
     path = os.path.realpath(
@@ -70,7 +75,7 @@ for entry in entries:
         if os.path.isabs(entry["file"])
         else os.path.join(entry.get("directory", ""), entry["file"])
     )
-    if not path.startswith(os.path.join(root, "shell") + os.sep):
+    if not any(path.startswith(r) for r in roots):
         continue
     if any(path.startswith(ex) for ex in excludes):
         continue

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -28,6 +28,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 mapfile -d '' FILES < <(
     find \
         "${REPO_ROOT}/shell" \
+        "${REPO_ROOT}/shared" \
         "${REPO_ROOT}/test" \
         \( -name '*.cc' -o -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) \
         -not -path "${REPO_ROOT}/shell/platform/homescreen/client_wrapper/*" \

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -1,0 +1,131 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ihs_shared: the C-ABI shared library that fronts logging, tracing,
+# platform-view surface negotiation, and config read-back for out-of-tree
+# Dart FFI plugins. See docs/PLUGIN_ABI.md for the boundary contract.
+#
+# Shared-only, on purpose: a static copy in both the shell and a plugin would
+# give the process two copies of the logging bridge, ring registry, and trace
+# sink table. There is exactly one copy of that state, in this .so.
+
+include(GNUInstallDirs)
+include(GenerateExportHeader)
+include(CMakePackageConfigHelpers)
+
+set(IHS_SHARED_ABI_VERSION_STR 1.0.0)
+
+add_library(ihs_shared SHARED
+        src/ihs_api.cc
+)
+add_library(ivi_homescreen::ihs_shared ALIAS ihs_shared)
+
+set_target_properties(ihs_shared PROPERTIES
+        OUTPUT_NAME ihs_shared
+        VERSION ${IHS_SHARED_ABI_VERSION_STR}
+        SOVERSION 1
+        CXX_VISIBILITY_PRESET hidden
+        C_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+)
+
+# Generates <build>/include/ihs/ihs_export.h defining IHS_EXPORT. With the
+# hidden visibility presets above, only the entry points marked IHS_EXPORT are
+# candidates for export; the version script below is the belt-and-suspenders
+# that also strips anything that slips through.
+generate_export_header(ihs_shared
+        BASE_NAME IHS
+        EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/include/ihs/ihs_export.h
+)
+
+target_include_directories(ihs_shared
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# Restrict the dynamic symbol table to the ihs_* C ABI (see ihs_shared.map).
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(_ihs_version_script ${CMAKE_CURRENT_SOURCE_DIR}/ihs_shared.map)
+    target_link_options(ihs_shared PRIVATE
+            "LINKER:--version-script=${_ihs_version_script}")
+    set_target_properties(ihs_shared PROPERTIES
+            LINK_DEPENDS ${_ihs_version_script})
+endif ()
+
+# Match the shell's standard library selection (libc++ on clang builds) so the
+# bridge relocated here later links cleanly against the shell.
+if (TARGET toolchain)
+    target_link_libraries(ihs_shared PRIVATE toolchain::toolchain)
+endif ()
+if (COMMAND ihs_apply_cxx_compat)
+    ihs_apply_cxx_compat(ihs_shared)
+endif ()
+
+target_compile_options(ihs_shared PRIVATE -Wall -Wextra)
+
+#
+# Install + CMake package export
+#
+install(TARGETS ihs_shared EXPORT ihs_shared_targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Public headers (hand-written) + the generated export header.
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ihs
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.h"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/ihs/ihs_export.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ihs
+)
+
+install(EXPORT ihs_shared_targets
+        FILE ivi-homescreen-shared-targets.cmake
+        NAMESPACE ivi_homescreen::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ivi-homescreen-shared
+)
+
+configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ivi-homescreen-shared-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/ivi-homescreen-shared-config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ivi-homescreen-shared
+)
+write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/ivi-homescreen-shared-config-version.cmake
+        VERSION ${IHS_SHARED_ABI_VERSION_STR}
+        COMPATIBILITY SameMajorVersion
+)
+install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/ivi-homescreen-shared-config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/ivi-homescreen-shared-config-version.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ivi-homescreen-shared
+)
+
+# pkg-config for meson / Yocto / quick sanity checks.
+set(PKGCONFIG_LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR})
+set(PKGCONFIG_INCLUDEDIR ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+set(IHS_SHARED_PC_VERSION ${IHS_SHARED_ABI_VERSION_STR})
+configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ivi-homescreen-shared.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/ivi-homescreen-shared.pc @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ivi-homescreen-shared.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/shared/cmake/ivi-homescreen-shared-config.cmake.in
+++ b/shared/cmake/ivi-homescreen-shared-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+# Consumers do: find_package(ivi-homescreen-shared CONFIG REQUIRED)
+#               target_link_libraries(<tgt> PRIVATE ivi_homescreen::ihs_shared)
+include("${CMAKE_CURRENT_LIST_DIR}/ivi-homescreen-shared-targets.cmake")
+
+check_required_components(ivi-homescreen-shared)

--- a/shared/cmake/ivi-homescreen-shared.pc.in
+++ b/shared/cmake/ivi-homescreen-shared.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@PKGCONFIG_LIBDIR@
+includedir=@PKGCONFIG_INCLUDEDIR@
+
+Name: ivi-homescreen-shared
+Description: ivi-homescreen shared FFI ABI (logging, tracing, platform-view negotiation, config)
+Version: @IHS_SHARED_PC_VERSION@
+Libs: -L${libdir} -lihs_shared
+Cflags: -I${includedir}

--- a/shared/ihs_shared.map
+++ b/shared/ihs_shared.map
@@ -1,0 +1,12 @@
+# Linker version script for libihs_shared.so.
+#
+# Only the sanctioned C ABI (ihs_*) is exported; every other symbol — including
+# the C++ internals of the logging bridge and any vendored dependency compiled
+# in — stays local regardless of its visibility attributes. This is the hard
+# boundary: a plugin can reach nothing but the ihs_* surface.
+{
+  global:
+    ihs_*;
+  local:
+    *;
+};

--- a/shared/include/ihs/ihs.h
+++ b/shared/include/ihs/ihs.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * ihs_shared: the C ABI entry point for out-of-tree ivi-homescreen FFI
+ * plugins. See docs/PLUGIN_ABI.md for the boundary contract.
+ */
+
+#ifndef IHS_IHS_H_
+#define IHS_IHS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ihs/ihs_export.h"
+#include "ihs/ihs_version.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Capability sub-tables. Each is defined by its own header once the
+ * corresponding surface is present; the pointer in IhsApi is NULL in a build
+ * that does not provide the capability.
+ */
+typedef struct IhsLoggingApi IhsLoggingApi;
+typedef struct IhsTraceApi IhsTraceApi;
+typedef struct IhsPlatformViewApi IhsPlatformViewApi;
+typedef struct IhsConfigApi IhsConfigApi;
+
+/*
+ * The top-level capability table, valid for the process lifetime. struct_size
+ * is first and additive growth only, so a plugin built against an older minor
+ * safely reads a prefix of a newer table.
+ */
+typedef struct IhsApi {
+  size_t struct_size;
+  uint32_t abi_version;
+  const IhsLoggingApi* logging;
+  const IhsTraceApi* trace;
+  const IhsPlatformViewApi* platform_view;
+  const IhsConfigApi* config;
+} IhsApi;
+
+/*
+ * Returns the capability table, or NULL if requested_abi's major version is
+ * not the one this library provides (query ihs_last_error_message() for the
+ * reason). requested_abi is normally IHS_SHARED_ABI_VERSION of the header the
+ * plugin was built against.
+ */
+IHS_EXPORT const IhsApi* ihs_get_api(uint32_t requested_abi);
+
+/*
+ * A human-readable description of the last failure on the calling thread.
+ * Never NULL; the empty string when there has been no failure. The returned
+ * pointer is valid until the next ihs_* call on the same thread.
+ */
+IHS_EXPORT const char* ihs_last_error_message(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* IHS_IHS_H_ */

--- a/shared/include/ihs/ihs_version.h
+++ b/shared/include/ihs/ihs_version.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IHS_IHS_VERSION_H_
+#define IHS_IHS_VERSION_H_
+
+#include <stdint.h>
+
+/*
+ * The ihs_shared ABI version, laid out as (major << 16) | minor.
+ *
+ * Additive changes (new entry points; new trailing struct fields behind a
+ * leading struct_size) bump the minor. Breaking changes bump the major and the
+ * library SOVERSION. A plugin built against an older minor keeps working
+ * against a newer library; a plugin requiring a newer major is rejected at
+ * ihs_get_api().
+ */
+#define IHS_SHARED_ABI_MAJOR 1u
+#define IHS_SHARED_ABI_MINOR 0u
+#define IHS_SHARED_ABI_VERSION \
+  ((IHS_SHARED_ABI_MAJOR << 16) | IHS_SHARED_ABI_MINOR)
+
+#define IHS_ABI_MAJOR(v) ((uint32_t)(v) >> 16)
+#define IHS_ABI_MINOR(v) ((uint32_t)(v) & 0xffffu)
+
+#endif /* IHS_IHS_VERSION_H_ */

--- a/shared/src/ihs_api.cc
+++ b/shared/src/ihs_api.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ihs/ihs.h"
+
+#include <string>
+
+namespace {
+
+// Per-thread description of the last failure, surfaced through
+// ihs_last_error_message(). Thread-local so a diagnostic on one thread cannot
+// be clobbered by a call on another.
+thread_local std::string g_last_error;
+
+// The process-lifetime capability table. Sub-table pointers are null until the
+// corresponding surface is compiled into the library; a consumer treats a null
+// sub-table as "capability absent" (see docs/PLUGIN_ABI.md).
+const IhsApi g_api = {
+    /* struct_size   */ sizeof(IhsApi),
+    /* abi_version   */ IHS_SHARED_ABI_VERSION,
+    /* logging       */ nullptr,
+    /* trace         */ nullptr,
+    /* platform_view */ nullptr,
+    /* config        */ nullptr,
+};
+
+}  // namespace
+
+extern "C" const IhsApi* ihs_get_api(uint32_t requested_abi) {
+  const uint32_t requested_major = IHS_ABI_MAJOR(requested_abi);
+  if (requested_major != IHS_SHARED_ABI_MAJOR) {
+    g_last_error = "ihs_get_api: unsupported ABI major " +
+                   std::to_string(requested_major) +
+                   "; this library provides " +
+                   std::to_string(IHS_SHARED_ABI_MAJOR);
+    return nullptr;
+  }
+  g_last_error.clear();
+  return &g_api;
+}
+
+extern "C" const char* ihs_last_error_message(void) {
+  return g_last_error.c_str();
+}


### PR DESCRIPTION
Introduces `ihs_shared`, the shared library that will front logging, tracing, platform-view surface negotiation, and config read-back for out-of-tree Dart FFI plugins. This PR lands the **boundary and the versioned entry point only** —
the capability sub-tables are filled in by follow-up PRs as each surface is implemented. Kept deliberately small so the scaffold is reviewable on its own, ahead of the larger bridge-relocation diff.

## What's here

- **New top-level `shared/`** — `libihs_shared.so`, shared-only by design so the
  process holds exactly one copy of the bridge / ring registry / trace sink state. Hidden visibility plus a linker version script (`ihs_shared.map`)
  export only the `ihs_*` C ABI; the built `.so` exposes exactly
  `ihs_get_api` and `ihs_last_error_message`.
- **Version handshake** — `ihs_get_api(requested_abi)` returns a
  `struct_size`-first capability table valid for the process lifetime, or
  `NULL` with a thread-local diagnostic when the requested **major** is
  unsupported. ABI version is `(major << 16) | minor`; additive = minor bump,
  breaking = major + SOVERSION bump.
- **Installable CMake package** — `find_package(ivi-homescreen-shared CONFIG
  REQUIRED)` → `ivi_homescreen::ihs_shared`, plus a generated export header, a relocatable package config, and a `pkg-config` file, all under `GNUInstallDirs`.
- **`docs/PLUGIN_ABI.md`** — the C-only boundary, single-copy-state rule, non-overlap with the in-tree `flutter_homescreen.h` registrar, and the versioning contract.
- **Lint coverage** — `scripts/format.sh` and `scripts/clang_tidy.sh` extended to cover `shared/`, so the new module rides the existing gates.

## Verification

A from-scratch external **C11** consumer resolves the package via `find_package`, links `ivi_homescreen::ihs_shared`, and exercises the handshake:

- matching major → self-consistent table (`struct_size` correct, sub-tables
  `NULL`);
- newer major → clean `NULL` + non-empty diagnostic.

The installed public headers compile under strict C11 (`ffigen`-parseable).
`clang-tidy-19 --warnings-as-errors='*'` and `clang-format-19 --dry-run
-Werror` are clean on the new module.