### PR TITLE
third_party: bump wayland-cxx-scanner to 9c86b8e

### DIFF
--- a/.emb/raspberry-pi.emb.yaml
+++ b/.emb/raspberry-pi.emb.yaml
@@ -65,7 +65,7 @@ cross:
         # Anchored so the trixie targets (no libdisplay-info augment) reuse it.
         - &augment_scanner
           pkg: wayland-cxx-scanner
-          url: https://github.com/jwinarske/wayland-cxx-scanner/archive/596addb0f614eeb5cdfb18bcfccf1ed3810e2188.tar.gz
+          url: https://github.com/jwinarske/wayland-cxx-scanner/archive/9c86b8e7e87e2c9d5ff34939d044df4053e70970.tar.gz
           build: cmake
           host: true
           defines:

--- a/emb.lock
+++ b/emb.lock
@@ -11,5 +11,5 @@ targets:
     provider: 'arm-gnu'
     triple: 'aarch64-none-linux-gnu'
     toolchain_version: '15.2.rel1'
-    sysroot_key: '098866c934c2'
-    build_key: '19c9246dcda8'
+    sysroot_key: '7174633915a0'
+    build_key: 'd7626fb6e7d5'


### PR DESCRIPTION
## What

Bump the vendored `wayland-cxx-scanner` submodule from `596addb0` to `9c86b8e` and point the emb cross-build augment (and lock) at the matching tarball.

The `596addb0..9c86b8e` range is chiefly the `skia-vulkan-dmabuf` example
series and the framework additions behind it:
- **`DmabufFeedback` wl helper** — `zwp_linux_dmabuf_v1` v4 feedback (tranche parsing), the basis for feedback-driven modifier selection.
- Generated proxies moved onto **`wl_proxy_add_dispatcher`** (each handler now emits a static `_Dispatch`), separating the dispatcher from `user_data`.

## Why now

Unblocks the upcoming `drm_kms_vulkan` optimal-path work (explicit sync +
refresh-adaptive pacing) that patterns after `skia-vulkan-dmabuf`.

## No source changes

The protocol headers are generated at configure time from the submodule, so the dispatcher-API change is absorbed by a fresh regenerate — the tree builds clean with no shell/ edits. Verified by reconfiguring from scratch and building the full `homescreen` target (Wayland surface included) against `9c86b8e`.

Note: `origin/main` has since advanced to `3fb4376` (adds a Dear ImGui example backend); `9c86b8e` is the prepared/in-flight target and carries the full dmabuf series.
