### PR TITLE
software: include config/common.h in sink_factory

### DIFF
--- a/shell/backend/software/sink_factory.cc
+++ b/shell/backend/software/sink_factory.cc
@@ -17,6 +17,12 @@
 #include "backend/software/sink_factory.h"
 #include "logging/logging.h"
 
+// Defines BUILD_SOFTWARE_SINK_DRM / BUILD_SOFTWARE_SINK_FBDEV, which gate both
+// the sink includes and the factory branches below. Nothing else this file
+// includes pulls it in, and an undefined identifier in #if is 0, so without it
+// every drm-dumb / fbdev spec silently falls back to NoneSink.
+#include "config/common.h"
+
 #include <cstdlib>
 #include <string>
 


### PR DESCRIPTION
`sink_factory.cc` gates its sink includes and factory branches on
`BUILD_SOFTWARE_SINK_DRM` / `BUILD_SOFTWARE_SINK_FBDEV`, but never includes the header that defines them — and nothing else it includes pulls `config/common.h` in transitively. An undefined identifier in `#if` evaluates to `0`, so both tests were always false: `MakeSinkFromSpec` never saw a `DrmDumbSink` or `FbDevSink` branch, and **every `drm-dumb` / `fbdev` spec fell back to `NoneSink`**.

The fix is the one include.

## Why it looks like a build problem but isn't

cmake sets `BUILD_SOFTWARE_SINK_DRM=ON` whenever pkg-config finds libdrm, compiles `drm_dumb_sink.cc`, and links `PkgConfig::DRM_DUMB`. So the sink is in the binary as unreachable code, the cache reads
`BUILD_SOFTWARE_SINK_DRM:BOOL=ON` and `DRM_DUMB_FOUND=1`, and the operator is nevertheless told:

```
drm-dumb sink requested but compiled without BUILD_SOFTWARE_SINK_DRM;
falling back to NoneSink
```

That message points at the build for something the preprocessor decided. It is accurate once the define is actually visible, so this change leaves it alone.

`register_backends.cc` gates `BUILD_SOFTWARE_INPUT_LIBINPUT` with the same pattern and is unaffected — it picks the define up transitively via
`backend/backend.h`. That asymmetry is why input worked while output silently did not.

## Impact

Worst exactly where the software backend is the only option. On a no-GPU board the backend could reach `none`, `memory`, and `file`, but neither sink that drives a display.

## Verification

On an NXP FRDM-IMX93 (i.MX93 Cortex-A55, no GPU, `imx-drm` `card0`), built from this branch. Before, with `IVI_SW_SINK=drm-dumb`, the fallback warning above. 

After:
```
[DrmDumbSink] opened /dev/dri/card0
[DrmDumbSink] connector=37 mode=1280x720@60.00Hz
[DrmDumbSink] format=xrgb8888 (32 bpp)
[SoftwareBackend] sink: drm-dumb (device='(probed)', 1280x720@60.00Hz)
[DrmDumbSink] software cursor installed
[SoftwareSeat] cursor tracking pointer (first motion 0,0)
```

with the cursor tracking the pointer on the panel.

Preprocessing the real translation unit confirms the mechanism rather than
inferring it — `-dM` on `sink_factory.cc.o`'s compile line shows neither macro
defined before the change and both defined after, and `DrmDumbSink` goes from **0 to 7** mentions in the preprocessed output.

## Note for reviewers

Worth a follow-up: this class of bug is invisible to a build that only checks
for compile/link success, since the sink compiles and links either way. A cheap guard would be a `static_assert` or an `#ifndef BUILD_SOFTWARE_SINK_DRM`
`#error` in the files that consume these macros, so a missing include fails
loudly instead of silently selecting the null sink. Not done here, to keep the
fix minimal.
