### PR TITLE
ci: run the census + input harness on vkms with an emb-built bundle

### DIFF
--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -121,15 +121,19 @@ jobs:
       - name: Setup libdisplay-info (system or from-source)
         uses: ./.github/actions/setup-libdisplay-info
 
-      - name: Build (clang, DRM + compositor)
+      - name: Build (clang, DRM + software + compositor)
         env:
           CC: clang-19
           CXX: clang++-19
         run: |
+          # The census and input harness exercise both the DRM-KMS-EGL and the
+          # software (drm-dumb sink) backends, so build both here.
           cmake -GNinja \
             -B ${{github.workspace}}/build \
             -D CMAKE_BUILD_TYPE=Debug \
             -D BUILD_BACKEND_DRM_KMS_EGL=ON \
+            -D BUILD_BACKEND_SOFTWARE=ON \
+            -D BUILD_SOFTWARE_SINK_DRM=ON \
             -D BUILD_BACKEND_WAYLAND_EGL=OFF \
             -D BUILD_BACKEND_WAYLAND_VULKAN=OFF \
             -D BUILD_COMPOSITOR=ON \
@@ -160,16 +164,29 @@ jobs:
         run: |
           test/drm_kms_vkms.sh --check
 
-      # A full harness run requires a Flutter bundle whose
-      # libflutter_engine.so version matches the one in third_party/flutter.
-      # When a CI-ready bundle is available, uncomment the step below.
-      #
-      # - name: Full vkms smoke test
-      #   if: steps.vkms.outputs.available == 'true'
-      #   env:
-      #     HOMESCREEN: ${{github.workspace}}/build/shell/homescreen
-      #     BUNDLE: /path/to/ci/bundle/.desktop-homescreen
-      #     SOFTWARE_RENDER: '1'
-      #     DURATION: '5'
-      #   run: |
-      #     test/drm_kms_vkms.sh
+      - name: Load uinput module (input-injection gate)
+        if: steps.vkms.outputs.available == 'true'
+        run: |
+          # Best-effort: load uinput so the input harness's injection scenarios
+          # (I1/I6) can run where the runner can open /dev/uinput. It stays
+          # root-only on a hosted runner, so those scenarios SKIP (reported in
+          # the summary) rather than fail; a self-hosted runner that grants
+          # write access runs them for real.
+          sudo modprobe uinput 2>/dev/null \
+            || echo "::warning::uinput unavailable; input injection scenarios will skip"
+
+      - name: Fetch emb
+        if: steps.vkms.outputs.available == 'true'
+        run: git clone --depth 1 https://github.com/toyota-connected/emb_cli.git emb_cli
+
+      - name: Harness integration (census + input harness on vkms)
+        if: steps.vkms.outputs.available == 'true'
+        env:
+          IVI_BUILD: ${{github.workspace}}/build
+        run: |
+          eval "$(./emb_cli/bootstrap.sh --shellenv)"
+          emb --version
+          emb flutter --flutter-version "$(cat .flutter-version)"
+          source ./setup_env.sh
+          eval "$(./emb_cli/bootstrap.sh --shellenv)"
+          ./scripts/vkms_harness_integration.sh

--- a/scripts/vkms_harness_integration.sh
+++ b/scripts/vkms_harness_integration.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# vkms_harness_integration.sh — CI integration for the event-driven input harness
+# and the present-path census. Builds the deterministic scroll_bench bundle with
+# emb, points both harnesses at homescreen on a vkms card, and emits a
+# RAN/SKIPPED summary to $GITHUB_STEP_SUMMARY.
+#
+# Prerequisites (set up by the workflow before this runs):
+#   - homescreen built at ${IVI_BUILD}/shell/homescreen with the DRM-KMS-EGL and
+#     software backends (the census exercises both).
+#   - emb on PATH with a provisioned Flutter (emb flutter ...); FLUTTER_WORKSPACE set.
+#   - vkms loaded with a Virtual connector.
+#
+# Coverage note: the census runs in self-check with the strict correctness gates
+# (discarded==0, stalls==0) but a relaxed keep-up floor and a wider window,
+# because hosted runners are shared and software-GL — their frame timing is not
+# stable enough to gate on. The strict baseline diff
+# (present_census.sh --check test/baselines/present_census.vkms.txt) is for
+# self-hosted / hardware runners. Input injection scenarios need a writable
+# /dev/uinput; on a hosted runner it stays root-only so they SKIP (honestly
+# reported), and RUN where the runner can open it.
+set -uo pipefail
+
+IVI_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IVI_BUILD="${IVI_BUILD:-${IVI_SRC}/build}"
+APP_DIR="${IVI_SRC}/test/integration/scroll_bench"
+BUNDLE_ROOT="${FLUTTER_WORKSPACE:-${IVI_SRC}}/bundle"
+
+export HOMESCREEN="${IVI_BUILD}/shell/homescreen"
+export LD_LIBRARY_PATH="${IVI_BUILD}/shared:${IVI_BUILD}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+[[ -x "${HOMESCREEN}" ]] || { echo "error: homescreen not at ${HOMESCREEN}"; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Build the deterministic workload bundle. emb names the output
+# scroll_bench-debug-<arch>; resolve it by glob rather than guessing the arch
+# suffix (uname -i is "unknown" on some hosts while emb uses the machine arch).
+# ---------------------------------------------------------------------------
+echo "== building scroll_bench bundle =="
+emb bundle --app-path "${APP_DIR}" -m debug --build
+shopt -s nullglob
+bundles=( "${BUNDLE_ROOT}"/scroll_bench-debug-* )
+shopt -u nullglob
+[[ ${#bundles[@]} -ge 1 ]] || { echo "error: no scroll_bench bundle under ${BUNDLE_ROOT}"; exit 2; }
+export BUNDLE="${bundles[0]}"
+echo "bundle: ${BUNDLE}"
+
+# Append a section to the job summary (or stdout when run outside Actions).
+emit() { if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then cat >>"${GITHUB_STEP_SUMMARY}"; else cat; fi; }
+
+rc=0
+run_harness() {  # run_harness <title> <cmd...>
+    local title="$1"; shift
+    local out="/tmp/${title// /_}.out"
+    echo "== ${title} =="
+    local status=0
+    "$@" 2>&1 | tee "${out}" || status="${PIPESTATUS[0]}"
+    [[ "${status}" -ne 0 ]] && rc=1
+    {
+        echo "### ${title}"
+        echo
+        echo '```'
+        # The RESULTS lines ("  <name> <pass|fail|skip> — …") plus the tallies.
+        grep -E '(pass|fail|skip) —|RAN:|backends:' "${out}" || echo "(no summary emitted)"
+        echo '```'
+        echo
+        echo "exit: ${status}"
+        echo
+    } | emit
+}
+
+# ---------------------------------------------------------------------------
+# Present-path census (self-check, relaxed timing for shared runners)
+# ---------------------------------------------------------------------------
+run_harness "present census" \
+    env CENSUS_SECS=12 KEEPUP_MIN=0.30 "${IVI_SRC}/test/present_census.sh"
+
+# ---------------------------------------------------------------------------
+# Event-driven input harness (I2/I3 always; I1/I6 run only with writable uinput).
+# Raise I2's idle wake ceiling: a shared, loaded runner accrues more idle
+# context switches than a quiet box while staying far below a busy poll (~300/5s).
+# ---------------------------------------------------------------------------
+run_harness "event-driven input harness" \
+    env IDLE_CTXT_MAX=150 "${IVI_SRC}/test/input_event_driven.sh"
+
+echo "vkms harness integration: overall rc=${rc}"
+exit "${rc}"

--- a/test/input_event_driven.sh
+++ b/test/input_event_driven.sh
@@ -40,6 +40,7 @@ BUNDLE="${BUNDLE:-}"
 VKMS_CARD="${VKMS_CARD:-}"
 STORM_SECS="${STORM_SECS:-6}"
 IDLE_SECS="${IDLE_SECS:-5}"
+IDLE_CTXT_MAX="${IDLE_CTXT_MAX:-30}"  # max idle voluntary ctxt-switches for I2
 ONLY="${ONLY:-}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -208,10 +209,13 @@ scenario_I2() {  # scenario_I2 <backend> <comm>
     after="$(vctxt "$HS_PID" "$tid")"
     delta=$(( ${after:-0} - ${before:-0} ))
     stop_homescreen
-    # Idle event-driven: single digits (SIGTERM re-check, keymap timers). A busy
-    # poll at even 60Hz would be ~300 over 5s, so the gap to a real regression is
-    # wide; 30 leaves headroom for timer noise without hiding a busy loop.
-    if [[ "$delta" -le 30 ]]; then
+    # Idle event-driven: single digits (SIGTERM re-check, keymap timers) on a
+    # quiet box. A busy poll at even 60Hz would be ~300 over 5s, so the gap to a
+    # real regression is wide. The default 30 suits a quiet dev machine; a host
+    # with live input devices (a jittery mouse wakes the seat fd) or a loaded,
+    # shared CI runner legitimately accrues more idle wakes while staying far
+    # below busy-poll, so IDLE_CTXT_MAX raises the ceiling without hiding a loop.
+    if [[ "$delta" -le "$IDLE_CTXT_MAX" ]]; then
         record I2 pass "$comm idle ${IDLE_SECS}s vctxt delta=$delta"
     else
         record I2 fail "$comm vctxt delta=$delta over ${IDLE_SECS}s idle (busy-polling?)"


### PR DESCRIPTION
Wires the present-path census and the event-driven input harness into CI, replacing the `vkms-smoke` job's `--check`-only pre-flight and its "when a CI-ready bundle is available, uncomment this" stub.

## The bundle was never actually blocked
The repo already provisions Flutter and builds per-app bundles with **emb** (see `oss-integration.yaml`'s `watchdog` job: `emb flutter --flutter-version $(cat .flutter-version)` + `emb bundle --app-path <app> --build`). This uses the same pattern with the deterministic `test/integration/scroll_bench` app.

## What runs
`scripts/vkms_harness_integration.sh` (mirrors `watchdog_integration.sh`):
- builds the `scroll_bench` bundle with emb, resolves the output dir by glob
- runs `test/present_census.sh` and `test/input_event_driven.sh` against `homescreen` on the vkms card
- appends a RAN/SKIPPED table to `$GITHUB_STEP_SUMMARY`

The `vkms-smoke` job now also builds the **software** backend (both harnesses exercise `drm-kms-egl` **and** software), loads `uinput` as a best-effort gate, and runs the integration when vkms is available.

## Robustness on shared, software-GL hosted runners
- **Census** runs in self-check with the strict correctness gates intact (`discarded==0`, `stalls==0`) but a **relaxed keep-up floor + wider window** — hosted-runner frame timing isn't stable enough to gate on. The strict baseline diff (`present_census.sh --check test/baselines/present_census.vkms.txt`) is for **self-hosted / hardware** runners (the closure plan's G6).
- **Input injection** needs a writable `/dev/uinput`; it stays root-only on hosted runners, so `I1`/`I6` **SKIP** (reported in the summary) and RUN where the runner can open it.
- **I2 idle-wake ceiling** is now tunable via `IDLE_CTXT_MAX` (default 30). A host with live input devices or a loaded runner accrues more idle wakes than a quiet box while staying far below a busy poll (~300/5s); the integration raises it to 150.

## Validation
Ran end-to-end locally against a **real emb-built** `scroll_bench` bundle on vkms:
- census: `drm-kms-egl` and `software` both pass, `discarded=0 stalls=0`
- input harness: `I2`/`I3` pass, `I1`/`I6`/`I8` skip cleanly
- `$GITHUB_STEP_SUMMARY` table rendered; overall rc=0

Where vkms is unavailable on a hosted runner, the existing guard skips the whole job with a warning (unchanged).