### PR TITLE
profiling: add a frame-pacing stall counter

### DIFF
--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -523,8 +523,9 @@ struct VulkanDrmBackend::CompositorState {
   // reader thread when its event arrives — hence atomic. scanning_slot /
   // pending_slot stay raster-thread-local (present_layers only).
   std::atomic<bool> flip_pending{false};
-  int scanning_slot = -1;  // slot the CRTC is currently scanning
-  int pending_slot = -1;   // slot in the in-flight non-blocking flip
+  int scanning_slot = -1;            // slot the CRTC is currently scanning
+  int pending_slot = -1;             // slot in the in-flight non-blocking flip
+  uint32_t period_ns = 16'666'667U;  // connector refresh period (from setup)
   drmEventContext evctx{};
 
   // Async page-flip reader: an asio descriptor over the DRM fd on its own
@@ -772,8 +773,10 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
   // Flutter targets the real refresh, and start the async page-flip reader that
   // returns each frame's baton on vblank.
   const uint32_t vr = target.mode.vrefresh;
-  vsync_.SetPeriodNs(vr > 0 ? static_cast<uint32_t>(1'000'000'000ULL / vr)
-                            : 16'666'667U);
+  const uint32_t period_ns =
+      vr > 0 ? static_cast<uint32_t>(1'000'000'000ULL / vr) : 16'666'667U;
+  compositor_->period_ns = period_ns;
+  vsync_.SetPeriodNs(period_ns);
   vsync_.EnableProfile(profiling::FrameProfile::Enabled("IVI_VSYNC_PROFILE"),
                        "DrmVkVsync");
   {
@@ -1103,16 +1106,20 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
   // the kernel — not the raster thread — waits on it; -1 means CPU-fenced.
   const int scanout_fence_fd = SubmitScanoutBarrier(c, store->image());
 
-  // The previous non-blocking flip has normally already completed: its event
-  // returned the vsync baton, which is what let the engine build this frame.
-  // Do NOT read the fd here — the async reader is the single reader (a second
-  // drmHandleEvent would race it). If a frame somehow arrives with a flip still
-  // in flight, wait on the flag (bounded) so the commit below does not EBUSY;
-  // under vsync pacing this loop never spins.
-  for (int i = 0; i < 100 && c.flip_pending.load(std::memory_order_acquire);
-       ++i) {
+  // The engine's raster thread pipelines: it hands us frame N+1 while flip N is
+  // still in flight, and a single plane can hold only one flip, so we wait for
+  // the previous flip here. Do NOT read the fd — the async reader is the single
+  // reader (a second drmHandleEvent would race it); poll the flag instead.
+  // A short wait (~1 vblank slice) is the normal cost of single-plane double
+  // buffering; only a wait past the refresh period is a real stall (a dropped
+  // flip event or buffer starvation), which the counter flags.
+  int spin_ms = 0;
+  for (; spin_ms < 100 && c.flip_pending.load(std::memory_order_acquire);
+       ++spin_ms) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
+  const bool stalled =
+      static_cast<uint32_t>(spin_ms) * 1'000'000U > c.period_ns;
   // Rotate: the completed flip's slot is now scanning; the slot it replaced
   // returns to the free pool. Raster-thread-local (the reader never touches
   // it).
@@ -1190,7 +1197,8 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
   static const bool profile_enabled =
       profiling::FrameProfile::Enabled("IVI_DRMVK_PROFILE");
   if (profile_enabled) {
-    frame_profile_.Record("VulkanDrmBackend", /*ok=*/true);
+    frame_profile_.Record("VulkanDrmBackend", /*ok=*/true, /*now_ns=*/0,
+                          stalled);
   }
   return true;
 }

--- a/shell/profiling/frame_profile.cc
+++ b/shell/profiling/frame_profile.cc
@@ -70,6 +70,7 @@ void FrameProfile::Stats::Merge(const Stats& other) {
   }
   frames += other.frames;
   discarded += other.discarded;
+  stalls += other.stalls;
   b60 += other.b60;
   b30 += other.b30;
   b20 += other.b20;
@@ -86,10 +87,14 @@ bool FrameProfile::Enabled(const char* legacy_env) {
 
 void FrameProfile::Record(const std::string_view label,
                           const bool ok,
-                          uint64_t now_ns) {
+                          uint64_t now_ns,
+                          const bool stalled) {
   if (!ok) {
     ++window_.discarded;
     return;
+  }
+  if (stalled) {
+    ++window_.stalls;
   }
   if (now_ns == 0) {
     now_ns = MonotonicNs();
@@ -107,10 +112,10 @@ void FrameProfile::Record(const std::string_view label,
       MeanIntervalNs(window_.interval_sum_ns, window_.frames);
   ihs::log::info(
       "[{}] profile (n={}): fps={:.2f} mean_interval={}us max_interval={}us "
-      "discarded={} buckets[60Hz/30Hz/20Hz/slow/idle]={}/{}/{}/{}/{}",
+      "discarded={} stalls={} buckets[60Hz/30Hz/20Hz/slow/idle]={}/{}/{}/{}/{}",
       label, window_.frames, FpsFromMean(mean_ns), mean_ns / 1000,
-      window_.interval_max_ns / 1000, window_.discarded, window_.b60,
-      window_.b30, window_.b20, window_.bslow, window_.bidle);
+      window_.interval_max_ns / 1000, window_.discarded, window_.stalls,
+      window_.b60, window_.b30, window_.b20, window_.bslow, window_.bidle);
 
   session_.Merge(window_);
   window_ = Stats{};  // reset the window; last_present_ns_ carries continuity
@@ -127,9 +132,9 @@ void FrameProfile::LogSessionSummary(const std::string_view label) const {
   const uint64_t mean_ns = MeanIntervalNs(s.interval_sum_ns, s.frames);
   ihs::log::info(
       "[{}] session summary: frames={} fps={:.2f} mean_interval={}us "
-      "max_interval={}us discarded={}",
+      "max_interval={}us discarded={} stalls={}",
       label, s.frames, FpsFromMean(mean_ns), mean_ns / 1000,
-      s.interval_max_ns / 1000, s.discarded);
+      s.interval_max_ns / 1000, s.discarded, s.stalls);
 
   if (const uint32_t total = s.b60 + s.b30 + s.b20 + s.bslow + s.bidle;
       total > 0) {

--- a/shell/profiling/frame_profile.h
+++ b/shell/profiling/frame_profile.h
@@ -48,9 +48,14 @@ class FrameProfile {
 
   // Record one present. When ok is false the frame is counted as discarded
   // (superseded / not scanned out) and contributes no interval. now_ns is a
-  // CLOCK_MONOTONIC timestamp; pass 0 to sample it internally. label is the
-  // backend tag for the window log line.
-  void Record(std::string_view label, bool ok, uint64_t now_ns = 0);
+  // CLOCK_MONOTONIC timestamp; pass 0 to sample it internally. Set stalled when
+  // the present had to block waiting for a buffer/flip — under correct pacing
+  // and buffer depth this stays zero, so a nonzero count flags a stall. label
+  // is the backend tag for the window log line.
+  void Record(std::string_view label,
+              bool ok,
+              uint64_t now_ns = 0,
+              bool stalled = false);
 
   // Emit the session-aggregate summary. No-op when no frames were recorded.
   void LogSessionSummary(std::string_view label) const;
@@ -63,11 +68,12 @@ class FrameProfile {
     uint64_t interval_max_ns{0};
     uint32_t frames{0};
     uint32_t discarded{0};
-    uint32_t b60{0};    // <= 17ms  (60Hz)
-    uint32_t b30{0};    // 18-33ms  (30Hz)
-    uint32_t b20{0};    // 34-50ms  (20Hz)
-    uint32_t bslow{0};  // 51-100ms
-    uint32_t bidle{0};  // > 100ms
+    uint32_t stalls{0};  // presents that blocked on a buffer/flip
+    uint32_t b60{0};     // <= 17ms  (60Hz)
+    uint32_t b30{0};     // 18-33ms  (30Hz)
+    uint32_t b20{0};     // 34-50ms  (20Hz)
+    uint32_t bslow{0};   // 51-100ms
+    uint32_t bidle{0};   // > 100ms
 
     void AddInterval(uint64_t dt_ns);
     void Merge(const Stats& other);


### PR DESCRIPTION
## What

Adds a frame-pacing **stall counter** to `FrameProfile` — the diagnostic
complement to the vulkan pacing work (#307): a wrong buffer depth or a pacing regression shows up as nonzero `stalls`.

- `FrameProfile::Record(label, ok, now_ns, stalled=false)` — new optional flag;
  the window and session log lines now report `stalls=N`.
- `drm_kms_vulkan` wires it at the flip-wait: the raster thread pipelines (it
  presents frame N+1 while flip N is still in flight), and a single plane holds
  only one flip, so it waits for the previous flip before committing. That short
  wait (~1 ms) is the **normal** cost of single-plane double buffering, so a
  stall is counted only when the wait **exceeds the connector's refresh period**
  — a dropped flip event or buffer starvation, not the per-frame wait.

Backward compatible: the new param defaults false, so other callers (and the `IVsyncProvider`'s own `FrameProfile`) are unaffected.

## Validation — Steam Deck OLED (90 Hz), RADV VANGOGH

```
[VulkanDrmBackend] profile (n=60): fps=88.48 ... discarded=0 stalls=0 buckets[...]=60/0/0/0/0
```

`stalls=0` under clean 90 Hz pacing. A one-off 50 ms scheduler hiccup (a +1 in the `slow` bucket) correctly reports `stalls=0` — it isn't a flip-wait — which is exactly the discrimination that makes the counter useful as a regression signal.

A first binary "did we wait at all" version reported `stalls=60` every frame,
which surfaced the inherent per-frame ~1 ms flip-wait; the period-based threshold turns it into a true anomaly detector.
