### PR TITLE
DRM backends: measure motion-to-photon (egl + software)

### DIFF
--- a/shell/backend/backend.h
+++ b/shell/backend/backend.h
@@ -20,6 +20,7 @@
 
 #include "config/common.h"
 #include "configuration/configuration.h"
+#include "profiling/motion_to_photon.h"
 
 #include <flutter_texture_registrar.h>
 #include <shell/platform/embedder/embedder.h>
@@ -227,4 +228,28 @@ class Backend {
                                        int32_t /*width*/,
                                        int32_t /*height*/) {}
 #endif
+
+  /**
+   * @brief The motion-to-photon profiler for this backend, or nullptr when it
+   * is not profiling.
+   *
+   * The DRM/KMS backends own an instance and opt in via InitMotionToPhoton()
+   * (enabled by IVI_M2P_PROFILE); they feed RecordPresent from the page-flip
+   * path and the input seat feeds RecordInput, both marshaled onto the platform
+   * task runner. The Wayland backends never opt in — their profiler lives on
+   * Display — so this returns nullptr for them.
+   */
+  [[nodiscard]] profiling::MotionToPhoton* GetMotionToPhoton() {
+    return m2p_enabled_ ? &m2p_ : nullptr;
+  }
+
+ protected:
+  /// Enable the motion-to-photon profiler for this backend if IVI_M2P_PROFILE
+  /// is set. Called from the DRM/KMS backend constructors.
+  void InitMotionToPhoton() {
+    m2p_enabled_ = profiling::MotionToPhoton::Enabled();
+  }
+
+  profiling::MotionToPhoton m2p_;
+  bool m2p_enabled_ = false;
 };

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -361,6 +361,9 @@ DrmBackend::DrmBackend(DrmConfig cfg, homescreen::DrmSession* session)
   // RecordFlipComplete(). Enabled() also honors the umbrella IVI_PROFILE.
   vsync_.EnableProfile(profiling::FrameProfile::Enabled("IVI_VSYNC_PROFILE"),
                        "DrmVsync");
+  // Motion-to-photon (IVI_M2P_PROFILE): the flip path feeds RecordPresent and
+  // DrmSeat feeds RecordInput, both marshaled onto the platform task runner.
+  InitMotionToPhoton();
 }
 
 homescreen::ICursorPositionSink* DrmBackend::gl_cursor() const {
@@ -1331,6 +1334,13 @@ void DrmBackend::DeliverVsyncFromFlip(const unsigned int tv_sec,
   // uniformity; the one extra task hop is harmless.
   const uint64_t tv_ns = static_cast<uint64_t>(tv_sec) * 1'000'000'000ULL +
                          static_cast<uint64_t>(tv_usec) * 1000ULL;
+  // Record the scanout endpoint for motion-to-photon before returning the
+  // baton. The cutoff is the frame_start of the most recent baton — the input
+  // cutoff of the frame this flip presents. Marshaled onto the platform runner
+  // so it shares a thread with DrmSeat's RecordInput.
+  profiling::MarshalRecordPresent(
+      platform_task_runner_.load(std::memory_order_acquire),
+      GetMotionToPhoton(), tv_ns, vsync_.LastDeliveredFrameStartNs(), "drm");
   vsync_.DeliverVsync(tv_ns);
 }
 
@@ -1360,6 +1370,12 @@ void DrmBackend::StopVsyncMonitor() {
   // session summary. Any page-flip event the reader drains after this finds the
   // provider cleared and no-ops its DeliverVsync — correct, we're tearing down.
   vsync_.Stop();
+
+  // Motion-to-photon session summary. Runs on the platform thread, the same
+  // thread the marshaled RecordInput/RecordPresent tasks execute on.
+  if (m2p_enabled_) {
+    m2p_.LogSessionSummary("drm");
+  }
 
   // Wait for any in-flight PAGE_FLIP_EVENT to be drained by the card's flip
   // reader (owned by DrmDisplay, still running through our teardown) so

--- a/shell/backend/software/drm_dumb_sink.cc
+++ b/shell/backend/software/drm_dumb_sink.cc
@@ -41,6 +41,7 @@
 #include "backend/software/software_cursor.h"
 #include "libflutter_engine.h"
 #include "logging.h"
+#include "profiling/motion_to_photon.h"
 #include "task_runner.h"
 
 namespace {
@@ -700,6 +701,13 @@ void DrmDumbSink::OnPageFlip(const uint64_t tv_ns) {
   // dtor per the lifetime contract).
   flip_pending_.store(false, std::memory_order_release);
   vsync_.SetSourcePending(false);
+  // Record the scanout endpoint for motion-to-photon. Already on the platform
+  // runner thread here, but route through the strand for one uniform contract
+  // with the seat's RecordInput (MarshalRecordPresent no-ops when m2p_ is
+  // null).
+  profiling::MarshalRecordPresent(
+      platform_task_runner_.load(std::memory_order_acquire), m2p_, tv_ns,
+      vsync_.LastDeliveredFrameStartNs(), "sw");
   // Hand the parked baton back with the kernel-provided scanout timestamp.
   vsync_.DeliverVsync(tv_ns);
 }

--- a/shell/backend/software/drm_dumb_sink.h
+++ b/shell/backend/software/drm_dumb_sink.h
@@ -92,6 +92,9 @@ class DrmDumbSink final : public ISurfaceSink {
   void SetEngineHandle(void* engine) override;
   void SetPlatformTaskRunner(TaskRunner* runner) override;
   void StopVsyncMonitor() override;
+  void SetMotionToPhoton(profiling::MotionToPhoton* m2p) override {
+    m2p_ = m2p;
+  }
 
   // For the SoftwareDisplay constructor, so it can report the actual
   // mode's refresh rate rather than a guessed default.
@@ -183,6 +186,11 @@ class DrmDumbSink final : public ISurfaceSink {
   ivi::IVsyncProvider vsync_;
   std::atomic<void*> engine_handle_{nullptr};
   std::atomic<TaskRunner*> platform_task_runner_{nullptr};
+
+  // Motion-to-photon profiler owned by SoftwareBackend, or nullptr when not
+  // profiling. Set via SetMotionToPhoton; read on the platform-runner thread
+  // (OnPageFlip) to record the scanout endpoint.
+  profiling::MotionToPhoton* m2p_{nullptr};
   // Refresh period as nanoseconds; computed once from the picked mode.
   std::atomic<uint64_t> refresh_period_ns_{16'666'667};
 

--- a/shell/backend/software/input/software_seat.cc
+++ b/shell/backend/software/input/software_seat.cc
@@ -16,6 +16,7 @@
 
 #include "backend/software/input/software_seat.h"
 
+#include "backend/backend.h"
 #include "backend/software/input/libinput_log_bridge.h"
 #include "config/common.h"
 #include "logging/logging.h"
@@ -712,6 +713,9 @@ SoftwareSeat::EngineRef SoftwareSeat::CurrentEngine() const {
   EngineRef out;
   out.engine = static_cast<void*>(s->engine->GetFlutterEngine());
   out.platform_runner = static_cast<void*>(s->engine->GetPlatformTaskRunner());
+  if (auto* backend = s->engine->GetBackend(); backend != nullptr) {
+    out.m2p = static_cast<void*>(backend->GetMotionToPhoton());
+  }
   return out;
 }
 
@@ -731,8 +735,17 @@ void SoftwareSeat::DispatchPointerEvents(const FlutterPointerEvent* pe,
     return;
   }
   auto* engine = static_cast<FLUTTER_API_SYMBOL(FlutterEngine)>(ref.engine);
+  // Motion-to-photon input endpoint (IVI_M2P_PROFILE): the batch shares one
+  // engine-clock timestamp; record it on the strand so it joins the sink's
+  // flip-path RecordPresent on the same thread. Null unless profiling.
+  auto* m2p = static_cast<profiling::MotionToPhoton*>(ref.m2p);
+  const uint64_t input_us = count > 0 ? pe[count - 1].timestamp : 0;
   std::vector<FlutterPointerEvent> events(pe, pe + count);
-  asio::dispatch(*strand, [engine, events = std::move(events)]() {
+  asio::dispatch(*strand, [engine, events = std::move(events), m2p,
+                           input_us]() {
+    if (m2p != nullptr && input_us != 0) {
+      m2p->RecordInput(input_us * 1000ULL);
+    }
     LibFlutterEngine->SendPointerEvent(engine, events.data(), events.size());
   });
 }

--- a/shell/backend/software/input/software_seat.h
+++ b/shell/backend/software/input/software_seat.h
@@ -119,6 +119,8 @@ class SoftwareSeat final : public ISeat {
   struct EngineRef {
     void* engine{nullptr};           // FlutterEngine
     void* platform_runner{nullptr};  // TaskRunner
+    void* m2p{nullptr};              // profiling::MotionToPhoton (null unless
+                                     // IVI_M2P_PROFILE)
   };
   [[nodiscard]] EngineRef CurrentEngine() const;
 

--- a/shell/backend/software/sink_factory.cc
+++ b/shell/backend/software/sink_factory.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/software/sink_factory.h"
+#include "config/common.h"  // BUILD_SOFTWARE_SINK_DRM / _FBDEV gates below
 #include "logging/logging.h"
 
 #include <cstdlib>

--- a/shell/backend/software/software_backend.cc
+++ b/shell/backend/software/software_backend.cc
@@ -35,7 +35,12 @@ SoftwareBackend::SoftwareBackend(const uint32_t initial_width,
       width_(initial_width),
       height_(initial_height),
       sink_(std::move(sink)) {
+  // Motion-to-photon (IVI_M2P_PROFILE): the sink's page-flip path feeds
+  // RecordPresent and SoftwareSeat feeds RecordInput, both on the platform
+  // task runner. Hand the profiler to the sink so it can record scanout.
+  InitMotionToPhoton();
   if (sink_) {
+    sink_->SetMotionToPhoton(GetMotionToPhoton());
     // Adopt the sink's native extent (the DRM mode / fbdev virtual size) so
     // Flutter renders at the panel's resolution — the frame fills and centers,
     // and the seat/cursor share the framebuffer coordinate space — instead of

--- a/shell/backend/software/software_backend.h
+++ b/shell/backend/software/software_backend.h
@@ -96,6 +96,11 @@ class SoftwareBackend final : public Backend {
     if (sink_) {
       sink_->StopVsyncMonitor();
     }
+    // Motion-to-photon session summary, on the platform thread — the same
+    // thread the marshaled RecordInput/RecordPresent tasks execute on.
+    if (m2p_enabled_) {
+      m2p_.LogSessionSummary("sw");
+    }
   }
 
  private:

--- a/shell/backend/software/surface_sink.h
+++ b/shell/backend/software/surface_sink.h
@@ -26,6 +26,10 @@ class TaskRunner;
 class SoftwareCursor;
 typedef void (*VsyncCallback)(void*, intptr_t);
 
+namespace profiling {
+class MotionToPhoton;
+}
+
 // Pluggable output destination for SoftwareBackend's
 // surface_present_callback. Sinks own one direction of data — pixels in,
 // either dropped, stored, or pushed to a device. They never call back
@@ -90,6 +94,10 @@ class ISurfaceSink {
   virtual void SetEngineHandle(void* /*engine*/) {}
   virtual void SetPlatformTaskRunner(TaskRunner* /*runner*/) {}
   virtual void StopVsyncMonitor() {}
+
+  // Hand the backend's motion-to-photon profiler (or nullptr) to a sink that
+  // drives page flips, so it can record the scanout endpoint. Default no-op.
+  virtual void SetMotionToPhoton(profiling::MotionToPhoton* /*m2p*/) {}
 
  protected:
   ISurfaceSink() = default;

--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -45,6 +45,7 @@
 
 #include "asio/dispatch.hpp"
 #include "asio/post.hpp"
+#include "backend/backend.h"
 #include "backend/drm_kms_egl/drm_cursor.h"
 #include "engine.h"
 #include "libflutter_engine.h"
@@ -308,9 +309,20 @@ void DrmSeat::DispatchToRegion(const ViewRegion& region,
   if (runner == nullptr || engine_handle == nullptr) {
     return;
   }
+  // Motion-to-photon input endpoint (IVI_M2P_PROFILE): the batch shares one
+  // engine-clock timestamp; record it on the strand so it joins the flip-path
+  // RecordPresent on the same thread. Backend* is null-checked; nullptr when
+  // not profiling. The event timestamp is microseconds on the engine's
+  // CLOCK_MONOTONIC clock — the same clock as the page-flip time.
+  auto* backend = s->engine->GetBackend();
+  auto* m2p = backend != nullptr ? backend->GetMotionToPhoton() : nullptr;
+  const uint64_t input_us = count > 0 ? events[count - 1].timestamp : 0;
   std::vector<FlutterPointerEvent> batch(events, events + count);
   asio::dispatch(*runner->GetStrandContext(),
-                 [engine_handle, batch = std::move(batch)]() {
+                 [engine_handle, batch = std::move(batch), m2p, input_us]() {
+                   if (m2p != nullptr && input_us != 0) {
+                     m2p->RecordInput(input_us * 1000ULL);
+                   }
                    LibFlutterEngine->SendPointerEvent(
                        engine_handle, batch.data(), batch.size());
                  });

--- a/shell/profiling/motion_to_photon.cc
+++ b/shell/profiling/motion_to_photon.cc
@@ -17,8 +17,12 @@
 #include "profiling/motion_to_photon.h"
 
 #include <cstdlib>
+#include <string>
+
+#include <asio/post.hpp>
 
 #include "logging/logging.h"
+#include "task_runner.h"
 
 namespace profiling {
 
@@ -138,6 +142,22 @@ void MotionToPhoton::LogSessionSummary(const std::string_view label) const {
         session_floor_.Pct(0.50) / 1000.0, session_floor_.Pct(0.95) / 1000.0,
         session_floor_.Pct(0.99) / 1000.0, session_floor_.max_us / 1000.0);
   }
+}
+
+void MarshalRecordPresent(TaskRunner* runner,
+                          MotionToPhoton* m2p,
+                          const uint64_t present_ns,
+                          const uint64_t cutoff_ns,
+                          const std::string_view label) {
+  if (m2p == nullptr || runner == nullptr) {
+    return;
+  }
+  // The label is a backend-static literal, but copy it into the task so the
+  // contract holds regardless of caller lifetime.
+  asio::post(*runner->GetStrandContext(),
+             [m2p, present_ns, cutoff_ns, label = std::string(label)]() {
+               m2p->RecordPresent(present_ns, cutoff_ns, label);
+             });
 }
 
 }  // namespace profiling

--- a/shell/profiling/motion_to_photon.h
+++ b/shell/profiling/motion_to_photon.h
@@ -21,6 +21,8 @@
 #include <cstdint>
 #include <string_view>
 
+class TaskRunner;
+
 namespace profiling {
 
 /**
@@ -112,6 +114,19 @@ class MotionToPhoton {
 
   [[nodiscard]] bool Empty() const { return head_ == tail_; }
 };
+
+/// Marshal a scanout record onto the platform task runner's strand, then call
+/// RecordPresent there. The DRM/KMS page-flip handler runs on the flip-reader
+/// or raster thread, but the DRM input seats post RecordInput onto the same
+/// strand — routing the present through it keeps both endpoints on one thread,
+/// preserving MotionToPhoton's lock-free single-thread contract without the
+/// Wayland path's luxury of a shared event thread. No-op if @p m2p or
+/// @p runner is null (i.e. profiling off or the runner not yet wired).
+void MarshalRecordPresent(TaskRunner* runner,
+                          MotionToPhoton* m2p,
+                          uint64_t present_ns,
+                          uint64_t cutoff_ns,
+                          std::string_view label);
 
 }  // namespace profiling
 

--- a/shell/vsync/ivsync_provider.h
+++ b/shell/vsync/ivsync_provider.h
@@ -130,12 +130,15 @@ class IVsyncProvider {
     return engine_.load(std::memory_order_acquire);
   }
 
+ public:
   /// The frame_start_time of the most recent baton handed to Flutter — i.e. the
   /// input cutoff of the frame currently building/committing. Because a present
   /// in flight keeps the next baton parked, this value is stable across a
   /// single frame's commit, letting a source tag that frame's presentation
   /// feedback with the cutoff of the inputs it actually consumed
-  /// (motion-to-photon). 0 until the first baton is delivered.
+  /// (motion-to-photon). 0 until the first baton is delivered. Public so a
+  /// backend that owns (rather than subclasses) the provider — the DRM/KMS
+  /// page-flip path — can read the cutoff when recording the scanout endpoint.
   [[nodiscard]] uint64_t LastDeliveredFrameStartNs() const {
     return last_frame_start_ns_.load(std::memory_order_acquire);
   }


### PR DESCRIPTION
Wire motion-to-photon (input-to-scanout latency, `IVI_M2P_PROFILE`) on the DRM backends. It was previously Wayland-only, where both endpoints happen to fire on the display event thread; the DRM backends had neither, so the metric was unavailable on the bare-KMS targets where input latency matters most.

## Design (shared seam)

`MotionToPhoton` is lock-free and single-thread by contract. On DRM the two endpoints would land on different threads (page-flip handler vs platform runner), so the present record is **marshaled onto the platform task runner's strand** (`MarshalRecordPresent`), the same strand the seats post input to — both endpoints run on one thread, contract untouched, no lock added.

The profiler instance + accessor live on the `Backend` base
(`GetMotionToPhoton()`); DRM backends opt in with `InitMotionToPhoton()`.
`LastDeliveredFrameStartNs()` (the frame cutoff) is public so a backend that
*owns* the vsync provider can read it.

## Commits

1. **drm_kms_egl** — `RecordPresent` from the page-flip path, `RecordInput`    from `DrmSeat`.
2. **sink factory fix** — `sink_factory.cc` gated the DRM/fbdev sinks on
   `BUILD_SOFTWARE_SINK_DRM`/`_FBDEV` but never included `config/common.h`, so    the guards were always 0 and the drm-dumb sink was **silently compiled out** (fell back to NoneSink). One-line include fix; independent of M2P but needed to exercise the software path.
3. **software** — `DrmDumbSink` records present from its page-flip handler (already on the runner), `SoftwareSeat` records input on the same strand, via the same base seam.

## Validation

**drm-kms-egl, on vkms with the machine's pointer** — real input + page-flip timestamps joined on the `drm` label:

```
[drm] motion->photon: frame-accurate p50=49.5ms p99=99.5ms max=277.3ms | floor p50=33.5ms p99=66.5ms | n=608 dropped=0
```

The frame-accurate − floor gap is the engine pipeline depth the design
predicts; high absolutes are vkms + llvmpipe, not the measurement.

The **sink fix is runtime-verified** (the software backend now brings up
`sink: drm-dumb ... 1024x768@60Hz` instead of NoneSink). The **software M2P** compiles clean (clang + gcc) and reuses the mechanism proven on EGL; full `[sw]` numbers weren't captured here because the software backend didn't produce frames in this vkms/JIT env (a separate present-path matter, not the M2P wiring).

## Follow-on

**drm-kms-vulkan** is deferred: it has no `DeliverVsync`/baton path (paces via `WaitForFlip`), so no per-frame cutoff — it needs a different hook — and it's GPU-only. Tracked separately.