### PR TITLE
drm-kms-egl: drain the flip event from the waiting thread

### DIFF
--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -35,6 +35,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
+
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
@@ -86,6 +95,15 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Update apt package index
+        # Refresh the index before cache-apt-pkgs-action resolves versions, so
+        # it pins the revision currently on the mirror rather than a stale one
+        # the runner image still lists (a dropped .deb 404s and aborts install).
+        run: sudo apt-get update
+
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
@@ -83,6 +89,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      - name: Update apt package index
+        # Refresh the index before cache-apt-pkgs-action resolves versions, so
+        # it pins the revision currently on the mirror rather than a stale one
+        # the runner image still lists (a dropped .deb 404s and aborts install).
+        run: sudo apt-get update
 
       - name: Install dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/drm_backend.h"
+#include "display/drm_display.h"    // DrainReadyFlips from WaitForPendingFlip
 #include "display/drm_mode_list.h"  // ConnectorTypeName, PrintDrmModes (shared)
 #include "logging/logging.h"
 
@@ -1402,23 +1403,40 @@ bool DrmBackend::RasterDrainEnabled() {
 
 bool DrmBackend::WaitForPendingFlip() const {
   using namespace std::chrono_literals;
-  // The card's flip reader (DrmDisplay, its own thread) is the single reader of
-  // the shared fd; it drains PAGE_FLIP_EVENTs and clears flip_pending_. We only
-  // wait for the flag -- reading the fd here would race the reader thread.
-  // Bounded wait. On nvidia-drm a flip's PAGE_FLIP_EVENT can go undelivered, so
-  // an unbounded loop would spin forever in hrtimer_nanosleep, hanging Present
-  // and ~DrmBackend so the process never exits on SIGTERM. Cap the wait and
-  // proceed; a healthy 60Hz flip clears in ~16ms.
+  // Actively drain this flip's PAGE_FLIP_EVENT rather than passively waiting
+  // for the card's reader thread to do it. That thread is unprioritized, so
+  // under heavy raster load (software GL on a GPU-less board) it can be
+  // CPU-starved and miss the deadline below -- leaving flip_pending_ set so the
+  // next drmModePageFlip returns EBUSY, and every subsequent flip cascades. We
+  // submitted the flip, we are blocked on it, so we drain it ourselves; the
+  // drain is mutex-serialized with the reader thread (see DrainReadyFlips), so
+  // the fd is never read twice. The reader thread still handles idle-time
+  // flips.
+  //
+  // Bounded wait as a hang-guard: on nvidia-drm a flip's PAGE_FLIP_EVENT can go
+  // genuinely undelivered, and an unbounded loop would hang Present and
+  // ~DrmBackend so the process never exits on SIGTERM. Cap and proceed.
   constexpr auto kFlipWaitTimeout = 100ms;
   const auto deadline = std::chrono::steady_clock::now() + kFlipWaitTimeout;
   while (flip_pending_.load(std::memory_order_acquire)) {
-    if (std::chrono::steady_clock::now() >= deadline) {
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) {
       spdlog::warn(
           "[DrmBackend] WaitForPendingFlip: no flip completion after 100ms; "
           "proceeding (PAGE_FLIP_EVENT likely lost)");
       return true;
     }
-    std::this_thread::sleep_for(200us);
+    if (drm_display_ != nullptr) {
+      const auto remaining =
+          std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)
+              .count();
+      // Blocks up to the remaining budget waiting for the event, then drains
+      // it (clearing flip_pending_ via the handler). Falls through to re-check
+      // the flag when it returns.
+      drm_display_->DrainReadyFlips(static_cast<int>(remaining));
+    } else {
+      std::this_thread::sleep_for(200us);
+    }
   }
   return true;
 }

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -327,19 +327,37 @@ void DrmDisplay::ArmFlipRead() {
 }
 
 void DrmDisplay::DrainFlip() {
+  // The reader thread's re-arm callback: drain whatever is ready right now.
+  (void)DrainReadyFlips(0);
+}
+
+bool DrmDisplay::DrainReadyFlips(const int timeout_ms) {
   if (!drm_dev_.has_value() || flip_handler_ == nullptr) {
-    return;
+    return false;
   }
-  // Single reader thread, so no lock: poll(0) then read only if readable. The
-  // handler (user_data == the committing DrmBackend*) routes each flip to its
-  // backend, clears that backend's flip_pending_, and returns its vsync baton.
-  pollfd pfd{drm_dev_->fd(), POLLIN, 0};
-  if (::poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLIN)) {
-    drmEventContext ctx{};
-    ctx.version = 2;
-    ctx.page_flip_handler = flip_handler_;
-    drmHandleEvent(drm_dev_->fd(), &ctx);
+  const int fd = drm_dev_->fd();
+  // Wait for readability WITHOUT the lock so the reader thread and the raster
+  // thread can both block here; whichever wins the drain locks below.
+  pollfd pfd{fd, POLLIN, 0};
+  if (::poll(&pfd, 1, timeout_ms) <= 0 || (pfd.revents & POLLIN) == 0) {
+    return false;
   }
+  // Serialize the actual fd read: two threads may have seen it readable, but
+  // only one may consume the event. The loser re-polls(0) below, finds nothing,
+  // and returns -- no double-read, no lost event. The handler (user_data == the
+  // committing sink) records the flip, clears its flip_pending_, and returns
+  // the vsync baton; safe from either thread (flip_pending_ is atomic and
+  // DeliverVsync marshals onto the runner strand).
+  const std::lock_guard<std::mutex> lock(flip_drain_mu_);
+  pollfd pfd2{fd, POLLIN, 0};
+  if (::poll(&pfd2, 1, 0) <= 0 || (pfd2.revents & POLLIN) == 0) {
+    return false;
+  }
+  drmEventContext ctx{};
+  ctx.version = 2;
+  ctx.page_flip_handler = flip_handler_;
+  drmHandleEvent(fd, &ctx);
+  return true;
 }
 
 void DrmDisplay::StopFlipReader() {

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -93,6 +93,18 @@ class DrmDisplay final : public IDisplay {
   // platform thread. Idempotent; a no-op until SharedDevice + SetFlipHandler.
   void StartFlipReader();
 
+  // Actively drain any ready PAGE_FLIP_EVENT(s). The card's reader thread is
+  // the normal drainer, but under heavy raster load (e.g. software GL on a
+  // GPU-less board) that unprioritized thread can be CPU-starved and miss a
+  // flip's completion within a backend's wait window -- leaving the flip
+  // pending so the next drmModePageFlip returns EBUSY. The backend's
+  // WaitForPendingFlip calls this so the thread that submitted the flip drains
+  // its own completion, immune to reader-thread scheduling. Serialized with the
+  // reader via a mutex, so the fd is never read by two threads at once.
+  // @p timeout_ms > 0 blocks up to that long waiting for an event; 0 polls
+  // without blocking. Returns true if at least one event was handled.
+  bool DrainReadyFlips(int timeout_ms);
+
   // Per-card plane coordination: overlay/cursor planes on a card may be valid
   // for several CRTCs, so independent per-view backends would otherwise pick
   // the same one and collide. A backend records the planes it owns here; the
@@ -216,6 +228,9 @@ class DrmDisplay final : public IDisplay {
   void ArmFlipRead();
   // Drain readable flip events on the reader thread (poll(0)+drmHandleEvent).
   void DrainFlip();
+  // Serializes the fd drain between the reader thread (DrainFlip) and the
+  // raster thread (DrainReadyFlips) so a PAGE_FLIP_EVENT is never read twice.
+  std::mutex flip_drain_mu_;
   // Stop + join the reader thread and detach the fd (drm_dev_ still owns it).
   void StopFlipReader();
 


### PR DESCRIPTION
## Problem

`DrmBackend::WaitForPendingFlip` passively spun on `flip_pending_`, relying on
the card's **unprioritized asio reader thread** (`DrmDisplay`) to drain the
`PAGE_FLIP_EVENT` and clear the flag. Under heavy raster load — software GL on a
GPU-less board, where the raster threads saturate every core — that reader
thread is CPU-starved and misses the 100 ms wait window. The flip stays pending,
the next `drmModePageFlip` returns **`EBUSY`**, and every subsequent frame
cascades. On a StarFive VisionFive 2 this pinned drm-kms-egl at **~0.8 fps** with
a continuous EBUSY / "PAGE_FLIP_EVENT likely lost" spew.

## Fix

Drain the event from the thread that submitted the flip and is already blocked
on it, instead of waiting on a thread that can't get scheduled:

- New `DrmDisplay::DrainReadyFlips(timeout_ms)` — `poll()`s the DRM fd up to the
  remaining budget, then `drmHandleEvent()`s **under a new mutex** that
  serializes with the reader thread. A poll-then-lock-then-repoll(0) sequence
  means the fd is never read by two threads at once and no event is lost.
- `WaitForPendingFlip` calls it each iteration; the reader thread still handles
  idle-time flips. The 100 ms bounded wait stays as the undelivered-event
  hang-guard (nvidia-drm can drop a flip's event entirely).

This is a general robustness fix for any CPU-bound/slow board — it just happens
to be exposed hard by a GPU-less software-GL target.

## Validation (StarFive VisionFive 2, riscv64, DC8200, software GL)

flutter-wonderous over **drm-kms-egl** at 1280x720:

| | old | **fixed** |
|---|---|---|
| flips / 20 s | 16 (**0.8 fps**) | 601 (**~30 fps**) |
| EBUSY / lost-flips | cascade | **0 / 0** |

60 s soak: 0 EBUSY, 1 lost-flip, ~25 fps, wonderous navigable on the panel. At
4K the board is render-bound by software GL, but throughput still roughly
tripled. clang-tidy-19 / clang-format-19 clean on the change.