### PR TITLE
drm: remove the USE_DRM_SCENE opt-out; scene path is always compiled

### DIFF
--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -33,9 +33,6 @@
 #ifndef BUILD_BACKEND_DRM_KMS_EGL
 #cmakedefine01 BUILD_BACKEND_DRM_KMS_EGL
 #endif
-#ifndef USE_DRM_SCENE
-#cmakedefine01 USE_DRM_SCENE
-#endif
 #ifndef BUILD_BACKEND_DRM_KMS_VULKAN
 #cmakedefine01 BUILD_BACKEND_DRM_KMS_VULKAN
 #endif

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -122,22 +122,6 @@ option(BUILD_DRM_KMS_VULKAN_PROBE
         "Build the standalone drm_kms_vulkan zero-copy capability probe"
         OFF)
 
-# Drive the non-framed DRM/KMS present path through drm::scene::LayerScene
-# rather than the in-tree PlaneRegistry + Allocator + AtomicRequest pipeline.
-# Scoped to the DRM backends: the option only exists (and defaults ON) when a
-# DRM backend is built — it is the same path the Vulkan DRM backend always
-# uses. Set OFF to fall back to the in-tree pipeline, which is slated for
-# removal. The framed-mode path is unaffected by this flag. A non-DRM build
-# (wayland / software only) never sees the option: USE_DRM_SCENE is forced OFF
-# so config_common.h's #cmakedefine01 resolves and nothing else is impacted.
-if (BUILD_BACKEND_DRM_KMS_EGL OR BUILD_BACKEND_DRM_KMS_VULKAN)
-    option(USE_DRM_SCENE
-            "Drive DRM/KMS non-framed present path via drm::scene::LayerScene"
-            ON)
-else ()
-    set(USE_DRM_SCENE OFF)
-endif ()
-
 #
 # Software (CPU rendering; no GPU, no display server)
 #

--- a/scripts/build_beagleplay.sh
+++ b/scripts/build_beagleplay.sh
@@ -661,12 +661,11 @@ phase4_build() {
         wayland-vulkan) cmake_args+=(-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=ON -DBUILD_BACKEND_DRM_KMS_EGL=OFF -DBUILD_BACKEND_SOFTWARE=OFF) ;;
         drm-kms-egl)
             cmake_args+=(-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF -DBUILD_BACKEND_DRM_KMS_EGL=ON -DBUILD_BACKEND_SOFTWARE=OFF)
-            [[ "$WITH_SCENE" -eq 1 ]] && cmake_args+=(-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON) ;;
+            [[ "$WITH_SCENE" -eq 1 ]] && cmake_args+=(-DBUILD_COMPOSITOR=ON) ;;
         drm-kms-vulkan)
             # Flutter Vulkan renderer scanned out zero-copy on KMS planes via
             # dma-buf import. Requires the compositor (the engine presents
-            # through CreateBackingStore/PresentLayers); the LayerScene path is
-            # linked unconditionally, so USE_DRM_SCENE stays off.
+            # through CreateBackingStore/PresentLayers).
             cmake_args+=(-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF -DBUILD_BACKEND_DRM_KMS_EGL=OFF -DBUILD_BACKEND_DRM_KMS_VULKAN=ON -DBUILD_BACKEND_SOFTWARE=OFF -DBUILD_COMPOSITOR=ON) ;;
         software)       cmake_args+=(-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF -DBUILD_BACKEND_DRM_KMS_EGL=OFF -DBUILD_BACKEND_SOFTWARE=ON) ;;
     esac

--- a/scripts/build_nitrogen8mm.sh
+++ b/scripts/build_nitrogen8mm.sh
@@ -52,7 +52,7 @@
 #     --plugins-dir <path>    ivi-homescreen-plugins/plugins (default: ../ivi-homescreen-plugins/plugins)
 #     --no-plugins            build homescreen only
 #     --with-scene            enable the plane compositor + drm-cxx LayerScene
-#                               (BUILD_COMPOSITOR + USE_DRM_SCENE)
+#                               (BUILD_COMPOSITOR)
 #     --display-info-version <v>  libdisplay-info source tag (default: 0.2.0)
 #     --jobs <N>              parallel build jobs (default: nproc)
 #     --clean                 wipe the CMake build dir before configuring
@@ -287,7 +287,7 @@ phase4_build() {
     -DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF
     -DBUILD_BACKEND_DRM_KMS_EGL=ON  -DBUILD_BACKEND_SOFTWARE=OFF
   )
-  [[ "$WITH_SCENE" -eq 1 ]] && args+=(-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON)
+  [[ "$WITH_SCENE" -eq 1 ]] && args+=(-DBUILD_COMPOSITOR=ON)
   if [[ "$NO_PLUGINS" -eq 1 ]]; then
     args+=(-DDISABLE_PLUGINS=ON)
   else

--- a/scripts/build_radxa_zero3.sh
+++ b/scripts/build_radxa_zero3.sh
@@ -916,12 +916,11 @@ phase4_build() {
         wayland-vulkan) cmake_args+=(-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=ON -DBUILD_BACKEND_DRM_KMS_EGL=OFF -DBUILD_BACKEND_SOFTWARE=OFF) ;;
         drm-kms-egl)
             cmake_args+=(-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF -DBUILD_BACKEND_DRM_KMS_EGL=ON -DBUILD_BACKEND_SOFTWARE=OFF)
-            [[ "$WITH_SCENE" -eq 1 ]] && cmake_args+=(-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON) ;;
+            [[ "$WITH_SCENE" -eq 1 ]] && cmake_args+=(-DBUILD_COMPOSITOR=ON) ;;
         drm-kms-vulkan)
             # Flutter Vulkan renderer scanned out zero-copy on KMS planes via
             # dma-buf import. Requires the compositor (the engine presents
-            # through CreateBackingStore/PresentLayers); the LayerScene path is
-            # linked unconditionally, so USE_DRM_SCENE stays off.
+            # through CreateBackingStore/PresentLayers).
             cmake_args+=(-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF -DBUILD_BACKEND_DRM_KMS_EGL=OFF -DBUILD_BACKEND_DRM_KMS_VULKAN=ON -DBUILD_BACKEND_SOFTWARE=OFF -DBUILD_COMPOSITOR=ON) ;;
         software)       cmake_args+=(-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF -DBUILD_BACKEND_DRM_KMS_EGL=OFF -DBUILD_BACKEND_SOFTWARE=ON) ;;
     esac

--- a/scripts/build_unoq.sh
+++ b/scripts/build_unoq.sh
@@ -62,7 +62,7 @@
 #                                   support); independent of the chosen backend
 #     --with-scene                  drm-kms-egl only: enable the plane compositor +
 #                                     drm-cxx LayerScene present path
-#                                     (BUILD_COMPOSITOR + USE_DRM_SCENE).
+#                                     (BUILD_COMPOSITOR).
 #     --jobs <N>                    default: nproc
 #     --clean                       wipe build dir before configure
 #     --prepare-only                fetch/extract toolchain, sync sysroot, engine, exit
@@ -905,7 +905,7 @@ phase5_build() {
                 -DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=OFF
                 -DBUILD_BACKEND_DRM_KMS_EGL=ON  -DBUILD_BACKEND_SOFTWARE=OFF)
             if [[ "$WITH_SCENE" -eq 1 ]]; then
-                cmake_args+=(-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON)
+                cmake_args+=(-DBUILD_COMPOSITOR=ON)
             fi ;;
         drm-kms-vulkan)
             cmake_args+=(

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -227,18 +227,14 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
                 backend/wayland_egl/gl_caps.cc
                 backend/wayland_egl/gl_compositor.cc
         )
-        # LayerScene-driven non-framed present path. Sources compile only
-        # when USE_DRM_SCENE=ON; the OFF build keeps the in-tree allocator
-        # path and never references drm::scene symbols. scene_layer_source_vk
-        # is built dormant: it provides the interface for an Impeller-on-Linux
+        # LayerScene-driven non-framed present path. scene_layer_source_vk is
+        # built dormant: it provides the interface for an Impeller-on-Linux
         # backing-store wrapper that lights up once the Vulkan renderer config
         # is wired through; nothing references it at runtime today.
-        if (USE_DRM_SCENE)
-            target_sources(${PROJECT_NAME} PRIVATE
-                    backend/drm_kms_egl/scene_layer_source_gl.cc
-                    backend/drm_kms_egl/scene_layer_source_vk.cc
-            )
-        endif ()
+        target_sources(${PROJECT_NAME} PRIVATE
+                backend/drm_kms_egl/scene_layer_source_gl.cc
+                backend/drm_kms_egl/scene_layer_source_vk.cc
+        )
     endif ()
     target_link_libraries(${PROJECT_NAME} PRIVATE
             drm-cxx::drm-cxx

--- a/shell/backend/drm_kms_egl/README.md
+++ b/shell/backend/drm_kms_egl/README.md
@@ -220,23 +220,21 @@ what was compiled in):
 | Config | CMake flags | Present path compiled in |
 |--------|-------------|--------------------------|
 | **C1** | `-DBUILD_COMPOSITOR=OFF` | Legacy GL only — `eglSwapBuffers` + `drmModePageFlip`. `drm_compositor.cc` is excluded. |
-| **C2** | `-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=OFF` | Atomic plane allocator + GL composite. The drm-cxx `LayerScene` zero-copy path is excluded. |
-| **C3** | `-DBUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON` | Full path: `LayerScene` direct-scanout when the primary supports `REFLECT_Y`, GL composite otherwise. **Recommended / canonical.** |
+| **C2** | `-DBUILD_COMPOSITOR=ON` | Full path: `LayerScene` direct-scanout when the primary supports `REFLECT_Y`, GL composite otherwise. **Recommended / canonical.** |
 
-`USE_DRM_SCENE=ON` requires `BUILD_COMPOSITOR=ON` (it has no effect
-otherwise). Any code reachable from the unconditional `BUILD_COMPOSITOR`
-API (e.g. `DrmCompositor::ReserveCursorPlane`) must compile in **all**
-three configs — C2 in particular (compositor without scene) is an easy
-one to break, so the build matrix is exercised on both x86_64 and
-aarch64.
+`BUILD_COMPOSITOR=ON` compiles `DrmCompositor` together with the drm-cxx
+`LayerScene` present path; the GL composite runs as a runtime fallback
+where no plane supports `REFLECT_Y` (or a frame overflows the backing
+store / carries a platform view). The build matrix exercises both C1 and
+C2 on x86_64 and aarch64.
 
 The aarch64 cross-build maps these as: emb's `drm-kms-egl` backend → **C1**
-(default direct DRM/KMS + GBM); adding `USE_DRM_SCENE=ON` (with
-`BUILD_COMPOSITOR=ON`) to that backend's `defines` → **C3**.
+(default direct DRM/KMS + GBM); adding `BUILD_COMPOSITOR=ON` to that
+backend's `defines` → **C2**.
 
 Per-driver note: on **rockchip** (rk3588 VOP2) the primary advertises
 `REFLECT_Y` and passes a `TEST_ONLY` atomic commit with it, but a live
-reflected scanout faults the display IOMMU; C3 therefore force-selects
+reflected scanout faults the display IOMMU; C2 therefore force-selects
 the GL-composite sub-path on that driver (zero-copy direct-scanout is
 not usable there). vc4 and amdgpu are unaffected.
 

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -43,10 +43,8 @@
 #include "backend/drm_kms_egl/driver_probe.h"
 #include "backend/drm_kms_egl/drm_backend.h"
 #include "backend/drm_kms_egl/drm_cursor.h"
-#include "display/drm_display.h"
-#if USE_DRM_SCENE
 #include "backend/drm_kms_egl/scene_layer_source_gl.h"
-#endif
+#include "display/drm_display.h"
 #include "drm-cxx/src/modeset/atomic.hpp"
 #include "libflutter_engine.h"
 #include "logging.h"
@@ -449,7 +447,6 @@ bool DrmCompositor::InitPlaneAllocator() {
     return false;
   }
 
-#if USE_DRM_SCENE
   // The LayerScene drives the non-framed present path, but it only pays
   // off where the bottom-up GL backing store can reach scanout — i.e.
   // some plane supports REFLECT_Y. On hardware where NO plane does
@@ -496,7 +493,6 @@ bool DrmCompositor::InitPlaneAllocator() {
         "[DrmCompositor] no plane supports REFLECT_Y; using GL-composite "
         "path (scene direct-scanout needs the flip)");
   }
-#endif
 
   return true;
 }
@@ -1719,7 +1715,6 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
     return PresentFramed(layers, layer_count);
   }
 
-#if USE_DRM_SCENE
   // Zero-copy direct-overlay path (primary lacks REFLECT_Y): BG on the
   // primary, the single Flutter BS direct-scanned on a REFLECT_Y
   // overlay. Owns its own GL-fallback decision for multi-layer / PV
@@ -1728,8 +1723,8 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
     return PresentDirectOverlay(layers, layer_count);
   }
 
-  // Non-framed path under USE_DRM_SCENE: route every frame through
-  // LayerScene. PresentLayersViaScene owns the fallback decision —
+  // Non-framed path: route every frame through the LayerScene.
+  // PresentLayersViaScene owns the fallback decision —
   // returns true on a successful scene commit, false (after invoking
   // PresentViaGlFallback itself) when any layer would be Composited
   // (BS overflow), when the frame contains a platform view (not yet
@@ -1739,7 +1734,6 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
   if (scene_) {
     return PresentLayersViaScene(layers, layer_count);
   }
-#endif
 
   // Profile fence post t0 (entry). Same wait/compose/commit/total
   // breakdown as PresentFramed; logs every kProfileWindow frames when
@@ -2284,7 +2278,6 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
   return true;
 }
 
-#if USE_DRM_SCENE
 // ─── LayerScene-driven non-framed present path ───────────────────────────
 
 bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
@@ -3050,7 +3043,6 @@ bool DrmCompositor::PresentDirectOverlay(const FlutterLayer** layers,
   }
   return true;
 }
-#endif  // USE_DRM_SCENE
 
 // ─── Backing store create / collect ──────────────────────────────────────
 
@@ -3103,17 +3095,14 @@ bool DrmCompositor::CreateBackingStore(const FlutterBackingStoreConfig* config,
   auto* baton = new StoreBaton{};
   baton->owner = this;
   baton->store = store.get();
-#if USE_DRM_SCENE
   // Pre-build the LayerBufferSource wrapper for the LayerScene path.
-  // It stays in the baton until the first PresentLayers under
-  // USE_DRM_SCENE moves it into scene_->add_layer(). If the store
-  // retires (CollectBackingStore) before any Present, the wrapper is
-  // freed with the baton.
+  // It stays in the baton until the first PresentLayers moves it into
+  // scene_->add_layer(). If the store retires (CollectBackingStore)
+  // before any Present, the wrapper is freed with the baton.
   if (scene_) {
     baton->scene_source = std::make_unique<GbmBackingStoreLayerSource>(
         store.get(), [this](GbmBackingStore& s) { return EnsureDrmFbId(s); });
   }
-#endif
 
   out->struct_size = sizeof(FlutterBackingStore);
   out->type = kFlutterBackingStoreTypeOpenGL;
@@ -3153,7 +3142,6 @@ bool DrmCompositor::CollectBackingStore(const FlutterBackingStore* store) {
   if (!baton) {
     return false;
   }
-#if USE_DRM_SCENE
   // If the store appeared in a Present this generation, the LayerScene
   // owns a Layer with identity_tag == baton. Drop it before the baton
   // disappears so the scene doesn't leave a stale layer referring to
@@ -3163,7 +3151,6 @@ bool DrmCompositor::CollectBackingStore(const FlutterBackingStore* store) {
       scene_->remove_layer(layer->handle());
     }
   }
-#endif
   if (const auto it = stores_.find(baton); it != stores_.end()) {
     // Return the store to the pool instead of destroying it. Keeps the
     // GBM BO + EGLImage + GL FBO/tex/RB and (if already imported) the
@@ -3191,7 +3178,6 @@ void DrmCompositor::ReserveCursorPlane(const uint32_t plane_id) {
 }
 
 void DrmCompositor::ApplyCursorReservation() {
-#if USE_DRM_SCENE
   if (!scene_ || cursor_reserved_plane_ == 0) {
     return;
   }
@@ -3201,12 +3187,10 @@ void DrmCompositor::ApplyCursorReservation() {
       "[DrmCompositor] reserved cursor plane {} from scene allocator "
       "(disable-unused pass will leave it alone)",
       cursor_reserved_plane_);
-#endif
 }
 
 void DrmCompositor::SetPaused(const bool paused) {
   paused_.store(paused, std::memory_order_release);
-#if USE_DRM_SCENE
   // Mirror the pause edge into the scene so its layer sources can
   // drop fd-bound state before the kernel revokes master. Idempotent
   // and infallible per the LayerBufferSource::on_session_paused
@@ -3214,7 +3198,6 @@ void DrmCompositor::SetPaused(const bool paused) {
   if (paused && scene_) {
     scene_->on_session_paused();
   }
-#endif
   ihs::log::info("[DrmCompositor] session {}", paused ? "paused" : "resumed");
 }
 
@@ -3229,7 +3212,6 @@ void DrmCompositor::OnResume() {
   paused_.store(false, std::memory_order_release);
   resume_pending_logged_ = false;
 
-#if USE_DRM_SCENE
   // Rebuild the scene's per-fd kernel state (plane registry, property
   // caches, GEM/FB handles). DrmSession::TakeDevice opts in to
   // preserve_fd_across_resume, so backend_->device() wraps the same
@@ -3242,7 +3224,6 @@ void DrmCompositor::OnResume() {
                       r.error().message());
     }
   }
-#endif
 
   // Drain the BS-slot release pipeline — any flip events that would
   // have freed slots queued before pause never fired. Promote

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -42,9 +42,7 @@
 
 #include "config/common.h"
 
-#if USE_DRM_SCENE
 #include <drm-cxx/scene/layer_scene.hpp>
-#endif
 
 #include "backend/drm_kms_egl/drm_output_context.h"
 #include "backend/drm_kms_egl/flip_sink.h"
@@ -214,15 +212,13 @@ class DrmCompositor : public IFlipSink {
   struct StoreBaton {
     DrmCompositor* owner;
     GbmBackingStore* store;
-#if USE_DRM_SCENE
     // Borrowed LayerBufferSource adapter — owned by the LayerScene
     // once add_layer() consumes it; nullptr after that. CreateBackingStore
-    // constructs it; PresentLayers (under USE_DRM_SCENE) moves it into
-    // the scene the first time the store appears in a FlutterLayer.
+    // constructs it; PresentLayers moves it into the scene the first
+    // time the store appears in a FlutterLayer.
     // CollectBackingStore destroys the wrapper if it never reached the
     // scene (e.g. the store retired before its first Present).
     std::unique_ptr<GbmBackingStoreLayerSource> scene_source;
-#endif
   };
 
   bool InitEglExtensions();
@@ -320,7 +316,6 @@ class DrmCompositor : public IFlipSink {
   // rejects that anyway.
   bool PresentFramed(const FlutterLayer** layers, size_t count);
 
-#if USE_DRM_SCENE
   // Non-framed present path driven by drm::scene::LayerScene. Walks
   // FlutterLayer[], syncs the scene's layer membership against it via
   // find_by_identity_tag / add_layer / remove_layer keyed on the
@@ -362,7 +357,6 @@ class DrmCompositor : public IFlipSink {
   // any frame that isn't exactly one backing-store layer (multi-layer /
   // platform-view frames are a follow-on).
   bool PresentDirectOverlay(const FlutterLayer** layers, size_t count);
-#endif
 
   DrmBackend* backend_;
 
@@ -438,7 +432,6 @@ class DrmCompositor : public IFlipSink {
   // blob for atomic modesets. attach()-ed to the first commit.
   std::optional<drm::modeset::Modeset> modeset_;
 
-#if USE_DRM_SCENE
   // LayerScene-driven non-framed present path. Constructed in
   // InitPlaneAllocator when !framed_; null in framed mode (the
   // primary-BG + overlay layout keeps the manual atomic path).
@@ -457,15 +450,13 @@ class DrmCompositor : public IFlipSink {
   // capacity in steady state; std::vector + linear scan is faster
   // than any hashing for that size.
   std::vector<StoreBaton*> scene_layer_batons_;
-#endif
 
   // DRM plane id of an externally-managed cursor to reserve from the
   // scene allocator's disable-unused pass. Set by ReserveCursorPlane()
   // (from DrmBackend, once the cursor exists); applied to scene_ each
-  // time the scene is built. 0 = none / legacy cursor path. Declared
-  // unconditionally (ReserveCursorPlane is part of the BUILD_COMPOSITOR
-  // API regardless of USE_DRM_SCENE); ApplyCursorReservation's body is
-  // a no-op when USE_DRM_SCENE is off (no scene to reserve from).
+  // time the scene is built. 0 = none / legacy cursor path.
+  // ApplyCursorReservation is a no-op when scene_ is null (the
+  // GL-composite fallback has no scene to reserve from).
   uint32_t cursor_reserved_plane_{0};
   void ApplyCursorReservation();
 

--- a/shell/backend/drm_kms_egl/drm_cursor.h
+++ b/shell/backend/drm_kms_egl/drm_cursor.h
@@ -131,8 +131,8 @@ class DrmCursor final : public ICursorShapeSink {
   [[nodiscard]] bool Stage(drm::AtomicRequest& req, bool* needs_modeset);
 
   // Self-commit the recorded position. Used by present paths that own
-  // their commit and can't accept a staged plane (the USE_DRM_SCENE
-  // LayerScene path) so the cursor stays visible in staged mode. No-op
+  // their commit and can't accept a staged plane (the LayerScene
+  // path) so the cursor stays visible in staged mode. No-op
   // outside staged mode or before the first SetPosition. Raster-thread
   // only. NOTE: this is a separate cursor commit on the CRTC and so
   // reintroduces the flip contention on nvidia-drm — a proper fix needs

--- a/shell/backend/drm_kms_egl/scene_layer_source_vk.h
+++ b/shell/backend/drm_kms_egl/scene_layer_source_vk.h
@@ -42,7 +42,7 @@ class Device;
 // plus a VkExternalMemoryImageCreateInfo on image creation) lives in the
 // caller — this wrapper takes the already-exported (fd, format, modifier,
 // plane layout) tuple. That keeps the wrapper free of Vulkan headers and
-// keeps USE_DRM_SCENE off the BUILD_BACKEND_VULKAN dependency graph.
+// keeps the LayerScene sources off the BUILD_BACKEND_VULKAN dependency graph.
 //
 // Sync is an OPEN QUESTION, not a solved one. FlutterVulkanImage carries
 // only {image, format} — the embedder exposes no per-backing-store


### PR DESCRIPTION
## Summary

The drm-cxx `LayerScene` present path is now always compiled with `BUILD_COMPOSITOR`. This removes the `USE_DRM_SCENE` build option and its `#if` guards — the in-tree opt-out (atomic plane allocator + GL composite, no scene) is gone.

The old build matrix had three DRM/KMS-EGL configs:

| | Config | Fate |
|---|---|---|
| C1 | `BUILD_COMPOSITOR=OFF` | kept (legacy GL only) |
| C2 | `BUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=OFF` | **removed** |
| C3 | `BUILD_COMPOSITOR=ON -DUSE_DRM_SCENE=ON` | now just `BUILD_COMPOSITOR=ON` |

## Why this is safe

The `#if USE_DRM_SCENE` blocks are purely *additive* — there is no `#else` and no `#if !USE_DRM_SCENE` anywhere. The scene code early-returns (`if (scene_) return PresentLayersViaScene(...)`), and the GL-composite code below the guard is a **runtime** fallback, not the OFF branch. It still runs where:

- no plane supports `REFLECT_Y` (e.g. amdgpu DC),
- a frame overflows the backing store, or
- a frame carries a platform view.

So only the *compile-time* ability to disable the scene path is removed; no display path loses coverage.

## Changes

- `cmake/options.cmake`, `cmake/config_common.h.in` — drop the option + `#cmakedefine01`
- `shell/CMakeLists.txt` — `scene_layer_source_{gl,vk}.cc` now compiled unconditionally (still under the DRM `BUILD_COMPOSITOR` gate)
- `shell/backend/drm_kms_egl/drm_compositor.{cc,h}` — strip 13 `#if USE_DRM_SCENE` guards; comment cleanup
- `drm_cursor.h`, `scene_layer_source_vk.h` — comment cleanup
- `scripts/build_{beagleplay,radxa_zero3,unoq,nitrogen8mm}.sh` — `--with-scene` maps to `BUILD_COMPOSITOR=ON` (dead `-DUSE_DRM_SCENE=ON` dropped)
- `shell/backend/drm_kms_egl/README.md` — matrix collapsed to two configs

Net **+37 / −92**.

## Testing

**Static / build**
- `homescreen` builds green (all render backends, x86_64 / clang-18)
- clang-tidy-19 on `drm_compositor.cc` (`--warnings-as-errors='*'`) — clean
- clang-format-19 — clean; `bash -n` on all edited scripts — valid
- Full-repo sweep confirms zero `USE_DRM_SCENE` references remain

**Runtime — flutter-wonderous-app**

| Scenario | Result |
|---|---|
| Host x86_64 — `wayland-egl` | ✅ engine runs, app boots, renders, 0 errors/fatals |
| Host x86_64 — `wayland-vulkan` | ✅ Vulkan swapchain + engine runs, app boots, 0 errors/fatals |
| **RPi4 (vc4) — `drm-kms-egl` + `BUILD_COMPOSITOR=ON`** | ✅ **the changed path** — see below |

The **RPi4 run is the direct exercise of this change**: cross-built from this branch with `-D BUILD_COMPOSITOR=ON`, deployed, and run on hardware. The now-unconditional scene path came up exactly as the old `USE_DRM_SCENE=ON` build did:

- `[DrmCompositor] direct-scanout REFLECT_Y available: yes`
- `[DrmCompositor] REFLECT_Y probe: primary 91 accepts REFLECT_Y (direct scanout on primary OK)`
- `[DrmCompositor] LayerScene constructed (crtc=102 connector=35)`
- `[DrmCompositor] LayerScene commit: total=1 assigned=1 composited=0` — the Flutter backing store is **direct-scanned out zero-copy** (assigned to a plane, no GL composition), sustained across ~218 frames
- `[E]=0, [F]=0` — no errors/fatals; clean steady-state run