### PR TITLE
drm_kms_vulkan: wire motion-to-photon on the KMS backend

### DIFF
--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -328,7 +328,11 @@ VulkanDrmBackend::VulkanDrmBackend(std::string drm_device,
       mode_spec_(std::move(mode_spec)),
       rotation_(rotation),
       enable_validation_(enable_validation),
-      session_(session) {}
+      session_(session) {
+  // Motion-to-photon (IVI_M2P_PROFILE): the flip path feeds RecordPresent and
+  // DrmSeat feeds RecordInput, both marshaled onto the platform task runner.
+  InitMotionToPhoton();
+}
 
 VulkanDrmBackend::~VulkanDrmBackend() {
   // Cadence profile summary (no-op unless IVI_PROFILE / IVI_DRMVK_PROFILE ran).
@@ -1007,6 +1011,12 @@ void VulkanDrmBackend::OnFlipEvent(const unsigned int tv_sec,
   vsync_.SetSourcePending(false);
   const uint64_t tv_ns = static_cast<uint64_t>(tv_sec) * 1'000'000'000ULL +
                          static_cast<uint64_t>(tv_usec) * 1000ULL;
+  // Motion-to-photon scanout endpoint (IVI_M2P_PROFILE). The cutoff is the
+  // frame_start of the baton this flip presents; marshaled onto the platform
+  // runner so it joins DrmSeat's RecordInput on the same thread.
+  profiling::MarshalRecordPresent(
+      platform_task_runner_.load(std::memory_order_acquire),
+      GetMotionToPhoton(), tv_ns, vsync_.LastDeliveredFrameStartNs(), "drm-vk");
   vsync_.DeliverVsync(tv_ns);  // returns the baton, marshaled onto the runner
 }
 
@@ -1016,6 +1026,11 @@ void VulkanDrmBackend::StopVsyncMonitor() {
     compositor_->StopFlipReader();
   }
   vsync_.Stop();
+  // Motion-to-photon session summary, on the platform thread (the same thread
+  // the marshaled RecordInput/RecordPresent tasks ran on).
+  if (m2p_enabled_) {
+    m2p_.LogSessionSummary("drm-vk");
+  }
 }
 
 int VulkanDrmBackend::SubmitScanoutBarrier(CompositorState& c, VkImage image) {


### PR DESCRIPTION
## What

Extends motion-to-photon (input-to-scanout latency, `IVI_M2P_PROFILE`) to the `drm_kms_vulkan` backend, which #307 just unblocked by giving it a real
page-flip-driven vsync provider (and thus a per-frame cutoff).

Three small hooks on the `Backend` base seam added in #302:
- `InitMotionToPhoton()` in the ctor (opt in).
- `MarshalRecordPresent(...)` in `OnFlipEvent` — the flip's kernel scanout time
  as the present, `vsync_.LastDeliveredFrameStartNs()` as the frame cutoff,
  posted onto the platform runner so it joins RecordInput on one thread.
- `LogSessionSummary("drm-vk")` in `StopVsyncMonitor`.

`RecordInput` needs no new code: the vulkan backend uses `DrmSeat`, which already feeds `backend->GetMotionToPhoton()->RecordInput` (from #302).

## Validation — Steam Deck (RADV VANGOGH), built on-device

Live and non-crashing: `DrmSeat started`, `RecordPresent` runs at the 90 Hz flip cadence, cursor ready. It reuses the **exact** `RecordInput` path #302 validated with real numbers on the host mouse, and the new hook (`OnFlipEvent →MarshalRecordPresent`) is a direct analog of the egl `DeliverVsyncFromFlip`.

Full input→scanout numbers on the Deck are blocked only by the harness: no physical touch over SSH, and `/dev/uinput` injection is denied by the rootless
distrobox user-namespace (container-root maps to the unprivileged `deck` user). Not a code limitation.

## Completes the vulkan optimal-path arc
#306 explicit sync → #307 refresh-adaptive pacing → this. The backend now:
zero-copy modifier-tiled dma-buf scanout, explicit GPU→KMS sync, real-refresh pacing, and motion-to-photon.