### PR TITLE
[ci] Run unit-tests + collect coverage across all backends

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -284,40 +284,6 @@ jobs:
             -D BUILD_SYSTEMD_WATCHDOG=ON \
             --build
 
-# Reads .emb/base.emb.yaml and emits a GitHub Actions matrix whose entries
-  # map each backend name to its cmake flags, runner image, and any extra
-  # packages required (e.g. DRM backends need libdrm-dev etc. on ubuntu-24.04,
-  # mirroring the setup in drm-kms.yml).
-  collect-backends:
-    name: collect-backends
-    if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' }}
-    runs-on: ubuntu-22.04
-    outputs:
-      matrix: ${{ steps.gen.outputs.matrix }}
-    steps:
-      - name: Checkout (shallow, no submodules)
-        uses: actions/checkout@v5
-        with:
-          submodules: false
-
-      - name: Generate backend matrix
-        id: gen
-        run: |
-          pip install --quiet pyyaml
-          python3 - <<'EOF'
-          import json, yaml, os
-
-          with open(".emb/base.emb.yaml") as f:
-              data = yaml.safe_load(f)
-
-          includes = [{"backend": name}
-                      for name in data["cross"]["backends"]]
-
-          matrix = json.dumps({"include": includes})
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"matrix={matrix}\n")
-          EOF
-
   # Unit-test + coverage-capture job.
   #
   # Runs once per backend from the collect-backends matrix. Reads
@@ -329,89 +295,84 @@ jobs:
   # All legs run on ubuntu-24.04, which satisfies both the DRM backend
   # requirements (libdrm-dev, libgbm-dev, etc.) and the wayland/software ones.
   unit-tests:
-    needs: collect-backends
     if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' && always() }}
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.collect-backends.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - name: Resolve backend cmake flags
-        id: backend
-        run: |
-          pip install --quiet pyyaml
-          python3 - <<'EOF'
-          import json, yaml, os
+      - name: Update apt package index
+        # Refresh the index before cache-apt-pkgs-action resolves versions, so
+        # it pins the revision currently on the mirror rather than a stale one
+        # the runner image still lists (a dropped .deb 404s and aborts install).
+        run: sudo apt-get update
 
-          with open(".emb/base.emb.yaml") as f:
-              data = yaml.safe_load(f)
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev libpugixml-dev libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev libxcursor-dev clang-19 clang-tidy-19 clang-format-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
+          version: 1.0
 
-          defines = data["cross"]["backends"]["${{ matrix.backend }}"]
-          flags = " ".join(f"-D {k}={v}" for k, v in defines.items())
-          with open(os.environ["GITHUB_ENV"], "a") as f:
-              f.write(f"BACKEND_CMAKE_FLAGS={flags}\n")
-          EOF
+      - name: Update apt package index
+        # Refresh the index before cache-apt-pkgs-action resolves versions, so
+        # it pins the revision currently on the mirror rather than a stale one
+        # the runner image still lists (a dropped .deb 404s and aborts install).
+        run: sudo apt-get update
 
-      - name: Install base packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            ninja-build lcov libglib2.0-dev \
-            libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev \
-            mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils \
-            clang-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
+      - name: Install extra dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            libdrm-dev libgbm-dev
+            libinput-dev libudev-dev libseat-dev libxcursor-dev
+            libsystemd-dev libpugixml-dev libcurl4-openssl-dev
+          version: 1.0-extra
 
-      - name: Install DRM backend packages
-        if: ${{ startsWith(matrix.backend, 'drm-') }}
-        run: |
-          sudo apt-get install -y \
-            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
-            libxcursor-dev
 
       - name: Setup libdisplay-info
-        if: ${{ startsWith(matrix.backend, 'drm-') }}
         uses: ./.github/actions/setup-libdisplay-info
 
       - name: Configure (coverage)
         run: |
           cmake -GNinja \
-            -B ${{github.workspace}}/build/unit-tests-${{ matrix.backend }} \
+            -B ${{github.workspace}}/build/unit-tests \
             -D CMAKE_BUILD_TYPE=Debug \
             -D BUILD_UNIT_TESTS=ON \
             -D COVERAGE=ON \
             -D CMAKE_STAGING_PREFIX=${{github.workspace}}/build/staging/usr/local \
             -D BUILD_NUMBER=${GITHUB_RUN_ID} \
-            ${BACKEND_CMAKE_FLAGS}
+            -D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -D BUILD_BACKEND_WAYLAND_EGL=ON \
+            -D BUILD_BACKEND_WAYLAND_VULKAN=ON \
+            -D BUILD_BACKEND_DRM_KMS_EGL=ON \
+            -D BUILD_BACKEND_DRM_KMS_VULKAN=ON \
+            -D BUILD_BACKEND_SOFTWARE=ON \
+            -D BUILD_COMPOSITOR=ON \
+            -D BUILD_ACCESSIBILITY=ON \
+            -D BUILD_CRASH_HANDLER=OFF \
+            -D BUILD_WATCHDOG=ON \
+            -D BUILD_SYSTEMD_WATCHDOG=ON
 
       - name: Build
-        working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
+        working-directory: ${{github.workspace}}/build/unit-tests
         run: ninja -C .
 
       - name: Run unit tests (CTest)
-        working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
+        working-directory: ${{github.workspace}}/build/unit-tests
         run: ctest --output-on-failure --test-dir .
 
       - name: Capture coverage data
-        working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
+        working-directory: ${{github.workspace}}/build/unit-tests
         run: |
           lcov -d . -c --rc lcov_branch_coverage=1 --ignore-errors mismatch -o coverage.info
           lcov -r coverage.info \
             '*/test/*' '*/usr/*' '*/third_party/*' '*/wayland-protocols/*' \
             --rc lcov_branch_coverage=1 --ignore-errors mismatch -o coverage.info
 
-      - name: Upload per-backend coverage data
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{ matrix.backend }}
-          path: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}/coverage.info
-        
       - name: Coverage summary
-        working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
+        working-directory: ${{github.workspace}}/build/unit-tests
         run: |
           {
             echo "## Unit test coverage"
@@ -427,47 +388,14 @@ jobs:
               | awk -F'|' '{printf "| %s | %s |\n", $1, $2}'
           } >> "$GITHUB_STEP_SUMMARY"
           cat "${GITHUB_STEP_SUMMARY}"
-  
-  # Coverage merge + report job.
-  #
-  # Downloads all per-backend coverage.info files uploaded by the unit-tests
-  # matrix, merges them with lcov, generates a single HTML report, and
-  # uploads it as a downloadable artifact. All unit-test matrix legs must
-  # succeed before this job runs.
-  coverage:
-    name: coverage
-    needs: unit-tests
-    if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Install lcov
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y lcov
-
-      - name: Download per-backend coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: coverage-*
-          path: coverage-artifacts
-          merge-multiple: false
-
-      - name: Merge coverage data
-        run: |
-          inputs=$(find coverage-artifacts -name 'coverage.info' \
-                     -printf '-a %p ')
-          lcov ${inputs} --rc lcov_branch_coverage=1 -o merged.info
-          lcov -r merged.info \
-            '*/test/*' '*/usr/*' '*/third_party/*' \
-            --rc lcov_branch_coverage=1 -o merged.info
 
       - name: Print coverage summary
         run: |
           echo "=== Coverage Summary (all backends merged) ==="
-          lcov --summary merged.info 2>&1 | grep -E 'lines\.|functions\.|branches\.'
+          lcov --summary coverage.info 2>&1 | grep -E 'lines\.|functions\.|branches\.'
 
       - name: Generate HTML report
-        run: genhtml -o lcovHtml -s --legend --branch-coverage merged.info
+        run: genhtml -o lcovHtml -s --legend --branch-coverage coverage.info
 
       - name: Upload coverage HTML report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -284,23 +284,80 @@ jobs:
             -D BUILD_SYSTEMD_WATCHDOG=ON \
             --build
 
-  # Unit-test + coverage job.
-  #
-  # Builds the full unit-test suite with -DCOVERAGE=ON (--coverage on every
-  # object), runs all *_test_driver binaries via CTest, captures per-file
-  # line/branch/function data with lcov, filters out third-party and test
-  # sources, generates an HTML report, prints the coverage percentages to the
-  # job log, and uploads the HTML as a downloadable artifact.
-  unit-tests:
-    if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' && always() }}
+# Reads .emb/base.emb.yaml and emits a GitHub Actions matrix whose entries
+  # map each backend name to its cmake flags, runner image, and any extra
+  # packages required (e.g. DRM backends need libdrm-dev etc. on ubuntu-24.04,
+  # mirroring the setup in drm-kms.yml).
+  collect-backends:
+    name: collect-backends
+    if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' }}
     runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - name: Checkout (shallow, no submodules)
+        uses: actions/checkout@v5
+        with:
+          submodules: false
+
+      - name: Generate backend matrix
+        id: gen
+        run: |
+          pip install --quiet pyyaml
+          python3 - <<'EOF'
+          import json, yaml, os
+
+          with open(".emb/base.emb.yaml") as f:
+              data = yaml.safe_load(f)
+
+          includes = [{"backend": name}
+                      for name in data["cross"]["backends"]]
+
+          matrix = json.dumps({"include": includes})
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"matrix={matrix}\n")
+          EOF
+
+  # Unit-test + coverage-capture job.
+  #
+  # Runs once per backend from the collect-backends matrix. Reads
+  # .emb/base.emb.yaml to resolve cmake flags for the current backend.
+  # Builds the full unit-test suite with -DCOVERAGE=ON, runs CTest and the
+  # *_test_driver binaries, captures per-file line/branch/function data with
+  # lcov, filters out third-party and test sources, and uploads coverage.info
+  # as an artifact for the subsequent coverage-merge job.
+  # All legs run on ubuntu-24.04, which satisfies both the DRM backend
+  # requirements (libdrm-dev, libgbm-dev, etc.) and the wayland/software ones.
+  unit-tests:
+    needs: collect-backends
+    if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' && always() }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.collect-backends.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - name: Install packages
+      - name: Resolve backend cmake flags
+        id: backend
+        run: |
+          pip install --quiet pyyaml
+          python3 - <<'EOF'
+          import json, yaml, os
+
+          with open(".emb/base.emb.yaml") as f:
+              data = yaml.safe_load(f)
+
+          defines = data["cross"]["backends"]["${{ matrix.backend }}"]
+          flags = " ".join(f"-D {k}={v}" for k, v in defines.items())
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+              f.write(f"BACKEND_CMAKE_FLAGS={flags}\n")
+          EOF
+
+      - name: Install base packages
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -308,32 +365,57 @@ jobs:
             libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev \
             mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev
 
+      - name: Install DRM backend packages
+        if: ${{ startsWith(matrix.backend, 'drm-') }}
+        run: |
+          sudo apt-get install -y \
+            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
+            libxcursor-dev libglib2.0-dev
+
+      - name: Setup libdisplay-info
+        if: ${{ startsWith(matrix.backend, 'drm-') }}
+        uses: ./.github/actions/setup-libdisplay-info
+
       - name: Configure (coverage)
         run: |
           cmake -GNinja \
-            -B ${{github.workspace}}/build/unit-tests \
+            -B ${{github.workspace}}/build/unit-tests-${{ matrix.backend }} \
             -D CMAKE_BUILD_TYPE=Debug \
             -D BUILD_UNIT_TESTS=ON \
             -D COVERAGE=ON \
             -D CMAKE_STAGING_PREFIX=${{github.workspace}}/build/staging/usr/local \
-            -D BUILD_NUMBER=${GITHUB_RUN_ID}
+            -D BUILD_NUMBER=${GITHUB_RUN_ID} \
+            ${BACKEND_CMAKE_FLAGS}
 
       - name: Build
-        working-directory: ${{github.workspace}}/build/unit-tests
+        working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
         run: ninja -C .
 
       - name: Run unit tests (CTest)
-        working-directory: ${{github.workspace}}/build/unit-tests
+        working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
         run: ctest --output-on-failure --test-dir .
 
-      - name: Capture coverage data
+      - name: Reset coverage counters
         working-directory: ${{github.workspace}}/build/unit-tests
+        run: lcov -d . -z
+
+      - name: Run test drivers (coverage collection)
+        working-directory: ${{github.workspace}}/build/unit-tests
+        run: |
+          for driver in $(find test/unit_test/ -name '*_test_driver'); do
+            ./${driver}
+          done
+
+      - name: Capture coverage data
+        working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
         run: |
           lcov -d . -c --rc lcov_branch_coverage=1 -o coverage.info
           lcov -r coverage.info \
             '*/test/*' '*/usr/*' '*/third_party/*' '*/wayland-protocols/*' \
             --rc lcov_branch_coverage=1 -o coverage.info
 
+      - name: Upload per-backend coverage data
+        uses: actions/upload-artifact@v4
       - name: Coverage summary
         working-directory: ${{github.workspace}}/build/unit-tests
         run: |
@@ -359,5 +441,5 @@ jobs:
       - name: Upload coverage HTML report
         uses: actions/upload-artifact@v5
         with:
-          name: unit-test-coverage-html
-          path: ${{github.workspace}}/build/unit-tests/lcovHtml/
+          name: coverage-${{ matrix.backend }}
+          path: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}/coverage.info

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -376,7 +376,7 @@ jobs:
             '*/test/*' '*/usr/*' '*/third_party/*' '*/wayland-protocols/*' \
             --rc lcov_branch_coverage=1 --ignore-errors mismatch -o coverage.info
 
-      - name: Coverage summary
+      - name: Print coverage summary
         working-directory: ${{github.workspace}}/build/unit-tests
         run: |
           {
@@ -394,16 +394,12 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           cat "${GITHUB_STEP_SUMMARY}"
 
-      - name: Print coverage summary
-        run: |
-          echo "=== Coverage Summary (all backends merged) ==="
-          lcov --summary coverage.info 2>&1 | grep -E 'lines\.|functions\.|branches\.'
-
       - name: Generate HTML report
+        working-directory: ${{github.workspace}}/build/unit-tests
         run: genhtml -o lcovHtml -s --legend --branch-coverage coverage.info
 
       - name: Upload coverage HTML report
         uses: actions/upload-artifact@v4
         with:
           name: unit-test-coverage-html
-          path: lcovHtml/
+          path: ${{github.workspace}}/build/unit-tests/lcovHtml/

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -396,17 +396,6 @@ jobs:
         working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
         run: ctest --output-on-failure --test-dir .
 
-      - name: Reset coverage counters
-        working-directory: ${{github.workspace}}/build/unit-tests
-        run: lcov -d . -z
-
-      - name: Run test drivers (coverage collection)
-        working-directory: ${{github.workspace}}/build/unit-tests
-        run: |
-          for driver in $(find test/unit_test/ -name '*_test_driver'); do
-            ./${driver}
-          done
-
       - name: Capture coverage data
         working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
         run: |

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -406,8 +406,12 @@ jobs:
 
       - name: Upload per-backend coverage data
         uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.backend }}
+          path: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}/coverage.info
+        
       - name: Coverage summary
-        working-directory: ${{github.workspace}}/build/unit-tests
+        working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
         run: |
           {
             echo "## Unit test coverage"
@@ -423,18 +427,8 @@ jobs:
               | awk -F'|' '{printf "| %s | %s |\n", $1, $2}'
           } >> "$GITHUB_STEP_SUMMARY"
           cat "${GITHUB_STEP_SUMMARY}"
-
-      - name: Generate HTML report
-        working-directory: ${{github.workspace}}/build/unit-tests
-        run: genhtml -o lcovHtml -s --legend --branch-coverage coverage.info
-
-      - name: Upload coverage HTML report
-        uses: actions/upload-artifact@v5
-        with:
-          name: coverage-${{ matrix.backend }}
-          path: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}/coverage.info
   
-          # Coverage merge + report job.
+  # Coverage merge + report job.
   #
   # Downloads all per-backend coverage.info files uploaded by the unit-tests
   # matrix, merges them with lcov, generates a single HTML report, and

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -361,16 +361,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            ninja-build lcov \
+            ninja-build lcov libglib2.0-dev \
             libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev \
-            mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev
+            mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils \
+            clang-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
 
       - name: Install DRM backend packages
         if: ${{ startsWith(matrix.backend, 'drm-') }}
         run: |
           sudo apt-get install -y \
             libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
-            libxcursor-dev libglib2.0-dev
+            libxcursor-dev
 
       - name: Setup libdisplay-info
         if: ${{ startsWith(matrix.backend, 'drm-') }}

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -399,10 +399,10 @@ jobs:
       - name: Capture coverage data
         working-directory: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}
         run: |
-          lcov -d . -c --rc lcov_branch_coverage=1 -o coverage.info
+          lcov -d . -c --rc lcov_branch_coverage=1 --ignore-errors mismatch -o coverage.info
           lcov -r coverage.info \
             '*/test/*' '*/usr/*' '*/third_party/*' '*/wayland-protocols/*' \
-            --rc lcov_branch_coverage=1 -o coverage.info
+            --rc lcov_branch_coverage=1 --ignore-errors mismatch -o coverage.info
 
       - name: Upload per-backend coverage data
         uses: actions/upload-artifact@v4

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -330,7 +330,6 @@ jobs:
             libsystemd-dev libpugixml-dev libcurl4-openssl-dev
           version: 1.0-extra
 
-
       - name: Setup libdisplay-info
         uses: ./.github/actions/setup-libdisplay-info
 
@@ -358,6 +357,12 @@ jobs:
       - name: Build
         working-directory: ${{github.workspace}}/build/unit-tests
         run: ninja -C .
+
+      - name: Install unit test deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: lcov
+          version: 1.0-unit_test
 
       - name: Run unit tests (CTest)
         working-directory: ${{github.workspace}}/build/unit-tests

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -443,3 +443,50 @@ jobs:
         with:
           name: coverage-${{ matrix.backend }}
           path: ${{github.workspace}}/build/unit-tests-${{ matrix.backend }}/coverage.info
+  
+          # Coverage merge + report job.
+  #
+  # Downloads all per-backend coverage.info files uploaded by the unit-tests
+  # matrix, merges them with lcov, generates a single HTML report, and
+  # uploads it as a downloadable artifact. All unit-test matrix legs must
+  # succeed before this job runs.
+  coverage:
+    name: coverage
+    needs: unit-tests
+    if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install lcov
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lcov
+
+      - name: Download per-backend coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+          merge-multiple: false
+
+      - name: Merge coverage data
+        run: |
+          inputs=$(find coverage-artifacts -name 'coverage.info' \
+                     -printf '-a %p ')
+          lcov ${inputs} --rc lcov_branch_coverage=1 -o merged.info
+          lcov -r merged.info \
+            '*/test/*' '*/usr/*' '*/third_party/*' \
+            --rc lcov_branch_coverage=1 -o merged.info
+
+      - name: Print coverage summary
+        run: |
+          echo "=== Coverage Summary (all backends merged) ==="
+          lcov --summary merged.info 2>&1 | grep -E 'lines\.|functions\.|branches\.'
+
+      - name: Generate HTML report
+        run: genhtml -o lcovHtml -s --legend --branch-coverage merged.info
+
+      - name: Upload coverage HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-coverage-html
+          path: lcovHtml/

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -93,6 +93,16 @@ endif ()
 
 target_compile_options(ihs_shared PRIVATE -Wall -Wextra)
 
+# Coverage instrumentation. The COVERAGE flag is handled in
+# test/unit_test/CMakeLists.txt via CMAKE_CXX_FLAGS, but that runs after
+# add_subdirectory(shared) in the root so ihs_shared would otherwise be built
+# without --coverage and produce no .gcda data. Wire it here so lcov captures
+# shared/ sources when COVERAGE=ON.
+if (COVERAGE)
+    target_compile_options(ihs_shared PRIVATE --coverage)
+    target_link_options(ihs_shared PRIVATE --coverage)
+endif ()
+
 # Never unload this library: the DLT bridge owns a worker thread and per-thread
 # ring TLS whose destructors must not fire against code unmapped by dlclose.
 # -z nodelete pins it for the process lifetime even if a plugin that pulled it

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -101,13 +101,43 @@ target_include_directories(homescreen_ut_shell
     # unit_test_utils.cc (in the archive) and test case .cc files both
     # include gtest/gtest.h; propagate it through the archive.
     $<TARGET_PROPERTY:gtest,INTERFACE_INCLUDE_DIRECTORIES>
+    # platform_homescreen is linked PRIVATE below (to keep its INTERFACE_SOURCES
+    # from being compiled into every driver), which also drops its PUBLIC
+    # include-dir usage requirements. Some shell headers reused as
+    # TYPICAL_TEST_SOURCES (flutter_view.h / engine.h) and test cases
+    # (test_case_text_input.cc) include platform_homescreen's public headers
+    # (flutter_desktop_view_controller_state.h, flutter_desktop_engine_state.h),
+    # so re-propagate just its include dirs here.
+    $<TARGET_PROPERTY:platform_homescreen,INTERFACE_INCLUDE_DIRECTORIES>
 )
+# platform_homescreen is a STATIC library that re-exports its platform-view
+# sources (platform_views_handler.cc / platform_view_registry.cc /
+# platform_view_touch.cc) as INTERFACE_SOURCES via target_sources(... PUBLIC ...)
+# — so every target that links it *compiles* those .cc into itself. That is fine
+# for the shell binary (a static archive only pulls .o on demand), but this
+# OBJECT library's object files are always linked, and linking platform_homescreen
+# PUBLIC would re-propagate its INTERFACE_SOURCES to every test driver as well.
+# The driver would then compile the same three TUs a second time, producing
+# "multiple definition of PlatformViewsHandler/PlatformViewRegistry/PlatformViewTouch"
+# at link time. So split platform_homescreen out of the PUBLIC link set and link
+# it PRIVATE: its interface sources are then compiled exactly once — here, into
+# homescreen_ut_shell — while its archive (and usage requirements) still
+# propagate to the drivers that link this object library. Keep everything else
+# PUBLIC so drivers inherit the transitive link deps (wayland, EGL, flutter,
+# toolchain isystem paths).
+#
+# Use a LOCAL copy for the split: the old-style test subdirectories added below
+# link ${TYPICAL_TEST_LINK_LIBS} directly and rely on platform_homescreen's
+# PUBLIC include dirs (flutter_desktop_*.h), so the shared variable must stay
+# intact.
+set(HOMESCREEN_UT_SHELL_PUBLIC_LIBS ${TYPICAL_TEST_LINK_LIBS})
+list(REMOVE_ITEM HOMESCREEN_UT_SHELL_PUBLIC_LIBS platform_homescreen)
 target_link_libraries(homescreen_ut_shell
-    # PUBLIC: test executables that link this archive must also see the
-    # transitive link deps (wayland, EGL, flutter, toolchain isystem paths).
     PUBLIC
-    ${TYPICAL_TEST_LINK_LIBS}
+    ${HOMESCREEN_UT_SHELL_PUBLIC_LIBS}
     toolchain::toolchain
+    PRIVATE
+    platform_homescreen
 )
 
 


### PR DESCRIPTION
This PR improves the CI/CD pipeline for coverage reporting and unit tests across multiple backends. Key changes include:

- **Enhanced Coverage Reporting**:
  - Provides a unified `lcov` report including source from all build variants.
  - Included `ihs_shared` in the coverage analysis.
  - Fixed coverage report upload processes and addressed `lcov` mismatch errors.
- **Build & Dependency Fixes**:
  - Resolved build dependency issues for unit tests across different build configurations.
  - Fixed multi-backend coverage build configurations.
- **CI Cleanup**