### PR TITLE
wayland_vulkan: experimental zero-copy dma-buf present path (IVI_VK_DMABUF)

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -38,6 +38,10 @@ env:
   # it resolves as a cache hit instead of re-downloading + re-extracting. Repo
   # defaults to `emb-cache`, so entries land at <registry>/emb-cache:<tag>.
   EMB_CACHE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  # oras (OCI client) pinned version. Cached per job keyed on this value, so the
+  # binary is fetched from GitHub releases only when the version changes — every
+  # matrix job re-downloading it otherwise gets rate-limited.
+  ORAS_VERSION: "1.2.0"
 
 jobs:
   publish:
@@ -90,8 +94,7 @@ jobs:
       # step below (EMB_CACHE_REGISTRY). Pinned; installed to /usr/local/bin.
       - name: Install + log in oras
         run: |
-          ORAS_VERSION=1.2.0
-          curl -fsSL \
+          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
             "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
             | sudo tar -xzf - -C /usr/local/bin oras
           echo "${{ secrets.GITHUB_TOKEN }}" \
@@ -165,12 +168,20 @@ jobs:
       # oras pulls the resolved store entries (sysroot base + toolchain) from the
       # OCI cache in the Build step (EMB_CACHE_REGISTRY), so the resolve is a
       # cache hit. Root in-container; the image ships curl.
+      - name: Cache oras binary
+        uses: actions/cache@v5
+        with:
+          path: /usr/local/bin/oras
+          key: oras-${{ env.ORAS_VERSION }}-linux-amd64
       - name: Install + log in oras
         run: |
-          ORAS_VERSION=1.2.0
-          curl -fsSL \
-            "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
-            | tar -xzf - -C /usr/local/bin oras
+          # Only fetch from GitHub releases on a cache miss (version bump); the
+          # cache restores /usr/local/bin/oras otherwise.
+          if [ ! -x /usr/local/bin/oras ]; then
+            curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
+              "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+              | tar -xzf - -C /usr/local/bin oras
+          fi
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 

--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -176,6 +176,16 @@ function(ivi_wayland_protocols target)
         MODE client-header EMIT_INTERFACE_TABLES
         OUTPUT wayland-protocols/viewporter_client.hpp TARGET ${target})
 
+    # linux-dmabuf-unstable-v1 — the wayland_vulkan zero-copy present path binds
+    # v4 feedback for the compositor's scanout modifiers. Shipped header
+    # wl/linux_dmabuf.hpp carries the interface tables, so generate WITHOUT
+    # --emit-interface-tables (same rule as xdg-shell). Generating it
+    # unconditionally costs nothing on stacks that never bind it.
+    wayland_cxx_generate(PROTOCOL
+        "${IVI_WL_PROTOCOLS_BASE}/unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml"
+        MODE client-header
+        OUTPUT wayland-protocols/linux_dmabuf_client.hpp TARGET ${target})
+
     # fractional-scale-v1 — always. Vendored: the XML only ships with
     # wayland-protocols >= 1.31, which Dunfell/Ubuntu-20.04 hosts predate.
     # Both protocols are gated at runtime on the compositor advertising the

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -100,6 +100,13 @@ if (BUILD_BACKEND_WAYLAND_VULKAN)
             backend/wayland_vulkan/vulkan_queue_interposer.cc
             backend/wayland_vulkan/wl_dmabuf_present.cc
     )
+    # The dma-buf present path needs drm_fourcc.h (DRM_FORMAT_* constants), a
+    # libdrm header. On a cross sysroot it lives under <libdrm/>, so the include
+    # dir must come from pkg-config rather than the default search path.
+    if (NOT TARGET PkgConfig::DRM)
+        pkg_check_modules(DRM REQUIRED IMPORTED_TARGET libdrm)
+    endif ()
+    target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::DRM)
     if (BUILD_COMPOSITOR)
         target_sources(${PROJECT_NAME} PRIVATE
                 backend/wayland_vulkan/vulkan_backing_store.cc

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -98,6 +98,7 @@ if (BUILD_BACKEND_WAYLAND_VULKAN)
     target_sources(${PROJECT_NAME} PRIVATE
             backend/wayland_vulkan/wayland_vulkan.cc
             backend/wayland_vulkan/vulkan_queue_interposer.cc
+            backend/wayland_vulkan/wl_dmabuf_present.cc
     )
     if (BUILD_COMPOSITOR)
         target_sources(${PROJECT_NAME} PRIVATE

--- a/shell/backend/wayland_vulkan/README.md
+++ b/shell/backend/wayland_vulkan/README.md
@@ -68,6 +68,38 @@ internal wall-clock scheduler. The decision is logged once at startup.
 | `IVI_VK_PROFILE` | (off) | Anything non-empty enables per-frame cadence profiling. Every 60 frames the profiler logs `profile (n=60): fps=X mean_interval=Yus max_interval=Zus present_failures=N discarded=M refresh=Rus flags=0xF pipeline_mean=Lus pipeline_max=Lmaxus buckets[60Hz/30Hz/20Hz/slow/idle]=…`. `pipeline_*` measures beginFrame-to-present latency (time from the `frame_start_time` handed to Flutter via OnVsync to the next `vkQueuePresentKHR` return). |
 | `IVI_M2P_PROFILE` | (off) | Anything non-empty enables the **motion-to-photon** (input-to-scanout) profiler. Joins kernel input time from `zwp_input_timestamps_v1` (pointer/touch) with compositor scanout time from `wp_presentation` feedback. Reports two latencies per window: **frame-accurate** — each input is attributed to the frame whose build cutoff (the baton's `frame_start_time`) is at or after it, i.e. the frame that actually rendered it, giving true `present − input`; and **floor** — `present − input` for the first scanout at or after the input, which under-counts by the engine pipeline depth. Every 120 presents logs `[wayland] motion->photon: frame-accurate p50=Xms p99=Yms max=Zms \| floor p50=xms p99=yms \| n=N dropped=D`, plus a session summary (both metrics) at teardown. The frame-accurate metric is the input-side complement of the `pipeline_*` (beginFrame-to-present) latency above: together they span input → build → present. `IVI_PROFILE` enables it too. |
 | `IVI_VK_PRESENT_MODE` | `fifo` | One of `fifo`, `fifo_relaxed`, `mailbox`, `immediate`. Selects the swapchain present mode if the compositor advertises it; otherwise falls back to FIFO with a warn. See "Present-mode interaction" below — `mailbox` is the only setting where `vsync_callback`'s contribution becomes large. |
+| `IVI_VK_DMABUF` | (off) | **Experimental** zero-copy dma-buf present path (see below). When set, and the compositor advertises a DRM format modifier this GPU can render into, the compositor path bypasses the WSI swapchain entirely: it blits the engine's frame into a modifier-tiled, dma-buf-exported `VkImage` and commits it as a `wl_buffer` (via `zwp_linux_dmabuf_v1`) directly on the `wl_surface`, so the compositor can promote the surface to a hardware plane. Off by default; falls back to the swapchain when unset or when no renderable modifier is shared. |
+
+## Experimental: zero-copy dma-buf present (`IVI_VK_DMABUF`)
+
+Patterned on the wayland-cxx-scanner `skia-vulkan-dmabuf` example. The default
+present path renders through Mesa's `VK_KHR_wayland_surface` WSI swapchain, which
+means Mesa owns pacing (our `vsync_callback` is invisible at the present layer),
+needs `zwp_linux_dmabuf_v1`/`wl_drm` to allocate at all (`VK_ERROR_SURFACE_LOST`
+otherwise), and under MAILBOX discards thousands of frames for latency. The
+dma-buf path removes that layer:
+
+1. `wl::DmabufFeedback` (v4) reports the compositor's scanout-capable modifiers
+   and `main_device`; `NegotiateModifiers` intersects them with the modifiers
+   this device can export for `B8G8R8A8_UNORM`/`XRGB8888`.
+2. A ring of modifier-tiled, dma-buf-exported `VkImage` slots (`wl_dmabuf_present`),
+   each wrapped as a `wl_buffer` via `zwp_linux_buffer_params`.
+3. `PresentLayersDmabuf` blits the engine's backing-store layers into the current
+   slot (reusing the swapchain blit, retargeted), waits a per-slot CPU fence,
+   then attaches/damages/commits the `wl_buffer` — no `vkQueuePresentKHR`.
+
+Surface damage is version-driven: `wl_surface.damage_buffer` (buffer coords) on a
+v4+ surface, else `wl_surface.damage` (surface coords). ivi binds `wl_compositor`
+at v3 today, so it takes the v1 path — calling `damage_buffer` on a v3 surface is
+a **fatal protocol error** that disconnects the client.
+
+**Status / limitations.** Renders continuously and correctly on mutter
+(gnome-shell), default-off, no swapchain-path regression. Not yet done: (a) no
+vsync pacing, so the rasterizer runs free (MAILBOX-like, high fps) — refresh-
+adaptive pacing is a follow-up; (b) CPU-fence sync, not explicit sync
+(`wp_linux_drm_syncobj`, needs a scanner bump); (c) `wl_buffer.release` gating is
+best-effort (falls back to round-robin under the unpaced frame rate); (d)
+validated on mutter only. Platform-view layers are not yet composited on this path.
 
 ## Present-mode interaction (the surprising part)
 

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -33,7 +33,8 @@
 #include "task_runner.h"
 #include "wayland/display.h"
 
-#include <drm_fourcc.h>  // DRM_FORMAT_XRGB8888
+#include <drm_fourcc.h>      // DRM_FORMAT_XRGB8888
+#include <wayland-client.h>  // wl_surface_attach/damage_buffer/commit
 
 #include "backend/wayland_vulkan/wl_dmabuf_present.h"
 #include "vulkan_queue_interposer.h"
@@ -185,6 +186,27 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
     d().vkDeviceWaitIdle(device_);
 #if BUILD_COMPOSITOR
     CompositorPipeliningCleanup();
+    // Tear down the dma-buf present ring before the device — DmabufImage's
+    // destructor destroys its image view/image/memory with device_, and the
+    // command buffers belong to dmabuf_cmd_pool_.
+    for (auto& s : dmabuf_slots_) {
+      if (s.fence != VK_NULL_HANDLE) {
+        d().vkDestroyFence(device_, s.fence, nullptr);
+      }
+    }
+    dmabuf_slots_.clear();
+    if (dmabuf_cmd_pool_ != VK_NULL_HANDLE) {
+      d().vkDestroyCommandPool(device_, dmabuf_cmd_pool_, nullptr);
+      dmabuf_cmd_pool_ = VK_NULL_HANDLE;
+    }
+    // Destroy the backing stores while device_ is still valid. These pools are
+    // members, so their default destruction runs AFTER this dtor body — i.e.
+    // after vkDestroyDevice below — and VulkanBackingStore::~ calls
+    // vkDestroyImageView with the (by then invalid) device, aborting in the
+    // loader. Flushing here fixes both present paths (a SIGTERM mid-run leaves
+    // stores checked out).
+    m_alive_stores.clear();
+    m_store_pool.Flush();
 #endif
     if (swapchain_command_pool_ != nullptr) {
       d().vkDestroyCommandPool(device_, swapchain_command_pool_, nullptr);
@@ -1293,12 +1315,12 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
   findPhysicalDevice();
   createLogicalDevice();
 
-  // Verify the zero-copy present path can allocate a modifier-tiled dma-buf
-  // image the compositor advertised. Prefer scanout-tranche modifiers (the
-  // compositor's plane-promotable candidates), fall back to any advertised one.
-  // This is diagnostic only for now — the buffer is not yet wired into present;
-  // a later commit builds a wl_buffer from it and commits it instead of the
-  // WSI swapchain.
+#if BUILD_COMPOSITOR
+  // Select the zero-copy dma-buf present path when the compositor advertises a
+  // modifier this device can render into and IVI_VK_DMABUF is set. Prefer
+  // scanout-tranche modifiers (the compositor's plane-promotable candidates),
+  // fall back to any advertised one. Off by default: the swapchain path stays
+  // the default until this proves out.
   if (dmabuf_feedback_) {
     std::vector<uint64_t> comp_mods;
     {
@@ -1308,44 +1330,24 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
         comp_mods = fb_snapshot_.ModifiersFor(DRM_FORMAT_XRGB8888);
       }
     }
-    const auto negotiated = wl_vulkan::NegotiateModifiers(
+    dmabuf_modifiers_ = wl_vulkan::NegotiateModifiers(
         physical_device_, VK_FORMAT_B8G8R8A8_UNORM, comp_mods);
-    if (negotiated.empty()) {
+    const bool env_on = std::getenv("IVI_VK_DMABUF") != nullptr;
+    if (!dmabuf_modifiers_.empty() && env_on) {
+      dmabuf_present_active_ = true;
       ihs::log::info(
-          "[WaylandVulkanBackend] no renderable dma-buf modifier shared with "
-          "the compositor ({} offered); zero-copy present disabled",
-          comp_mods.size());
+          "[WaylandVulkanBackend] zero-copy dma-buf present ENABLED ({} "
+          "renderable modifier(s) shared with the compositor)",
+          dmabuf_modifiers_.size());
     } else {
-      std::string err;
-      auto img = wl_vulkan::DmabufImage::Create(
-          physical_device_, device_, width_, height_, VK_FORMAT_B8G8R8A8_UNORM,
-          DRM_FORMAT_XRGB8888,
-          VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-              VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-          negotiated, err);
-      if (img) {
-        ihs::log::info(
-            "[WaylandVulkanBackend] dma-buf present image OK: {}x{} modifier "
-            "{:#018x} planes={} fd={}",
-            img->width(), img->height(), img->modifier(), img->planes().size(),
-            img->dma_buf_fd());
-        auto buf = wl_vulkan::WlDmabufBuffer::Create(
-            dmabuf_feedback_->CreateParams(), *img);
-        if (buf) {
-          ihs::log::info(
-              "[WaylandVulkanBackend] dma-buf wl_buffer created (released={})",
-              buf->released());
-        } else {
-          ihs::log::warn(
-              "[WaylandVulkanBackend] dma-buf wl_buffer creation failed");
-        }
-      } else {
-        ihs::log::warn(
-            "[WaylandVulkanBackend] dma-buf present image alloc failed: {}",
-            err);
-      }
+      ihs::log::info(
+          "[WaylandVulkanBackend] dma-buf present {} (modifiers={}, env={}); "
+          "using WSI swapchain",
+          dmabuf_modifiers_.empty() ? "unavailable" : "disabled",
+          dmabuf_modifiers_.size(), env_on);
     }
   }
+#endif
 
   // --------------------------------------------------------------------------
   // Create sync primitives and command pool to use in the render loop
@@ -1728,6 +1730,9 @@ void WaylandVulkanBackend::BlitStoreToSwapchain(VkCommandBuffer cmd,
 
 bool WaylandVulkanBackend::PresentLayersImpl(const FlutterLayer** layers,
                                              size_t count) {
+  if (dmabuf_present_active_) {
+    return PresentLayersDmabuf(layers, count);
+  }
   if (resize_pending_) {
     InitializeSwapChain();
   }
@@ -1909,6 +1914,190 @@ bool WaylandVulkanBackend::PresentLayersImpl(const FlutterLayer** layers,
   ProfilePresent(result == VK_SUCCESS);
 
   ++m_compositor_current_frame_;
+  return ok;
+}
+
+bool WaylandVulkanBackend::InitDmabufRing(uint32_t w, uint32_t h) {
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    d().vkQueueWaitIdle(queue_);
+  }
+  for (auto& s : dmabuf_slots_) {
+    if (s.fence != VK_NULL_HANDLE) {
+      d().vkDestroyFence(device_, s.fence, nullptr);
+    }
+  }
+  dmabuf_slots_.clear();
+
+  if (dmabuf_cmd_pool_ == VK_NULL_HANDLE) {
+    VkCommandPoolCreateInfo pi{};
+    pi.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pi.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    pi.queueFamilyIndex = queue_family_index_;
+    if (d().vkCreateCommandPool(device_, &pi, nullptr, &dmabuf_cmd_pool_) !=
+        VK_SUCCESS) {
+      ihs::log::error("[WaylandVulkanBackend] dma-buf cmd pool create failed");
+      dmabuf_present_active_ = false;
+      return false;
+    }
+  }
+
+  constexpr size_t kRing = 3;
+  for (size_t i = 0; i < kRing; ++i) {
+    DmabufSlot slot;
+    std::string err;
+    slot.image = wl_vulkan::DmabufImage::Create(
+        physical_device_, device_, w, h, VK_FORMAT_B8G8R8A8_UNORM,
+        DRM_FORMAT_XRGB8888,
+        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+            VK_IMAGE_USAGE_SAMPLED_BIT,
+        dmabuf_modifiers_, err);
+    if (!slot.image) {
+      ihs::log::error("[WaylandVulkanBackend] dma-buf ring image {} failed: {}",
+                      i, err);
+      dmabuf_present_active_ = false;
+      return false;
+    }
+    slot.buffer = wl_vulkan::WlDmabufBuffer::Create(
+        dmabuf_feedback_->CreateParams(), *slot.image);
+    if (!slot.buffer) {
+      ihs::log::error("[WaylandVulkanBackend] dma-buf ring buffer {} failed",
+                      i);
+      dmabuf_present_active_ = false;
+      return false;
+    }
+    VkCommandBufferAllocateInfo ai{};
+    ai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    ai.commandPool = dmabuf_cmd_pool_;
+    ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    ai.commandBufferCount = 1;
+    d().vkAllocateCommandBuffers(device_, &ai, &slot.cmd);
+    VkFenceCreateInfo fi{};
+    fi.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    fi.flags = VK_FENCE_CREATE_SIGNALED_BIT;  // first wait returns immediately
+    d().vkCreateFence(device_, &fi, nullptr, &slot.fence);
+    slot.layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    dmabuf_slots_.push_back(std::move(slot));
+  }
+  dmabuf_ring_w_ = w;
+  dmabuf_ring_h_ = h;
+  dmabuf_frame_ = 0;
+  ihs::log::info(
+      "[WaylandVulkanBackend] dma-buf present ring: {} slots {}x{} modifier "
+      "{:#018x}",
+      dmabuf_slots_.size(), w, h, dmabuf_slots_.front().image->modifier());
+  return true;
+}
+
+bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
+                                               size_t count) {
+  const uint32_t w = width_;
+  const uint32_t h = height_;
+  if (dmabuf_slots_.empty() || dmabuf_ring_w_ != w || dmabuf_ring_h_ != h) {
+    if (!InitDmabufRing(w, h)) {
+      // Allocation failed — fall back to the swapchain path for good.
+      return PresentLayersImpl(layers, count);
+    }
+  }
+  DmabufSlot& slot = dmabuf_slots_[dmabuf_frame_ % dmabuf_slots_.size()];
+
+  CHECK_VK_RESULT(
+      d().vkWaitForFences(device_, 1, &slot.fence, VK_TRUE, UINT64_MAX));
+  CHECK_VK_RESULT(d().vkResetFences(device_, 1, &slot.fence));
+
+  VkCommandBuffer cmd = slot.cmd;
+  d().vkResetCommandBuffer(cmd, 0);
+  VkCommandBufferBeginInfo begin{};
+  begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+  begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+  d().vkBeginCommandBuffer(cmd, &begin);
+
+  // Transition the dma-buf image to TRANSFER_DST for the blit.
+  VkImageMemoryBarrier to_dst{};
+  to_dst.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  to_dst.oldLayout = slot.layout;
+  to_dst.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+  to_dst.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  to_dst.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  to_dst.image = slot.image->image();
+  to_dst.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+  to_dst.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+  d().vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                           nullptr, 1, &to_dst);
+
+  m_sequencer.Present(layers, count, nullptr,
+                      [](FlutterPlatformViewIdentifier) {});
+
+  bool ok = true;
+  for (size_t i = 0; i < count; ++i) {
+    const FlutterLayer* layer = layers[i];
+    if (!layer) {
+      continue;
+    }
+    if (layer->type == kFlutterLayerContentTypeBackingStore &&
+        layer->backing_store) {
+      auto* baton =
+          static_cast<VulkanStoreBaton*>(layer->backing_store->user_data);
+      if (!baton || !baton->store) {
+        continue;
+      }
+      const auto dx = static_cast<int32_t>(layer->offset.x);
+      const auto dy = static_cast<int32_t>(layer->offset.y);
+      const auto dw = static_cast<int32_t>(layer->size.width);
+      const auto dh = static_cast<int32_t>(layer->size.height);
+      BlitStoreToSwapchain(cmd, *baton->store, slot.image->image(), dx, dy, dw,
+                           dh);
+    }
+    // Platform-view layers are not yet composited on the dma-buf path.
+  }
+
+  // GENERAL so the compositor's external dma-buf read sees a coherent frame.
+  // The CPU fence wait below is the producer/consumer sync for this first
+  // (non-explicit-sync) version.
+  VkImageMemoryBarrier to_general{};
+  to_general.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  to_general.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+  to_general.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+  to_general.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  to_general.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  to_general.image = slot.image->image();
+  to_general.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+  to_general.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+  to_general.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+  d().vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr,
+                           0, nullptr, 1, &to_general);
+  slot.layout = VK_IMAGE_LAYOUT_GENERAL;
+
+  d().vkEndCommandBuffer(cmd);
+
+  VkSubmitInfo submit{};
+  submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+  submit.commandBufferCount = 1;
+  submit.pCommandBuffers = &cmd;
+  {
+    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+    d().vkQueueSubmit(queue_, 1, &submit, slot.fence);
+  }
+  // CPU fence: block until the blit completes so the dma-buf holds a full frame
+  // before the compositor samples it.
+  CHECK_VK_RESULT(
+      d().vkWaitForFences(device_, 1, &slot.fence, VK_TRUE, UINT64_MAX));
+
+  RequestPresentationFeedback();
+
+  wl_surface* surface = wl_surface_.load(std::memory_order_acquire);
+  auto* buffer = reinterpret_cast<wl_buffer*>(slot.buffer->proxy());
+  wl_surface_attach(surface, buffer, 0, 0);
+  wl_surface_damage_buffer(surface, 0, 0, static_cast<int32_t>(w),
+                           static_cast<int32_t>(h));
+  wl_surface_commit(surface);
+  wl_display_flush(wl_display_);
+  slot.buffer->mark_in_use();
+
+  ProfilePresent(true);
+  ++dmabuf_frame_;
   return ok;
 }
 

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -1329,6 +1329,16 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
             "{:#018x} planes={} fd={}",
             img->width(), img->height(), img->modifier(), img->planes().size(),
             img->dma_buf_fd());
+        auto buf = wl_vulkan::WlDmabufBuffer::Create(
+            dmabuf_feedback_->CreateParams(), *img);
+        if (buf) {
+          ihs::log::info(
+              "[WaylandVulkanBackend] dma-buf wl_buffer created (released={})",
+              buf->released());
+        } else {
+          ihs::log::warn(
+              "[WaylandVulkanBackend] dma-buf wl_buffer creation failed");
+        }
       } else {
         ihs::log::warn(
             "[WaylandVulkanBackend] dma-buf present image alloc failed: {}",

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -2008,7 +2008,20 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
       return PresentLayersImpl(layers, count);
     }
   }
-  DmabufSlot& slot = dmabuf_slots_[dmabuf_frame_ % dmabuf_slots_.size()];
+  // Prefer a slot whose wl_buffer the compositor has released, so we don't
+  // overwrite a buffer that is still being scanned out. Start at the
+  // round-robin position and take the first free slot; if every slot is still
+  // in flight (the rasterizer is outrunning the compositor — expected until
+  // refresh- adaptive pacing lands), fall back to the round-robin slot.
+  size_t idx = dmabuf_frame_ % dmabuf_slots_.size();
+  for (size_t i = 0; i < dmabuf_slots_.size(); ++i) {
+    const size_t cand = (dmabuf_frame_ + i) % dmabuf_slots_.size();
+    if (dmabuf_slots_[cand].buffer->released()) {
+      idx = cand;
+      break;
+    }
+  }
+  DmabufSlot& slot = dmabuf_slots_[idx];
 
   CHECK_VK_RESULT(
       d().vkWaitForFences(device_, 1, &slot.fence, VK_TRUE, UINT64_MAX));
@@ -2099,10 +2112,19 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
   wl_surface* surface = wl_surface_.load(std::memory_order_acquire);
   auto* buffer = reinterpret_cast<wl_buffer*>(slot.buffer->proxy());
   wl_surface_attach(surface, buffer, 0, 0);
-  // wl_surface.damage (v1, surface coords), NOT damage_buffer (v4) — ivi binds
-  // wl_compositor at v3, so damage_buffer is a fatal protocol error. Full-
-  // surface damage covers any size regardless of the viewport scale.
-  wl_surface_damage(surface, 0, 0, INT32_MAX, INT32_MAX);
+  // Damage the surface. wl_surface.damage_buffer (buffer coordinates) is a v4
+  // request; ivi binds wl_compositor at v3 today, so calling it there is a
+  // FATAL protocol error that disconnects the client. Fall back to
+  // wl_surface.damage (v1, surface coordinates) on older surfaces. This branch
+  // is version-driven, so it auto-upgrades to the precise buffer-coordinate
+  // path (needed for partial-repaint damage) if the compositor bind is ever
+  // raised to v4+. Full-surface damage is equivalent under either request.
+  if (wl_proxy_get_version(reinterpret_cast<wl_proxy*>(surface)) >= 4) {
+    wl_surface_damage_buffer(surface, 0, 0, static_cast<int32_t>(w),
+                             static_cast<int32_t>(h));
+  } else {
+    wl_surface_damage(surface, 0, 0, INT32_MAX, INT32_MAX);
+  }
   wl_surface_commit(surface);
   wl_display_flush(wl_display_);
   slot.buffer->mark_in_use();

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -1354,22 +1354,31 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
   // callbacks.
   // --------------------------------------------------------------------------
 
-  VkFenceCreateInfo f_info{};
-  f_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-  d().vkCreateFence(device_, &f_info, nullptr, &image_ready_fence_);
+  // On the dma-buf present path we commit buffers directly on the wl_surface
+  // and never touch a VkSwapchainKHR, so skip all swapchain setup. Creating a
+  // Mesa WSI swapchain on the same surface — even one we never present to —
+  // leaves Mesa owning the surface's buffer state, and the compositor then
+  // never presents (or sends presentation feedback for) our direct commits,
+  // which stalls the engine after its first pipeline of frames. The
+  // skia-vulkan-dmabuf reference never creates a swapchain either.
+  if (!dmabuf_present_active_) {
+    VkFenceCreateInfo f_info{};
+    f_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    d().vkCreateFence(device_, &f_info, nullptr, &image_ready_fence_);
 
-  // present_transition_semaphores_ are created per swapchain image inside
-  // InitializeSwapChain (below), since their count tracks the swapchain.
+    // present_transition_semaphores_ are created per swapchain image inside
+    // InitializeSwapChain (below), since their count tracks the swapchain.
 
-  VkCommandPoolCreateInfo pool_info{};
-  pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-  pool_info.queueFamilyIndex = queue_family_index_;
-  d().vkCreateCommandPool(device_, &pool_info, nullptr,
-                          &swapchain_command_pool_);
+    VkCommandPoolCreateInfo pool_info{};
+    pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pool_info.queueFamilyIndex = queue_family_index_;
+    d().vkCreateCommandPool(device_, &pool_info, nullptr,
+                            &swapchain_command_pool_);
 
-  if (!InitializeSwapChain()) {
-    ihs::log::critical("Failed to create swap chain.");
-    exit(EXIT_FAILURE);
+    if (!InitializeSwapChain()) {
+      ihs::log::critical("Failed to create swap chain.");
+      exit(EXIT_FAILURE);
+    }
   }
 }
 

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -33,6 +33,8 @@
 #include "task_runner.h"
 #include "wayland/display.h"
 
+#include <drm_fourcc.h>  // DRM_FORMAT_XRGB8888
+
 #include "vulkan_queue_interposer.h"
 
 // The vulkan.hpp dynamic dispatcher needs its storage defined in exactly ONE
@@ -73,6 +75,7 @@ WaylandVulkanBackend::WaylandVulkanBackend(Display* shell_display,
       wl_display_(display),
       width_(width),
       height_(height) {
+  shell_display_ = shell_display;
   if (shell_display != nullptr) {
     // wp_presentation + vsync feedback machinery live in the Display-owned
     // provider; the backend forwards to it.
@@ -1204,6 +1207,22 @@ void WaylandVulkanBackend::Resize(size_t /* index */,
   }
 }
 
+void WaylandVulkanBackend::OnDmabufFeedback(const wl::FeedbackSnapshot& snap) {
+  {
+    std::lock_guard<std::mutex> lock(fb_mu_);
+    fb_snapshot_ = snap;
+  }
+  const auto scanout = snap.ScanoutModifiersFor(DRM_FORMAT_XRGB8888);
+  const auto all = snap.ModifiersFor(DRM_FORMAT_XRGB8888);
+  ihs::log::info(
+      "[WaylandVulkanBackend] dma-buf feedback: main_device={:#x} "
+      "XRGB8888 modifiers scanout={} total={}",
+      static_cast<uint64_t>(snap.main_device), scanout.size(), all.size());
+  for (const uint64_t m : scanout) {
+    ihs::log::debug("[WaylandVulkanBackend]   scanout modifier {:#018x}", m);
+  }
+}
+
 void WaylandVulkanBackend::CreateSurface(size_t /* index */,
                                          wl_surface* surface,
                                          int32_t /* width */,
@@ -1223,6 +1242,28 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
   wl_surface_.store(surface, std::memory_order_release);
   if (vsync_ != nullptr) {
     vsync_->SetSurface(surface);
+  }
+
+  // Bind v4 dma-buf feedback for the zero-copy present path. Independent of
+  // Mesa's WSI dmabuf bind; per-surface feedback carries the accurate scanout
+  // flag for this surface. A roundtrip drains the initial advertisement so
+  // fb_snapshot_ is populated before the first frame.
+  if (shell_display_ != nullptr && shell_display_->GetLinuxDmabufName() != 0) {
+    dmabuf_feedback_ =
+        std::make_unique<wl::DmabufFeedback<WaylandVulkanBackend>>();
+    dmabuf_feedback_->Record(shell_display_->GetLinuxDmabufName(),
+                             shell_display_->GetLinuxDmabufVersion());
+    if (dmabuf_feedback_->Bind(shell_display_->GetRegistry(), this) &&
+        dmabuf_feedback_->StartSurface(wl_display_,
+                                       reinterpret_cast<wl_proxy*>(surface))) {
+      wl_display_roundtrip(wl_display_);
+    } else {
+      ihs::log::info(
+          "[WaylandVulkanBackend] dma-buf feedback v{} unavailable; zero-copy "
+          "present path disabled (WSI swapchain fallback)",
+          shell_display_->GetLinuxDmabufVersion());
+      dmabuf_feedback_.reset();
+    }
   }
 
   VkWaylandSurfaceCreateInfoKHR createInfo{};

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -35,6 +35,7 @@
 
 #include <drm_fourcc.h>  // DRM_FORMAT_XRGB8888
 
+#include "backend/wayland_vulkan/wl_dmabuf_present.h"
 #include "vulkan_queue_interposer.h"
 
 // The vulkan.hpp dynamic dispatcher needs its storage defined in exactly ONE
@@ -487,6 +488,21 @@ void WaylandVulkanBackend::findPhysicalDevice() {
         score += 1 << 29;
         supported_extensions.push_back(
             VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+      }
+      // dma-buf zero-copy present path: import/export a modifier-tiled image
+      // the compositor can scan out. Enabled when advertised; the path stays
+      // gated at runtime on a successful DmabufImage allocation, so a device
+      // missing any of these simply falls back to the WSI swapchain.
+      else {
+        for (const char* want :
+             {VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME,
+              VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
+              VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+              VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME}) {
+          if (strcmp(want, extensionName) == 0) {
+            supported_extensions.push_back(want);
+          }
+        }
       }
     }
 
@@ -1276,6 +1292,50 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
 
   findPhysicalDevice();
   createLogicalDevice();
+
+  // Verify the zero-copy present path can allocate a modifier-tiled dma-buf
+  // image the compositor advertised. Prefer scanout-tranche modifiers (the
+  // compositor's plane-promotable candidates), fall back to any advertised one.
+  // This is diagnostic only for now — the buffer is not yet wired into present;
+  // a later commit builds a wl_buffer from it and commits it instead of the
+  // WSI swapchain.
+  if (dmabuf_feedback_) {
+    std::vector<uint64_t> comp_mods;
+    {
+      std::lock_guard<std::mutex> lock(fb_mu_);
+      comp_mods = fb_snapshot_.ScanoutModifiersFor(DRM_FORMAT_XRGB8888);
+      if (comp_mods.empty()) {
+        comp_mods = fb_snapshot_.ModifiersFor(DRM_FORMAT_XRGB8888);
+      }
+    }
+    const auto negotiated = wl_vulkan::NegotiateModifiers(
+        physical_device_, VK_FORMAT_B8G8R8A8_UNORM, comp_mods);
+    if (negotiated.empty()) {
+      ihs::log::info(
+          "[WaylandVulkanBackend] no renderable dma-buf modifier shared with "
+          "the compositor ({} offered); zero-copy present disabled",
+          comp_mods.size());
+    } else {
+      std::string err;
+      auto img = wl_vulkan::DmabufImage::Create(
+          physical_device_, device_, width_, height_, VK_FORMAT_B8G8R8A8_UNORM,
+          DRM_FORMAT_XRGB8888,
+          VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+              VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+          negotiated, err);
+      if (img) {
+        ihs::log::info(
+            "[WaylandVulkanBackend] dma-buf present image OK: {}x{} modifier "
+            "{:#018x} planes={} fd={}",
+            img->width(), img->height(), img->modifier(), img->planes().size(),
+            img->dma_buf_fd());
+      } else {
+        ihs::log::warn(
+            "[WaylandVulkanBackend] dma-buf present image alloc failed: {}",
+            err);
+      }
+    }
+  }
 
   // --------------------------------------------------------------------------
   // Create sync primitives and command pool to use in the render loop

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -2004,8 +2004,14 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
   const uint32_t h = height_;
   if (dmabuf_slots_.empty() || dmabuf_ring_w_ != w || dmabuf_ring_h_ != h) {
     if (!InitDmabufRing(w, h)) {
-      // Allocation failed — fall back to the swapchain path for good.
-      return PresentLayersImpl(layers, count);
+      // Ring allocation failed. There is no swapchain to fall back to at
+      // runtime — it was skipped in CreateSurface when the dma-buf path was
+      // selected — so drop this frame. Rare: dma-buf allocation only fails
+      // under GPU memory pressure, and InitDmabufRing has already cleared
+      // dmabuf_present_active_.
+      ihs::log::error(
+          "[WaylandVulkanBackend] dma-buf ring init failed; frame dropped");
+      return false;
     }
   }
   // Prefer a slot whose wl_buffer the compositor has released, so we don't

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -1354,13 +1354,20 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
   // callbacks.
   // --------------------------------------------------------------------------
 
-  // On the dma-buf present path we commit buffers directly on the wl_surface
-  // and never touch a VkSwapchainKHR, so skip all swapchain setup. Creating a
-  // Mesa WSI swapchain on the same surface — even one we never present to —
-  // leaves Mesa owning the surface's buffer state, and the compositor then
-  // never presents (or sends presentation feedback for) our direct commits,
-  // which stalls the engine after its first pipeline of frames. The
-  // skia-vulkan-dmabuf reference never creates a swapchain either.
+  // swapchain_command_pool_ backs TransitionLayout, which runs on BOTH present
+  // paths (backing-store layout transitions in CreateBackingStore), so always
+  // create it — the name is historical.
+  VkCommandPoolCreateInfo pool_info{};
+  pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+  pool_info.queueFamilyIndex = queue_family_index_;
+  d().vkCreateCommandPool(device_, &pool_info, nullptr,
+                          &swapchain_command_pool_);
+
+  // The VkSwapchainKHR (and its image-acquire fence) is only for the WSI
+  // present path. On the dma-buf path we commit buffers directly on the
+  // wl_surface and never create a swapchain — a Mesa WSI swapchain on the same
+  // surface would otherwise own the surface's buffer state. skia-vulkan-dmabuf
+  // works the same.
   if (!dmabuf_present_active_) {
     VkFenceCreateInfo f_info{};
     f_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
@@ -1368,13 +1375,6 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
 
     // present_transition_semaphores_ are created per swapchain image inside
     // InitializeSwapChain (below), since their count tracks the swapchain.
-
-    VkCommandPoolCreateInfo pool_info{};
-    pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-    pool_info.queueFamilyIndex = queue_family_index_;
-    d().vkCreateCommandPool(device_, &pool_info, nullptr,
-                            &swapchain_command_pool_);
-
     if (!InitializeSwapChain()) {
       ihs::log::critical("Failed to create swap chain.");
       exit(EXIT_FAILURE);
@@ -2099,8 +2099,10 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
   wl_surface* surface = wl_surface_.load(std::memory_order_acquire);
   auto* buffer = reinterpret_cast<wl_buffer*>(slot.buffer->proxy());
   wl_surface_attach(surface, buffer, 0, 0);
-  wl_surface_damage_buffer(surface, 0, 0, static_cast<int32_t>(w),
-                           static_cast<int32_t>(h));
+  // wl_surface.damage (v1, surface coords), NOT damage_buffer (v4) — ivi binds
+  // wl_compositor at v3, so damage_buffer is a fatal protocol error. Full-
+  // surface damage covers any size regardless of the viewport scale.
+  wl_surface_damage(surface, 0, 0, INT32_MAX, INT32_MAX);
   wl_surface_commit(surface);
   wl_display_flush(wl_display_);
   slot.buffer->mark_in_use();

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -415,6 +415,12 @@ class WaylandVulkanBackend final : public Backend {
                             size_t layers_count,
                             void* user_data);
 
+  // Whether the zero-copy dma-buf present path is active (see the DmabufSlot
+  // ring below). Declared outside BUILD_COMPOSITOR because CreateSurface reads
+  // it to decide whether to create the WSI swapchain, which is compiled on
+  // every configuration; it can only ever become true under BUILD_COMPOSITOR.
+  bool dmabuf_present_active_{false};
+
 #if BUILD_COMPOSITOR
   bool dma_buf_export_ok_{false};
 
@@ -493,7 +499,6 @@ class WaylandVulkanBackend final : public Backend {
     VkFence fence{VK_NULL_HANDLE};
     VkImageLayout layout{VK_IMAGE_LAYOUT_UNDEFINED};
   };
-  bool dmabuf_present_active_{false};
   std::vector<uint64_t> dmabuf_modifiers_;  // negotiated set, cached in Create
   VkCommandPool dmabuf_cmd_pool_{VK_NULL_HANDLE};
   std::vector<DmabufSlot> dmabuf_slots_;

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -22,6 +22,15 @@
 #include <mutex>
 #include <vector>
 
+// clang-format off
+// Include order is load-bearing: the generated protocol client header defines
+// the linux_dmabuf_unstable_v1::client traits that the shipped wl/ helpers
+// below reference, so it must precede them — clang-format must not reorder.
+#include "linux_dmabuf_client.hpp"  // generated (linux_dmabuf_unstable_v1::client)
+#include <wl/linux_dmabuf.hpp>      // shipped interface tables + wl_iface()
+#include <wl/dmabuf_feedback.hpp>   // wl::DmabufFeedback, wl::FeedbackSnapshot
+// clang-format on
+
 #include "vsync/wayland_vsync_provider.h"
 
 // Use vulkan.hpp's convenient proc table and resolver.
@@ -522,6 +531,20 @@ class WaylandVulkanBackend final : public Backend {
   FLUTTER_API_SYMBOL(FlutterEngine) engine_handle_ { nullptr };
   TaskRunner* platform_task_runner_{nullptr};
 
+  // Owning Display, kept so CreateSurface can bind the v4 dma-buf feedback
+  // (the compositor's scanout-capable modifiers + main device) for the
+  // zero-copy present path, independent of Mesa's own WSI dmabuf bind.
+  Display* shell_display_{nullptr};
+  std::unique_ptr<wl::DmabufFeedback<WaylandVulkanBackend>> dmabuf_feedback_;
+  mutable std::mutex fb_mu_;
+  wl::FeedbackSnapshot fb_snapshot_;  // guarded by fb_mu_
+
+ public:
+  // Fired by the dma-buf feedback helper on every `done`; records the snapshot
+  // and logs the scanout-capable modifiers the direct present path can use.
+  void OnDmabufFeedback(const wl::FeedbackSnapshot& snap);
+
+ private:
   // frame_start_time most recently handed to FlutterEngineOnVsync.
   // Updated atomically by the OnVsync-posting paths (PostOnVsync's
   // lambda and on_feedback_presented's inline post). Read by

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -59,6 +59,11 @@
 class Display;
 class TaskRunner;
 
+namespace wl_vulkan {
+class DmabufImage;
+class WlDmabufBuffer;
+}  // namespace wl_vulkan
+
 class WaylandVulkanBackend final : public Backend {
  public:
   // @p shell_display may be null in headless / test contexts; the
@@ -473,6 +478,36 @@ class WaylandVulkanBackend final : public Backend {
   // MissingAcquireWait).
   std::vector<VkSemaphore> m_compositor_render_finished_;
   size_t m_compositor_current_frame_{0};
+
+  // --- Zero-copy dma-buf present path (bypasses the WSI swapchain) ----------
+  // The engine's composited frame is blitted into a modifier-tiled dma-buf
+  // image the compositor imports as a wl_buffer and can promote to a hardware
+  // plane, committed directly on the wl_surface instead of vkQueuePresentKHR.
+  // Gated on the compositor advertising a usable modifier AND IVI_VK_DMABUF;
+  // off by default (the swapchain path stays the default until this proves
+  // out).
+  struct DmabufSlot {
+    std::unique_ptr<wl_vulkan::DmabufImage> image;
+    std::unique_ptr<wl_vulkan::WlDmabufBuffer> buffer;
+    VkCommandBuffer cmd{VK_NULL_HANDLE};
+    VkFence fence{VK_NULL_HANDLE};
+    VkImageLayout layout{VK_IMAGE_LAYOUT_UNDEFINED};
+  };
+  bool dmabuf_present_active_{false};
+  std::vector<uint64_t> dmabuf_modifiers_;  // negotiated set, cached in Create
+  VkCommandPool dmabuf_cmd_pool_{VK_NULL_HANDLE};
+  std::vector<DmabufSlot> dmabuf_slots_;
+  uint32_t dmabuf_ring_w_{0};
+  uint32_t dmabuf_ring_h_{0};
+  size_t dmabuf_frame_{0};
+
+  // Build (or rebuild after a resize) the ring of dma-buf image+wl_buffer
+  // slots at @p w x @p h. Returns false (and clears dmabuf_present_active_) on
+  // any allocation failure, so present falls back to the swapchain.
+  bool InitDmabufRing(uint32_t w, uint32_t h);
+  // Composite the layers into the current slot and commit its wl_buffer on the
+  // surface. Returns the present result like PresentLayersImpl.
+  bool PresentLayersDmabuf(const FlutterLayer** layers, size_t count);
 
   /// Allocate the per-slot pool, command buffers, fences, and semaphores.
   /// Idempotent — releases prior state first, so safe to call again after

--- a/shell/backend/wayland_vulkan/wl_dmabuf_present.cc
+++ b/shell/backend/wayland_vulkan/wl_dmabuf_present.cc
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/wayland_vulkan/wl_dmabuf_present.h"
+
+#include <unistd.h>
+#include <array>
+#include <set>
+
+#include <drm_fourcc.h>
+
+// Dynamic dispatch, matching the backend (which owns the loader storage and
+// calls VULKAN_HPP_DEFAULT_DISPATCHER.init()); do NOT define the storage here.
+#define VULKAN_HPP_NO_EXCEPTIONS 1
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+#include <vulkan/vulkan.hpp>
+
+namespace wl_vulkan {
+
+namespace {
+
+const auto& d() {
+  return vk::detail::defaultDispatchLoaderDynamic;
+}
+
+uint32_t PickMemoryType(VkPhysicalDevice phys,
+                        uint32_t type_bits,
+                        VkMemoryPropertyFlags want) {
+  VkPhysicalDeviceMemoryProperties mp{};
+  d().vkGetPhysicalDeviceMemoryProperties(phys, &mp);
+  for (uint32_t i = 0; i < mp.memoryTypeCount; ++i) {
+    if ((type_bits & (1u << i)) &&
+        (mp.memoryTypes[i].propertyFlags & want) == want) {
+      return i;
+    }
+  }
+  return UINT32_MAX;
+}
+
+// Plane count the driver uses for @p modifier with @p vk_format.
+uint32_t PlaneCountForModifier(VkPhysicalDevice phys,
+                               VkFormat vk_format,
+                               uint64_t modifier) {
+  VkDrmFormatModifierPropertiesListEXT list{};
+  list.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+  VkFormatProperties2 fp{};
+  fp.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+  fp.pNext = &list;
+  d().vkGetPhysicalDeviceFormatProperties2(phys, vk_format, &fp);
+  std::vector<VkDrmFormatModifierPropertiesEXT> mods(
+      list.drmFormatModifierCount);
+  list.pDrmFormatModifierProperties = mods.data();
+  d().vkGetPhysicalDeviceFormatProperties2(phys, vk_format, &fp);
+  for (const auto& m : mods) {
+    if (m.drmFormatModifier == modifier) {
+      return m.drmFormatModifierPlaneCount;
+    }
+  }
+  return 0;
+}
+
+}  // namespace
+
+std::vector<uint64_t> NegotiateModifiers(
+    VkPhysicalDevice physical_device,
+    VkFormat vk_format,
+    const std::vector<uint64_t>& compositor_modifiers) {
+  VkDrmFormatModifierPropertiesListEXT list{};
+  list.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+  VkFormatProperties2 fp{};
+  fp.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+  fp.pNext = &list;
+  d().vkGetPhysicalDeviceFormatProperties2(physical_device, vk_format, &fp);
+  std::vector<VkDrmFormatModifierPropertiesEXT> mods(
+      list.drmFormatModifierCount);
+  list.pDrmFormatModifierProperties = mods.data();
+  d().vkGetPhysicalDeviceFormatProperties2(physical_device, vk_format, &fp);
+
+  // Renderable + blit-target + sampleable: the compositor path blits the
+  // engine's frame into this image, then the compositor samples/scans it out.
+  const VkFormatFeatureFlags need = VK_FORMAT_FEATURE_TRANSFER_DST_BIT |
+                                    VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
+  std::set<uint64_t> exportable;
+  for (const auto& m : mods) {
+    if ((m.drmFormatModifierTilingFeatures & need) == need) {
+      exportable.insert(m.drmFormatModifier);
+    }
+  }
+
+  const std::set<uint64_t> comp(compositor_modifiers.begin(),
+                                compositor_modifiers.end());
+  std::vector<uint64_t> tiled;
+  bool has_linear = false;
+  for (uint64_t m : exportable) {
+    if (!comp.count(m)) {
+      continue;
+    }
+    if (m == DRM_FORMAT_MOD_LINEAR) {
+      has_linear = true;
+    } else {
+      tiled.push_back(m);
+    }
+  }
+  if (has_linear) {
+    tiled.push_back(DRM_FORMAT_MOD_LINEAR);
+  }
+  return tiled;
+}
+
+std::unique_ptr<DmabufImage> DmabufImage::Create(
+    VkPhysicalDevice physical_device,
+    VkDevice device,
+    uint32_t width,
+    uint32_t height,
+    VkFormat vk_format,
+    uint32_t drm_fourcc,
+    VkImageUsageFlags usage,
+    const std::vector<uint64_t>& allowed_modifiers,
+    std::string& err) {
+  if (allowed_modifiers.empty()) {
+    err = "no allowed modifiers (empty negotiation result)";
+    return nullptr;
+  }
+
+  std::unique_ptr<DmabufImage> img(new DmabufImage(device, width, height));
+  img->drm_fourcc_ = drm_fourcc;
+
+  VkImageDrmFormatModifierListCreateInfoEXT mod_list{};
+  mod_list.sType =
+      VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT;
+  mod_list.drmFormatModifierCount =
+      static_cast<uint32_t>(allowed_modifiers.size());
+  mod_list.pDrmFormatModifiers = allowed_modifiers.data();
+  VkExternalMemoryImageCreateInfo ext{};
+  ext.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+  ext.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+  ext.pNext = &mod_list;
+
+  VkImageCreateInfo ic{};
+  ic.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  ic.pNext = &ext;
+  ic.imageType = VK_IMAGE_TYPE_2D;
+  ic.format = vk_format;
+  ic.extent = {width, height, 1};
+  ic.mipLevels = 1;
+  ic.arrayLayers = 1;
+  ic.samples = VK_SAMPLE_COUNT_1_BIT;
+  ic.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
+  ic.usage = usage;
+  ic.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  if (d().vkCreateImage(device, &ic, nullptr, &img->image_) != VK_SUCCESS) {
+    err = "vkCreateImage with modifier list failed";
+    return nullptr;
+  }
+
+  VkImageDrmFormatModifierPropertiesEXT mp{};
+  mp.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT;
+  if (d().vkGetImageDrmFormatModifierPropertiesEXT(device, img->image_, &mp) !=
+      VK_SUCCESS) {
+    err = "vkGetImageDrmFormatModifierPropertiesEXT failed";
+    return nullptr;
+  }
+  img->modifier_ = mp.drmFormatModifier;
+
+  const uint32_t plane_count =
+      PlaneCountForModifier(physical_device, vk_format, img->modifier_);
+  if (plane_count < 1 || plane_count > 4) {
+    err = "unexpected plane count for chosen modifier";
+    return nullptr;
+  }
+
+  VkMemoryRequirements req{};
+  d().vkGetImageMemoryRequirements(device, img->image_, &req);
+  const uint32_t mt = PickMemoryType(physical_device, req.memoryTypeBits,
+                                     VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+  if (mt == UINT32_MAX) {
+    err = "no DEVICE_LOCAL memory type for scanout image";
+    return nullptr;
+  }
+  // Dedicated allocation: many drivers require (and all allow) a dma-buf
+  // exported image's memory to be bound 1:1 to that image. Without it
+  // vkBindImageMemory fails on Mesa/RADV and others.
+  VkMemoryDedicatedAllocateInfo dedicated{};
+  dedicated.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+  dedicated.image = img->image_;
+  VkExportMemoryAllocateInfo emai{};
+  emai.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
+  emai.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+  emai.pNext = &dedicated;
+  VkMemoryAllocateInfo mai{};
+  mai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  mai.pNext = &emai;
+  mai.allocationSize = req.size;
+  mai.memoryTypeIndex = mt;
+  if (d().vkAllocateMemory(device, &mai, nullptr, &img->memory_) !=
+      VK_SUCCESS) {
+    err = "vkAllocateMemory (exported) failed";
+    return nullptr;
+  }
+  if (d().vkBindImageMemory(device, img->image_, img->memory_, 0) !=
+      VK_SUCCESS) {
+    err = "vkBindImageMemory failed";
+    return nullptr;
+  }
+
+  static constexpr std::array<VkImageAspectFlagBits, 4> kMemPlane = {
+      VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT,
+      VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT,
+      VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT,
+      VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT,
+  };
+  img->planes_.resize(plane_count);
+  for (uint32_t i = 0; i < plane_count; ++i) {
+    VkImageSubresource sub{};
+    sub.aspectMask = kMemPlane[i];
+    VkSubresourceLayout sl{};
+    d().vkGetImageSubresourceLayout(device, img->image_, &sub, &sl);
+    img->planes_[i] = {sl.offset, sl.rowPitch};
+  }
+
+  VkMemoryGetFdInfoKHR gfi{};
+  gfi.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+  gfi.memory = img->memory_;
+  gfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+  if (d().vkGetMemoryFdKHR(device, &gfi, &img->dma_buf_fd_) != VK_SUCCESS) {
+    err = "vkGetMemoryFdKHR failed";
+    return nullptr;
+  }
+
+  VkImageViewCreateInfo vci{};
+  vci.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+  vci.image = img->image_;
+  vci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+  vci.format = vk_format;
+  vci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+  if (d().vkCreateImageView(device, &vci, nullptr, &img->view_) != VK_SUCCESS) {
+    err = "vkCreateImageView failed";
+    return nullptr;
+  }
+
+  return img;
+}
+
+DmabufImage::~DmabufImage() {
+  if (view_ != VK_NULL_HANDLE) {
+    d().vkDestroyImageView(device_, view_, nullptr);
+  }
+  if (image_ != VK_NULL_HANDLE) {
+    d().vkDestroyImage(device_, image_, nullptr);
+  }
+  if (memory_ != VK_NULL_HANDLE) {
+    d().vkFreeMemory(device_, memory_, nullptr);
+  }
+  if (dma_buf_fd_ >= 0) {
+    close(dma_buf_fd_);
+  }
+}
+
+}  // namespace wl_vulkan

--- a/shell/backend/wayland_vulkan/wl_dmabuf_present.cc
+++ b/shell/backend/wayland_vulkan/wl_dmabuf_present.cc
@@ -28,6 +28,29 @@
 #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
 #include <vulkan/vulkan.hpp>
 
+// clang-format off
+// Order is load-bearing: the generated client headers define the traits the
+// shipped wl/ helper below references. clang-format must not reorder these.
+#include "linux_dmabuf_client.hpp"  // linux_dmabuf_unstable_v1::client + traits
+#include "wayland_client.hpp"       // wayland::client::CWlBuffer, wl_buffer_traits
+#include <wl/wayland.hpp>           // core wl_iface() impls (wl_buffer, ...)
+#include <wl/linux_dmabuf.hpp>      // shipped tables (must follow the generated)
+// clang-format on
+#include <wl/client_helpers.hpp>  // wl::SetupHandler
+#include <wl/proxy_impl.hpp>      // wl::construct
+#include <wl/wl_ptr.hpp>          // wl::WlPtr
+
+// wl_buffer is a core object. ivi generates the core protocol without interface
+// tables (they come from libwayland), and no other translation unit has needed
+// a core object's wl_iface() before, so the shipped wl/ headers do not define
+// this one. Provide it — it simply maps to libwayland's wl_buffer_interface —
+// so wl::construct<wl_buffer_traits> can create the dma-buf wl_buffer.
+namespace wayland::client {
+const wl_interface& wl_buffer_traits::wl_iface() noexcept {
+  return wl_buffer_interface;
+}
+}  // namespace wayland::client
+
 namespace wl_vulkan {
 
 namespace {
@@ -267,6 +290,77 @@ DmabufImage::~DmabufImage() {
   if (dma_buf_fd_ >= 0) {
     close(dma_buf_fd_);
   }
+}
+
+namespace {
+
+// Tracks wl_buffer.release; released_ starts true (compositor does not hold
+// it).
+class WlBufferHandler : public wayland::client::CWlBuffer<WlBufferHandler> {
+ public:
+  bool released_ = true;
+  void OnRelease() override { released_ = true; }
+};
+
+// create_immed is synchronous — no created/failed events to handle.
+class LinuxBufferParamsHandler
+    : public linux_dmabuf_unstable_v1::client::CZwpLinuxBufferParamsV1<
+          LinuxBufferParamsHandler> {};
+
+}  // namespace
+
+struct WlDmabufBuffer::Impl {
+  wl::WlPtr<WlBufferHandler> buffer;
+};
+
+WlDmabufBuffer::WlDmabufBuffer() : impl_(std::make_unique<Impl>()) {}
+WlDmabufBuffer::~WlDmabufBuffer() = default;
+
+std::unique_ptr<WlDmabufBuffer> WlDmabufBuffer::Create(wl_proxy* params_proxy,
+                                                       const DmabufImage& img) {
+  if (params_proxy == nullptr) {
+    return nullptr;
+  }
+  wl::WlPtr<LinuxBufferParamsHandler> params;
+  params.Attach(params_proxy);
+
+  // One add() per memory plane, all sharing the fd (libwayland dups it).
+  const uint64_t mod = img.modifier();
+  const auto& planes = img.planes();
+  for (uint32_t i = 0; i < planes.size(); ++i) {
+    params.Get()->Add(img.dma_buf_fd(), i,
+                      static_cast<uint32_t>(planes[i].offset),
+                      static_cast<uint32_t>(planes[i].pitch),
+                      static_cast<uint32_t>(mod >> 32u),
+                      static_cast<uint32_t>(mod & 0xffffffffu));
+  }
+
+  wl_proxy* raw =
+      wl::construct<wayland::client::wl_buffer_traits,
+                    linux_dmabuf_unstable_v1::client::
+                        zwp_linux_buffer_params_v1_traits::Op::CreateImmed>(
+          *params.Get(), static_cast<int32_t>(img.width()),
+          static_cast<int32_t>(img.height()), img.drm_fourcc(), 0u);
+  if (raw == nullptr) {
+    return nullptr;
+  }
+
+  std::unique_ptr<WlDmabufBuffer> out(new WlDmabufBuffer());
+  out->impl_->buffer.Get()->_SetProxy(raw);
+  out->impl_->buffer.Get()->released_ = true;
+  return out;
+}
+
+wl_proxy* WlDmabufBuffer::proxy() const {
+  return impl_->buffer.Get()->GetProxy();
+}
+
+bool WlDmabufBuffer::released() const {
+  return impl_->buffer.Get()->released_;
+}
+
+void WlDmabufBuffer::mark_in_use() {
+  impl_->buffer.Get()->released_ = false;
 }
 
 }  // namespace wl_vulkan

--- a/shell/backend/wayland_vulkan/wl_dmabuf_present.h
+++ b/shell/backend/wayland_vulkan/wl_dmabuf_present.h
@@ -24,6 +24,8 @@
 
 #include <vulkan/vulkan.h>
 
+struct wl_proxy;
+
 namespace wl_vulkan {
 
 // Per-memory-plane layout of an exported dma-buf image.
@@ -95,6 +97,37 @@ class DmabufImage {
   VkImageView view_{VK_NULL_HANDLE};
   int dma_buf_fd_{-1};
   std::vector<PlaneLayout> planes_;
+};
+
+// A wl_buffer backed by a DmabufImage's dma-buf, for wl_surface.attach. Tracks
+// wl_buffer.release so the owning slot is not re-rendered while the compositor
+// is still scanning out of it. The wayland-client wrapper is hidden behind a
+// PIMPL so this header stays free of the generated protocol types.
+class WlDmabufBuffer {
+ public:
+  // Build the buffer from @p img: one zwp_linux_buffer_params add() per memory
+  // plane (all sharing the fd, which libwayland dups), then create_immed.
+  // @p params_proxy comes from wl::DmabufFeedback::CreateParams(); this
+  // consumes it. Returns nullptr on failure. The DmabufImage must outlive the
+  // buffer.
+  static std::unique_ptr<WlDmabufBuffer> Create(wl_proxy* params_proxy,
+                                                const DmabufImage& img);
+  ~WlDmabufBuffer();
+  WlDmabufBuffer(const WlDmabufBuffer&) = delete;
+  WlDmabufBuffer& operator=(const WlDmabufBuffer&) = delete;
+
+  // The wl_buffer proxy to hand to wl_surface.attach.
+  [[nodiscard]] wl_proxy* proxy() const;
+  // False while the compositor holds the buffer (attached, not yet released).
+  [[nodiscard]] bool released() const;
+  // Call at present, after attach, to mark the buffer in the compositor's
+  // hands.
+  void mark_in_use();
+
+ private:
+  WlDmabufBuffer();
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace wl_vulkan

--- a/shell/backend/wayland_vulkan/wl_dmabuf_present.h
+++ b/shell/backend/wayland_vulkan/wl_dmabuf_present.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_BACKEND_WAYLAND_VULKAN_WL_DMABUF_PRESENT_H_
+#define SHELL_BACKEND_WAYLAND_VULKAN_WL_DMABUF_PRESENT_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <vulkan/vulkan.h>
+
+namespace wl_vulkan {
+
+// Per-memory-plane layout of an exported dma-buf image.
+struct PlaneLayout {
+  uint64_t offset = 0;
+  uint64_t pitch = 0;
+};
+
+// Intersect the modifiers this Vulkan device can EXPORT for @p vk_format as a
+// transfer/color target with the compositor's advertised @p
+// compositor_modifiers (from the dma-buf feedback). Returns the common set,
+// tiled-first / LINEAR-last (the driver prefers a compressed/tiled layout).
+// Empty when there is no overlap — the caller then stays on the WSI swapchain
+// path.
+std::vector<uint64_t> NegotiateModifiers(
+    VkPhysicalDevice physical_device,
+    VkFormat vk_format,
+    const std::vector<uint64_t>& compositor_modifiers);
+
+// A modifier-tiled, dma-buf-exported VkImage the compositor can import (and
+// promote to a hardware plane) as a wl_buffer. The engine's composited frame is
+// blitted into it before present. Owns its Vulkan objects + the dma-buf fd.
+class DmabufImage {
+ public:
+  // Allocate an exported image constrained to @p allowed_modifiers (the driver
+  // picks one, read back into modifier()). @p usage must include the flags the
+  // caller needs (e.g. TRANSFER_DST for a blit target). Returns nullptr and
+  // sets
+  // @p err on failure.
+  static std::unique_ptr<DmabufImage> Create(
+      VkPhysicalDevice physical_device,
+      VkDevice device,
+      uint32_t width,
+      uint32_t height,
+      VkFormat vk_format,
+      uint32_t drm_fourcc,
+      VkImageUsageFlags usage,
+      const std::vector<uint64_t>& allowed_modifiers,
+      std::string& err);
+
+  DmabufImage(const DmabufImage&) = delete;
+  DmabufImage& operator=(const DmabufImage&) = delete;
+  ~DmabufImage();
+
+  [[nodiscard]] VkImage image() const { return image_; }
+  [[nodiscard]] VkImageView view() const { return view_; }
+  [[nodiscard]] uint32_t width() const { return width_; }
+  [[nodiscard]] uint32_t height() const { return height_; }
+  [[nodiscard]] uint32_t drm_fourcc() const { return drm_fourcc_; }
+  [[nodiscard]] uint64_t modifier() const { return modifier_; }
+  [[nodiscard]] const std::vector<PlaneLayout>& planes() const {
+    return planes_;
+  }
+  // Owned; closed in the destructor. Callers that hand it to
+  // zwp_linux_buffer_params (which dups it) must NOT close it.
+  [[nodiscard]] int dma_buf_fd() const { return dma_buf_fd_; }
+
+ private:
+  DmabufImage(VkDevice device, uint32_t width, uint32_t height)
+      : device_(device), width_(width), height_(height) {}
+
+  VkDevice device_{VK_NULL_HANDLE};
+  uint32_t width_;
+  uint32_t height_;
+  uint32_t drm_fourcc_{0};
+  uint64_t modifier_{0};
+  VkImage image_{VK_NULL_HANDLE};
+  VkDeviceMemory memory_{VK_NULL_HANDLE};
+  VkImageView view_{VK_NULL_HANDLE};
+  int dma_buf_fd_{-1};
+  std::vector<PlaneLayout> planes_;
+};
+
+}  // namespace wl_vulkan
+
+#endif  // SHELL_BACKEND_WAYLAND_VULKAN_WL_DMABUF_PRESENT_H_

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -233,6 +233,11 @@ void Display::HandleGlobal(wl::CRegistry& reg,
   // backend pre-flight and emit a clear error rather than asserting.
   if (iface == "zwp_linux_dmabuf_v1") {
     d->m_has_linux_dmabuf = true;
+    // Remember the global's name + advertised version so a Vulkan backend can
+    // bind the v4 dma-buf feedback later (for the zero-copy present path),
+    // independent of Mesa's WSI, which binds its own instance.
+    d->m_linux_dmabuf_name = name;
+    d->m_linux_dmabuf_version = version;
   } else if (iface == "wl_drm") {
     d->m_has_wl_drm = true;
   }

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -669,10 +669,23 @@ class Display : public IDisplay,
   // HandleGlobal; consumed by the Vulkan backend pre-flight.
   bool m_has_linux_dmabuf{false};
   bool m_has_wl_drm{false};
+  // Registry name + advertised version of zwp_linux_dmabuf_v1, for a Vulkan
+  // backend that binds its own v4 feedback instance for the zero-copy present
+  // path. Zero name means the global was never advertised.
+  uint32_t m_linux_dmabuf_name{0};
+  uint32_t m_linux_dmabuf_version{0};
 
  public:
   [[nodiscard]] bool HasLinuxDmabuf() const { return m_has_linux_dmabuf; }
   [[nodiscard]] bool HasWlDrm() const { return m_has_wl_drm; }
+  [[nodiscard]] uint32_t GetLinuxDmabufName() const {
+    return m_linux_dmabuf_name;
+  }
+  [[nodiscard]] uint32_t GetLinuxDmabufVersion() const {
+    return m_linux_dmabuf_version;
+  }
+  // The registry the dma-buf feedback helper binds against.
+  [[nodiscard]] wl::CRegistry& GetRegistry() { return registry_; }
 
  private:
   static void wayland_event_mask_update(


### PR DESCRIPTION
Adds a zero-copy dma-buf present path to the `wayland_vulkan` backend, behind `IVI_VK_DMABUF` (**default off**), patterned on the wayland-cxx-scanner `skia-vulkan-dmabuf` example. This is Increment 1 of the arc; explicit sync and refresh-adaptive pacing are follow-ups.

## Why
The default path presents through Mesa's `VK_KHR_wayland_surface` WSI swapchain — Mesa owns pacing (our `vsync_callback` is "invisible at the present layer", ~70% on-vblank vs egl's 97%), it needs `zwp_linux_dmabuf_v1`/`wl_drm` to allocate at all (`VK_ERROR_SURFACE_LOST` otherwise), and MAILBOX buys latency by discarding thousands of frames. The dma-buf path bypasses the swapchain so the compositor can promote the surface to a hardware plane.

## What
- **Bind `zwp_linux_dmabuf_v1` v4 feedback** (`wl::DmabufFeedback`) → compositor's scanout modifiers + `main_device`. Generates the linux-dmabuf protocol (ivi only bound the base global raw before).
- **`wl_dmabuf_present`** — `NegotiateModifiers` (intersect device-exportable with compositor-advertised) + `DmabufImage` (modifier-tiled, dma-buf-exported `VkImage`; ported from `drm_kms_vulkan`) + `WlDmabufBuffer` (`zwp_linux_buffer_params` → `wl_buffer`, PIMPL).
- **`PresentLayersDmabuf`** — a ring of image+buffer slots; blit the engine's backing-store layers into the current slot (reusing `BlitStoreToSwapchain`, retargeted), CPU-fence, then attach/damage/commit the `wl_buffer` directly on the `wl_surface`. Skips the swapchain entirely on this path.
- **Version-driven damage** — `wl_surface.damage_buffer` (v4) or `wl_surface.damage` (v1 fallback), since ivi binds `wl_compositor` at v3.
- **`wl_buffer.release` gating** (best-effort) so a slot in flight isn't overwritten.

## Root-cause note (the interesting bug)
An early version stalled after 2 frames. The cause was calling `wl_surface.damage_buffer` — a **v4** request — on ivi's **v3** surface: a fatal protocol error that disconnected the client after the first commit, which cascaded into "0 feedback / engine idle / compositor ignores buffer". Fixed by the version-driven damage. (Also fixed: the swapchain suppression had gated the command pool `TransitionLayout` needs every frame → RADV segfault; the pool is now created unconditionally.)

## Validation
On mutter (gnome-shell), `IVI_VK_DMABUF=1`: allocates a modifier-tiled dma-buf against the compositor's advertised AMD tiled modifier (2-plane), builds the `wl_buffer`, and **renders continuously** (192 profile windows / 12s, 0 protocol errors, clean teardown). Default swapchain path verified unregressed (0 errors).

## Known limitations (why it's experimental / default-off)
- **No vsync pacing yet** — the rasterizer runs free (~1140 fps, MAILBOX-like). Refresh-adaptive pacing is the next increment.
- **CPU-fence sync**, not explicit sync (`wp_linux_drm_syncobj` — needs a scanner bump).
- **mutter-validated only** so far; weston/AGL/hardware pending.
- Platform-view layers not yet composited on this path.