### PR TITLE
wayland_vulkan: explicit sync for the dma-buf present path via wp_linux_drm_syncobj

### DIFF
--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -194,6 +194,17 @@ function(ivi_wayland_protocols target)
         MODE client-header EMIT_INTERFACE_TABLES
         OUTPUT wayland-protocols/fractional_scale_v1_client.hpp TARGET ${target})
 
+    # linux-drm-syncobj-v1 — the wayland_vulkan dma-buf present path binds this
+    # for explicit sync (acquire/release timeline points that replace the CPU
+    # fence). Vendored: the staging XML only ships with wayland-protocols >= 1.32,
+    # newer than the oldest supported sysroots. No shipped wl/ helper carries its
+    # interface tables, so generate self-contained with EMIT_INTERFACE_TABLES.
+    # Runtime-gated on the compositor advertising the global, so generating it
+    # unconditionally costs nothing on stacks that never bind it.
+    wayland_cxx_generate(PROTOCOL "${_loc}/linux-drm-syncobj-v1.xml"
+        MODE client-header EMIT_INTERFACE_TABLES
+        OUTPUT wayland-protocols/linux_drm_syncobj_client.hpp TARGET ${target})
+
     # text-input (IME) — the build-selected backend's client header. The
     # wl::ime backend header (<wl/ime/backends/text_input_v{1,3}.hpp>) includes
     # the generated header by its fixed name with --emit-interface-tables, so it

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -99,6 +99,7 @@ if (BUILD_BACKEND_WAYLAND_VULKAN)
             backend/wayland_vulkan/wayland_vulkan.cc
             backend/wayland_vulkan/vulkan_queue_interposer.cc
             backend/wayland_vulkan/wl_dmabuf_present.cc
+            backend/wayland_vulkan/wl_explicit_sync.cc
     )
     # The dma-buf present path needs drm_fourcc.h (DRM_FORMAT_* constants), a
     # libdrm header. On a cross sysroot it lives under <libdrm/>, so the include

--- a/shell/backend/wayland_vulkan/README.md
+++ b/shell/backend/wayland_vulkan/README.md
@@ -69,6 +69,7 @@ internal wall-clock scheduler. The decision is logged once at startup.
 | `IVI_M2P_PROFILE` | (off) | Anything non-empty enables the **motion-to-photon** (input-to-scanout) profiler. Joins kernel input time from `zwp_input_timestamps_v1` (pointer/touch) with compositor scanout time from `wp_presentation` feedback. Reports two latencies per window: **frame-accurate** — each input is attributed to the frame whose build cutoff (the baton's `frame_start_time`) is at or after it, i.e. the frame that actually rendered it, giving true `present − input`; and **floor** — `present − input` for the first scanout at or after the input, which under-counts by the engine pipeline depth. Every 120 presents logs `[wayland] motion->photon: frame-accurate p50=Xms p99=Yms max=Zms \| floor p50=xms p99=yms \| n=N dropped=D`, plus a session summary (both metrics) at teardown. The frame-accurate metric is the input-side complement of the `pipeline_*` (beginFrame-to-present) latency above: together they span input → build → present. `IVI_PROFILE` enables it too. |
 | `IVI_VK_PRESENT_MODE` | `fifo` | One of `fifo`, `fifo_relaxed`, `mailbox`, `immediate`. Selects the swapchain present mode if the compositor advertises it; otherwise falls back to FIFO with a warn. See "Present-mode interaction" below — `mailbox` is the only setting where `vsync_callback`'s contribution becomes large. |
 | `IVI_VK_DMABUF` | (off) | **Experimental** zero-copy dma-buf present path (see below). When set, and the compositor advertises a DRM format modifier this GPU can render into, the compositor path bypasses the WSI swapchain entirely: it blits the engine's frame into a modifier-tiled, dma-buf-exported `VkImage` and commits it as a `wl_buffer` (via `zwp_linux_dmabuf_v1`) directly on the `wl_surface`, so the compositor can promote the surface to a hardware plane. Off by default; falls back to the swapchain when unset or when no renderable modifier is shared. |
+| `IVI_VK_NO_EXPLICIT_SYNC` | (off) | On the dma-buf path, force the CPU-fence producer sync instead of `wp_linux_drm_syncobj` explicit sync (see below). For bisecting / A-B'ing the timeline path; no effect on the swapchain path. |
 
 ## Experimental: zero-copy dma-buf present (`IVI_VK_DMABUF`)
 
@@ -85,9 +86,23 @@ dma-buf path removes that layer:
 2. A ring of modifier-tiled, dma-buf-exported `VkImage` slots (`wl_dmabuf_present`),
    each wrapped as a `wl_buffer` via `zwp_linux_buffer_params`.
 3. `PresentLayersDmabuf` blits the engine's backing-store layers into the current
-   slot (reusing the swapchain blit, retargeted), waits a per-slot CPU fence,
-   then attaches/damages/commits the `wl_buffer` — no `vkQueuePresentKHR`.
-4. Refresh pacing via `wl_surface.frame`. Each commit arms a frame callback; the
+   slot (reusing the swapchain blit, retargeted), synchronizes producer/consumer
+   (explicit sync below, or a per-slot CPU fence), then attaches/damages/commits
+   the `wl_buffer` — no `vkQueuePresentKHR`.
+4. Explicit sync via `wp_linux_drm_syncobj` (`wl_explicit_sync`), when the
+   compositor advertises the manager and the device has timeline semaphores +
+   external-semaphore-fd. Instead of the CPU fence stalling the rasterizer until
+   the blit finishes, the blit submit signals an acquire timeline (a
+   `VK_SEMAPHORE_TYPE_TIMELINE` `VkSemaphore` imported — OPAQUE_FD — from a DRM
+   syncobj); the compositor waits on that point before sampling. A second
+   (release) syncobj the compositor signals is polled with a zero-timeout
+   `drmSyncobjTimelineWait` to reclaim slots — the explicit-sync replacement for
+   `wl_buffer.release`. The render node is opened from the device's
+   `VkPhysicalDeviceDrmPropertiesEXT` (a Wayland client has no DRM master). Falls
+   back to the CPU fence if any of this is unavailable; `IVI_VK_NO_EXPLICIT_SYNC`
+   forces the fallback. Validated hazard-free under the Vulkan synchronization
+   validation layer.
+5. Refresh pacing via `wl_surface.frame`. Each commit arms a frame callback; the
    next present's rasterizer thread blocks until it fires (the compositor
    signalling it is ready for the next frame). This is the backpressure the
    swapchain path gets for free from `vkQueuePresentKHR` blocking at vblank under
@@ -119,11 +134,12 @@ Measured with a scrolling workload:
 follows a window dragged between two mixed-refresh mutter outputs.
 
 **Status / limitations.** Renders continuously and correctly, paced to the
-compositor's refresh, default-off, no swapchain-path regression. Validated on
-mutter (gnome-shell) and gamescope (Steam Deck, RADV Van Gogh). Not yet done:
-(a) CPU-fence sync, not explicit sync (`wp_linux_drm_syncobj`, needs a scanner
-bump); (b) not yet run against a gamescope DRM session (headless only on the
-Deck). Platform-view layers are not yet composited on this path.
+compositor's refresh, explicit-sync where available (else CPU fence), default-off,
+no swapchain-path regression. Validated on mutter (gnome-shell) and gamescope
+(Steam Deck, RADV Van Gogh); explicit sync is hazard-free under the Vulkan
+synchronization validation layer on mutter/RADV. Not yet done: (a) not yet run
+against a gamescope DRM session (headless only on the Deck). Platform-view layers
+are not yet composited on this path.
 
 ## Present-mode interaction (the surprising part)
 

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -37,6 +37,7 @@
 #include <wayland-client.h>  // wl_surface_attach/damage_buffer/commit
 
 #include "backend/wayland_vulkan/wl_dmabuf_present.h"
+#include "backend/wayland_vulkan/wl_explicit_sync.h"
 #include "vulkan_queue_interposer.h"
 
 // The vulkan.hpp dynamic dispatcher needs its storage defined in exactly ONE
@@ -199,6 +200,10 @@ WaylandVulkanBackend::~WaylandVulkanBackend() {
         frame_callback_ = nullptr;
       }
     }
+    // Tear down explicit sync before the device: it destroys its acquire
+    // timeline VkSemaphore with device_ (safe after the vkDeviceWaitIdle above)
+    // and its wp_linux_drm_syncobj proxies while the connection is still up.
+    explicit_sync_.reset();
     // Tear down the dma-buf present ring before the device — DmabufImage's
     // destructor destroys its image view/image/memory with device_, and the
     // command buffers belong to dmabuf_cmd_pool_.
@@ -527,13 +532,20 @@ void WaylandVulkanBackend::findPhysicalDevice() {
       // dma-buf zero-copy present path: import/export a modifier-tiled image
       // the compositor can scan out. Enabled when advertised; the path stays
       // gated at runtime on a successful DmabufImage allocation, so a device
-      // missing any of these simply falls back to the WSI swapchain.
+      // missing any of these simply falls back to the WSI swapchain. The last
+      // four back the wp_linux_drm_syncobj explicit-sync path (a timeline
+      // semaphore imported from a DRM syncobj + the render-node resolve);
+      // absent, that path degrades to the CPU fence.
       else {
         for (const char* want :
              {VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME,
               VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
               VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
-              VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME}) {
+              VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME,
+              VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+              VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
+              VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+              VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME}) {
           if (strcmp(want, extensionName) == 0) {
             supported_extensions.push_back(want);
           }
@@ -627,6 +639,20 @@ void WaylandVulkanBackend::createLogicalDevice() {
       static_cast<uint32_t>(enabled_device_extensions_.size());
   device_info.ppEnabledExtensionNames = enabled_device_extensions_.data();
   device_info.pEnabledFeatures = &device_features;
+
+  // Enable the timeline-semaphore feature when the extension was selected, so
+  // the wp_linux_drm_syncobj explicit-sync path can create the timeline
+  // semaphore it imports the acquire DRM syncobj into. Harmless otherwise.
+  VkPhysicalDeviceTimelineSemaphoreFeatures timeline_feature{};
+  timeline_feature.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+  for (const char* ext : enabled_device_extensions_) {
+    if (strcmp(ext, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME) == 0) {
+      timeline_feature.timelineSemaphore = VK_TRUE;
+      device_info.pNext = &timeline_feature;
+      break;
+    }
+  }
 
   CHECK_VK_RESULT(
       d().vkCreateDevice(physical_device_, &device_info, nullptr, &device_));
@@ -1352,6 +1378,27 @@ void WaylandVulkanBackend::CreateSurface(size_t /* index */,
           "[WaylandVulkanBackend] zero-copy dma-buf present ENABLED ({} "
           "renderable modifier(s) shared with the compositor)",
           dmabuf_modifiers_.size());
+      // Bring up wp_linux_drm_syncobj explicit sync if the compositor
+      // advertises the manager and the device supports the timeline bridge. On
+      // failure the CPU fence is used — never fatal. IVI_VK_NO_EXPLICIT_SYNC
+      // forces the CPU fence (bisecting / A-B against the timeline path).
+      if (shell_display_ != nullptr &&
+          shell_display_->GetDrmSyncobjName() != 0 &&
+          std::getenv("IVI_VK_NO_EXPLICIT_SYNC") == nullptr) {
+        std::string sync_err;
+        explicit_sync_ = wl_vulkan::ExplicitSync::Create(
+            physical_device_, device_, shell_display_->GetRegistry(),
+            shell_display_->GetDrmSyncobjName(),
+            shell_display_->GetDrmSyncobjVersion(), wl_display_,
+            reinterpret_cast<wl_proxy*>(surface), sync_err);
+        if (!explicit_sync_) {
+          ihs::log::info(
+              "[WaylandVulkanBackend] explicit sync unavailable ({}); using "
+              "CPU "
+              "fence for the dma-buf path",
+              sync_err);
+        }
+      }
     } else {
       ihs::log::info(
           "[WaylandVulkanBackend] dma-buf present {} (modifiers={}, env={}); "
@@ -2064,7 +2111,14 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
   size_t idx = dmabuf_frame_ % dmabuf_slots_.size();
   for (size_t i = 0; i < dmabuf_slots_.size(); ++i) {
     const size_t cand = (dmabuf_frame_ + i) % dmabuf_slots_.size();
-    if (dmabuf_slots_[cand].buffer->released()) {
+    // On the explicit-sync path the compositor signals a release timeline
+    // instead of sending wl_buffer.release, so poll that; otherwise use the
+    // wl_buffer.release flag.
+    const bool released =
+        explicit_sync_
+            ? explicit_sync_->SlotReleased(dmabuf_slots_[cand].release_point)
+            : dmabuf_slots_[cand].buffer->released();
+    if (released) {
       idx = cand;
       break;
     }
@@ -2146,14 +2200,35 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
   submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
   submit.commandBufferCount = 1;
   submit.pCommandBuffers = &cmd;
+
+  // Explicit sync: the blit submit signals the acquire timeline at this frame's
+  // point (the compositor waits on it before sampling), so the CPU stall below
+  // is skipped. The fence still fires for command-buffer/image reuse safety at
+  // slot selection. Without explicit sync, the CPU fence is the producer sync.
+  wl_vulkan::ExplicitSync::FramePoints sync_pts{};
+  VkSemaphore acquire_sem = VK_NULL_HANDLE;
+  VkTimelineSemaphoreSubmitInfo tl{};
+  if (explicit_sync_) {
+    sync_pts = explicit_sync_->NextFrame();
+    acquire_sem = explicit_sync_->acquire_semaphore();
+    tl.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
+    tl.signalSemaphoreValueCount = 1;
+    tl.pSignalSemaphoreValues = &sync_pts.acquire;
+    submit.pNext = &tl;
+    submit.signalSemaphoreCount = 1;
+    submit.pSignalSemaphores = &acquire_sem;
+  }
   {
     std::lock_guard<std::mutex> queue_lock(queue_mutex_);
     d().vkQueueSubmit(queue_, 1, &submit, slot.fence);
   }
-  // CPU fence: block until the blit completes so the dma-buf holds a full frame
-  // before the compositor samples it.
-  CHECK_VK_RESULT(
-      d().vkWaitForFences(device_, 1, &slot.fence, VK_TRUE, UINT64_MAX));
+  if (!explicit_sync_) {
+    // CPU fence: block until the blit completes so the dma-buf holds a full
+    // frame before the compositor samples it. Explicit sync replaces this stall
+    // with the acquire timeline point the compositor waits on GPU-side.
+    CHECK_VK_RESULT(
+        d().vkWaitForFences(device_, 1, &slot.fence, VK_TRUE, UINT64_MAX));
+  }
 
   RequestPresentationFeedback();
 
@@ -2184,6 +2259,14 @@ bool WaylandVulkanBackend::PresentLayersDmabuf(const FlutterLayer** layers,
                              static_cast<int32_t>(h));
   } else {
     wl_surface_damage(surface, 0, 0, INT32_MAX, INT32_MAX);
+  }
+  // Explicit sync: attach the acquire/release points to this commit (must be
+  // between attach and commit) and record the slot's release point for the
+  // reuse poll. The compositor waits on acquire before sampling and signals
+  // release when done.
+  if (explicit_sync_) {
+    explicit_sync_->SetSurfacePoints(sync_pts);
+    slot.release_point = sync_pts.release;
   }
   wl_surface_commit(surface);
   wl_display_flush(wl_display_);

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -63,6 +63,7 @@ class TaskRunner;
 namespace wl_vulkan {
 class DmabufImage;
 class WlDmabufBuffer;
+class ExplicitSync;
 }  // namespace wl_vulkan
 
 class WaylandVulkanBackend final : public Backend {
@@ -499,6 +500,9 @@ class WaylandVulkanBackend final : public Backend {
     VkCommandBuffer cmd{VK_NULL_HANDLE};
     VkFence fence{VK_NULL_HANDLE};
     VkImageLayout layout{VK_IMAGE_LAYOUT_UNDEFINED};
+    // Explicit-sync release point for this slot's last commit; polled to know
+    // the compositor is done (replaces wl_buffer.release). 0 = never committed.
+    uint64_t release_point{0};
   };
   std::vector<uint64_t> dmabuf_modifiers_;  // negotiated set, cached in Create
   VkCommandPool dmabuf_cmd_pool_{VK_NULL_HANDLE};
@@ -506,6 +510,13 @@ class WaylandVulkanBackend final : public Backend {
   uint32_t dmabuf_ring_w_{0};
   uint32_t dmabuf_ring_h_{0};
   size_t dmabuf_frame_{0};
+
+  // Explicit sync via wp_linux_drm_syncobj: when the compositor advertises the
+  // manager and the device supports timeline/external-semaphore-fd, the blit
+  // submit signals an acquire timeline the compositor waits on and the slot is
+  // reclaimed by polling a release timeline — replacing the per-frame CPU
+  // fence. Null when unavailable; the CPU-fence path is used instead.
+  std::unique_ptr<wl_vulkan::ExplicitSync> explicit_sync_;
 
   // Refresh pacing for the dma-buf path. The WSI swapchain path is paced by
   // vkQueuePresentKHR blocking at vblank under FIFO; the dma-buf commit is

--- a/shell/backend/wayland_vulkan/wl_explicit_sync.cc
+++ b/shell/backend/wayland_vulkan/wl_explicit_sync.cc
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/wayland_vulkan/wl_explicit_sync.h"
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+#include <algorithm>
+#include <string>
+
+#include <xf86drm.h>
+
+// Dynamic dispatch, matching the backend (which owns the loader storage and
+// calls VULKAN_HPP_DEFAULT_DISPATCHER.init()); do NOT define the storage here.
+#define VULKAN_HPP_NO_EXCEPTIONS 1
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+#include <vulkan/vulkan.hpp>
+
+// clang-format off
+// Order is load-bearing: the generated client header defines the traits and the
+// interface tables (EMIT_INTERFACE_TABLES). clang-format must not reorder these.
+#include "linux_drm_syncobj_client.hpp"  // linux_drm_syncobj_v1::client + traits
+// clang-format on
+#include <wl/proxy_impl.hpp>  // wl::construct
+#include <wl/registry.hpp>    // wl::CRegistry
+#include <wl/wl_ptr.hpp>      // wl::WlPtr
+
+#include "logging/logging.h"
+
+namespace wl_vulkan {
+
+namespace {
+
+const auto& d() {
+  return vk::detail::defaultDispatchLoaderDynamic;
+}
+
+namespace sync = linux_drm_syncobj_v1::client;
+
+// The three wp_linux_drm_syncobj objects carry no events — bare handlers.
+class SyncobjManagerHandler
+    : public sync::CWpLinuxDrmSyncobjManagerV1<SyncobjManagerHandler> {};
+class SyncobjSurfaceHandler
+    : public sync::CWpLinuxDrmSyncobjSurfaceV1<SyncobjSurfaceHandler> {};
+class SyncobjTimelineHandler
+    : public sync::CWpLinuxDrmSyncobjTimelineV1<SyncobjTimelineHandler> {};
+
+constexpr uint32_t Hi(uint64_t v) {
+  return static_cast<uint32_t>(v >> 32u);
+}
+constexpr uint32_t Lo(uint64_t v) {
+  return static_cast<uint32_t>(v & 0xffffffffu);
+}
+
+// Resolve the /dev/dri node whose device number matches @p major/@p minor. A
+// Wayland client has no DRM master, so the render node is opened purely for the
+// drmSyncobj* ioctls. Returns "" if none matches.
+std::string FindDrmNode(int64_t major_num, int64_t minor_num) {
+  DIR* dir = opendir("/dev/dri");
+  if (dir == nullptr) {
+    return "";
+  }
+  std::string found;
+  const dev_t want = makedev(static_cast<unsigned>(major_num),
+                             static_cast<unsigned>(minor_num));
+  for (dirent* e = readdir(dir); e != nullptr; e = readdir(dir)) {
+    if (e->d_name[0] == '.') {
+      continue;
+    }
+    std::string path = std::string("/dev/dri/") + e->d_name;
+    struct stat st{};
+    if (stat(path.c_str(), &st) == 0 && S_ISCHR(st.st_mode) &&
+        st.st_rdev == want) {
+      found = path;
+      break;
+    }
+  }
+  closedir(dir);
+  return found;
+}
+
+}  // namespace
+
+struct ExplicitSync::Impl {
+  VkDevice device = VK_NULL_HANDLE;
+  int drm_fd = -1;
+  uint32_t acquire_syncobj = 0;  // Vulkan signals this (acquire)
+  uint32_t release_syncobj = 0;  // compositor signals this (release)
+  VkSemaphore acquire_sem = VK_NULL_HANDLE;  // timeline, imported from acquire
+  // Destruction order (reverse of declaration): surface, release_tl,
+  // acquire_tl, manager — children before the manager that created them.
+  wl::WlPtr<SyncobjManagerHandler> manager;
+  wl::WlPtr<SyncobjTimelineHandler> acquire_tl;
+  wl::WlPtr<SyncobjTimelineHandler> release_tl;
+  wl::WlPtr<SyncobjSurfaceHandler> surface;
+  uint64_t acquire_point = 0;
+  uint64_t release_point = 0;
+};
+
+ExplicitSync::ExplicitSync() : impl_(std::make_unique<Impl>()) {}
+
+ExplicitSync::~ExplicitSync() {
+  if (impl_->acquire_sem != VK_NULL_HANDLE) {
+    d().vkDestroySemaphore(impl_->device, impl_->acquire_sem, nullptr);
+  }
+  // Tear down the wp objects while the connection is still up (the backend
+  // destroys ExplicitSync from its dtor, after App::~App() stopped Wayland
+  // dispatch via Display::StopEvents() but before wl_display_disconnect). These
+  // objects carry no events, so no OnXxx handler can race the destroy.
+  impl_->surface.Reset();
+  impl_->release_tl.Reset();
+  impl_->acquire_tl.Reset();
+  impl_->manager.Reset();
+  if (impl_->drm_fd >= 0) {
+    if (impl_->acquire_syncobj != 0) {
+      drmSyncobjDestroy(impl_->drm_fd, impl_->acquire_syncobj);
+    }
+    if (impl_->release_syncobj != 0) {
+      drmSyncobjDestroy(impl_->drm_fd, impl_->release_syncobj);
+    }
+    close(impl_->drm_fd);
+  }
+}
+
+std::unique_ptr<ExplicitSync> ExplicitSync::Create(
+    VkPhysicalDevice physical_device,
+    VkDevice device,
+    wl::CRegistry& registry,
+    uint32_t manager_name,
+    uint32_t manager_version,
+    wl_display* display,
+    wl_proxy* surface,
+    std::string& err) {
+  if (manager_name == 0) {
+    err = "compositor does not advertise wp_linux_drm_syncobj_manager_v1";
+    return nullptr;
+  }
+  if (surface == nullptr || display == nullptr) {
+    err = "null surface/display";
+    return nullptr;
+  }
+
+  std::unique_ptr<ExplicitSync> self(new ExplicitSync());
+  Impl& s = *self->impl_;
+  s.device = device;
+
+  // Resolve + open the render node from the device's DRM properties.
+  VkPhysicalDeviceDrmPropertiesEXT drm{};
+  drm.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT;
+  VkPhysicalDeviceProperties2 p2{};
+  p2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+  p2.pNext = &drm;
+  d().vkGetPhysicalDeviceProperties2(physical_device, &p2);
+  if (drm.hasRender == VK_FALSE) {
+    err = "device reports no DRM render node (VK_EXT_physical_device_drm)";
+    return nullptr;
+  }
+  const std::string node = FindDrmNode(drm.renderMajor, drm.renderMinor);
+  if (node.empty()) {
+    err = "could not resolve /dev/dri render node";
+    return nullptr;
+  }
+  s.drm_fd = open(node.c_str(), O_RDWR | O_CLOEXEC);
+  if (s.drm_fd < 0) {
+    err = "open(" + node + ") failed";
+    return nullptr;
+  }
+
+  // Two DRM syncobjs: acquire (Vulkan signals) + release (compositor signals).
+  if (drmSyncobjCreate(s.drm_fd, 0, &s.acquire_syncobj) != 0 ||
+      drmSyncobjCreate(s.drm_fd, 0, &s.release_syncobj) != 0) {
+    err = "drmSyncobjCreate failed";
+    return nullptr;
+  }
+
+  // Bind the manager, then import both syncobjs as wp timeline objects. The fd
+  // is dup'd by libwayland; flush the requests before closing the fds.
+  wl_proxy* mgr_raw =
+      registry.Bind<sync::wp_linux_drm_syncobj_manager_v1_traits>(
+          manager_name,
+          std::min(manager_version,
+                   sync::wp_linux_drm_syncobj_manager_v1_traits::version));
+  if (mgr_raw == nullptr) {
+    err = "wl_registry_bind(wp_linux_drm_syncobj_manager_v1) failed";
+    return nullptr;
+  }
+  s.manager.Attach(mgr_raw);
+
+  int afd = -1;
+  int rfd = -1;
+  if (drmSyncobjHandleToFD(s.drm_fd, s.acquire_syncobj, &afd) != 0 ||
+      drmSyncobjHandleToFD(s.drm_fd, s.release_syncobj, &rfd) != 0) {
+    err = "drmSyncobjHandleToFD failed";
+    if (afd >= 0) {
+      close(afd);
+    }
+    return nullptr;
+  }
+  s.acquire_tl.Attach(
+      wl::construct<
+          sync::wp_linux_drm_syncobj_timeline_v1_traits,
+          sync::wp_linux_drm_syncobj_manager_v1_traits::Op::ImportTimeline>(
+          *s.manager.Get(), afd));
+  s.release_tl.Attach(
+      wl::construct<
+          sync::wp_linux_drm_syncobj_timeline_v1_traits,
+          sync::wp_linux_drm_syncobj_manager_v1_traits::Op::ImportTimeline>(
+          *s.manager.Get(), rfd));
+  wl_display_flush(display);
+  close(afd);
+  close(rfd);
+  if (s.acquire_tl.Get()->IsNull() || s.release_tl.Get()->IsNull()) {
+    err = "ImportTimeline produced no proxy";
+    return nullptr;
+  }
+
+  // Import the acquire syncobj into Vulkan as a timeline semaphore (a fresh fd;
+  // OPAQUE_FD, permanent import — Vulkan takes ownership of the fd on success).
+  // The blit submit signals this timeline, which materializes the acquire point
+  // the compositor waits on.
+  VkSemaphoreTypeCreateInfo type{};
+  type.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
+  type.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+  type.initialValue = 0;
+  VkSemaphoreCreateInfo sci{};
+  sci.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+  sci.pNext = &type;
+  if (d().vkCreateSemaphore(device, &sci, nullptr, &s.acquire_sem) !=
+      VK_SUCCESS) {
+    err = "vkCreateSemaphore (timeline) failed";
+    return nullptr;
+  }
+  int vk_afd = -1;
+  if (drmSyncobjHandleToFD(s.drm_fd, s.acquire_syncobj, &vk_afd) != 0) {
+    err = "drmSyncobjHandleToFD (Vulkan import) failed";
+    return nullptr;
+  }
+  VkImportSemaphoreFdInfoKHR ifi{};
+  ifi.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+  ifi.semaphore = s.acquire_sem;
+  ifi.flags = 0;  // permanent
+  ifi.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+  ifi.fd = vk_afd;
+  if (d().vkImportSemaphoreFdKHR(device, &ifi) != VK_SUCCESS) {
+    close(vk_afd);
+    err = "vkImportSemaphoreFdKHR (OPAQUE_FD) unsupported";
+    return nullptr;
+  }
+
+  // The per-surface syncobj object the acquire/release points are set on.
+  s.surface.Attach(
+      wl::construct<
+          sync::wp_linux_drm_syncobj_surface_v1_traits,
+          sync::wp_linux_drm_syncobj_manager_v1_traits::Op::GetSurface>(
+          *s.manager.Get(), surface));
+  if (s.surface.Get()->IsNull()) {
+    err = "GetSurface produced no proxy";
+    return nullptr;
+  }
+
+  ihs::log::info(
+      "[WaylandVulkanBackend] explicit sync enabled (wp_linux_drm_syncobj on "
+      "{})",
+      node);
+  return self;
+}
+
+VkSemaphore ExplicitSync::acquire_semaphore() const {
+  return impl_->acquire_sem;
+}
+
+ExplicitSync::FramePoints ExplicitSync::NextFrame() {
+  return {++impl_->acquire_point, ++impl_->release_point};
+}
+
+void ExplicitSync::SetSurfacePoints(const FramePoints& points) {
+  impl_->surface.Get()->SetAcquirePoint(impl_->acquire_tl.Get()->GetProxy(),
+                                        Hi(points.acquire), Lo(points.acquire));
+  impl_->surface.Get()->SetReleasePoint(impl_->release_tl.Get()->GetProxy(),
+                                        Hi(points.release), Lo(points.release));
+}
+
+bool ExplicitSync::SlotReleased(uint64_t release_point) const {
+  if (release_point == 0) {
+    return true;  // slot never committed
+  }
+  uint32_t handle = impl_->release_syncobj;
+  uint64_t point = release_point;
+  // Zero timeout: returns 0 iff the point is already signalled (compositor done
+  // reading), a timeout error otherwise. The non-blocking release poll.
+  const int r = drmSyncobjTimelineWait(
+      impl_->drm_fd, &handle, &point, 1,
+      /*timeout_nsec=*/0, DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL, nullptr);
+  return r == 0;
+}
+
+}  // namespace wl_vulkan

--- a/shell/backend/wayland_vulkan/wl_explicit_sync.h
+++ b/shell/backend/wayland_vulkan/wl_explicit_sync.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_BACKEND_WAYLAND_VULKAN_WL_EXPLICIT_SYNC_H_
+#define SHELL_BACKEND_WAYLAND_VULKAN_WL_EXPLICIT_SYNC_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <vulkan/vulkan.h>
+
+struct wl_display;
+struct wl_proxy;
+
+namespace wl {
+class CRegistry;
+}
+
+namespace wl_vulkan {
+
+// Explicit sync for the dma-buf present path via wp_linux_drm_syncobj.
+//
+// Instead of a CPU fence (vkWaitForFences after the blit, stalling the
+// rasterizer until the GPU finishes so the compositor never samples a partial
+// frame), the compositor is handed timeline sync points:
+//   * acquire — the blit submit signals a timeline VkSemaphore imported FROM a
+//     DRM syncobj; the compositor waits on that point before sampling.
+//   * release — the compositor signals a second DRM syncobj when done; the slot
+//     is reclaimed by polling it (the explicit-sync analogue of
+//     wl_buffer.release), so no CPU stall and no cross-thread release event.
+//
+// All the DRM-syncobj + Vulkan-import plumbing is Vulkan/libdrm specific and
+// lives here; the generated wp_linux_drm_syncobj protocol types are hidden
+// behind a PIMPL so this header stays free of them.
+class ExplicitSync {
+ public:
+  // A frame's acquire (GPU-signalled) and release (compositor-signalled)
+  // timeline points. Both are monotonic; release is recorded per slot.
+  struct FramePoints {
+    uint64_t acquire = 0;
+    uint64_t release = 0;
+  };
+
+  // Bring up the drm_syncobj <-> Vulkan-timeline bridge and the syncobj surface
+  // for @p surface. Returns nullptr (the caller keeps the CPU-fence path) if
+  // @p manager_name is 0, the render node can't be resolved/opened, or the
+  // device lacks timeline-semaphore / external-semaphore-fd / OPAQUE_FD import.
+  // @p err carries the reason on failure.
+  static std::unique_ptr<ExplicitSync> Create(VkPhysicalDevice physical_device,
+                                              VkDevice device,
+                                              wl::CRegistry& registry,
+                                              uint32_t manager_name,
+                                              uint32_t manager_version,
+                                              wl_display* display,
+                                              wl_proxy* surface,
+                                              std::string& err);
+  ~ExplicitSync();
+  ExplicitSync(const ExplicitSync&) = delete;
+  ExplicitSync& operator=(const ExplicitSync&) = delete;
+
+  // The timeline semaphore the blit submit must signal at FramePoints::acquire
+  // (chain a VkTimelineSemaphoreSubmitInfo with that signal value).
+  [[nodiscard]] VkSemaphore acquire_semaphore() const;
+
+  // Allocate this frame's acquire + release points. Call once per present,
+  // before the blit submit.
+  [[nodiscard]] FramePoints NextFrame();
+
+  // Attach the frame's acquire + release points to the syncobj surface. MUST be
+  // called between wl_surface.attach and wl_surface.commit.
+  void SetSurfacePoints(const FramePoints& points);
+
+  // Non-blocking: has the compositor signalled the release syncobj at
+  // @p release_point yet? Replaces wl_buffer.release for slot reclaim.
+  // @p release_point == 0 (slot never committed) returns true.
+  [[nodiscard]] bool SlotReleased(uint64_t release_point) const;
+
+ private:
+  ExplicitSync();
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace wl_vulkan
+
+#endif  // SHELL_BACKEND_WAYLAND_VULKAN_WL_EXPLICIT_SYNC_H_

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -240,6 +240,12 @@ void Display::HandleGlobal(wl::CRegistry& reg,
     d->m_linux_dmabuf_version = version;
   } else if (iface == "wl_drm") {
     d->m_has_wl_drm = true;
+  } else if (iface == "wp_linux_drm_syncobj_manager_v1") {
+    // Remember the explicit-sync manager global so a Vulkan backend can bind it
+    // for the wp_linux_drm_syncobj timeline path (acquire/release points that
+    // replace the dma-buf present's CPU fence). Gated at runtime on this name.
+    d->m_drm_syncobj_name = name;
+    d->m_drm_syncobj_version = version;
   }
 
   if (iface == wl_compositor_interface.name) {

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -674,6 +674,11 @@ class Display : public IDisplay,
   // path. Zero name means the global was never advertised.
   uint32_t m_linux_dmabuf_name{0};
   uint32_t m_linux_dmabuf_version{0};
+  // Registry name + advertised version of wp_linux_drm_syncobj_manager_v1, for
+  // a Vulkan backend that binds explicit-sync timelines on the dma-buf present
+  // path. Zero name means the global was never advertised.
+  uint32_t m_drm_syncobj_name{0};
+  uint32_t m_drm_syncobj_version{0};
 
  public:
   [[nodiscard]] bool HasLinuxDmabuf() const { return m_has_linux_dmabuf; }
@@ -683,6 +688,12 @@ class Display : public IDisplay,
   }
   [[nodiscard]] uint32_t GetLinuxDmabufVersion() const {
     return m_linux_dmabuf_version;
+  }
+  [[nodiscard]] uint32_t GetDrmSyncobjName() const {
+    return m_drm_syncobj_name;
+  }
+  [[nodiscard]] uint32_t GetDrmSyncobjVersion() const {
+    return m_drm_syncobj_version;
   }
   // The registry the dma-buf feedback helper binds against.
   [[nodiscard]] wl::CRegistry& GetRegistry() { return registry_; }

--- a/shell/wayland/protocols/linux-drm-syncobj-v1.xml
+++ b/shell/wayland/protocols/linux-drm-syncobj-v1.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="linux_drm_syncobj_v1">
+  <copyright>
+    Copyright 2016 The Chromium Authors.
+    Copyright 2017 Intel Corporation
+    Copyright 2018 Collabora, Ltd
+    Copyright 2021 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="protocol for providing explicit synchronization">
+    This protocol allows clients to request explicit synchronization for
+    buffers. It is tied to the Linux DRM synchronization object framework.
+
+    Synchronization refers to co-ordination of pipelined operations performed
+    on buffers. Most GPU clients will schedule an asynchronous operation to
+    render to the buffer, then immediately send the buffer to the compositor
+    to be attached to a surface.
+
+    With implicit synchronization, ensuring that the rendering operation is
+    complete before the compositor displays the buffer is an implementation
+    detail handled by either the kernel or userspace graphics driver.
+
+    By contrast, with explicit synchronization, DRM synchronization object
+    timeline points mark when the asynchronous operations are complete. When
+    submitting a buffer, the client provides a timeline point which will be
+    waited on before the compositor accesses the buffer, and another timeline
+    point that the compositor will signal when it no longer needs to access the
+    buffer contents for the purposes of the surface commit.
+
+    Linux DRM synchronization objects are documented at:
+    https://dri.freedesktop.org/docs/drm/gpu/drm-mm.html#drm-sync-objects
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="wp_linux_drm_syncobj_manager_v1" version="1">
+    <description summary="global for providing explicit synchronization">
+      This global is a factory interface, allowing clients to request
+      explicit synchronization for buffers on a per-surface basis.
+
+      See wp_linux_drm_syncobj_surface_v1 for more information.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy explicit synchronization factory object">
+        Destroy this explicit synchronization factory object. Other objects
+        shall not be affected by this request.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="surface_exists" value="0"
+        summary="the surface already has a synchronization object associated"/>
+      <entry name="invalid_timeline" value="1"
+        summary="the timeline object could not be imported"/>
+    </enum>
+
+    <request name="get_surface">
+      <description summary="extend surface interface for explicit synchronization">
+        Instantiate an interface extension for the given wl_surface to provide
+        explicit synchronization.
+
+        If the given wl_surface already has an explicit synchronization object
+        associated, the surface_exists protocol error is raised.
+
+        Graphics APIs, like EGL or Vulkan, that manage the buffer queue and
+        commits of a wl_surface themselves, are likely to be using this
+        extension internally. If a client is using such an API for a
+        wl_surface, it should not directly use this extension on that surface,
+        to avoid raising a surface_exists protocol error.
+      </description>
+      <arg name="id" type="new_id" interface="wp_linux_drm_syncobj_surface_v1"
+        summary="the new synchronization surface object id"/>
+      <arg name="surface" type="object" interface="wl_surface"
+        summary="the surface"/>
+    </request>
+
+    <request name="import_timeline">
+      <description summary="import a DRM syncobj timeline">
+        Import a DRM synchronization object timeline.
+
+        If the FD cannot be imported, the invalid_timeline error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_linux_drm_syncobj_timeline_v1"/>
+      <arg name="fd" type="fd" summary="drm_syncobj file descriptor"/>
+    </request>
+  </interface>
+
+  <interface name="wp_linux_drm_syncobj_timeline_v1" version="1">
+    <description summary="synchronization object timeline">
+      This object represents an explicit synchronization object timeline
+      imported by the client to the compositor.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the timeline">
+        Destroy the synchronization object timeline. Other objects are not
+        affected by this request, in particular timeline points set by
+        set_acquire_point and set_release_point are not unset.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="wp_linux_drm_syncobj_surface_v1" version="1">
+    <description summary="per-surface explicit synchronization">
+      This object is an add-on interface for wl_surface to enable explicit
+      synchronization.
+
+      Each surface can be associated with only one object of this interface at
+      any time.
+
+      Explicit synchronization is guaranteed to be supported for buffers
+      created with any version of the linux-dmabuf protocol. Compositors are
+      free to support explicit synchronization for additional buffer types.
+      If at surface commit time the attached buffer does not support explicit
+      synchronization, an unsupported_buffer error is raised.
+
+      As long as the wp_linux_drm_syncobj_surface_v1 object is alive, the
+      compositor may ignore implicit synchronization for buffers attached and
+      committed to the wl_surface. The delivery of wl_buffer.release events
+      for buffers attached to the surface becomes undefined.
+
+      Clients must set both acquire and release points if and only if a
+      non-null buffer is attached in the same surface commit. See the
+      no_buffer, no_acquire_point and no_release_point protocol errors.
+
+      If at surface commit time the acquire and release DRM syncobj timelines
+      are identical, the acquire point value must be strictly less than the
+      release point value, or else the conflicting_points protocol error is
+      raised.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the surface synchronization object">
+        Destroy this surface synchronization object.
+
+        Any timeline point set by this object with set_acquire_point or
+        set_release_point since the last commit may be discarded by the
+        compositor. Any timeline point set by this object before the last
+        commit will not be affected.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="no_surface" value="1"
+        summary="the associated wl_surface was destroyed"/>
+      <entry name="unsupported_buffer" value="2"
+        summary="the buffer does not support explicit synchronization"/>
+      <entry name="no_buffer" value="3" summary="no buffer was attached"/>
+      <entry name="no_acquire_point" value="4"
+        summary="no acquire timeline point was set"/>
+      <entry name="no_release_point" value="5"
+        summary="no release timeline point was set"/>
+      <entry name="conflicting_points" value="6"
+        summary="acquire and release timeline points are in conflict"/>
+    </enum>
+
+    <request name="set_acquire_point">
+      <description summary="set the acquire timeline point">
+        Set the timeline point that must be signalled before the compositor may
+        sample from the buffer attached with wl_surface.attach.
+
+        The 64-bit unsigned value combined from point_hi and point_lo is the
+        point value.
+
+        The acquire point is double-buffered state, and will be applied on the
+        next wl_surface.commit request for the associated surface. Thus, it
+        applies only to the buffer that is attached to the surface at commit
+        time.
+
+        If an acquire point has already been attached during the same commit
+        cycle, the new point replaces the old one.
+
+        If the associated wl_surface was destroyed, a no_surface error is
+        raised.
+
+        If at surface commit time there is a pending acquire timeline point set
+        but no pending buffer attached, a no_buffer error is raised. If at
+        surface commit time there is a pending buffer attached but no pending
+        acquire timeline point set, the no_acquire_point protocol error is
+        raised.
+      </description>
+      <arg name="timeline" type="object" interface="wp_linux_drm_syncobj_timeline_v1"/>
+      <arg name="point_hi" type="uint" summary="high 32 bits of the point value"/>
+      <arg name="point_lo" type="uint" summary="low 32 bits of the point value"/>
+    </request>
+
+    <request name="set_release_point">
+      <description summary="set the release timeline point">
+        Set the timeline point that must be signalled by the compositor when it
+        has finished its usage of the buffer attached with wl_surface.attach
+        for the relevant commit.
+
+        Once the timeline point is signaled, and assuming the associated buffer
+        is not pending release from other wl_surface.commit requests, no
+        additional explicit or implicit synchronization with the compositor is
+        required to safely re-use the buffer.
+
+        Note that clients cannot rely on the release point being always
+        signaled after the acquire point: compositors may release buffers
+        without ever reading from them. In addition, the compositor may use
+        different presentation paths for different commits, which may have
+        different release behavior. As a result, the compositor may signal the
+        release points in a different order than the client committed them.
+
+        Because signaling a timeline point also signals every previous point,
+        it is generally not safe to use the same timeline object for the
+        release points of multiple buffers. The out-of-order signaling
+        described above may lead to a release point being signaled before the
+        compositor has finished reading. To avoid this, it is strongly
+        recommended that each buffer should use a separate timeline for its
+        release points.
+
+        The 64-bit unsigned value combined from point_hi and point_lo is the
+        point value.
+
+        The release point is double-buffered state, and will be applied on the
+        next wl_surface.commit request for the associated surface. Thus, it
+        applies only to the buffer that is attached to the surface at commit
+        time.
+
+        If a release point has already been attached during the same commit
+        cycle, the new point replaces the old one.
+
+        If the associated wl_surface was destroyed, a no_surface error is
+        raised.
+
+        If at surface commit time there is a pending release timeline point set
+        but no pending buffer attached, a no_buffer error is raised. If at
+        surface commit time there is a pending buffer attached but no pending
+        release timeline point set, the no_release_point protocol error is
+        raised.
+      </description>
+      <arg name="timeline" type="object" interface="wp_linux_drm_syncobj_timeline_v1"/>
+      <arg name="point_hi" type="uint" summary="high 32 bits of the point value"/>
+      <arg name="point_lo" type="uint" summary="low 32 bits of the point value"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
## What

Explicit sync via `wp_linux_drm_syncobj` for the experimental `wayland_vulkan` zero-copy dma-buf present path (`IVI_VK_DMABUF`, default-off). Follow-up to #316/#318; addresses the explicit-sync item in #317.

Replaces the per-slot CPU fence (`vkWaitForFences` after the blit, stalling the rasterizer every frame) with GPU-side timeline sync where the compositor and device support it.

## How

- The blit submit signals an **acquire timeline** — a `VK_SEMAPHORE_TYPE_TIMELINE` `VkSemaphore` imported (OPAQUE_FD, permanent) from a DRM syncobj. The compositor waits on that point before sampling, so the CPU stall is gone.
- A **release** syncobj the compositor signals is polled with a zero-timeout `drmSyncobjTimelineWait` to reclaim slots — the explicit-sync replacement for `wl_buffer.release`.
- Acquire/release points are set on the syncobj surface between `attach` and `commit`. The render node is opened from `VkPhysicalDeviceDrmPropertiesEXT` (a Wayland client has no DRM master).
- Because ivi owns the blit submit (unlike the Skia example, where Skia owns it), the acquire timeline is signalled **directly on that one submit** — no separate bridging submit or per-slot binary semaphore.
- All DRM-syncobj + Vulkan-import plumbing lives in the new `wl_explicit_sync.{h,cc}` behind a PIMPL; the backend just wires it into the present path.
- Falls back to the CPU fence when the compositor doesn't advertise the manager or the device lacks timeline-semaphore / external-semaphore-fd. `IVI_VK_NO_EXPLICIT_SYNC` forces the fallback for bisecting.

**No scanner bump needed** (this supersedes the "needs a wcs bump" assumption in #317): the client header is generated from a vendored `linux-drm-syncobj-v1.xml` with `EMIT_INTERFACE_TABLES`, exactly like presentation-time / xdg-shell.

## Validation

| Target | GPU / compositor | dma-buf path | Explicit sync | Result |
| --- | --- | --- | --- | --- |
| Host | RADV / mutter | ✅ | ✅ active | renders, **0 sync-validation-layer hazards** |
| Steam Deck | RADV Van Gogh / gamescope (DRM master, 90 Hz) | ✅ | ✅ active | ~88.5 fps, 0 errors/discards |
| Raspberry Pi 4 (aarch64) | V3D / weston | ✅ activates (tiled modifier) | ⤵ CPU-fence fallback (compositor advertises no manager) | renders, no crash |

Explicit sync is hazard-free under the Vulkan **synchronization** validation layer, and confirmed active on both compositors that advertise the protocol. The dma-buf path + CPU-fence fallback are confirmed on a second GPU family (V3D). Explicit-sync *active* on V3D has no available compositor (weston-on-V3D doesn't expose the manager); the device extensions are all present, so it's a compositor-support gap, not a code one.

clang-tidy-19 and clang-format-19 clean; host build green.

## Not in this PR (tracked in #317)

- Platform-view compositing on the dma-buf path.
