### PR TITLE
wayland_vulkan: pace the dma-buf present path to compositor refresh

### DIFF
--- a/shell/backend/wayland_vulkan/README.md
+++ b/shell/backend/wayland_vulkan/README.md
@@ -87,19 +87,43 @@ dma-buf path removes that layer:
 3. `PresentLayersDmabuf` blits the engine's backing-store layers into the current
    slot (reusing the swapchain blit, retargeted), waits a per-slot CPU fence,
    then attaches/damages/commits the `wl_buffer` — no `vkQueuePresentKHR`.
+4. Refresh pacing via `wl_surface.frame`. Each commit arms a frame callback; the
+   next present's rasterizer thread blocks until it fires (the compositor
+   signalling it is ready for the next frame). This is the backpressure the
+   swapchain path gets for free from `vkQueuePresentKHR` blocking at vblank under
+   FIFO — without it the non-blocking dma-buf commit lets the rasterizer run
+   free. The callback fires on the Display event thread; a `condition_variable`
+   hands the signal to the rasterizer thread. The wait is bounded (100 ms), so an
+   occluded/unmapped surface (whose callbacks stop firing) degrades to ~10 fps
+   free-running instead of hanging. The callback proxy is retired in the backend
+   destructor, which runs after `App::~App()` has already stopped Wayland event
+   dispatch via `Display::StopEvents()`, so the retire cannot race `OnFrameDone`.
 
 Surface damage is version-driven: `wl_surface.damage_buffer` (buffer coords) on a
 v4+ surface, else `wl_surface.damage` (surface coords). ivi binds `wl_compositor`
 at v3 today, so it takes the v1 path — calling `damage_buffer` on a v3 surface is
 a **fatal protocol error** that disconnects the client.
 
-**Status / limitations.** Renders continuously and correctly on mutter
-(gnome-shell), default-off, no swapchain-path regression. Not yet done: (a) no
-vsync pacing, so the rasterizer runs free (MAILBOX-like, high fps) — refresh-
-adaptive pacing is a follow-up; (b) CPU-fence sync, not explicit sync
-(`wp_linux_drm_syncobj`, needs a scanner bump); (c) `wl_buffer.release` gating is
-best-effort (falls back to round-robin under the unpaced frame rate); (d)
-validated on mutter only. Platform-view layers are not yet composited on this path.
+Because the pacing tracks the compositor's own repaint cadence rather than a
+fixed rate, the surface renders at whatever refresh the compositor drives it at.
+Measured with a scrolling workload:
+
+| Compositor | GPU | Refresh | fps |
+| --- | --- | --- | --- |
+| mutter (gnome-shell) | — | 60 Hz | ~59 |
+| mutter (gnome-shell) | — | 240 Hz | ~235 (mean interval 4.24 ms) |
+| gamescope (headless) | RADV Van Gogh (Steam Deck) | 120 Hz | ~118 |
+| gamescope (headless) | RADV Van Gogh (Steam Deck) | 60 Hz | 59.0 |
+
+0 present failures / 0 discarded / 0 protocol errors in every case, and the rate
+follows a window dragged between two mixed-refresh mutter outputs.
+
+**Status / limitations.** Renders continuously and correctly, paced to the
+compositor's refresh, default-off, no swapchain-path regression. Validated on
+mutter (gnome-shell) and gamescope (Steam Deck, RADV Van Gogh). Not yet done:
+(a) CPU-fence sync, not explicit sync (`wp_linux_drm_syncobj`, needs a scanner
+bump); (b) not yet run against a gamescope DRM session (headless only on the
+Deck). Platform-view layers are not yet composited on this path.
 
 ## Present-mode interaction (the surprising part)
 

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -186,6 +186,19 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
     d().vkDeviceWaitIdle(device_);
 #if BUILD_COMPOSITOR
     CompositorPipeliningCleanup();
+    // Retire any in-flight pacing callback. Safe here: App::~App() has already
+    // called Display::StopEvents() on every display, so the reactor is no
+    // longer dispatching Wayland events and OnFrameDone cannot race this — but
+    // the connection is still up (wl_display_disconnect runs later, in
+    // ~Display), so the proxy destroy is valid. Same teardown ordering the
+    // vsync feedback proxies rely on.
+    {
+      std::lock_guard<std::mutex> lock(frame_mu_);
+      if (frame_callback_ != nullptr) {
+        wl_callback_destroy(frame_callback_);
+        frame_callback_ = nullptr;
+      }
+    }
     // Tear down the dma-buf present ring before the device — DmabufImage's
     // destructor destroys its image view/image/memory with device_, and the
     // command buffers belong to dmabuf_cmd_pool_.
@@ -1998,6 +2011,24 @@ bool WaylandVulkanBackend::InitDmabufRing(uint32_t w, uint32_t h) {
   return true;
 }
 
+void WaylandVulkanBackend::OnFrameDone(void* data,
+                                       wl_callback* cb,
+                                       uint32_t /*time*/) {
+  auto* self = static_cast<WaylandVulkanBackend*>(data);
+  {
+    std::lock_guard<std::mutex> lock(self->frame_mu_);
+    // Only the current in-flight callback advances pacing; a stale one (a prior
+    // frame whose callback fired after this frame's present timed out waiting)
+    // is still retired, just without touching state.
+    if (self->frame_callback_ == cb) {
+      self->frame_callback_ = nullptr;
+      self->frame_ready_ = true;
+    }
+  }
+  wl_callback_destroy(cb);
+  self->frame_cv_.notify_one();
+}
+
 bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
                                                size_t count) {
   const uint32_t w = width_;
@@ -2014,11 +2045,22 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
       return false;
     }
   }
+  // Refresh pacing. Block until the previous frame's wl_surface.frame callback
+  // fired — the compositor signalling it is ready for the next frame — before
+  // producing this one. This is the dma-buf path's backpressure; the swapchain
+  // path gets the equivalent from vkQueuePresentKHR blocking at vblank under
+  // FIFO. Bounded so an occluded/unmapped surface (whose callbacks stop firing)
+  // degrades to ~10 fps free-running instead of hanging the rasterizer.
+  {
+    std::unique_lock<std::mutex> lock(frame_mu_);
+    frame_cv_.wait_for(lock, std::chrono::milliseconds(100),
+                       [this] { return frame_ready_; });
+  }
   // Prefer a slot whose wl_buffer the compositor has released, so we don't
   // overwrite a buffer that is still being scanned out. Start at the
-  // round-robin position and take the first free slot; if every slot is still
-  // in flight (the rasterizer is outrunning the compositor — expected until
-  // refresh- adaptive pacing lands), fall back to the round-robin slot.
+  // round-robin position and take the first free slot; with refresh pacing the
+  // previous buffer is normally released by now, but fall back to the
+  // round-robin slot if none is free.
   size_t idx = dmabuf_frame_ % dmabuf_slots_.size();
   for (size_t i = 0; i < dmabuf_slots_.size(); ++i) {
     const size_t cand = (dmabuf_frame_ + i) % dmabuf_slots_.size();
@@ -2116,6 +2158,18 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
   RequestPresentationFeedback();
 
   wl_surface* surface = wl_surface_.load(std::memory_order_acquire);
+  // Arm the pacing callback for this commit, so the next frame's present waits
+  // on it. Request it before the commit it is paired with. A prior callback
+  // still in flight (this frame's wait timed out) is left to fire and self-
+  // retire in OnFrameDone; only the newest one advances pacing.
+  {
+    static const wl_callback_listener kFrameListener = {
+        &WaylandVulkanBackend::OnFrameDone};
+    std::lock_guard<std::mutex> lock(frame_mu_);
+    frame_callback_ = wl_surface_frame(surface);
+    wl_callback_add_listener(frame_callback_, &kFrameListener, this);
+    frame_ready_ = false;
+  }
   auto* buffer = reinterpret_cast<wl_buffer*>(slot.buffer->proxy());
   wl_surface_attach(surface, buffer, 0, 0);
   // Damage the surface. wl_surface.damage_buffer (buffer coordinates) is a v4

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <ctime>
 #include <mutex>
@@ -505,6 +506,22 @@ class WaylandVulkanBackend final : public Backend {
   uint32_t dmabuf_ring_w_{0};
   uint32_t dmabuf_ring_h_{0};
   size_t dmabuf_frame_{0};
+
+  // Refresh pacing for the dma-buf path. The WSI swapchain path is paced by
+  // vkQueuePresentKHR blocking at vblank under FIFO; the dma-buf commit is
+  // non-blocking, so without this the rasterizer runs free. Each present arms a
+  // wl_surface.frame callback (fires on the Display event thread at ~refresh
+  // when the surface is visible) and the next present's rasterizer thread waits
+  // on it — the same backpressure FIFO gives the swapchain path. A bounded wait
+  // degrades an occluded/unmapped surface (no callbacks) to free-running rather
+  // than a hang.
+  std::mutex frame_mu_;
+  std::condition_variable frame_cv_;
+  bool frame_ready_{true};  // guarded by frame_mu_; true = may present
+  wl_callback* frame_callback_{
+      nullptr};  // in-flight, retired on the event thread
+  // wl_surface.frame done handler (Display event thread).
+  static void OnFrameDone(void* data, wl_callback* cb, uint32_t time);
 
   // Build (or rebuild after a resize) the ring of dma-buf image+wl_buffer
   // slots at @p w x @p h. Returns false (and clears dmabuf_present_active_) on


### PR DESCRIPTION
## What

Refresh-adaptive pacing for the experimental `wayland_vulkan` zero-copy dma-buf present path (`IVI_VK_DMABUF`, default-off). Follow-up to #316; addresses the pacing item in #317.

The dma-buf commit is non-blocking, so the rasterizer ran free (~1140 fps on mutter). The swapchain path gets its backpressure for free from `vkQueuePresentKHR` blocking at vblank under FIFO — the dma-buf path had none.

## How

Each present arms a `wl_surface.frame` callback; the next present's rasterizer thread blocks until it fires (the compositor signalling it is ready for the next frame) — the FIFO-equivalent backpressure. It tracks the compositor's own repaint cadence rather than a fixed rate, so the surface renders at whatever refresh it is driven at. The wait is bounded (100 ms), so an occluded/unmapped surface degrades to free-running instead of hanging.

The callback fires on the Display event thread; a `condition_variable` hands the signal to the rasterizer thread. The callback proxy is retired in the backend destructor, which runs after `App::~App()` has stopped Wayland event dispatch via `Display::StopEvents()`, so the retire cannot race the done handler.

Isolated to the dma-buf path: the swapchain path and the shared vsync provider are untouched.

## Validation

Scrolling workload, all cases **0 present failures / 0 discarded / 0 protocol errors**, refresh-adaptive:

| Compositor | GPU | Refresh | fps |
| --- | --- | --- | --- |
| mutter (gnome-shell) | host | 60 Hz | ~59 |
| mutter (gnome-shell) | host | 240 Hz | ~235 (mean interval 4.24 ms, 4200 frames) |
| gamescope (headless) | RADV Van Gogh (Steam Deck) | 120 Hz | ~118 |
| gamescope (headless) | RADV Van Gogh (Steam Deck) | 60 Hz | 59.0 |

The rate also follows a window dragged between two mixed-refresh mutter outputs.

clang-tidy-19 and clang-format-19 clean.

## Not in this PR (tracked in #317)

- Explicit sync (`wp_linux_drm_syncobj`, needs a scanner bump)
- Platform-view compositing on the dma-buf path
- gamescope DRM-session validation (headless-only on the Deck so far)
