### PR TITLE
crash: build and ship the handler on cross and deployed targets

### DIFF
--- a/.emb/base.emb.yaml
+++ b/.emb/base.emb.yaml
@@ -28,6 +28,31 @@ cross:
   package:
     name: ivi-homescreen
     bin: shell/homescreen
+    files:
+      # crashpad_handler is a separate runtime executable staged into the augment
+      # overlay by sentry-native (not a link input), so it ships explicitly.
+      # Gated on the same define as the augment below.
+      overlay/usr/bin/crashpad_handler:
+        to: /usr/bin/crashpad_handler
+        mode: "0755"
+        requires_define: BUILD_CRASH_HANDLER
+  # Optional native crash handler (sentry-native + crashpad), inherited by every
+  # target. Off by default; enable per invocation with
+  # `--define BUILD_CRASH_HANDLER=ON`. The curl transport needs libcurl at
+  # runtime, which the board dev_packages already carry (libcurl4-openssl-dev).
+  augment:
+    - pkg: sentry-native
+      requires_define: BUILD_CRASH_HANDLER
+      min: "0.15.3"
+      url: https://github.com/getsentry/sentry-native/releases/download/0.15.3/sentry-native.zip
+      build: cmake
+      static: true
+      defines:
+        SENTRY_BACKEND: crashpad
+        SENTRY_TRANSPORT: curl
+        SENTRY_BUILD_SHARED_LIBS: 'OFF'
+        SENTRY_BUILD_TESTS: 'OFF'
+        SENTRY_BUILD_EXAMPLES: 'OFF'
   defines:
     DISABLE_PLUGINS: 'ON'              # shared by the native build and the boards
   # Native host backend matrix: `emb cross . --build` (no --target) compiles

--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -71,8 +71,10 @@
 #cmakedefine01 BUILD_CRASH_HANDLER
 #if BUILD_CRASH_HANDLER
 static constexpr char kSentryEnvDefault[] = "@CMAKE_BUILD_TYPE@";
-static constexpr char kCrashpadBinaryPath[] =
-    "@CRASHPAD_BINARY_DIR@/crashpad_handler";
+// Path to crashpad_handler on the deployed target (see CRASHPAD_RUNTIME_PATH in
+// cmake/options.cmake). For a cross/staged build this is the on-target install
+// path, not the host build-tree location.
+static constexpr char kCrashpadBinaryPath[] = "@CRASHPAD_RUNTIME_PATH@";
 #endif
 #cmakedefine01 INTEGRATION_TEST_CRASH_HANDLER
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -192,57 +192,89 @@ if (BUILD_CRASH_HANDLER)
 
     include(GNUInstallDirs)
 
-    # sentry-native installs its CMake package config under the GNUInstallDirs
-    # libdir of its staging prefix -- typically lib/cmake/sentry, but lib64 on
-    # some distros and a flat cmake/sentry on older layouts. Hardcoding a single
-    # suffix breaks whenever ${CMAKE_INSTALL_LIBDIR} here differs from the one
-    # sentry-native installed with (or is empty because GNUInstallDirs had not
-    # been included yet). Search the likely suffixes under the chosen base so a
-    # libdir mismatch can't break configure.
-    if (SENTRY_NATIVE_LIBDIR)
-        set(_sentry_base ${SENTRY_NATIVE_LIBDIR})
-    else ()
-        set(_sentry_base ${CMAKE_INSTALL_PREFIX})
+    # Locate sentry-native. When the caller pins a staging prefix
+    # (SENTRY_NATIVE_LIBDIR), honor it first so a build that stages a specific
+    # sentry-native stays deterministic. Otherwise prefer CMake config mode: it
+    # honors CMAKE_PREFIX_PATH / CMAKE_FIND_ROOT_PATH, so a sentry staged into a
+    # cross overlay (e.g. an emb augment) is found with no extra plumbing.
+    if (NOT SENTRY_NATIVE_LIBDIR)
+        find_package(sentry QUIET CONFIG)
     endif ()
 
-    set(sentry_DIR "")
-    foreach (_suffix
-            ${CMAKE_INSTALL_LIBDIR}/cmake/sentry
-            lib/cmake/sentry
-            lib64/cmake/sentry
-            cmake/sentry)
-        if (EXISTS ${_sentry_base}/${_suffix}/sentry-config.cmake)
-            set(sentry_DIR ${_sentry_base}/${_suffix})
-            break ()
+    if (NOT sentry_FOUND)
+        # Fallback: search a caller-provided staging prefix. sentry-native
+        # installs its CMake package config under the GNUInstallDirs libdir of
+        # that prefix -- typically lib/cmake/sentry, but lib64 on some distros
+        # and a flat cmake/sentry on older layouts. Hardcoding a single suffix
+        # breaks whenever ${CMAKE_INSTALL_LIBDIR} here differs from the one
+        # sentry-native installed with (or is empty because GNUInstallDirs had
+        # not been included yet). Search the likely suffixes under the chosen
+        # base so a libdir mismatch can't break configure.
+        if (SENTRY_NATIVE_LIBDIR)
+            set(_sentry_base ${SENTRY_NATIVE_LIBDIR})
+        else ()
+            set(_sentry_base ${CMAKE_INSTALL_PREFIX})
         endif ()
-    endforeach ()
 
-    if (sentry_DIR)
-        message(STATUS "Found libsentry: ${sentry_DIR}/sentry-config.cmake")
-    else ()
-        message(FATAL_ERROR
-                "sentry-config.cmake not found under ${_sentry_base} "
-                "(searched */cmake/sentry). Set SENTRY_NATIVE_LIBDIR to the "
-                "sentry-native staging prefix.")
+        set(sentry_DIR "")
+        foreach (_suffix
+                ${CMAKE_INSTALL_LIBDIR}/cmake/sentry
+                lib/cmake/sentry
+                lib64/cmake/sentry
+                cmake/sentry)
+            if (EXISTS ${_sentry_base}/${_suffix}/sentry-config.cmake)
+                set(sentry_DIR ${_sentry_base}/${_suffix})
+                break ()
+            endif ()
+        endforeach ()
+
+        if (NOT sentry_DIR)
+            message(FATAL_ERROR
+                    "sentry-config.cmake not found via CMAKE_PREFIX_PATH or "
+                    "under ${_sentry_base} (searched */cmake/sentry). Set "
+                    "SENTRY_NATIVE_LIBDIR to the sentry-native staging prefix.")
+        endif ()
+
+        find_package(sentry REQUIRED)
     endif ()
 
+    message(STATUS "Found libsentry: ${sentry_DIR}")
 
+    # crashpad_handler resolution. CRASHPAD_BINARY_DIR is a HOST/build-tree
+    # location, validated here only as a configure-time sanity gate -- it is NOT
+    # the path baked into the binary (see CRASHPAD_RUNTIME_PATH below), so a
+    # cross build may set it to the overlay/build tree (host path) freely.
     if (CRASHPAD_BINARY_DIR)
         if (NOT EXISTS ${CRASHPAD_BINARY_DIR}/crashpad_handler)
             message(FATAL_ERROR "${CRASHPAD_BINARY_DIR}/crashpad_handler does not exist")
-        else ()
-            message(STATUS "Using crashpad_handler at specified directory: ${CRASHPAD_BINARY_DIR}")
         endif ()
+        message(STATUS "Using crashpad_handler at specified directory: ${CRASHPAD_BINARY_DIR}")
+    elseif (CMAKE_CROSSCOMPILING)
+        # Cross build: crashpad_handler is packaged onto the target rootfs by the
+        # cross tooling, not consumed here, so there is no host binary to check.
+        message(STATUS "Cross build: crashpad_handler expected on target")
+    elseif (EXISTS ${CMAKE_INSTALL_PREFIX}/bin/crashpad_handler)
+        message(STATUS "Defaulting to system crashpad_handler at ${CMAKE_INSTALL_PREFIX}")
+        set(CRASHPAD_BINARY_DIR ${CMAKE_INSTALL_PREFIX}/bin)
     else ()
-        if (EXISTS ${CMAKE_INSTALL_PREFIX}/bin/crashpad_handler)
-            message(STATUS "Defaulting to system crashpad_handler at ${CMAKE_INSTALL_PREFIX}")
-            set(CRASHPAD_BINARY_DIR ${CMAKE_INSTALL_PREFIX}/bin)
+        message(FATAL_ERROR "System crashpad_handler not found at ${CMAKE_INSTALL_PREFIX}, please set CRASHPAD_BINARY_DIR")
+    endif ()
+
+    # Absolute path to crashpad_handler on the DEPLOYED target -- this is what is
+    # baked into the binary and handed to sentry at runtime. For a native build
+    # it is the resolved host location; for a cross/staged build it is the
+    # on-target install path (the cross tooling packages the handler there).
+    # Override with -DCRASHPAD_RUNTIME_PATH=... when the target differs.
+    if (NOT DEFINED CRASHPAD_RUNTIME_PATH OR CRASHPAD_RUNTIME_PATH STREQUAL "")
+        if (CMAKE_CROSSCOMPILING)
+            set(CRASHPAD_RUNTIME_PATH "/usr/bin/crashpad_handler")
         else ()
-            message(FATAL_ERROR "System crashpad_handler not found at ${CMAKE_INSTALL_PREFIX}, please set CRASHPAD_BINARY_DIR")
-        endif()
-    endif()
-    
-    find_package(sentry REQUIRED)
+            set(CRASHPAD_RUNTIME_PATH "${CRASHPAD_BINARY_DIR}/crashpad_handler")
+        endif ()
+    endif ()
+    set(CRASHPAD_RUNTIME_PATH "${CRASHPAD_RUNTIME_PATH}" CACHE STRING
+            "Absolute path to crashpad_handler on the deployed target" FORCE)
+    message(STATUS "Crashpad handler runtime path: ${CRASHPAD_RUNTIME_PATH}")
     string(TIMESTAMP BUILD_VER "%y%m%d")
 else()
     message(STATUS "Crash Handler .......... Disabled")

--- a/shell/crash_handler.cc
+++ b/shell/crash_handler.cc
@@ -105,7 +105,18 @@ CrashHandler::CrashHandler(const std::string& config_path) {
   auto home_path = Utils::GetConfigHomePath();
   std::filesystem::path db_path = home_path;
   db_path /= ".sentry";
-  sentry_options_set_handler_path(options, kCrashpadBinaryPath);
+  // kCrashpadBinaryPath is where the handler is expected on the deployed
+  // target. If it is missing (relocated install, side-by-side tarball), leave
+  // the handler path unset so sentry-native searches next to the executable
+  // rather than failing outright.
+  if (std::filesystem::exists(kCrashpadBinaryPath)) {
+    sentry_options_set_handler_path(options, kCrashpadBinaryPath);
+  } else {
+    ihs::log::warn(
+        "crashpad_handler not found at {}, letting sentry locate it next to "
+        "the executable",
+        kCrashpadBinaryPath);
+  }
   sentry_options_set_database_path(options, db_path.c_str());
 
   sentry_options_set_release(options, config_.release.c_str());


### PR DESCRIPTION
Makes the optional crash handler (sentry-native + crashpad) build, link, and ship correctly when cross-compiled and installed onto a target, not only in a native build. Declares it once for every target via `.emb/base.emb.yaml`, gated on `BUILD_CRASH_HANDLER` (off by default).

Based on `jw/s4-spdlog-retire` (uses `ihs::log`, not spdlog).

## Changes

- **options.cmake** — resolve sentry via `find_package(sentry CONFIG)` first (honors `CMAKE_PREFIX_PATH` / an emb augment overlay), falling back to the explicit `SENTRY_NATIVE_LIBDIR` search so a pinned prefix still wins. Split the host-only `CRASHPAD_BINARY_DIR` (a configure-time sanity check) from a new `CRASHPAD_RUNTIME_PATH` — the on-target handler path baked into the binary (`/usr/bin/crashpad_handler` when cross-compiling) — so a cross build no longer bakes a host path into the target binary.
- **config_common.h.in** — bake `CRASHPAD_RUNTIME_PATH` into `kCrashpadBinaryPath`.
- **crash_handler.cc** — when the baked handler path is missing at runtime, leave it unset so sentry-native locates `crashpad_handler` next to the executable (relocated / side-by-side installs).
- **.emb/base.emb.yaml** — the `sentry-native` augment and the `crashpad_handler` package file, both gated on `BUILD_CRASH_HANDLER`. Every target inherits them; no per-board duplication.

## Validation

Cross-built `rpi5-trixie` (aarch64) and installed the `.deb` on a Raspberry Pi 5:

- `--define BUILD_CRASH_HANDLER=ON` → sentry-native built from the base augment, `/usr/bin/crashpad_handler` shipped and runs on the device, `libcurl4t64` auto-derived into `Depends`.
- default (no define) → no sentry build, no `crashpad_handler`, no libcurl dep.

## Dependency

The base-manifest inheritance relies on emb_cli #111 (union `augment` across layers). Enabling the crash handler builds nothing until that lands; with the handler off (the default) this is inert, so CI is unaffected.