### PR TITLE
wayland-leased-drm: lease a connector from a Wayland compositor (egl/vulkan/software tiers)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,11 @@ include(options)
 # and main() has nothing to run.
 if (NOT (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN OR
          BUILD_BACKEND_DRM_KMS_EGL OR BUILD_BACKEND_DRM_KMS_VULKAN OR
-         BUILD_BACKEND_SOFTWARE))
+         BUILD_BACKEND_SOFTWARE OR BUILD_BACKEND_WAYLAND_LEASED_DRM))
     message(FATAL_ERROR
             "No backend selected — enable at least one BUILD_BACKEND_* "
             "(WAYLAND_EGL, WAYLAND_VULKAN, DRM_KMS_EGL, DRM_KMS_VULKAN, "
-            "SOFTWARE)")
+            "SOFTWARE, WAYLAND_LEASED_DRM)")
 endif ()
 
 message(STATUS "Project ................ ${PROJECT_NAME}")
@@ -77,7 +77,12 @@ endif ()
 # `toolchain` INTERFACE library exists when we add_subdirectory the
 # wayland-cxx-scanner subproject on clang/libc++ builds. Gated internally on the
 # Wayland backends.
-if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN)
+#
+# IVI_WAYLAND_ANY, not the surface backends: wayland-leased-drm speaks
+# drm-lease-v1 over a wl_display and so needs the scanner + the
+# ivi_wayland_protocols()/ivi_wayland_link() helpers this module defines,
+# despite never creating a wl_surface.
+if (IVI_WAYLAND_ANY)
     include(wayland_cxx)
 endif ()
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,22 @@ uses it.
 | DRM/KMS EGL | `drm-kms-egl` | `BUILD_BACKEND_DRM_KMS_EGL` | Direct-to-display GL on bare KMS (no compositor) |
 | DRM/KMS Vulkan | `drm-kms-vulkan` | `BUILD_BACKEND_DRM_KMS_VULKAN` | Zero-copy dma-buf scanout on bare KMS |
 | Software | `software` | `BUILD_BACKEND_SOFTWARE` | CPU renderer; no GPU or display server |
+| Leased DRM (EGL) | `wayland-leased-drm-egl` | `BUILD_BACKEND_WAYLAND_LEASED_DRM` + `BUILD_BACKEND_DRM_KMS_EGL` | GL on a connector leased from a compositor via drm-lease-v1 |
+| Leased DRM (software) | `wayland-leased-drm-software` | `BUILD_BACKEND_WAYLAND_LEASED_DRM` + `BUILD_BACKEND_SOFTWARE` | CPU renderer on a leased connector |
 
 With no explicit selection, the resolver is environment-aware: a live Wayland
 session picks `wayland-egl`, otherwise `drm-kms-egl`.
+
+The `wayland-leased-drm-*` backends acquire a connector from a running Wayland
+compositor rather than opening a card, so one process can own a panel while the
+compositor owns the rest of the GPU. They are never selected implicitly, and a
+leased key is refused rather than substituted if unavailable — falling back to an
+unleased backend would grab hardware the operator did not ask for. The bare
+family name `wayland-leased-drm` picks the first available tier. Note that a
+compositor implementing drm-lease-v1 is necessary but **not** sufficient: the
+wlroots family only offers connectors flagged non-desktop in EDID, so an ordinary
+panel is not leasable without intervention. See
+[shell/backend/wayland_leased_drm/README.md](shell/backend/wayland_leased_drm/README.md).
 
 Running a Vulkan backend requires an engine build that supports Vulkan.
 
@@ -304,7 +317,10 @@ annotated all-keys file see
 | `[view.shell.window.activation_area]` | `width` | `int` | `view.width` | `int` | agl |
 | `[view.shell.window.activation_area]` | `x` | `int` | `0` | `int` | agl |
 | `[view.shell.window.activation_area]` | `y` | `int` | `0` | `int` | agl |
-| `[view.backend]` | `type` | `string` | `(env-aware)` | `wayland-egl\|wayland-vulkan\|drm-kms-egl\|drm-kms-vulkan\|software` | all |
+| `[view.backend]` | `type` | `string` | `(env-aware)` | `wayland-egl\|wayland-vulkan\|drm-kms-egl\|drm-kms-vulkan\|software\|wayland-leased-drm[-egl\|-software]` | all |
+| `[view.backend.lease]` | `connector` | `string` | `(sole offer)` | `e.g. HDMI-A-1` | leased |
+| `[view.backend.lease]` | `device` | `string` | `(sole device)` | index or `/dev/dri/cardN` | leased |
+| `[view.backend.lease]` | `timeout_ms` | `int` | `5000` | `> 0` | leased |
 | `[view.backend.drm]` | `allow_nonblock_modeset` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.drm]` | `async_flip` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.drm]` | `compositor` | `string` | `auto` | `auto\|planes\|gl` | drm |

--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ Usage:
       --lease-connector arg   wayland-leased-drm: connector to request by name 
                               (e.g. HDMI-A-1). Default: the sole offer; several 
                               offers with no choice is fatal.
+      --lease-on-revoke arg   wayland-leased-drm: what to do when the 
+                              compositor revokes the lease (it does so on every 
+                              VT switch away from it, not just on error). exit 
+                              (default) = log the cause and exit non-zero so a 
+                              supervisor restarts and renegotiates; gate = keep 
+                              running with a frozen panel (debugging only, 
+                              nothing recovers). reacquire is not implemented 
+                              yet.
       --lease-timeout-ms arg  wayland-leased-drm: bound on the whole lease 
                               negotiation. Default 5000. The protocol lets a 
                               compositor defer the DRM fd until it regains DRM 
@@ -355,6 +363,7 @@ annotated all-keys file see
 | `[view.backend.drm]` | `stage_cursor` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.lease]` | `connector` | `string` | `(sole offer)` | `e.g. HDMI-A-1` | leased |
 | `[view.backend.lease]` | `device` | `string` | `(sole device)` | `index or /dev/dri/cardN` | leased |
+| `[view.backend.lease]` | `on_revoke` | `string` | `exit` | `exit\|gate` | leased |
 | `[view.backend.lease]` | `timeout_ms` | `int` | `5000` | `> 0` | leased |
 | `[view.output]` | `drm_connector` | `string` | `(none)` | `e.g. HDMI-A-1` | drm |
 | `[view.output]` | `index` | `int` | `(none)` | `int` | all |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Flutter Linux CPP Embedder
     * DRM/KMS EGL (direct-to-display, no compositor)
     * DRM/KMS Vulkan (zero-copy dma-buf scanout)
     * Software (CPU renderer, no GPU or display-server dependency)
+    * Leased DRM, EGL / Vulkan / software (drm-lease-v1: own a connector leased
+      from a compositor while it keeps the rest of the card)
 * Multi-display
     * Multiple views across multiple outputs from one process
     * Per-view output binding by connector / `wl_output` name (`[view.output]`)
@@ -116,6 +118,7 @@ uses it.
 | DRM/KMS Vulkan | `drm-kms-vulkan` | `BUILD_BACKEND_DRM_KMS_VULKAN` | Zero-copy dma-buf scanout on bare KMS |
 | Software | `software` | `BUILD_BACKEND_SOFTWARE` | CPU renderer; no GPU or display server |
 | Leased DRM (EGL) | `wayland-leased-drm-egl` | `BUILD_BACKEND_WAYLAND_LEASED_DRM` + `BUILD_BACKEND_DRM_KMS_EGL` | GL on a connector leased from a compositor via drm-lease-v1 |
+| Leased DRM (Vulkan) | `wayland-leased-drm-vulkan` | `BUILD_BACKEND_WAYLAND_LEASED_DRM` + `BUILD_BACKEND_DRM_KMS_VULKAN` | Zero-copy dma-buf scanout on a leased connector |
 | Leased DRM (software) | `wayland-leased-drm-software` | `BUILD_BACKEND_WAYLAND_LEASED_DRM` + `BUILD_BACKEND_SOFTWARE` | CPU renderer on a leased connector |
 
 With no explicit selection, the resolver is environment-aware: a live Wayland
@@ -238,8 +241,11 @@ Usage:
  Backend options:
       --backend arg  Active backend: 
                      wayland-egl|wayland-vulkan|drm-kms-egl|drm-kms-vulkan|softw
-                     are (default: env-aware -- a Wayland session selects 
-                     wayland-egl, else drm-kms-egl)
+                     are|wayland-leased-drm[-egl|-vulkan|-software] (default: 
+                     env-aware -- a Wayland session selects wayland-egl, else 
+                     drm-kms-egl). The bare name wayland-leased-drm picks the 
+                     first available leased tier; a leased backend never falls 
+                     back to an unleased one.
 
  DRM options:
       --drm-list-modes [=arg(=)]
@@ -274,6 +280,21 @@ Usage:
       --input-transform arg     Per-device pointer transform (repeatable): 
                                 "<device-name-substring>=<0|90|180|270>[,flip-x]
                                 [,flip-y]"
+
+ Lease options:
+      --lease-device arg      wayland-leased-drm: which wp_drm_lease_device_v1 
+                              to lease from when several are advertised (one 
+                              per DRM node) -- a decimal index or a node path 
+                              (/dev/dri/card1). Default: the sole device; 
+                              ambiguous is fatal.
+      --lease-connector arg   wayland-leased-drm: connector to request by name 
+                              (e.g. HDMI-A-1). Default: the sole offer; several 
+                              offers with no choice is fatal.
+      --lease-timeout-ms arg  wayland-leased-drm: bound on the whole lease 
+                              negotiation. Default 5000. The protocol lets a 
+                              compositor defer the DRM fd until it regains DRM 
+                              master, so this is what stops a VT-switched-away 
+                              compositor hanging startup.
 ```
 
 <!-- END CLI-REFERENCE -->
@@ -317,10 +338,7 @@ annotated all-keys file see
 | `[view.shell.window.activation_area]` | `width` | `int` | `view.width` | `int` | agl |
 | `[view.shell.window.activation_area]` | `x` | `int` | `0` | `int` | agl |
 | `[view.shell.window.activation_area]` | `y` | `int` | `0` | `int` | agl |
-| `[view.backend]` | `type` | `string` | `(env-aware)` | `wayland-egl\|wayland-vulkan\|drm-kms-egl\|drm-kms-vulkan\|software\|wayland-leased-drm[-egl\|-software]` | all |
-| `[view.backend.lease]` | `connector` | `string` | `(sole offer)` | `e.g. HDMI-A-1` | leased |
-| `[view.backend.lease]` | `device` | `string` | `(sole device)` | index or `/dev/dri/cardN` | leased |
-| `[view.backend.lease]` | `timeout_ms` | `int` | `5000` | `> 0` | leased |
+| `[view.backend]` | `type` | `string` | `(env-aware)` | `wayland-egl\|wayland-vulkan\|drm-kms-egl\|drm-kms-vulkan\|software` | all |
 | `[view.backend.drm]` | `allow_nonblock_modeset` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.drm]` | `async_flip` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.drm]` | `compositor` | `string` | `auto` | `auto\|planes\|gl` | drm |
@@ -335,6 +353,9 @@ annotated all-keys file see
 | `[view.backend.drm]` | `primary_format` | `string` | `auto` | `auto\|xrgb8888\|xbgr8888\|argb8888\|abgr8888\|rgb565` | drm |
 | `[view.backend.drm]` | `rotation` | `int` | `0` | `0\|90\|180\|270` | drm |
 | `[view.backend.drm]` | `stage_cursor` | `string` | `auto` | `auto\|yes\|no` | drm |
+| `[view.backend.lease]` | `connector` | `string` | `(sole offer)` | `e.g. HDMI-A-1` | leased |
+| `[view.backend.lease]` | `device` | `string` | `(sole device)` | `index or /dev/dri/cardN` | leased |
+| `[view.backend.lease]` | `timeout_ms` | `int` | `5000` | `> 0` | leased |
 | `[view.output]` | `drm_connector` | `string` | `(none)` | `e.g. HDMI-A-1` | drm |
 | `[view.output]` | `index` | `int` | `(none)` | `int` | all |
 | `[view.output]` | `name` | `string` | `(primary)` | `e.g. DP-1, HDMI-A-1` | all |

--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -27,8 +27,13 @@
 #ifndef BUILD_BACKEND_WAYLAND_VULKAN
 #cmakedefine01 BUILD_BACKEND_WAYLAND_VULKAN
 #endif
-#ifndef BUILD_BACKEND_WAYLAND_DRM_LEASED
-#cmakedefine01 BUILD_BACKEND_WAYLAND_DRM_LEASED
+// Spelled to match the option in cmake/options.cmake and the
+// Backend::Type::WaylandLeasedDrm enum. It previously read
+// BUILD_BACKEND_WAYLAND_DRM_LEASED, which matched no CMake variable, so
+// #cmakedefine01 always emitted 0 — every gate on it would have been silently
+// dead even with the option ON.
+#ifndef BUILD_BACKEND_WAYLAND_LEASED_DRM
+#cmakedefine01 BUILD_BACKEND_WAYLAND_LEASED_DRM
 #endif
 #ifndef BUILD_BACKEND_DRM_KMS_EGL
 #cmakedefine01 BUILD_BACKEND_DRM_KMS_EGL

--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -27,8 +27,7 @@
 #ifndef BUILD_BACKEND_WAYLAND_VULKAN
 #cmakedefine01 BUILD_BACKEND_WAYLAND_VULKAN
 #endif
-// Spelled to match the option in cmake/options.cmake and the
-// Backend::Type::WaylandLeasedDrm enum. It previously read
+// Spelled to match the option in cmake/options.cmake. It previously read
 // BUILD_BACKEND_WAYLAND_DRM_LEASED, which matched no CMake variable, so
 // #cmakedefine01 always emitted 0 — every gate on it would have been silently
 // dead even with the option ON.

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -386,11 +386,10 @@ if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
                 "(wayland-leased-drm-vulkan), or BUILD_BACKEND_SOFTWARE + "
                 "BUILD_SOFTWARE_SINK_DRM (wayland-leased-drm-software).")
     endif ()
-    # Which tiers are actually selectable today. egl and software are wired;
-    # vulkan is built but not registered — it needs VulkanDrmBackend to accept an
-    # injected drm::Device instead of opening the card by path (WS5).
-    # ResolveKeyForConfig refuses an unregistered leased key rather than falling
-    # back to an unleased backend, so asking for vulkan fails loudly.
+    # All three tiers are wired. ResolveKeyForConfig refuses a leased key that
+    # is not registered rather than falling back to an unleased backend, so a
+    # tier missing its renderer stack fails loudly instead of silently running
+    # something else.
     if (IVI_LEASED_DRM_EGL)
         message(STATUS "  wayland-leased-drm-egl ........ registered")
     endif ()
@@ -398,16 +397,7 @@ if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
         message(STATUS "  wayland-leased-drm-software ... registered")
     endif ()
     if (IVI_LEASED_DRM_VULKAN)
-        message(STATUS "  wayland-leased-drm-vulkan ..... built, NOT registered (WS5 pending)")
-    endif ()
-    if (NOT IVI_LEASED_DRM_EGL AND NOT IVI_LEASED_DRM_SOFTWARE)
-        message(WARNING
-                "BUILD_BACKEND_WAYLAND_LEASED_DRM=ON but no leased backend is "
-                "selectable in this configuration: only the -egl and -software "
-                "tiers are wired so far, needing BUILD_BACKEND_DRM_KMS_EGL=ON "
-                "or BUILD_BACKEND_SOFTWARE=ON + BUILD_SOFTWARE_SINK_DRM=ON "
-                "respectively. The lease client will be compiled in but "
-                "unreachable.")
+        message(STATUS "  wayland-leased-drm-vulkan ..... registered")
     endif ()
 endif ()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -329,6 +329,77 @@ endif ()
 option(ENABLE_STATIC_LINK "Link stdlib with static libs" OFF)
 
 #
+# Derived backend flags
+#
+# Declared last so every BUILD_BACKEND_* / BUILD_SOFTWARE_SINK_* above is
+# already defined. These name the distinctions the gates actually care about,
+# which are NOT the same as "is some Wayland backend on":
+#
+#   IVI_WAYLAND_SURFACE_BACKENDS — backends that own a wl_surface and take
+#       input/focus from the compositor. These are the only consumers of
+#       wayland-cursor, xkbcommon, and the surface protocol set (xdg, IME,
+#       viewporter, dmabuf, fractional-scale, syncobj).
+#   IVI_WAYLAND_ANY — anything that opens a wl_display connection at all.
+#       wayland-leased-drm connects, but only to negotiate a DRM lease: it has
+#       no wl_surface, and takes input from evdev. It therefore needs the
+#       scanner + wayland-client and nothing else, so a lease-only build must
+#       gate on this rather than on IVI_WAYLAND_SURFACE_BACKENDS.
+#
+# The leased renderer tiers reuse the existing renderer stacks rather than
+# adding parallel options — the lease only changes how the DRM fd is acquired,
+# not how frames are produced.
+#
+if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN)
+    set(IVI_WAYLAND_SURFACE_BACKENDS TRUE)
+else ()
+    set(IVI_WAYLAND_SURFACE_BACKENDS FALSE)
+endif ()
+
+if (IVI_WAYLAND_SURFACE_BACKENDS OR BUILD_BACKEND_WAYLAND_LEASED_DRM)
+    set(IVI_WAYLAND_ANY TRUE)
+else ()
+    set(IVI_WAYLAND_ANY FALSE)
+endif ()
+
+# Per-tier availability for the three wayland-leased-drm registry keys.
+set(IVI_LEASED_DRM_EGL FALSE)
+set(IVI_LEASED_DRM_VULKAN FALSE)
+set(IVI_LEASED_DRM_SOFTWARE FALSE)
+if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
+    if (BUILD_BACKEND_DRM_KMS_EGL)
+        set(IVI_LEASED_DRM_EGL TRUE)
+    endif ()
+    if (BUILD_BACKEND_DRM_KMS_VULKAN)
+        set(IVI_LEASED_DRM_VULKAN TRUE)
+    endif ()
+    if (BUILD_BACKEND_SOFTWARE AND BUILD_SOFTWARE_SINK_DRM)
+        set(IVI_LEASED_DRM_SOFTWARE TRUE)
+    endif ()
+    if (NOT IVI_LEASED_DRM_EGL AND NOT IVI_LEASED_DRM_VULKAN AND
+        NOT IVI_LEASED_DRM_SOFTWARE)
+        message(FATAL_ERROR
+                "BUILD_BACKEND_WAYLAND_LEASED_DRM=ON but no renderer tier is "
+                "available — a lease acquires a DRM fd, it does not render, so "
+                "at least one renderer stack must be enabled to scan out on it. "
+                "Enable one of: BUILD_BACKEND_DRM_KMS_EGL "
+                "(wayland-leased-drm-egl), BUILD_BACKEND_DRM_KMS_VULKAN "
+                "(wayland-leased-drm-vulkan), or BUILD_BACKEND_SOFTWARE + "
+                "BUILD_SOFTWARE_SINK_DRM (wayland-leased-drm-software).")
+    endif ()
+    # NOTE: the wayland-leased-drm-* registry keys named above are NOT yet
+    # registered — that lands in WS6 (RegisterCompiledBackends + the family-hint
+    # resolution in ResolveKeyForConfig). Until then this option only compiles
+    # the lease client in; selecting a leased key at runtime will not resolve.
+    message(STATUS
+            "  wayland-leased-drm: lease client only — no backend registered "
+            "yet (WS6 pending)")
+endif ()
+
+message(STATUS "Wayland (surface) ...... ${IVI_WAYLAND_SURFACE_BACKENDS}")
+message(STATUS "Wayland (any conn.) .... ${IVI_WAYLAND_ANY}")
+message(STATUS "Leased DRM tiers ....... egl=${IVI_LEASED_DRM_EGL} vulkan=${IVI_LEASED_DRM_VULKAN} software=${IVI_LEASED_DRM_SOFTWARE}")
+
+#
 # Docs
 #
 option(BUILD_DOCS "Build documentation" OFF)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -386,29 +386,28 @@ if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
                 "(wayland-leased-drm-vulkan), or BUILD_BACKEND_SOFTWARE + "
                 "BUILD_SOFTWARE_SINK_DRM (wayland-leased-drm-software).")
     endif ()
-    # Which tiers are actually registered today. The egl tier is wired; the
-    # other two are built but not yet selectable:
-    #   vulkan   — needs VulkanDrmBackend to accept an injected drm::Device
-    #              instead of opening by path (WS5).
-    #   software — needs SoftwareDisplay to carry the LeaseHold through to a
-    #              DrmDumbSink built on the leased fd.
+    # Which tiers are actually selectable today. egl and software are wired;
+    # vulkan is built but not registered — it needs VulkanDrmBackend to accept an
+    # injected drm::Device instead of opening the card by path (WS5).
     # ResolveKeyForConfig refuses an unregistered leased key rather than falling
-    # back to an unleased backend, so asking for one of these fails loudly.
+    # back to an unleased backend, so asking for vulkan fails loudly.
     if (IVI_LEASED_DRM_EGL)
         message(STATUS "  wayland-leased-drm-egl ........ registered")
+    endif ()
+    if (IVI_LEASED_DRM_SOFTWARE)
+        message(STATUS "  wayland-leased-drm-software ... registered")
     endif ()
     if (IVI_LEASED_DRM_VULKAN)
         message(STATUS "  wayland-leased-drm-vulkan ..... built, NOT registered (WS5 pending)")
     endif ()
-    if (IVI_LEASED_DRM_SOFTWARE)
-        message(STATUS "  wayland-leased-drm-software ... built, NOT registered (display wiring pending)")
-    endif ()
-    if (NOT IVI_LEASED_DRM_EGL)
+    if (NOT IVI_LEASED_DRM_EGL AND NOT IVI_LEASED_DRM_SOFTWARE)
         message(WARNING
                 "BUILD_BACKEND_WAYLAND_LEASED_DRM=ON but no leased backend is "
-                "selectable in this configuration: only the -egl tier is wired "
-                "so far, and it needs BUILD_BACKEND_DRM_KMS_EGL=ON. The lease "
-                "client will be compiled in but unreachable.")
+                "selectable in this configuration: only the -egl and -software "
+                "tiers are wired so far, needing BUILD_BACKEND_DRM_KMS_EGL=ON "
+                "or BUILD_BACKEND_SOFTWARE=ON + BUILD_SOFTWARE_SINK_DRM=ON "
+                "respectively. The lease client will be compiled in but "
+                "unreachable.")
     endif ()
 endif ()
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -386,13 +386,30 @@ if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
                 "(wayland-leased-drm-vulkan), or BUILD_BACKEND_SOFTWARE + "
                 "BUILD_SOFTWARE_SINK_DRM (wayland-leased-drm-software).")
     endif ()
-    # NOTE: the wayland-leased-drm-* registry keys named above are NOT yet
-    # registered — that lands in WS6 (RegisterCompiledBackends + the family-hint
-    # resolution in ResolveKeyForConfig). Until then this option only compiles
-    # the lease client in; selecting a leased key at runtime will not resolve.
-    message(STATUS
-            "  wayland-leased-drm: lease client only — no backend registered "
-            "yet (WS6 pending)")
+    # Which tiers are actually registered today. The egl tier is wired; the
+    # other two are built but not yet selectable:
+    #   vulkan   — needs VulkanDrmBackend to accept an injected drm::Device
+    #              instead of opening by path (WS5).
+    #   software — needs SoftwareDisplay to carry the LeaseHold through to a
+    #              DrmDumbSink built on the leased fd.
+    # ResolveKeyForConfig refuses an unregistered leased key rather than falling
+    # back to an unleased backend, so asking for one of these fails loudly.
+    if (IVI_LEASED_DRM_EGL)
+        message(STATUS "  wayland-leased-drm-egl ........ registered")
+    endif ()
+    if (IVI_LEASED_DRM_VULKAN)
+        message(STATUS "  wayland-leased-drm-vulkan ..... built, NOT registered (WS5 pending)")
+    endif ()
+    if (IVI_LEASED_DRM_SOFTWARE)
+        message(STATUS "  wayland-leased-drm-software ... built, NOT registered (display wiring pending)")
+    endif ()
+    if (NOT IVI_LEASED_DRM_EGL)
+        message(WARNING
+                "BUILD_BACKEND_WAYLAND_LEASED_DRM=ON but no leased backend is "
+                "selectable in this configuration: only the -egl tier is wired "
+                "so far, and it needs BUILD_BACKEND_DRM_KMS_EGL=ON. The lease "
+                "client will be compiled in but unreachable.")
+    endif ()
 endif ()
 
 message(STATUS "Wayland (surface) ...... ${IVI_WAYLAND_SURFACE_BACKENDS}")

--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -13,24 +13,49 @@
 # call once it exists. Mirrors cmake/drm_kms.cmake.
 #
 
-if (NOT BUILD_BACKEND_WAYLAND_EGL AND NOT BUILD_BACKEND_WAYLAND_VULKAN)
+# Gate on IVI_WAYLAND_ANY, not on the surface backends: wayland-leased-drm
+# needs the scanner + wayland-client to speak drm-lease-v1, even though it
+# never creates a wl_surface.
+if (NOT IVI_WAYLAND_ANY)
     return()
 endif ()
 
 find_package(PkgConfig REQUIRED)
 
-# Core Wayland runtime libs. libwayland-client + libwayland-cursor + xkbcommon
-# are needed by every Wayland backend; wayland-egl only by the EGL backend.
-pkg_check_modules(WAYLAND_CXX_RUNTIME REQUIRED IMPORTED_TARGET
-    wayland-client wayland-cursor xkbcommon)
+# Core Wayland runtime libs, split by what actually needs them.
+#
+# wayland-client is required by any backend that opens a wl_display.
+#
+# wayland-cursor + xkbcommon are *surface* deps: they back wl/cursor.hpp and
+# wl/seat.hpp + wl/keyboard.hpp respectively, which only a backend with a
+# wl_surface and compositor input focus includes. wayland-leased-drm has
+# neither (input comes from evdev), so requiring them here would fail a
+# lease-only configure on an image that ships no cursor/xkb libs. The
+# wayland-cxx target itself is header-only with no pkg-config deps, so the
+# split is safe: the deps are per-header, not per-target.
+pkg_check_modules(WAYLAND_CXX_RUNTIME REQUIRED IMPORTED_TARGET wayland-client)
+if (IVI_WAYLAND_SURFACE_BACKENDS)
+    pkg_check_modules(WAYLAND_CXX_SURFACE REQUIRED IMPORTED_TARGET
+        wayland-cursor xkbcommon)
+endif ()
 if (BUILD_BACKEND_WAYLAND_EGL)
     pkg_check_modules(WAYLAND_CXX_EGL REQUIRED IMPORTED_TARGET wayland-egl)
 endif ()
 
 # Protocol XML base — xdg-shell + presentation-time ship with wayland-protocols.
-pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.20)
-pkg_get_variable(_wlcxx_proto_base wayland-protocols pkgdatadir)
-set(IVI_WL_PROTOCOLS_BASE "${_wlcxx_proto_base}" CACHE INTERNAL "wayland-protocols pkgdatadir")
+#
+# Surface builds only: a lease-only build reads nothing from wayland-protocols.
+# Its core wayland.xml comes from wayland-scanner's pkgdatadir (below) and
+# drm-lease-v1.xml is vendored in-tree (the staging XML needs >= 1.22, above our
+# 1.20 floor), so requiring the package here would fail a lease-only configure
+# on a minimal sysroot over data the build never reads. Every consumer of
+# IVI_WL_PROTOCOLS_BASE sits behind the surface-backend gate in
+# ivi_wayland_protocols().
+if (IVI_WAYLAND_SURFACE_BACKENDS)
+    pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.20)
+    pkg_get_variable(_wlcxx_proto_base wayland-protocols pkgdatadir)
+    set(IVI_WL_PROTOCOLS_BASE "${_wlcxx_proto_base}" CACHE INTERNAL "wayland-protocols pkgdatadir")
+endif ()
 
 # Core Wayland protocol XML (wl_seat / wl_keyboard / …) ships with
 # wayland-scanner. The generated wayland_client.hpp backs wl::KeyboardHandler;
@@ -145,22 +170,47 @@ endforeach ()
 # A protocol with no shipped header (presentation-time, ivi-*) needs
 # --emit-interface-tables so the generated header is self-contained.
 #
+# Everything except core wayland and drm-lease-v1 is *surface*-only: those
+# protocols exist to drive a wl_surface (shells, scaling, dmabuf present,
+# vsync, IME, input). wayland-leased-drm has no surface — it connects solely
+# to negotiate a DRM lease — so a lease-only build generates just core +
+# drm-lease. This also keeps non-lease builds byte-identical: the lease
+# codegen is conditional on the option.
+#
 function(ivi_wayland_protocols target)
     set(_xdg  "${IVI_WL_PROTOCOLS_BASE}/stable/xdg-shell/xdg-shell.xml")
     set(_pres "${IVI_WL_PROTOCOLS_BASE}/stable/presentation-time/presentation-time.xml")
     set(_bund "${IVI_WL_CXX_SRC}/protocols")
     set(_loc  "${CMAKE_SOURCE_DIR}/shell/wayland/protocols")
 
-    # core wayland — always (wl::KeyboardHandler needs wayland::client::CWlKeyboard);
+    # core wayland — always (wl::Registry drives the lease client's globals;
+    # wl::KeyboardHandler needs wayland::client::CWlKeyboard on surface builds);
     # core wl_interface tables come from libwayland, so do NOT emit tables.
     wayland_cxx_generate(PROTOCOL "${IVI_WL_CORE_XML}" MODE client-header
         OUTPUT wayland-protocols/wayland_client.hpp TARGET ${target})
 
-    # presentation-time — always (IVsyncProvider); no shipped header -> emit tables.
+    # drm-lease-v1 — the wayland-leased-drm backend's entire Wayland surface
+    # area: bind wp_drm_lease_device_v1, enumerate connectors, submit a lease
+    # request, then monitor for finished/withdrawn. Vendored: the staging XML
+    # only ships with wayland-protocols >= 1.22 and the project floor is 1.20
+    # (see the >=1.20 pkg_check_modules above), so it cannot be taken from
+    # IVI_WL_PROTOCOLS_BASE. No shipped wl/ helper carries its interface
+    # tables, so generate self-contained with EMIT_INTERFACE_TABLES.
+    if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
+        wayland_cxx_generate(PROTOCOL "${_loc}/drm-lease-v1.xml"
+            MODE client-header EMIT_INTERFACE_TABLES
+            OUTPUT wayland-protocols/drm_lease_v1_client.hpp TARGET ${target})
+    endif ()
+
+    if (NOT IVI_WAYLAND_SURFACE_BACKENDS)
+        return()
+    endif ()
+
+    # presentation-time — every surface build (IVsyncProvider); no shipped header -> emit tables.
     wayland_cxx_generate(PROTOCOL "${_pres}" MODE client-header EMIT_INTERFACE_TABLES
         OUTPUT wayland-protocols/presentation_time_client.hpp TARGET ${target})
 
-    # input-timestamps — always (ivi::InputTimestamps: high-resolution kernel
+    # input-timestamps — every surface build (ivi::InputTimestamps: high-resolution kernel
     # timestamps for the pointer/touch → Flutter path; runtime-optional, the
     # provider no-ops when the compositor doesn't advertise the manager).
     # No shipped header -> emit tables.
@@ -169,7 +219,7 @@ function(ivi_wayland_protocols target)
         MODE client-header EMIT_INTERFACE_TABLES
         OUTPUT wayland-protocols/input_timestamps_client.hpp TARGET ${target})
 
-    # viewporter — always (per-surface scaling; stable since wayland-protocols
+    # viewporter — every surface build (per-surface scaling; stable since wayland-protocols
     # 1.4, so present on Dunfell's 1.20). No shipped header -> emit tables.
     wayland_cxx_generate(PROTOCOL
         "${IVI_WL_PROTOCOLS_BASE}/stable/viewporter/viewporter.xml"
@@ -186,7 +236,7 @@ function(ivi_wayland_protocols target)
         MODE client-header
         OUTPUT wayland-protocols/linux_dmabuf_client.hpp TARGET ${target})
 
-    # fractional-scale-v1 — always. Vendored: the XML only ships with
+    # fractional-scale-v1 — every surface build. Vendored: the XML only ships with
     # wayland-protocols >= 1.31, which Dunfell/Ubuntu-20.04 hosts predate.
     # Both protocols are gated at runtime on the compositor advertising the
     # global, so generating unconditionally costs nothing on old stacks.
@@ -257,6 +307,9 @@ function(ivi_wayland_link target)
     target_link_libraries(${target} PRIVATE
         wayland-cxx::wayland-cxx
         PkgConfig::WAYLAND_CXX_RUNTIME)
+    if (TARGET PkgConfig::WAYLAND_CXX_SURFACE)
+        target_link_libraries(${target} PRIVATE PkgConfig::WAYLAND_CXX_SURFACE)
+    endif ()
     if (TARGET PkgConfig::WAYLAND_CXX_EGL)
         target_link_libraries(${target} PRIVATE PkgConfig::WAYLAND_CXX_EGL)
     endif ()

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -174,6 +174,19 @@
   # type=string default=auto values=auto|yes|no applies=drm
   stage_cursor =
 
+[view.backend.lease]
+  # Connector to request by name; several offers with no choice is fatal.
+  # type=string default=(sole offer) values=e.g. HDMI-A-1 applies=leased
+  connector =
+
+  # Which wp_drm_lease_device_v1 when several are advertised (one per DRM node); ambiguous + unset is fatal.
+  # type=string default=(sole device) values=index or /dev/dri/cardN applies=leased
+  device =
+
+  # Bound on the whole lease negotiation; a compositor may defer the DRM fd until it regains DRM master.
+  # type=int default=5000 values=> 0 applies=leased
+  timeout_ms =
+
 [view.output]
   # DRM: match this connector name (overrides output.name).
   # type=string default=(none) values=e.g. HDMI-A-1 applies=drm

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -183,6 +183,10 @@
   # type=string default=(sole device) values=index or /dev/dri/cardN applies=leased
   device =
 
+  # On revocation (every VT switch away from the compositor is one): exit non-zero so a supervisor restarts and renegotiates, or gate and keep running with a frozen panel (debugging only).
+  # type=string default=exit values=exit|gate applies=leased
+  on_revoke =
+
   # Bound on the whole lease negotiation; a compositor may defer the DRM fd until it regains DRM master.
   # type=int default=5000 values=> 0 applies=leased
   timeout_ms =

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -76,6 +76,12 @@ META = {
     "shell.window.activation_area.height": ("view.height", "int", "agl", "Activation rect height (omit table -> full view)."),
     # [view.backend]
     "backend.type": ("(env-aware)", "wayland-egl|wayland-vulkan|drm-kms-egl|drm-kms-vulkan|software", "all", "Renderer backend; unset = auto (Wayland session -> wayland-egl, else drm-kms-egl)."),
+    # [view.backend.lease] — wayland-leased-drm only. These say what to ask the
+    # compositor to lease, not how to drive a card we already own (backend.drm.*).
+    "backend.lease.device": ("(sole device)", "index or /dev/dri/cardN", "leased", "Which wp_drm_lease_device_v1 when several are advertised (one per DRM node); ambiguous + unset is fatal."),
+    "backend.lease.connector": ("(sole offer)", "e.g. HDMI-A-1", "leased", "Connector to request by name; several offers with no choice is fatal."),
+    "backend.lease.timeout_ms": ("5000", "> 0", "leased", "Bound on the whole lease negotiation; a compositor may defer the DRM fd until it regains DRM master."),
+
     # [view.backend.drm] — DRM/software only
     "backend.drm.device": ("(rank-pick)", "/dev/dri/cardN", "drm/sw", "DRM device node."),
     "backend.drm.connector": ("(rank-pick)", "e.g. eDP-1, HDMI-A-1", "drm/sw", "Connector to drive."),
@@ -110,7 +116,8 @@ META = {
 TABLE_ORDER = [
     "[global]", "[sentry]", "[[view]]", "[view.args]", "[view.shell]",
     "[view.shell.window]", "[view.shell.window.activation_area]",
-    "[view.backend]", "[view.backend.drm]", "[view.output]", "[view.engine]",
+    "[view.backend]", "[view.backend.drm]", "[view.backend.lease]",
+    "[view.output]", "[view.engine]",
 ]
 
 
@@ -131,6 +138,9 @@ def classify(key):
         return "[view.shell]", key.rsplit(".", 1)[1]
     if key.startswith("backend.drm."):
         return "[view.backend.drm]", key.rsplit(".", 1)[1]
+    if key.startswith("backend.lease."):
+        return "[view.backend.lease]", key.rsplit(".", 1)[1]
+    # Must stay last of the backend.* cases: it is the catch-all.
     if key.startswith("backend."):
         return "[view.backend]", key.rsplit(".", 1)[1]
     if key.startswith("output."):

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -81,6 +81,7 @@ META = {
     "backend.lease.device": ("(sole device)", "index or /dev/dri/cardN", "leased", "Which wp_drm_lease_device_v1 when several are advertised (one per DRM node); ambiguous + unset is fatal."),
     "backend.lease.connector": ("(sole offer)", "e.g. HDMI-A-1", "leased", "Connector to request by name; several offers with no choice is fatal."),
     "backend.lease.timeout_ms": ("5000", "> 0", "leased", "Bound on the whole lease negotiation; a compositor may defer the DRM fd until it regains DRM master."),
+    "backend.lease.on_revoke": ("exit", "exit|gate", "leased", "On revocation (every VT switch away from the compositor is one): exit non-zero so a supervisor restarts and renegotiates, or gate and keep running with a frozen panel (debugging only)."),
 
     # [view.backend.drm] — DRM/software only
     "backend.drm.device": ("(rank-pick)", "/dev/dri/cardN", "drm/sw", "DRM device node."),

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -130,6 +130,22 @@ if (BUILD_BACKEND_WAYLAND_EGL)
     endif ()
 endif ()
 
+# wayland-leased-drm: the drm-lease-v1 client. Renderer-agnostic — it only
+# acquires the DRM fd; the egl/vulkan/software tiers then scan out on it, so
+# this block is independent of which renderer stacks are enabled.
+if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
+    target_sources(${PROJECT_NAME} PRIVATE
+            backend/wayland_leased_drm/lease_client.cc
+    )
+    # drmGetDeviceNameFromFd2() resolves the lease/enumeration fd to a node path.
+    # On a cross sysroot xf86drm.h lives under <libdrm/>, so the include dir must
+    # come from pkg-config rather than the default search path.
+    if (NOT TARGET PkgConfig::DRM)
+        pkg_check_modules(DRM REQUIRED IMPORTED_TARGET libdrm)
+    endif ()
+    target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::DRM)
+endif ()
+
 if (BUILD_BACKEND_SOFTWARE)
     target_sources(${PROJECT_NAME} PRIVATE
             backend/software/file_sink.cc
@@ -408,7 +424,12 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 # link the wl/ framework + libwayland runtime onto the shell binary. Both helpers
 # are defined in cmake/wayland_cxx.cmake. Non-Wayland binaries (DRM EGL/Vulkan,
 # software) get neither the headers nor the libwayland-client / -cursor deps.
-if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN)
+#
+# Gated on IVI_WAYLAND_ANY so wayland-leased-drm is included: it opens a
+# wl_display to negotiate a DRM lease. Both helpers self-narrow for that case —
+# only core + drm-lease-v1 are generated, and wayland-cursor/xkbcommon are not
+# required — so a lease-only build stays free of the surface deps.
+if (IVI_WAYLAND_ANY)
     ivi_wayland_protocols(${PROJECT_NAME})
     ivi_wayland_link(${PROJECT_NAME})
 endif ()

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -104,8 +104,10 @@ if (BUILD_BACKEND_WAYLAND_VULKAN)
     # The dma-buf present path needs drm_fourcc.h (DRM_FORMAT_* constants), a
     # libdrm header. On a cross sysroot it lives under <libdrm/>, so the include
     # dir must come from pkg-config rather than the default search path.
+    # GLOBAL so test/ can resolve it via TYPICAL_TEST_LINK_LIBS — see the note
+    # in the wayland-leased-drm block below.
     if (NOT TARGET PkgConfig::DRM)
-        pkg_check_modules(DRM REQUIRED IMPORTED_TARGET libdrm)
+        pkg_check_modules(DRM REQUIRED IMPORTED_TARGET GLOBAL libdrm)
     endif ()
     target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::DRM)
     if (BUILD_COMPOSITOR)
@@ -140,8 +142,15 @@ if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
     # drmGetDeviceNameFromFd2() resolves the lease/enumeration fd to a node path.
     # On a cross sysroot xf86drm.h lives under <libdrm/>, so the include dir must
     # come from pkg-config rather than the default search path.
+    #
+    # GLOBAL: an IMPORTED target is directory-scoped by default, and the unit
+    # tests reuse this target's LINK_LIBRARIES (TYPICAL_TEST_LINK_LIBS) from
+    # test/. Without GLOBAL, every test target fails to configure with
+    # "PkgConfig::DRM ... but the target was not found" whenever the shell links
+    # libdrm from here rather than from cmake/drm_kms.cmake (which runs at
+    # top-level scope and so is visible everywhere).
     if (NOT TARGET PkgConfig::DRM)
-        pkg_check_modules(DRM REQUIRED IMPORTED_TARGET libdrm)
+        pkg_check_modules(DRM REQUIRED IMPORTED_TARGET GLOBAL libdrm)
     endif ()
     target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::DRM)
 endif ()

--- a/shell/backend/backend.h
+++ b/shell/backend/backend.h
@@ -55,14 +55,6 @@ struct BackendEglContext {
 // compositor-protocol shells in wayland/shell/ (the --shell option).
 class Backend {
  public:
-  enum Type {
-    WaylandEgl,
-    WaylandVulkan,
-    WaylandLeasedDrm,
-    DrmKms,
-    DrmKmsVulkan,
-  };
-
   Backend() = default;
   virtual ~Backend() = default;
 

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -513,7 +513,43 @@ bool DrmBackend::InitDrm() {
 
   drmModeConnector* connector = nullptr;
   std::string pick_reason;
-  if (cfg_.connector_name.has_value()) {
+  if (cfg_.lease_connector_id != 0) {
+    // A lease decides the connector for us, so this outranks both the name pin
+    // and the rank heuristic below. Failing here rather than falling back:
+    // every other connector on this fd is one we do not hold.
+    for (drmModeConnector* c : eligible) {
+      if (c->connector_id == cfg_.lease_connector_id) {
+        connector = c;
+        pick_reason = "lease";
+        break;
+      }
+    }
+    if (connector == nullptr) {
+      ihs::log::error(
+          "[DrmBackend] leased connector id {} is not eligible (absent, "
+          "disconnected, or no modes); eligible connectors on this lease fd:",
+          cfg_.lease_connector_id);
+      for (drmModeConnector* c : eligible) {
+        ihs::log::error("[DrmBackend]   {} (id {})", connector_name(c),
+                        c->connector_id);
+      }
+      for (drmModeConnector* c : eligible) {
+        drmModeFreeConnector(c);
+      }
+      drmModeFreeResources(res);
+      return false;
+    }
+    if (cfg_.connector_name.has_value()) {
+      // Both set means --drm-connector was given alongside a lease. The lease
+      // wins; say so rather than silently ignoring the operator's pin.
+      ihs::log::warn(
+          "[DrmBackend] --drm-connector={} ignored: this is a leased device "
+          "and the compositor leased connector {} ({}). Use --lease-connector "
+          "to influence which connector is requested.",
+          *cfg_.connector_name, cfg_.lease_connector_id,
+          connector_name(connector));
+    }
+  } else if (cfg_.connector_name.has_value()) {
     const std::string& want = *cfg_.connector_name;
     for (drmModeConnector* c : eligible) {
       if (connector_name(c) == want) {
@@ -1467,6 +1503,22 @@ bool DrmBackend::Present() {
   // frame without touching GL/KMS; OnSessionResumed re-modesets and restarts
   // the pacer.
   if (session_paused_.load(std::memory_order_acquire)) {
+    return true;
+  }
+  // Lease-revocation gate. Same shape as the session-pause gate above and for
+  // the same reason: the leased KMS objects are gone from this fd's view, so
+  // page flips naming them fail and never complete, and eglSwapBuffers would
+  // eventually block forever in gbm_surface_get_free_buffer with no buffer ever
+  // released -- wedging the rasterizer thread so FlutterEngineShutdown cannot
+  // join it. Unlike a VT pause this never resolves on its own: OnSessionResumed
+  // has no counterpart until reacquire, so the exit policy is the way out.
+  // Ack the frame without touching GL/KMS.
+  if (cfg_.lease_revoked && cfg_.lease_revoked()) {
+    if (!lease_revoked_logged_.exchange(true, std::memory_order_relaxed)) {
+      ihs::log::warn(
+          "[DrmBackend] lease revoked — gating presents; the panel stops "
+          "updating until the lease is reacquired");
+    }
     return true;
   }
   // Reclaim a buffer orphaned by a flip dropped during a VT-switch pause:

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -118,6 +119,21 @@ struct DrmConfig {
   // (e.g. "eDP-1", "HDMI-A-1") matches; init fails if no such connector
   // is connected. Name format matches --drm-list-modes output.
   std::optional<std::string> connector_name{};
+
+  // wayland-leased-drm: the leased connector's DRM object id. Takes precedence
+  // over connector_name and the rank heuristic -- on a lease the compositor
+  // decides which connector we get, so neither an operator's name pin nor a
+  // "prefer internal panels" ranking has standing. A lease may contain more
+  // than one connector (the requested set is only a suggestion), so without
+  // this the rank heuristic can drive the wrong panel and leave the requested
+  // one dark. 0 = not leased; use the rules above.
+  uint32_t lease_connector_id{0};
+
+  // wayland-leased-drm: polled before each commit. A revoked lease's KMS
+  // objects are gone from the fd's view, so every commit naming them fails and
+  // produces no PAGE_FLIP_EVENT. Empty = never gated (the path-opened tiers,
+  // which have no lease to lose).
+  std::function<bool()> lease_revoked{};
 
   // Unset = pick the connector's preferred mode (DRM_MODE_TYPE_PREFERRED).
   // Set = pick the first mode matching the spec "<W>x<H>@<R>" (e.g.
@@ -390,6 +406,10 @@ class DrmBackend : public Backend, public IFlipSink {
   // forever in gbm_surface_get_free_buffer, wedging the rasterizer thread and
   // hanging teardown. Mirrors DrmCompositor's own paused_ gate.
   std::atomic<bool> session_paused_{false};
+
+  // One-shot latch so the lease-revocation notice is logged once, not once per
+  // frame. The gate itself lives in cfg_.lease_revoked.
+  std::atomic<bool> lease_revoked_logged_{false};
 
   // EGL
   EGLDisplay egl_display_ = EGL_NO_DISPLAY;

--- a/shell/backend/drm_kms_vulkan/drm_scanout_target.cc
+++ b/shell/backend/drm_kms_vulkan/drm_scanout_target.cc
@@ -102,6 +102,7 @@ namespace {
 bool DiscoverScanoutTargetOnFd(int fd,
                                uint32_t fourcc,
                                const std::string& mode_spec,
+                               uint32_t want_connector_id,
                                ScanoutTarget& out,
                                std::string& err) {
   drmSetClientCap(fd, DRM_CLIENT_CAP_ATOMIC, 1);
@@ -116,14 +117,41 @@ bool DiscoverScanoutTargetOnFd(int fd,
   drmModeConnector* conn = nullptr;
   for (int i = 0; i < res->count_connectors && !conn; ++i) {
     drmModeConnector* c = drmModeGetConnector(fd, res->connectors[i]);
-    if (c && c->connection == DRM_MODE_CONNECTED && c->count_modes > 0) {
+    if (c == nullptr) {
+      continue;
+    }
+    // want_connector_id pins the connector; 0 keeps the historical "first
+    // connected with modes" pick. A lease may contain more than one connector
+    // -- the requested set is only a suggestion, the compositor picks the final
+    // set -- so on a leased fd the heuristic is a coin flip that lights up the
+    // wrong panel. It is still correct for the path-opened tiers, which drive
+    // whatever card they were pointed at.
+    const bool wanted =
+        want_connector_id == 0
+            ? (c->connection == DRM_MODE_CONNECTED && c->count_modes > 0)
+            : c->connector_id == want_connector_id;
+    if (wanted) {
       conn = c;
-    } else if (c) {
+    } else {
       drmModeFreeConnector(c);
     }
   }
-  if (!conn) {
-    err = "no connected connector with a mode";
+  if (conn == nullptr) {
+    err = want_connector_id == 0
+              ? "no connected connector with a mode"
+              : "requested connector " + std::to_string(want_connector_id) +
+                    " is not present on this fd";
+    drmModeFreeResources(res);
+    return false;
+  }
+  // A pinned connector still has to be usable: pinning says which panel, not
+  // whether it is attached. Reported distinctly from "not present" -- for a
+  // leased fd the difference is compositor-side (it leased us a dark
+  // connector) versus operator-side (wrong --lease-connector).
+  if (conn->connection != DRM_MODE_CONNECTED || conn->count_modes == 0) {
+    err = "requested connector " + std::to_string(want_connector_id) +
+          " is present but not connected with a mode";
+    drmModeFreeConnector(conn);
     drmModeFreeResources(res);
     return false;
   }
@@ -237,7 +265,10 @@ bool DiscoverScanoutTarget(const std::string& drm_device,
     err = "open('" + drm_device + "'): " + std::strerror(errno);
     return false;
   }
-  const bool ok = DiscoverScanoutTargetOnFd(fd, fourcc, mode_spec, out, err);
+  // The path-opened tiers drive the whole card, so there is no connector to pin
+  // and the first-connected pick stands.
+  const bool ok = DiscoverScanoutTargetOnFd(fd, fourcc, mode_spec,
+                                            /*want_connector_id=*/0, out, err);
   ::close(fd);
   return ok;
 }
@@ -245,13 +276,15 @@ bool DiscoverScanoutTarget(const std::string& drm_device,
 bool DiscoverScanoutTarget(int drm_fd,
                            uint32_t fourcc,
                            const std::string& mode_spec,
+                           uint32_t want_connector_id,
                            ScanoutTarget& out,
                            std::string& err) {
   if (drm_fd < 0) {
     err = "DiscoverScanoutTarget: invalid fd";
     return false;
   }
-  return DiscoverScanoutTargetOnFd(drm_fd, fourcc, mode_spec, out, err);
+  return DiscoverScanoutTargetOnFd(drm_fd, fourcc, mode_spec, want_connector_id,
+                                   out, err);
 }
 
 }  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/drm_scanout_target.cc
+++ b/shell/backend/drm_kms_vulkan/drm_scanout_target.cc
@@ -91,23 +91,25 @@ void ReadPlaneModifiers(int fd,
 
 }  // namespace
 
-bool DiscoverScanoutTarget(const std::string& drm_device,
-                           uint32_t fourcc,
-                           const std::string& mode_spec,
-                           ScanoutTarget& out,
-                           std::string& err) {
-  const int fd = ::open(drm_device.c_str(), O_RDWR | O_CLOEXEC);
-  if (fd < 0) {
-    err = "open('" + drm_device + "'): " + std::strerror(errno);
-    return false;
-  }
+namespace {
+
+// The body of DiscoverScanoutTarget, on an already-open fd. Split out at the
+// open() so the same probe runs against a supplied fd -- wayland-leased-drm
+// hands it a lease fd, which it must use rather than re-opening the card: the
+// kernel filters a lease fd's view to the leased objects, and a leased client
+// may have no permission to open the node at all. Never closes @p fd; the
+// caller owns it.
+bool DiscoverScanoutTargetOnFd(int fd,
+                               uint32_t fourcc,
+                               const std::string& mode_spec,
+                               ScanoutTarget& out,
+                               std::string& err) {
   drmSetClientCap(fd, DRM_CLIENT_CAP_ATOMIC, 1);
   drmSetClientCap(fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
 
   drmModeRes* res = drmModeGetResources(fd);
   if (!res) {
     err = "drmModeGetResources failed";
-    ::close(fd);
     return false;
   }
 
@@ -123,7 +125,6 @@ bool DiscoverScanoutTarget(const std::string& drm_device,
   if (!conn) {
     err = "no connected connector with a mode";
     drmModeFreeResources(res);
-    ::close(fd);
     return false;
   }
   out.connector_id = conn->connector_id;
@@ -180,7 +181,6 @@ bool DiscoverScanoutTarget(const std::string& drm_device,
   if (!out.crtc_id) {
     err = "no CRTC for connector";
     drmModeFreeResources(res);
-    ::close(fd);
     return false;
   }
 
@@ -194,14 +194,12 @@ bool DiscoverScanoutTarget(const std::string& drm_device,
   drmModeFreeResources(res);
   if (crtc_index < 0) {
     err = "CRTC not found in resources";
-    ::close(fd);
     return false;
   }
 
   drmModePlaneRes* pres = drmModeGetPlaneResources(fd);
   if (!pres) {
     err = "drmModeGetPlaneResources failed";
-    ::close(fd);
     return false;
   }
   for (uint32_t i = 0; i < pres->count_planes; ++i) {
@@ -220,13 +218,40 @@ bool DiscoverScanoutTarget(const std::string& drm_device,
   drmModeFreePlaneResources(pres);
   if (!out.primary_plane_id) {
     err = "no primary plane for CRTC";
-    ::close(fd);
     return false;
   }
 
   ReadPlaneModifiers(fd, out.primary_plane_id, fourcc, out.plane_modifiers);
-  ::close(fd);
   return true;
+}
+
+}  // namespace
+
+bool DiscoverScanoutTarget(const std::string& drm_device,
+                           uint32_t fourcc,
+                           const std::string& mode_spec,
+                           ScanoutTarget& out,
+                           std::string& err) {
+  const int fd = ::open(drm_device.c_str(), O_RDWR | O_CLOEXEC);
+  if (fd < 0) {
+    err = "open('" + drm_device + "'): " + std::strerror(errno);
+    return false;
+  }
+  const bool ok = DiscoverScanoutTargetOnFd(fd, fourcc, mode_spec, out, err);
+  ::close(fd);
+  return ok;
+}
+
+bool DiscoverScanoutTarget(int drm_fd,
+                           uint32_t fourcc,
+                           const std::string& mode_spec,
+                           ScanoutTarget& out,
+                           std::string& err) {
+  if (drm_fd < 0) {
+    err = "DiscoverScanoutTarget: invalid fd";
+    return false;
+  }
+  return DiscoverScanoutTargetOnFd(drm_fd, fourcc, mode_spec, out, err);
 }
 
 }  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/drm_scanout_target.h
+++ b/shell/backend/drm_kms_vulkan/drm_scanout_target.h
@@ -61,9 +61,16 @@ bool DiscoverScanoutTarget(const std::string& drm_device,
 // the compositor is still scanning out on. It may also be the only handle we
 // have: a leased client uses a lease precisely because it may not be permitted
 // to open the DRM node itself.
+//
+// @p want_connector_id pins the connector (0 = first connected with a mode).
+// Pass the LeaseHold's connector_id: a lease may contain several connectors --
+// the requested set is only a suggestion and the compositor picks the final set
+// -- so without it the probe can modeset the wrong panel and leave the
+// requested one dark, silently.
 bool DiscoverScanoutTarget(int drm_fd,
                            uint32_t fourcc,
                            const std::string& mode_spec,
+                           uint32_t want_connector_id,
                            ScanoutTarget& out,
                            std::string& err);
 

--- a/shell/backend/drm_kms_vulkan/drm_scanout_target.h
+++ b/shell/backend/drm_kms_vulkan/drm_scanout_target.h
@@ -52,4 +52,19 @@ bool DiscoverScanoutTarget(const std::string& drm_device,
                            ScanoutTarget& out,
                            std::string& err);
 
+// wayland-leased-drm: probe an already-open fd instead of opening a card.
+// @p drm_fd is borrowed -- never closed here.
+//
+// Not just a convenience. A lease fd's resource view is kernel-filtered to the
+// leased objects, so probing through it finds exactly the connector we hold;
+// re-opening the node by path would enumerate the whole card and could pick one
+// the compositor is still scanning out on. It may also be the only handle we
+// have: a leased client uses a lease precisely because it may not be permitted
+// to open the DRM node itself.
+bool DiscoverScanoutTarget(int drm_fd,
+                           uint32_t fourcc,
+                           const std::string& mode_spec,
+                           ScanoutTarget& out,
+                           std::string& err);
+
 }  // namespace drm_kms_vulkan

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -355,6 +355,33 @@ std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
   auto backend = std::shared_ptr<VulkanDrmBackend>(new VulkanDrmBackend(
       drm_device, enable_validation, session, mode_spec, rotation));
 
+  return FinishCreate(std::move(backend));
+}
+
+std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
+    const int drm_fd,
+    std::shared_ptr<void> fd_owner,
+    const std::string& drm_device,
+    const bool enable_validation,
+    const std::string& mode_spec,
+    const int rotation) {
+  if (drm_fd < 0) {
+    ihs::log::critical("[VulkanDrmBackend] Create: invalid lease fd {}",
+                       drm_fd);
+    return nullptr;
+  }
+  // session is null by construction: on a lease the compositor owns the seat's
+  // session, so there is no libseat session to pause/resume against. The
+  // existing bring-up already tolerates a null session.
+  auto backend = std::shared_ptr<VulkanDrmBackend>(new VulkanDrmBackend(
+      drm_device, enable_validation, /*session=*/nullptr, mode_spec, rotation));
+  backend->injected_fd_ = drm_fd;
+  backend->fd_owner_ = std::move(fd_owner);
+  return FinishCreate(std::move(backend));
+}
+
+std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::FinishCreate(
+    std::shared_ptr<VulkanDrmBackend> backend) {
   std::string err;
   if (!backend->BringUp(err)) {
     ihs::log::critical("[VulkanDrmBackend] init failed; refusing to start: {}",
@@ -564,8 +591,18 @@ struct VulkanDrmBackend::CompositorState {
 
 bool VulkanDrmBackend::SetupCompositor(std::string& err) {
   drm_kms_vulkan::ScanoutTarget target;
-  if (!drm_kms_vulkan::DiscoverScanoutTarget(drm_device_, DRM_FORMAT_XRGB8888,
-                                             mode_spec_, target, err)) {
+  // Probe through the lease fd when we have one. Not an optimisation: the
+  // kernel scopes that fd's view to the leased objects, so this finds exactly
+  // the connector we hold, where re-opening the card by path would enumerate
+  // the whole card and could pick one the compositor is still driving -- and
+  // may not be permitted at all.
+  const bool discovered =
+      injected_fd_ >= 0
+          ? drm_kms_vulkan::DiscoverScanoutTarget(
+                injected_fd_, DRM_FORMAT_XRGB8888, mode_spec_, target, err)
+          : drm_kms_vulkan::DiscoverScanoutTarget(
+                drm_device_, DRM_FORMAT_XRGB8888, mode_spec_, target, err);
+  if (!discovered) {
     return false;
   }
   const std::vector<uint64_t> allowed = drm_kms_vulkan::NegotiateModifiers(
@@ -592,12 +629,23 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
     ihs::log::info("[VulkanDrmBackend] modifiers negotiated:{}", neg);
   }
 
-  auto dev_exp = drm::Device::open(drm_device_);
-  if (!dev_exp) {
-    err = "drm::Device::open: " + dev_exp.error().message();
-    return false;
+  // On a lease, adopt the fd rather than opening the card: it is already master
+  // over its leased object set, its view is correctly scoped, and a leased
+  // client may not be permitted to open the node at all. from_fd borrows -- the
+  // fd stays owned by fd_owner_ (the LeaseHold), so CompositorState's Device
+  // will not close it.
+  std::optional<drm::Device> dev;
+  if (injected_fd_ >= 0) {
+    dev.emplace(drm::Device::from_fd(injected_fd_));
+  } else {
+    auto dev_exp = drm::Device::open(drm_device_);
+    if (!dev_exp) {
+      err = "drm::Device::open: " + dev_exp.error().message();
+      return false;
+    }
+    dev.emplace(std::move(dev_exp.value()));
   }
-  auto state = std::make_unique<CompositorState>(std::move(dev_exp.value()));
+  auto state = std::make_unique<CompositorState>(std::move(*dev));
   (void)state->device.enable_atomic();
   (void)state->device.enable_universal_planes();
   state->fourcc = DRM_FORMAT_XRGB8888;

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -364,7 +364,9 @@ std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
     const std::string& drm_device,
     const bool enable_validation,
     const std::string& mode_spec,
-    const int rotation) {
+    const int rotation,
+    const uint32_t connector_id,
+    std::function<bool()> revoked) {
   if (drm_fd < 0) {
     ihs::log::critical("[VulkanDrmBackend] Create: invalid lease fd {}",
                        drm_fd);
@@ -377,6 +379,10 @@ std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
       drm_device, enable_validation, /*session=*/nullptr, mode_spec, rotation));
   backend->injected_fd_ = drm_fd;
   backend->fd_owner_ = std::move(fd_owner);
+  // Set BEFORE FinishCreate: SetupCompositor runs inside it and is what pins
+  // the connector.
+  backend->lease_connector_id_ = connector_id;
+  backend->lease_revoked_ = std::move(revoked);
   return FinishCreate(std::move(backend));
 }
 
@@ -599,7 +605,8 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
   const bool discovered =
       injected_fd_ >= 0
           ? drm_kms_vulkan::DiscoverScanoutTarget(
-                injected_fd_, DRM_FORMAT_XRGB8888, mode_spec_, target, err)
+                injected_fd_, DRM_FORMAT_XRGB8888, mode_spec_,
+                lease_connector_id_, target, err)
           : drm_kms_vulkan::DiscoverScanoutTarget(
                 drm_device_, DRM_FORMAT_XRGB8888, mode_spec_, target, err);
   if (!discovered) {
@@ -1143,6 +1150,24 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
                                          size_t count) {
   if (!compositor_ || !compositor_->scene) {
     return false;
+  }
+  // Lease revoked: the leased KMS objects are gone from this fd's view, so
+  // every atomic commit naming them fails -- and a failed commit produces no
+  // PAGE_FLIP_EVENT, so the flip path would churn rather than settle. Park the
+  // vsync source instead: SubmitBaton parks the baton, no OnVsync fires, and
+  // raster stalls, which is the same steady state the libseat pause path
+  // produces for the gated state. Returning true
+  // reports the frame as presented -- it was not, but the alternative is the
+  // engine treating a revoked lease as a render error. Reacquire unparks by
+  // reacquiring; until then the exit policy is the way out.
+  if (lease_revoked_ && lease_revoked_()) {
+    vsync_.SetSourcePending(true);
+    if (!lease_revoked_logged_.exchange(true, std::memory_order_relaxed)) {
+      ihs::log::warn(
+          "[VulkanDrmBackend] lease revoked — gating commits and parking "
+          "vsync; the panel stops updating until the lease is reacquired");
+    }
+    return true;
   }
   CompositorState& c = *compositor_;
   const FlutterLayer* bs_layer = nullptr;

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -59,6 +59,26 @@ class VulkanDrmBackend final : public Backend {
       const std::string& mode_spec,
       int rotation);
 
+  // wayland-leased-drm: drive an externally-owned DRM fd (the master fd from
+  // wp_drm_lease_v1.lease_fd) instead of opening a card by path.
+  //
+  // The lease only changes how the fd was obtained; the Vulkan side is
+  // unaffected. Unlike the EGL path, the VkDevice was never created from the
+  // KMS fd — the physical device is matched by DRM dev-number and lives on the
+  // ICD's render node — so only the scanout/modeset half touches the lease.
+  //
+  // @p drm_fd is borrowed: this backend never closes it. @p fd_owner is the
+  // opaque keep-alive that does own it (the LeaseHold) and must outlive the
+  // backend. @p drm_device is still needed, derived from the lease fd, because
+  // the physical-device match stats the node — it is never opened on this path.
+  static std::shared_ptr<VulkanDrmBackend> Create(
+      int drm_fd,
+      std::shared_ptr<void> fd_owner,
+      const std::string& drm_device,
+      bool enable_validation,
+      const std::string& mode_spec,
+      int rotation);
+
   ~VulkanDrmBackend() override;
 
   VulkanDrmBackend(const VulkanDrmBackend&) = delete;
@@ -120,6 +140,11 @@ class VulkanDrmBackend final : public Backend {
                    std::string mode_spec,
                    int rotation);
 
+  // Shared tail of both Create() overloads: bring-up + compositor setup, which
+  // are identical once the backend knows where its DRM fd comes from.
+  static std::shared_ptr<VulkanDrmBackend> FinishCreate(
+      std::shared_ptr<VulkanDrmBackend> backend);
+
   // Bring-up steps. Each logs and returns false on failure; refusal_reason
   // carries the cause for gate failures.
   bool BringUp(std::string& refusal_reason);
@@ -158,6 +183,16 @@ class VulkanDrmBackend final : public Backend {
   bool PresentLayersImpl(const FlutterLayer** layers, size_t count);
 
   std::string drm_device_;
+
+  // wayland-leased-drm: a borrowed DRM fd to use instead of opening
+  // drm_device_. -1 on the path-opened path. When set, drm_device_ is only ever
+  // stat()ed (physical-device match), never opened -- see the leased Create().
+  int injected_fd_ = -1;
+  // Keeps the injected fd's owner (the LeaseHold) alive for this backend's
+  // lifetime. Opaque so this header stays free of the lease client: the backend
+  // needs the fd to stay valid, not to know what keeps it so.
+  std::shared_ptr<void> fd_owner_;
+
   // Scanout mode selector ("<W>x<H>[@<R>]"); empty = connector preferred mode.
   std::string mode_spec_;
   // DRM scanout rotation in degrees (0|90|180|270). 90/270 swap the render /

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -71,13 +72,24 @@ class VulkanDrmBackend final : public Backend {
   // opaque keep-alive that does own it (the LeaseHold) and must outlive the
   // backend. @p drm_device is still needed, derived from the lease fd, because
   // the physical-device match stats the node — it is never opened on this path.
+  //
+  // @p connector_id is the leased connector to drive; a lease may hold more
+  // than one (the compositor picks the final object set), so without it the
+  // scanout probe takes "first connected" and can drive the wrong panel. 0 =
+  // that heuristic.
+  //
+  // @p revoked is polled before each atomic commit: a revoked lease's KMS
+  // objects are gone from the fd's view, so every commit naming them fails.
+  // Null = never gated.
   static std::shared_ptr<VulkanDrmBackend> Create(
       int drm_fd,
       std::shared_ptr<void> fd_owner,
       const std::string& drm_device,
       bool enable_validation,
       const std::string& mode_spec,
-      int rotation);
+      int rotation,
+      uint32_t connector_id,
+      std::function<bool()> revoked);
 
   ~VulkanDrmBackend() override;
 
@@ -192,6 +204,14 @@ class VulkanDrmBackend final : public Backend {
   // lifetime. Opaque so this header stays free of the lease client: the backend
   // needs the fd to stay valid, not to know what keeps it so.
   std::shared_ptr<void> fd_owner_;
+
+  // The leased connector to drive (0 = first connected with a mode) and the
+  // lease's revocation gate (empty on the path-opened path, where there is no
+  // lease to lose). Both inert unless injected_fd_ >= 0.
+  uint32_t lease_connector_id_ = 0;
+  std::function<bool()> lease_revoked_;
+  // One-shot latch so the revocation notice is logged once, not once per frame.
+  std::atomic<bool> lease_revoked_logged_{false};
 
   // Scanout mode selector ("<W>x<H>[@<R>]"); empty = connector preferred mode.
   std::string mode_spec_;

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -463,9 +463,26 @@ std::shared_ptr<Backend> MakeDrmVulkanBackend(
       (config.view.drm_mode.has_value() && !config.view.drm_mode->empty())
           ? *config.view.drm_mode
           : std::string{};
-  auto vk_backend = VulkanDrmBackend::Create(
-      drm_display->device_path(), config.debug_backend.value_or(false),
-      drm_display->session(), drm_mode, config.view.drm_rotation.value_or(0));
+  // Serves both the direct and the leased descriptor: the lease changes only
+  // where the DRM fd came from. Unlike MakeDrmEglBackend — which is reused
+  // verbatim because DrmBackend::Create takes the device from the display —
+  // VulkanDrmBackend::Create takes a path, so the branch lives here rather than
+  // being invisible.
+  //
+  // device_path() is passed on both paths: on a lease it was derived from the
+  // lease fd and is only ever stat()ed, for the physical-device match. The fd
+  // itself is what gets opened/adopted.
+  auto vk_backend =
+      drm_display->adopted_fd()
+          ? VulkanDrmBackend::Create(
+                drm_display->SharedDevice()->fd(), drm_display->fd_owner(),
+                drm_display->device_path(),
+                config.debug_backend.value_or(false), drm_mode,
+                config.view.drm_rotation.value_or(0))
+          : VulkanDrmBackend::Create(drm_display->device_path(),
+                                     config.debug_backend.value_or(false),
+                                     drm_display->session(), drm_mode,
+                                     config.view.drm_rotation.value_or(0));
 
   // Create returns nullptr on any init failure (unsupported device, no
   // zero-copy scanout path). Continuing would dereference a null backend in
@@ -634,6 +651,15 @@ void RegisterCompiledBackends(backend::BackendRegistry& registry) {
   // listing (LeaseClient::Probe) can back it later.
   registry.Register({"wayland-leased-drm-egl", MakeLeasedDrmDisplay,
                      MakeDrmEglBackend, nullptr});
+#endif
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM && BUILD_BACKEND_DRM_KMS_VULKAN
+  // Same display as the leased-egl tier (MakeLeasedDrmDisplay serves either DRM
+  // renderer) and the same make_backend as the direct vulkan tier, which
+  // branches on the display's adopted_fd(). Only the scanout/modeset half of
+  // this backend touches the lease -- the VkDevice was never created from the
+  // KMS fd.
+  registry.Register({"wayland-leased-drm-vulkan", MakeLeasedDrmDisplay,
+                     MakeDrmVulkanBackend, nullptr});
 #endif
 #if BUILD_BACKEND_WAYLAND_LEASED_DRM && BUILD_BACKEND_SOFTWARE && \
     BUILD_SOFTWARE_SINK_DRM

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -46,6 +46,9 @@
 #include "backend/drm_kms_vulkan/vulkan_drm_backend.h"
 #include "display/drm_display.h"
 #endif
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM
+#include "backend/wayland_leased_drm/lease_client.h"
+#endif
 #if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
 #include "display/drm_device_resolver.h"  // ResolveDrmDevice
 #include "display/drm_mode_list.h"        // PrintDrmModes for --drm-list-modes
@@ -96,6 +99,50 @@ std::shared_ptr<IDisplay> MakeDrmDisplay(
   return std::make_shared<DrmDisplay>(static_cast<int32_t>(w),
                                       static_cast<int32_t>(h), 60.0,
                                       std::move(*device), no_seat);
+}
+#endif
+
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM && \
+    (BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN)
+// wayland-leased-drm: the DRM device comes from a compositor lease rather than
+// an open() of a card we chose. Everything downstream is the same DrmDisplay
+// the direct backends use -- the lease only changes the acquisition axis, not
+// the renderer -- so the DRM backend factories are reused verbatim.
+std::shared_ptr<IDisplay> MakeLeasedDrmDisplay(
+    const std::vector<Configuration::Config>& configs) {
+  homescreen::LeaseConfig lc;
+  lc.device = configs[0].view.lease_device;
+  lc.connector = configs[0].view.lease_connector;
+  if (configs[0].view.lease_timeout_ms.has_value()) {
+    lc.timeout_ms = *configs[0].view.lease_timeout_ms;
+  }
+
+  auto res = homescreen::LeaseClient::Acquire(lc);
+  if (!res.hold) {
+    // Fail fast, consistent with the rest of MakeDisplay: a leased backend that
+    // could not get its lease has nothing to fall back to, and silently running
+    // on a different device would be worse than not starting.
+    ihs::log::error("[leased-drm] could not acquire a lease: {}",
+                    homescreen::ToString(res.error));
+    for (const auto& o : res.offers) {
+      ihs::log::error("[leased-drm]   offered: {} (connector_id {}) — {}",
+                      o.name, o.connector_id, o.description);
+    }
+    std::exit(EXIT_FAILURE);
+  }
+
+  // The display owns the hold: drm::Device::from_fd only borrows the fd, so the
+  // LeaseHold (which owns it, and whose destruction returns the lease) must
+  // outlive every backend built on it.
+  const std::shared_ptr<homescreen::LeaseHold> hold(std::move(res.hold));
+  const int fd = hold->fd();
+  std::string card = hold->card_path();
+
+  const auto w = configs[0].view.width.value_or(kDefaultViewWidth);
+  const auto h = configs[0].view.height.value_or(kDefaultViewHeight);
+  return std::make_shared<DrmDisplay>(
+      DrmDisplay::AdoptFd{}, static_cast<int32_t>(w), static_cast<int32_t>(h),
+      60.0, fd, std::move(card), hold);
 }
 #endif
 
@@ -503,6 +550,19 @@ void RegisterCompiledBackends(backend::BackendRegistry& registry) {
   registry.Register(
       {"drm-kms-egl", MakeDrmDisplay, MakeDrmEglBackend, DrmListModes});
 #endif
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM && BUILD_BACKEND_DRM_KMS_EGL
+  // Same renderer as drm-kms-egl, different acquisition: the fd is leased from
+  // a compositor instead of opened directly. make_backend is reused as-is --
+  // MakeDrmEglBackend takes the device from the display, and session() is null
+  // on the adopted path, which DrmBackend::Create already supports.
+  //
+  // list_modes is deliberately null: --drm-list-modes on the direct backends
+  // prints a whole card's connectors by path, which for a lease would present
+  // inventory we cannot actually lease as though we could. A lease-aware
+  // listing (LeaseClient::Probe) can back it later.
+  registry.Register({"wayland-leased-drm-egl", MakeLeasedDrmDisplay,
+                     MakeDrmEglBackend, nullptr});
+#endif
 #if BUILD_BACKEND_DRM_KMS_VULKAN
   registry.Register(
       {"drm-kms-vulkan", MakeDrmDisplay, MakeDrmVulkanBackend, DrmListModes});
@@ -584,6 +644,46 @@ std::string ResolveKeyForConfig(const backend::BackendRegistry& reg,
   const std::string* drm_egl = has("drm-kms-egl");
   const std::string* drm_vk = has("drm-kms-vulkan");
   const std::string* sw = has("software");
+  const std::string* lease_egl = has("wayland-leased-drm-egl");
+  const std::string* lease_vk = has("wayland-leased-drm-vulkan");
+  const std::string* lease_sw = has("wayland-leased-drm-software");
+
+  // "wayland-leased-drm" as a bare family name resolves within the family, the
+  // same way the legacy egl/vulkan hint does: egl -> vulkan -> software among
+  // the tiers actually registered.
+  //
+  // Anything else under the family prefix is an error rather than a fallback.
+  // Leasing is not a preference, it is the difference between driving a
+  // connector the compositor handed us and grabbing a card outright: quietly
+  // running an unleased drm-kms-egl for someone who asked for a leased backend
+  // would do the opposite of what they configured, on hardware they may not
+  // own.
+  constexpr std::string_view kLeasedFamily = "wayland-leased-drm";
+  if (hint.rfind(kLeasedFamily, 0) == 0) {
+    if (hint == kLeasedFamily) {
+      if (want_vulkan && lease_vk != nullptr) {
+        return *lease_vk;
+      }
+      if (lease_egl != nullptr) {
+        return *lease_egl;
+      }
+      if (lease_vk != nullptr) {
+        return *lease_vk;
+      }
+      if (lease_sw != nullptr) {
+        return *lease_sw;
+      }
+    }
+    ihs::log::error(
+        "[backend] '{}' is not available in this build. Leased backends are "
+        "not interchangeable with the direct ones, so this will not fall back "
+        "to an unleased backend. Rebuild with "
+        "BUILD_BACKEND_WAYLAND_LEASED_DRM=ON plus a renderer stack "
+        "(BUILD_BACKEND_DRM_KMS_EGL / BUILD_BACKEND_DRM_KMS_VULKAN / "
+        "BUILD_BACKEND_SOFTWARE+BUILD_SOFTWARE_SINK_DRM).",
+        hint);
+    return std::string{};
+  }
 
   if (WaylandSessionAvailable() && (wl_egl != nullptr || wl_vk != nullptr)) {
     if (want_vulkan && wl_vk != nullptr) {

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -159,19 +159,16 @@ homescreen::LeaseConfig MakeLeaseConfig(const Configuration::Config& config) {
 }
 #endif
 
-#if BUILD_BACKEND_WAYLAND_LEASED_DRM && \
-    (BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN)
-// wayland-leased-drm: the DRM device comes from a compositor lease rather than
-// an open() of a card we chose. Everything downstream is the same DrmDisplay
-// the direct backends use -- the lease only changes the acquisition axis, not
-// the renderer -- so the DRM backend factories are reused verbatim.
-std::shared_ptr<IDisplay> MakeLeasedDrmDisplay(
-    const std::vector<Configuration::Config>& configs) {
-  auto res = homescreen::LeaseClient::Acquire(MakeLeaseConfig(configs[0]));
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM
+// Acquire the lease or exit. Shared by every leased tier's make_display: the
+// failure contract must not drift between tiers, and it is one contract --
+// a leased backend that could not get its lease has nothing to fall back to,
+// and silently running on a different device would be worse than not starting.
+// Fail-fast is consistent with the rest of MakeDisplay.
+std::shared_ptr<homescreen::LeaseHold> AcquireLeaseOrExit(
+    const Configuration::Config& config) {
+  auto res = homescreen::LeaseClient::Acquire(MakeLeaseConfig(config));
   if (!res.hold) {
-    // Fail fast, consistent with the rest of MakeDisplay: a leased backend that
-    // could not get its lease has nothing to fall back to, and silently running
-    // on a different device would be worse than not starting.
     ihs::log::error("[leased-drm] could not acquire a lease: {}",
                     homescreen::ToString(res.error));
     for (const auto& o : res.offers) {
@@ -180,19 +177,36 @@ std::shared_ptr<IDisplay> MakeLeasedDrmDisplay(
     }
     std::exit(EXIT_FAILURE);
   }
+  return std::shared_ptr<homescreen::LeaseHold>(std::move(res.hold));
+}
+#endif
 
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM && \
+    (BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN)
+// wayland-leased-drm: the DRM device comes from a compositor lease rather than
+// an open() of a card we chose. Everything downstream is the same DrmDisplay
+// the direct backends use -- the lease only changes the acquisition axis, not
+// the renderer -- so the DRM backend factories are reused verbatim.
+std::shared_ptr<IDisplay> MakeLeasedDrmDisplay(
+    const std::vector<Configuration::Config>& configs) {
   // The display owns the hold: drm::Device::from_fd only borrows the fd, so the
   // LeaseHold (which owns it, and whose destruction returns the lease) must
   // outlive every backend built on it.
-  const std::shared_ptr<homescreen::LeaseHold> hold(std::move(res.hold));
+  const std::shared_ptr<homescreen::LeaseHold> hold =
+      AcquireLeaseOrExit(configs[0]);
   const int fd = hold->fd();
   std::string card = hold->card_path();
 
   const auto w = configs[0].view.width.value_or(kDefaultViewWidth);
   const auto h = configs[0].view.height.value_or(kDefaultViewHeight);
+  // connector_id and the revocation gate ride along to the backend through the
+  // display -- the DRM backend factories take everything else from it too. The
+  // gate captures the hold by value: fd_owner_ holds the same share, so the
+  // callable cannot outlive what it reads.
   return std::make_shared<DrmDisplay>(
       DrmDisplay::AdoptFd{}, static_cast<int32_t>(w), static_cast<int32_t>(h),
-      60.0, fd, std::move(card), hold);
+      60.0, fd, std::move(card), hold, hold->connector_id(),
+      [hold] { return hold->revoked(); });
 }
 #endif
 
@@ -255,22 +269,12 @@ std::shared_ptr<IDisplay> MakeSoftwareDisplay(
 // software display; only the scanout device differs.
 std::shared_ptr<IDisplay> MakeLeasedSoftwareDisplay(
     const std::vector<Configuration::Config>& configs) {
-  auto res = homescreen::LeaseClient::Acquire(MakeLeaseConfig(configs[0]));
-  if (!res.hold) {
-    ihs::log::error("[leased-drm] could not acquire a lease: {}",
-                    homescreen::ToString(res.error));
-    for (const auto& o : res.offers) {
-      ihs::log::error("[leased-drm]   offered: {} (connector_id {}) — {}",
-                      o.name, o.connector_id, o.description);
-    }
-    std::exit(EXIT_FAILURE);
-  }
+  const std::shared_ptr<homescreen::LeaseHold> hold =
+      AcquireLeaseOrExit(configs[0]);
 
   auto display = MakeSoftwareDisplay(configs);
   auto* sw = dynamic_cast<SoftwareDisplay*>(display.get());
   assert(sw != nullptr);
-
-  const std::shared_ptr<homescreen::LeaseHold> hold(std::move(res.hold));
   SoftwareDisplay::LeasedScanout scanout;
   scanout.fd = hold->fd();
   scanout.connector_id = hold->connector_id();
@@ -408,6 +412,11 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
   // --drm-no-seat: DrmDisplay forced the session null; tell DrmBackend to
   // also skip the foreground-VT guard on its direct-open path.
   cfg.no_seat = config.view.drm_no_seat.value_or(false);
+  // Leased tier: the compositor chose the connector, and the lease can be
+  // revoked under us. Both are inert (0 / empty) on the direct tiers, which is
+  // what makes this factory serve the leased descriptor unchanged.
+  cfg.lease_connector_id = drm_display->lease_connector_id();
+  cfg.lease_revoked = drm_display->lease_revoked();
 
   // drm_display (resolved above) owns the process-wide libseat session — it may
   // be null when no seat backend is available, in which case DrmBackend takes
@@ -521,7 +530,8 @@ std::shared_ptr<Backend> MakeDrmVulkanBackend(
                 drm_display->SharedDevice()->fd(), drm_display->fd_owner(),
                 drm_display->device_path(),
                 config.debug_backend.value_or(false), drm_mode,
-                config.view.drm_rotation.value_or(0))
+                config.view.drm_rotation.value_or(0),
+                drm_display->lease_connector_id(), drm_display->lease_revoked())
           : VulkanDrmBackend::Create(drm_display->device_path(),
                                      config.debug_backend.value_or(false),
                                      drm_display->session(), drm_mode,
@@ -762,25 +772,6 @@ std::string ResolveKeyForConfig(const backend::BackendRegistry& reg,
     return hint;
   }
 
-  if (keys.size() == 1) {
-    // Only one backend is compiled in, so it is the only choice. Warn if the
-    // operator explicitly asked for a different one (a full key, not the legacy
-    // egl/vulkan renderer hint) so a typo or wrong-build isn't silent.
-    if (!hint.empty() && hint != "egl" && hint != "vulkan" &&
-        hint != keys.front()) {
-      ihs::log::warn(
-          "[backend] requested backend '{}' is not compiled into this build; "
-          "using the only available backend '{}'",
-          hint, keys.front());
-    }
-    return keys.front();
-  }
-
-  // Several backends and no exact key. Pick by environment, honoring the legacy
-  // egl/vulkan renderer-family hint within the chosen family:
-  //   - a live Wayland session -> a wayland-* backend (we run as a client);
-  //   - otherwise              -> KMS-direct (drm-kms-* / software).
-  const bool want_vulkan = (hint == "vulkan");
   const auto has = [&](std::string_view k) -> const std::string* {
     for (const auto& key : keys) {
       if (key == k) {
@@ -789,15 +780,19 @@ std::string ResolveKeyForConfig(const backend::BackendRegistry& reg,
     }
     return nullptr;
   };
-  const std::string* wl_egl = has("wayland-egl");
-  const std::string* wl_vk = has("wayland-vulkan");
-  const std::string* drm_egl = has("drm-kms-egl");
-  const std::string* drm_vk = has("drm-kms-vulkan");
-  const std::string* sw = has("software");
   const std::string* lease_egl = has("wayland-leased-drm-egl");
   const std::string* lease_vk = has("wayland-leased-drm-vulkan");
   const std::string* lease_sw = has("wayland-leased-drm-software");
 
+  // The leased family is resolved BEFORE any fallback below, including the
+  // single-backend short-circuit. Both fall back to a compiled-in backend when
+  // the requested one is absent, which for a leased request is the one outcome
+  // that must never happen: an unleased drm-kms-* opens a card and takes DRM
+  // master outright. That is not a degraded version of leasing, it is the
+  // opposite of it, on hardware the operator may not own. Order is load-bearing
+  // here, not stylistic -- this guard sitting after the keys.size() == 1 check
+  // is what let a leased request silently become drm-kms-egl.
+  //
   // "wayland-leased-drm" as a bare family name resolves within the family:
   // vulkan -> egl -> software among the tiers actually registered. Vulkan leads
   // because a leased connector is a dedicated scanout target, which is what the
@@ -836,6 +831,32 @@ std::string ResolveKeyForConfig(const backend::BackendRegistry& reg,
         hint);
     return std::string{};
   }
+
+  if (keys.size() == 1) {
+    // Only one backend is compiled in, so it is the only choice. Warn if the
+    // operator explicitly asked for a different one (a full key, not the legacy
+    // egl/vulkan renderer hint) so a typo or wrong-build isn't silent. A leased
+    // request never reaches here -- the guard above already refused it.
+    if (!hint.empty() && hint != "egl" && hint != "vulkan" &&
+        hint != keys.front()) {
+      ihs::log::warn(
+          "[backend] requested backend '{}' is not compiled into this build; "
+          "using the only available backend '{}'",
+          hint, keys.front());
+    }
+    return keys.front();
+  }
+
+  // Several backends and no exact key. Pick by environment, honoring the legacy
+  // egl/vulkan renderer-family hint within the chosen family:
+  //   - a live Wayland session -> a wayland-* backend (we run as a client);
+  //   - otherwise              -> KMS-direct (drm-kms-* / software).
+  const bool want_vulkan = (hint == "vulkan");
+  const std::string* wl_egl = has("wayland-egl");
+  const std::string* wl_vk = has("wayland-vulkan");
+  const std::string* drm_egl = has("drm-kms-egl");
+  const std::string* drm_vk = has("drm-kms-vulkan");
+  const std::string* sw = has("software");
 
   if (WaylandSessionAvailable() && (wl_egl != nullptr || wl_vk != nullptr)) {
     if (want_vulkan && wl_vk != nullptr) {

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -198,6 +198,48 @@ std::shared_ptr<IDisplay> MakeSoftwareDisplay(
 }
 #endif
 
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM && BUILD_BACKEND_SOFTWARE && \
+    BUILD_SOFTWARE_SINK_DRM
+// Negotiate a lease, then hand the fd to a SoftwareDisplay for the backend to
+// build its dumb sink on. Shares the seat/cursor wiring with the direct
+// software display; only the scanout device differs.
+std::shared_ptr<IDisplay> MakeLeasedSoftwareDisplay(
+    const std::vector<Configuration::Config>& configs) {
+  homescreen::LeaseConfig lc;
+  lc.device = configs[0].view.lease_device;
+  lc.connector = configs[0].view.lease_connector;
+  if (configs[0].view.lease_timeout_ms.has_value()) {
+    lc.timeout_ms = *configs[0].view.lease_timeout_ms;
+  }
+
+  auto res = homescreen::LeaseClient::Acquire(lc);
+  if (!res.hold) {
+    ihs::log::error("[leased-drm] could not acquire a lease: {}",
+                    homescreen::ToString(res.error));
+    for (const auto& o : res.offers) {
+      ihs::log::error("[leased-drm]   offered: {} (connector_id {}) — {}",
+                      o.name, o.connector_id, o.description);
+    }
+    std::exit(EXIT_FAILURE);
+  }
+
+  auto display = MakeSoftwareDisplay(configs);
+  auto* sw = dynamic_cast<SoftwareDisplay*>(display.get());
+  assert(sw != nullptr);
+
+  const std::shared_ptr<homescreen::LeaseHold> hold(std::move(res.hold));
+  SoftwareDisplay::LeasedScanout scanout;
+  scanout.fd = hold->fd();
+  scanout.connector_id = hold->connector_id();
+  // By value: the sink polls this for the process lifetime, so it must not
+  // capture anything with a shorter life than the hold it reads.
+  scanout.revoked = [hold]() { return hold->revoked(); };
+  scanout.owner = hold;
+  sw->SetLeasedScanout(std::move(scanout));
+  return display;
+}
+#endif
+
 #if BUILD_BACKEND_DRM_KMS_EGL
 std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
                                            IDisplay* display) {
@@ -518,6 +560,36 @@ std::shared_ptr<Backend> MakeSoftwareBackend(
 }
 #endif
 
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM && BUILD_BACKEND_SOFTWARE && \
+    BUILD_SOFTWARE_SINK_DRM
+std::shared_ptr<Backend> MakeLeasedSoftwareBackend(
+    const Configuration::Config& config,
+    IDisplay* display) {
+  auto* sw_display = dynamic_cast<SoftwareDisplay*>(display);
+  assert(sw_display != nullptr);
+  const auto& scanout = sw_display->leased_scanout();
+  // make_display fail-fasts when the lease cannot be had, so reaching here
+  // without one is programmer error, not an operator mistake.
+  assert(scanout.has_value());
+
+  // Deliberately NOT MakeSinkFromEnv: the sink is not IVI_SW_SINK's to choose
+  // once the backend key has pinned drm-dumb-on-a-leased-fd. IVI_SW_DRM_MODE
+  // and the format/dither knobs still apply -- those say how to drive the
+  // connector, which the lease does not change.
+  auto sink = DrmDumbSink::Create(scanout->fd, scanout->owner,
+                                  scanout->connector_id, scanout->revoked);
+  if (!sink) {
+    ihs::log::error(
+        "[leased-drm] could not drive leased connector {} on the lease fd",
+        scanout->connector_id);
+    return nullptr;
+  }
+  return std::make_shared<SoftwareBackend>(
+      config.view.width.value_or(kDefaultViewWidth),
+      config.view.height.value_or(kDefaultViewHeight), std::move(sink));
+}
+#endif
+
 }  // namespace
 
 #if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
@@ -562,6 +634,15 @@ void RegisterCompiledBackends(backend::BackendRegistry& registry) {
   // listing (LeaseClient::Probe) can back it later.
   registry.Register({"wayland-leased-drm-egl", MakeLeasedDrmDisplay,
                      MakeDrmEglBackend, nullptr});
+#endif
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM && BUILD_BACKEND_SOFTWARE && \
+    BUILD_SOFTWARE_SINK_DRM
+  // The cheapest tier: the engine renders to CPU memory and only the dumb
+  // buffers plus CRTC state live on the leased fd. Unlike the direct software
+  // backend this one does not consult IVI_SW_SINK -- the key already chose the
+  // sink. list_modes is null for the same reason as the egl tier.
+  registry.Register({"wayland-leased-drm-software", MakeLeasedSoftwareDisplay,
+                     MakeLeasedSoftwareBackend, nullptr});
 #endif
 #if BUILD_BACKEND_DRM_KMS_VULKAN
   registry.Register(

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -102,6 +102,63 @@ std::shared_ptr<IDisplay> MakeDrmDisplay(
 }
 #endif
 
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM
+// Build the LeaseConfig shared by every leased tier, including the revocation
+// policy.
+//
+// `exit` is the default because the alternative today is worse than it sounds:
+// gating leaves a frozen panel with no signal to anyone, and revocation is
+// routine — every VT switch away from the compositor is one. Exiting non-zero
+// hands the problem to the supervisor that can actually fix it, which
+// renegotiates from scratch on restart. Reacquire-in-place is later and will
+// change this default per tier.
+homescreen::LeaseConfig MakeLeaseConfig(const Configuration::Config& config) {
+  homescreen::LeaseConfig lc;
+  lc.device = config.view.lease_device;
+  lc.connector = config.view.lease_connector;
+  if (config.view.lease_timeout_ms.has_value()) {
+    lc.timeout_ms = *config.view.lease_timeout_ms;
+  }
+
+  const std::string policy = config.view.lease_on_revoke.value_or("exit");
+  if (policy == "gate") {
+    // Null handler: revoked() latches, the renderers' gates fire, and the panel
+    // stops updating. Debugging aid — nothing recovers.
+    ihs::log::warn(
+        "[leased-drm] lease_on_revoke=gate: on revocation the panel will "
+        "freeze "
+        "and the process will keep running. Nothing recovers from this; it is "
+        "for observing a revocation, not for production.");
+    return lc;
+  }
+  if (policy != "exit") {
+    ihs::log::warn(
+        "[leased-drm] lease_on_revoke='{}' is not implemented (accepted "
+        "values: "
+        "exit, gate); using 'exit'.",
+        policy);
+  }
+
+  lc.on_revoked = [](homescreen::RevokeCause cause) {
+    // Runs on the monitor thread. std::exit would run atexit handlers and
+    // static destructors concurrently with the threads still using them, so
+    // _Exit: the kernel closes the lease fd, which is what actually returns the
+    // connector, and the compositor re-advertises it. LatchRevoked has already
+    // logged the cause in operator terms; this says what is being done about
+    // it.
+    ihs::log::critical(
+        "[leased-drm] exiting on lease revocation ({}). lease_on_revoke=exit: "
+        "a "
+        "supervisor should restart and renegotiate. Use lease_on_revoke=gate "
+        "to "
+        "keep the process alive with a frozen panel instead.",
+        homescreen::ToString(cause));
+    std::_Exit(EXIT_FAILURE);
+  };
+  return lc;
+}
+#endif
+
 #if BUILD_BACKEND_WAYLAND_LEASED_DRM && \
     (BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN)
 // wayland-leased-drm: the DRM device comes from a compositor lease rather than
@@ -110,14 +167,7 @@ std::shared_ptr<IDisplay> MakeDrmDisplay(
 // the renderer -- so the DRM backend factories are reused verbatim.
 std::shared_ptr<IDisplay> MakeLeasedDrmDisplay(
     const std::vector<Configuration::Config>& configs) {
-  homescreen::LeaseConfig lc;
-  lc.device = configs[0].view.lease_device;
-  lc.connector = configs[0].view.lease_connector;
-  if (configs[0].view.lease_timeout_ms.has_value()) {
-    lc.timeout_ms = *configs[0].view.lease_timeout_ms;
-  }
-
-  auto res = homescreen::LeaseClient::Acquire(lc);
+  auto res = homescreen::LeaseClient::Acquire(MakeLeaseConfig(configs[0]));
   if (!res.hold) {
     // Fail fast, consistent with the rest of MakeDisplay: a leased backend that
     // could not get its lease has nothing to fall back to, and silently running
@@ -205,14 +255,7 @@ std::shared_ptr<IDisplay> MakeSoftwareDisplay(
 // software display; only the scanout device differs.
 std::shared_ptr<IDisplay> MakeLeasedSoftwareDisplay(
     const std::vector<Configuration::Config>& configs) {
-  homescreen::LeaseConfig lc;
-  lc.device = configs[0].view.lease_device;
-  lc.connector = configs[0].view.lease_connector;
-  if (configs[0].view.lease_timeout_ms.has_value()) {
-    lc.timeout_ms = *configs[0].view.lease_timeout_ms;
-  }
-
-  auto res = homescreen::LeaseClient::Acquire(lc);
+  auto res = homescreen::LeaseClient::Acquire(MakeLeaseConfig(configs[0]));
   if (!res.hold) {
     ihs::log::error("[leased-drm] could not acquire a lease: {}",
                     homescreen::ToString(res.error));

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -798,9 +798,14 @@ std::string ResolveKeyForConfig(const backend::BackendRegistry& reg,
   const std::string* lease_vk = has("wayland-leased-drm-vulkan");
   const std::string* lease_sw = has("wayland-leased-drm-software");
 
-  // "wayland-leased-drm" as a bare family name resolves within the family, the
-  // same way the legacy egl/vulkan hint does: egl -> vulkan -> software among
-  // the tiers actually registered.
+  // "wayland-leased-drm" as a bare family name resolves within the family:
+  // vulkan -> egl -> software among the tiers actually registered. Vulkan leads
+  // because a leased connector is a dedicated scanout target, which is what the
+  // vulkan tier's explicit-ownership model is built for; egl is the fallback
+  // for stacks without an ICD. This does NOT consult the legacy egl/vulkan
+  // renderer hint -- that hint and this family name arrive in the same string,
+  // so it can only ever be one or the other. Say wayland-leased-drm-egl to pin
+  // egl.
   //
   // Anything else under the family prefix is an error rather than a fallback.
   // Leasing is not a preference, it is the difference between driving a
@@ -811,14 +816,11 @@ std::string ResolveKeyForConfig(const backend::BackendRegistry& reg,
   constexpr std::string_view kLeasedFamily = "wayland-leased-drm";
   if (hint.rfind(kLeasedFamily, 0) == 0) {
     if (hint == kLeasedFamily) {
-      if (want_vulkan && lease_vk != nullptr) {
+      if (lease_vk != nullptr) {
         return *lease_vk;
       }
       if (lease_egl != nullptr) {
         return *lease_egl;
-      }
-      if (lease_vk != nullptr) {
-        return *lease_vk;
       }
       if (lease_sw != nullptr) {
         return *lease_sw;
@@ -887,6 +889,18 @@ bool EnsureActiveBackend(backend::BackendRegistry& registry,
         "registered:{}",
         key, available);
     return false;
+  }
+
+  // Report the resolved key when it is not what was configured -- a bare family
+  // name, a legacy egl/vulkan hint, or an unset backend field all resolve to
+  // something the operator never typed. The configured string is what gets
+  // echoed as "Backend:", so without this there is no way to tell which tier a
+  // family name actually landed on.
+  if (const std::string configured = configs[0].view.backend.value_or("");
+      key != configured) {
+    ihs::log::info("[backend] resolved '{}' -> '{}'",
+                   configured.empty() ? std::string{"<unset>"} : configured,
+                   key);
   }
 
   // The "active" backend is the process-wide default: it backs the first

--- a/shell/backend/software/drm_dumb_sink.cc
+++ b/shell/backend/software/drm_dumb_sink.cc
@@ -117,6 +117,31 @@ std::unique_ptr<DrmDumbSink> DrmDumbSink::Create(
   return sink;
 }
 
+std::unique_ptr<DrmDumbSink> DrmDumbSink::Create(
+    int drm_fd,
+    std::shared_ptr<void> fd_owner,
+    std::function<bool()> revoked) {
+  if (drm_fd < 0) {
+    ihs::log::error("[DrmDumbSink] Create: invalid fd {}", drm_fd);
+    return nullptr;
+  }
+  std::unique_ptr<DrmDumbSink> sink(new DrmDumbSink());
+  // The IVI_SW_DRM_MODE / format / dither env knobs pass through unchanged --
+  // the lease only changes where the fd came from, not how frames are made.
+  sink->format_ = RequestedFormatFromEnv();
+  sink->dither_ = DitherRequestedFromEnv();
+  sink->drm_fd_ = drm_fd;
+  sink->owns_fd_ = false;
+  sink->fd_owner_ = std::move(fd_owner);
+  sink->revoked_ = std::move(revoked);
+  if (!sink->InitFromFd()) {
+    return nullptr;
+  }
+  ihs::log::info("[DrmDumbSink] adopted lease fd {} (connector {})", drm_fd,
+                 sink->connector_id_);
+  return sink;
+}
+
 DrmDumbSink::DrmDumbSink() = default;
 
 DrmDumbSink::~DrmDumbSink() {
@@ -134,6 +159,8 @@ DrmDumbSink::~DrmDumbSink() {
     // Restore the prior CRTC mapping if we modeset; without this the
     // console doesn't come back after the embedder exits on a bare
     // TTY. saved_fb_ being unset means we never modeset, so skip.
+    // On a lease this hands the connector back as we found it, before the
+    // LeaseHold destroys the lease object and the compositor revokes.
     if (saved_fb_.has_value() && saved_crtc_id_ != 0) {
       drmModeSetCrtc(drm_fd_, saved_crtc_id_, *saved_fb_, 0, 0, &connector_id_,
                      1, nullptr);
@@ -141,7 +168,12 @@ DrmDumbSink::~DrmDumbSink() {
     for (size_t i = 0; i < buffers_.size(); ++i) {
       FreeBuffer(i);
     }
-    ::close(drm_fd_);
+    // Only close what we opened: a lease fd is owned by fd_owner_ (the
+    // LeaseHold), which closes it after returning the lease. Closing it here
+    // would be a double close.
+    if (owns_fd_) {
+      ::close(drm_fd_);
+    }
     drm_fd_ = -1;
   }
 }
@@ -155,8 +187,13 @@ bool DrmDumbSink::InitDevice(const std::string& device_path) {
     ihs::log::error("[DrmDumbSink] open('{}'): {}", path, std::strerror(errno));
     return false;
   }
+  owns_fd_ = true;
   ihs::log::info("[DrmDumbSink] opened {}", path);
 
+  return InitFromFd();
+}
+
+bool DrmDumbSink::InitFromFd() {
   drmModeRes* res = drmModeGetResources(drm_fd_);
   if (res == nullptr) {
     ihs::log::error("[DrmDumbSink] drmModeGetResources: {}",
@@ -541,6 +578,15 @@ bool DrmDumbSink::Present(const void* allocation,
                           const size_t row_bytes,
                           const size_t height) {
   if (stopped_.load(std::memory_order_acquire)) {
+    return true;
+  }
+  // Lease revoked: the KMS objects are gone from this fd's view, so the modeset
+  // and flip below would fail on every frame. Drop it instead of spraying ioctl
+  // errors. Returns true — the frame is "handled" as far as the rasterizer is
+  // concerned, so it neither stalls nor retries; the display simply stops
+  // updating, which is the same steady state the pause path already produces.
+  // Reacquiring the lease and rebuilding is WS7.
+  if (revoked_ && revoked_()) {
     return true;
   }
   // Strict ping-pong: render into the buffer that isn't currently

--- a/shell/backend/software/drm_dumb_sink.cc
+++ b/shell/backend/software/drm_dumb_sink.cc
@@ -120,6 +120,7 @@ std::unique_ptr<DrmDumbSink> DrmDumbSink::Create(
 std::unique_ptr<DrmDumbSink> DrmDumbSink::Create(
     int drm_fd,
     std::shared_ptr<void> fd_owner,
+    uint32_t connector_id,
     std::function<bool()> revoked) {
   if (drm_fd < 0) {
     ihs::log::error("[DrmDumbSink] Create: invalid fd {}", drm_fd);
@@ -134,7 +135,7 @@ std::unique_ptr<DrmDumbSink> DrmDumbSink::Create(
   sink->owns_fd_ = false;
   sink->fd_owner_ = std::move(fd_owner);
   sink->revoked_ = std::move(revoked);
-  if (!sink->InitFromFd()) {
+  if (!sink->InitFromFd(connector_id)) {
     return nullptr;
   }
   ihs::log::info("[DrmDumbSink] adopted lease fd {} (connector {})", drm_fd,
@@ -193,7 +194,7 @@ bool DrmDumbSink::InitDevice(const std::string& device_path) {
   return InitFromFd();
 }
 
-bool DrmDumbSink::InitFromFd() {
+bool DrmDumbSink::InitFromFd(uint32_t want_connector_id) {
   drmModeRes* res = drmModeGetResources(drm_fd_);
   if (res == nullptr) {
     ihs::log::error("[DrmDumbSink] drmModeGetResources: {}",
@@ -201,9 +202,15 @@ bool DrmDumbSink::InitFromFd() {
     return false;
   }
 
-  // Pick the first connected connector with at least one mode.
+  // Pin the requested connector when given (a lease may hold more than one, and
+  // the compositor -- not us -- picks the final object set, so "first
+  // connected" could light up the wrong panel). Otherwise take the first
+  // connected connector with at least one mode.
   drmModeConnector* connector = nullptr;
   for (int i = 0; i < res->count_connectors; ++i) {
+    if (want_connector_id != 0 && res->connectors[i] != want_connector_id) {
+      continue;
+    }
     drmModeConnector* c = drmModeGetConnector(drm_fd_, res->connectors[i]);
     if (c != nullptr && c->connection == DRM_MODE_CONNECTED &&
         c->count_modes > 0) {
@@ -215,7 +222,17 @@ bool DrmDumbSink::InitFromFd() {
     }
   }
   if (connector == nullptr) {
-    ihs::log::error("[DrmDumbSink] no connected connector with modes");
+    if (want_connector_id != 0) {
+      // Fail rather than silently falling back to another connector: the caller
+      // asked for a specific panel, and quietly driving a different one is
+      // worse than not starting.
+      ihs::log::error(
+          "[DrmDumbSink] requested connector {} is not present/connected with "
+          "modes on this fd",
+          want_connector_id);
+    } else {
+      ihs::log::error("[DrmDumbSink] no connected connector with modes");
+    }
     drmModeFreeResources(res);
     return false;
   }
@@ -581,12 +598,28 @@ bool DrmDumbSink::Present(const void* allocation,
     return true;
   }
   // Lease revoked: the KMS objects are gone from this fd's view, so the modeset
-  // and flip below would fail on every frame. Drop it instead of spraying ioctl
-  // errors. Returns true — the frame is "handled" as far as the rasterizer is
-  // concerned, so it neither stalls nor retries; the display simply stops
-  // updating, which is the same steady state the pause path already produces.
-  // Reacquiring the lease and rebuilding is WS7.
+  // and flip below would fail on every frame. Drop the frame rather than
+  // spraying ioctl errors.
+  //
+  // Park the vsync source rather than discarding. This path is a persistent
+  // state, not a transient error, which is why it does NOT mirror the
+  // drmModePageFlip-failure path below (SetSourcePending(false) +
+  // DeliverDiscard()): handing the baton straight back would make the engine
+  // immediately request the next vsync, SubmitBaton would drain it inline
+  // because nothing is in flight, and the UI+raster threads would spin
+  // rendering frames as fast as the CPU allows with nothing reaching a display.
+  // Holding the source pending instead means SubmitBaton parks the baton, no
+  // OnVsync fires, and raster stalls -- the same steady state the libseat pause
+  // path produces for the gated state. The
+  // platform thread, plugins and input keep running. Reacquire unparks it by
+  // reacquiring and rebuilding; until then the exit policy is the way out.
   if (revoked_ && revoked_()) {
+    vsync_.SetSourcePending(true);
+    if (!revoked_logged_.exchange(true, std::memory_order_relaxed)) {
+      ihs::log::warn(
+          "[DrmDumbSink] lease revoked — gating presents and parking vsync; "
+          "the panel stops updating until the lease is reacquired");
+    }
     return true;
   }
   // Strict ping-pong: render into the buffer that isn't currently

--- a/shell/backend/software/drm_dumb_sink.h
+++ b/shell/backend/software/drm_dumb_sink.h
@@ -85,12 +85,18 @@ class DrmDumbSink final : public ISurfaceSink {
   //
   // @p drm_fd is borrowed: the sink never closes it. @p fd_owner is the opaque
   // keep-alive that does own it (the LeaseHold) and must outlive the sink.
+  // @p connector_id is the connector to drive. A lease may contain more than
+  // one connector -- the requested set is only a suggestion and the compositor
+  // picks the final object set -- so the "first connected with modes" heuristic
+  // is only equivalent for a single-connector lease and would otherwise light
+  // up the wrong panel. 0 = fall back to that heuristic.
   // @p revoked, when set, is polled by Present(): once the lease is revoked its
   // KMS objects are gone from the fd's view and every commit naming them fails,
   // so frames are dropped rather than spraying ioctl errors. Null = never
   // gated.
   static std::unique_ptr<DrmDumbSink> Create(int drm_fd,
                                              std::shared_ptr<void> fd_owner,
+                                             uint32_t connector_id,
                                              std::function<bool()> revoked);
 
   ~DrmDumbSink() override;
@@ -142,7 +148,10 @@ class DrmDumbSink final : public ISurfaceSink {
   // buffers and attaches buffer 0 to the CRTC. Split out from InitDevice at the
   // open() so the same probing runs against a supplied fd (a DRM lease), which
   // is the whole of the leased software tier.
-  bool InitFromFd();
+  //
+  // @p want_connector_id, when non-zero, pins the connector instead of taking
+  // the first connected one with modes.
+  bool InitFromFd(uint32_t want_connector_id = 0);
   bool AllocBuffer(size_t index);
   void FreeBuffer(size_t index);
 
@@ -184,6 +193,9 @@ class DrmDumbSink final : public ISurfaceSink {
   // Lease revocation gate polled by Present(); null on the path-opened path,
   // where there is no lease to lose.
   std::function<bool()> revoked_;
+
+  // One-shot latch so the revocation notice is logged once, not once per frame.
+  std::atomic<bool> revoked_logged_{false};
 
   uint32_t connector_id_{0};
   uint32_t crtc_id_{0};

--- a/shell/backend/software/drm_dumb_sink.h
+++ b/shell/backend/software/drm_dumb_sink.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -71,6 +72,27 @@ class DrmDumbSink final : public ISurfaceSink {
   // mode is found.
   static std::unique_ptr<DrmDumbSink> Create(const std::string& device_path);
 
+  // wayland-leased-drm: drive an externally-owned DRM fd (the master fd from
+  // wp_drm_lease_v1.lease_fd) instead of opening a card by path.
+  //
+  // Nothing has to be subtracted for a lease: this sink does no master handling
+  // at all, and a lease fd arrives master over its object set -- strictly
+  // better than the implicit-master assumption of the path above. The legacy
+  // modeset and dumb-buffer ioctls it uses are valid on a lease fd, and because
+  // the kernel filters the fd's resource view to the leased objects, the "first
+  // connected connector with modes" pick lands on the leased connector by
+  // construction.
+  //
+  // @p drm_fd is borrowed: the sink never closes it. @p fd_owner is the opaque
+  // keep-alive that does own it (the LeaseHold) and must outlive the sink.
+  // @p revoked, when set, is polled by Present(): once the lease is revoked its
+  // KMS objects are gone from the fd's view and every commit naming them fails,
+  // so frames are dropped rather than spraying ioctl errors. Null = never
+  // gated.
+  static std::unique_ptr<DrmDumbSink> Create(int drm_fd,
+                                             std::shared_ptr<void> fd_owner,
+                                             std::function<bool()> revoked);
+
   ~DrmDumbSink() override;
 
   DrmDumbSink(const DrmDumbSink&) = delete;
@@ -112,10 +134,15 @@ class DrmDumbSink final : public ISurfaceSink {
  private:
   DrmDumbSink();
 
-  // Probe the drm fd for a connector / CRTC / mode triple. Allocates
-  // both dumb buffers and attaches buffer 0 to the CRTC. Returns false
-  // on any failure; caller logs and falls back.
+  // Open @p device_path, then hand off to InitFromFd. Returns false on any
+  // failure; caller logs and falls back.
   bool InitDevice(const std::string& device_path);
+
+  // Probe drm_fd_ for a connector / CRTC / mode triple. Allocates both dumb
+  // buffers and attaches buffer 0 to the CRTC. Split out from InitDevice at the
+  // open() so the same probing runs against a supplied fd (a DRM lease), which
+  // is the whole of the leased software tier.
+  bool InitFromFd();
   bool AllocBuffer(size_t index);
   void FreeBuffer(size_t index);
 
@@ -144,6 +171,20 @@ class DrmDumbSink final : public ISurfaceSink {
   void OnPageFlip(uint64_t tv_ns);
 
   int drm_fd_{-1};
+
+  // False when drm_fd_ is a borrowed lease fd: the destructor must not close
+  // what the LeaseHold owns and will close itself.
+  bool owns_fd_{true};
+
+  // Keeps the borrowed fd's owner alive for the sink's lifetime. Opaque so this
+  // header stays free of the lease client -- the sink needs the fd to stay
+  // valid, not to know what keeps it so. Null on the path-opened path.
+  std::shared_ptr<void> fd_owner_;
+
+  // Lease revocation gate polled by Present(); null on the path-opened path,
+  // where there is no lease to lose.
+  std::function<bool()> revoked_;
+
   uint32_t connector_id_{0};
   uint32_t crtc_id_{0};
   uint32_t saved_crtc_id_{0};  // for restoring on shutdown

--- a/shell/backend/wayland_leased_drm/README.md
+++ b/shell/backend/wayland_leased_drm/README.md
@@ -179,7 +179,7 @@ homescreen --backend=wayland-leased-drm-egl --lease-connector=HDMI-A-1 -b <bundl
 
 | Flag | Env | TOML | Meaning |
 |---|---|---|---|
-| `--backend` | — | `[view.backend] type` | `wayland-leased-drm[-egl\|-software]`; the bare family name picks the first available tier |
+| `--backend` | — | `[view.backend] type` | `wayland-leased-drm[-vulkan\|-egl\|-software]`; the bare family name resolves vulkan → egl → software among the tiers this build registered. Name a tier explicitly to pin it |
 | `--lease-connector` | `HOMESCREEN_LEASE_CONNECTOR` | `[view.backend.lease] connector` | Connector to request by name. Unset + one offer takes it; unset + several is fatal and lists them |
 | `--lease-device` | `HOMESCREEN_LEASE_DEVICE` | `[view.backend.lease] device` | Which `wp_drm_lease_device_v1` when several are advertised (one per DRM node): index or node path |
 | `--lease-timeout-ms` | `HOMESCREEN_LEASE_TIMEOUT_MS` | `[view.backend.lease] timeout_ms` | Bound on the whole negotiation (default 5000) |

--- a/shell/backend/wayland_leased_drm/README.md
+++ b/shell/backend/wayland_leased_drm/README.md
@@ -50,16 +50,18 @@ before `create_lease_request`, so it is safe against a live session) or with
 ## Architecture
 
 ```
-main → BackendRegistry["wayland-leased-drm-{egl|software}"]
+main → BackendRegistry["wayland-leased-drm-{egl|vulkan|software}"]
   make_display:
     LeaseClient::Acquire(cfg) ─▶ LeaseHold { lease_fd, connector_id, name,
         │                                    card path, wl_display + monitor
         │                                    thread, revoked flag }
-        ├── egl ──────▶ DrmDisplay(AdoptFd, …, fd, hold)
+        ├── egl/vulkan ▶ DrmDisplay(AdoptFd, …, fd, hold)
         └── software ─▶ SoftwareDisplay + LeasedScanout{fd, connector_id,
                                                         revoked, owner}
   make_backend:
         ├── MakeDrmEglBackend(cfg, display)          [egl — reused verbatim]
+        ├── MakeDrmVulkanBackend(cfg, display)       [vulkan — branches on
+        │                                             display->adopted_fd()]
         └── DrmDumbSink::Create(fd, owner, conn, revoked)   [software]
 ```
 
@@ -131,9 +133,9 @@ the panel stops updating until the process is restarted.
 |---|---|---|---|
 | EGL | `wayland-leased-drm-egl` | `BUILD_BACKEND_DRM_KMS_EGL` | registered |
 | Software | `wayland-leased-drm-software` | `BUILD_BACKEND_SOFTWARE` + `BUILD_SOFTWARE_SINK_DRM` | registered |
-| Vulkan | `wayland-leased-drm-vulkan` | `BUILD_BACKEND_DRM_KMS_VULKAN` | **not registered** — needs `VulkanDrmBackend` to accept an injected `drm::Device` instead of opening by path |
+| Vulkan | `wayland-leased-drm-vulkan` | `BUILD_BACKEND_DRM_KMS_VULKAN` | registered — least lease-coupled of the three: the VkDevice was never created from the KMS fd, so only scanout/modeset touches the lease |
 
-A leased key that is not registered is **refused, not substituted**. Leasing is
+A tier whose renderer stack is not built is **refused, not substituted**. Leasing is
 the difference between driving a connector a compositor handed you and grabbing a
 card outright, so falling back to an unleased backend would do the opposite of
 what was configured, on hardware you may not own.

--- a/shell/backend/wayland_leased_drm/README.md
+++ b/shell/backend/wayland_leased_drm/README.md
@@ -1,0 +1,220 @@
+# wayland_leased_drm backend
+
+Takes exclusive control of a DRM connector from a running Wayland compositor via
+`wp_drm_lease_device_v1` (drm-lease-v1, staging), then scans out on the leased fd
+through one of the existing DRM present paths.
+
+The Wayland connection is used **only** to negotiate the lease and to watch for
+its revocation. There is no `wl_surface` and no compositor-composited path: this
+is not a Wayland client in the usual sense, it is a DRM client that asks a
+compositor for a connector instead of grabbing a card. Input comes from evdev,
+not from the compositor — with no surface there is no keyboard or pointer focus
+to receive.
+
+Target use cases: an instrument cluster or HUD panel leased from a primary IVI
+compositor, and any deployment where one process must own a connector while a
+compositor owns the rest of the card.
+
+## Read this first: can you actually get a lease?
+
+Two things must both be true, and the second one is what usually bites.
+
+**The compositor must implement drm-lease-v1.** Per the wayland.app support
+matrix: KWin, the wlroots family (Sway, labwc, niri, Wayfire, …), Mutter,
+Hyprland and COSMIC do. **Weston does not**, and therefore neither do AGL's
+Weston-derived compositors. If your target is agl-compositor, this backend is
+inert without compositor-side work.
+
+**The compositor must be willing to offer your connector.** This is the real
+gate. The protocol comes from VR, and the wlroots family only offers a connector
+for leasing when its EDID carries the **non-desktop** flag; a compositor claims
+every ordinary connector for its own compositing. On a normal desktop the result
+is that the global exists and offers nothing:
+
+```
+$ wayland-info | grep -A1 drm_lease
+interface: 'wp_drm_lease_device_v1', version: 1, name: 27
+        path: /dev/dri/card1
+```
+
+...while every connector reports `"non-desktop" (immutable): range [0, 1] = 0`,
+and enumeration completes with **zero offers**. `non-desktop` is immutable — you
+cannot set it at runtime. Getting a lease from such a host needs one of: an EDID
+that trips the kernel's `EDID_QUIRK_NON_DESKTOP` list (`drm.edid_firmware=`), a
+compositor patch/config, or a compositor built for the job.
+
+Verify before assuming, with the lease client's own read-only path (it stops
+before `create_lease_request`, so it is safe against a live session) or with
+`wayland-info`.
+
+## Architecture
+
+```
+main → BackendRegistry["wayland-leased-drm-{egl|software}"]
+  make_display:
+    LeaseClient::Acquire(cfg) ─▶ LeaseHold { lease_fd, connector_id, name,
+        │                                    card path, wl_display + monitor
+        │                                    thread, revoked flag }
+        ├── egl ──────▶ DrmDisplay(AdoptFd, …, fd, hold)
+        └── software ─▶ SoftwareDisplay + LeasedScanout{fd, connector_id,
+                                                        revoked, owner}
+  make_backend:
+        ├── MakeDrmEglBackend(cfg, display)          [egl — reused verbatim]
+        └── DrmDumbSink::Create(fd, owner, conn, revoked)   [software]
+```
+
+Two axes, deliberately orthogonal:
+
+- **Acquisition** — how the DRM fd is obtained: direct open (`drm-kms-*`) vs
+  leased (here).
+- **Renderer** — how frames are produced: EGL/GBM, Vulkan, or CPU + dumb buffers.
+
+The lease only changes acquisition. That is why the egl tier's `make_backend` is
+`MakeDrmEglBackend` **unchanged**: the adopted-fd path is a construction tag on
+`DrmDisplay`, not a subclass, so the backend factory cannot tell the difference.
+
+### Why compound registry keys
+
+The renderer determines the display type (`DrmDisplay` vs `SoftwareDisplay`), and
+`BackendDescriptor` requires `make_backend` to receive the concrete `IDisplay`
+its own `make_display` produced. A single key with an internal renderer switch
+would have to resolve the renderer *before* `make_display` runs — re-implementing
+key resolution inside a descriptor. Three keys keep the invariant.
+
+### What the adopted-fd path does differently
+
+The compositor, not this process, is the lessor:
+
+- **No `drmSetMaster`, no foreground-VT guard.** The lease fd is already master
+  over its leased object set; the compositor owns the VT.
+- **No `drmDropMaster` at teardown.** The lease is returned by destroying the
+  `wp_drm_lease_v1` object, which lets the compositor revoke and re-advertise.
+- **No libseat session.** The compositor already holds the session controller for
+  the seat; taking it would fight. Input falls back to direct evdev.
+- **Outputs are enumerated through the lease fd**, whose resource view the kernel
+  filters to the leased objects. Re-opening the card by path would both show
+  connectors we do not hold *and* require permissions a leased client may not
+  have — the whole point of leasing is not needing them.
+
+The fd is **borrowed**: `drm::Device::from_fd` does not close it, and neither does
+the sink. The `LeaseHold` owns it, and must outlive everything built on it. That
+is why the display holds the hold.
+
+## Revocation
+
+Revocation is normal, not exceptional: **every VT switch away from the compositor
+is a revoke**, because the compositor loses DRM master. Hot-unplug and compositor
+exit do it too. It arrives as `wp_drm_lease_v1.finished` on the monitor thread,
+which latches `LeaseHold::revoked()`.
+
+What the kernel does, verified against a real lease on vkms (see
+`test/unit_test/leased_drm_vkms-test`):
+
+- The KMS objects vanish from the fd's view — every commit naming them fails.
+- **The fd stays open and remains a functional render fd**: GEM allocation and
+  prime export still succeed. Leases partition mode objects only.
+
+Renderers gate on `revoked()`. The software tier drops the frame and *parks the
+vsync source* rather than discarding: parking makes the engine stall (the
+documented steady state), whereas handing the baton back would spin the UI and
+raster threads at 100% CPU with nothing reaching a panel.
+
+Note `wp_drm_lease_connector_v1.withdrawn` **post-grant does not revoke** — the
+spec is explicit that the lease is unaffected; just destroy the offer object.
+
+Reacquire-and-rebuild is not implemented yet; today a revoked lease means
+the panel stops updating until the process is restarted.
+
+## Status
+
+| Tier | Registry key | Requires | State |
+|---|---|---|---|
+| EGL | `wayland-leased-drm-egl` | `BUILD_BACKEND_DRM_KMS_EGL` | registered |
+| Software | `wayland-leased-drm-software` | `BUILD_BACKEND_SOFTWARE` + `BUILD_SOFTWARE_SINK_DRM` | registered |
+| Vulkan | `wayland-leased-drm-vulkan` | `BUILD_BACKEND_DRM_KMS_VULKAN` | **not registered** — needs `VulkanDrmBackend` to accept an injected `drm::Device` instead of opening by path |
+
+A leased key that is not registered is **refused, not substituted**. Leasing is
+the difference between driving a connector a compositor handed you and grabbing a
+card outright, so falling back to an unleased backend would do the opposite of
+what was configured, on hardware you may not own.
+
+Scope today: one connector per lease, one lease per process. Multi-connector
+leases and lease-per-view are deferred; the protocol supports both.
+
+## Build
+
+```bash
+cmake -B build -G Ninja \
+  -DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON \
+  -DBUILD_BACKEND_DRM_KMS_EGL=ON        # or: -DBUILD_BACKEND_SOFTWARE=ON
+```
+
+The configure output says which tiers are registered. A lease-only build (no
+surface backends) links `wayland-client` alone — `wayland-cursor`, `xkbcommon`
+and `wayland-protocols` are surface-backend dependencies this client does not
+have. `drm-lease-v1.xml` is vendored under `shell/wayland/protocols/` because the
+staging XML only ships with wayland-protocols >= 1.22 and the project floor is
+1.20.
+
+## Running
+
+```bash
+homescreen --backend=wayland-leased-drm-egl --lease-connector=HDMI-A-1 -b <bundle>
+```
+
+| Flag | Env | TOML | Meaning |
+|---|---|---|---|
+| `--backend` | — | `[view.backend] type` | `wayland-leased-drm[-egl\|-software]`; the bare family name picks the first available tier |
+| `--lease-connector` | `HOMESCREEN_LEASE_CONNECTOR` | `[view.backend.lease] connector` | Connector to request by name. Unset + one offer takes it; unset + several is fatal and lists them |
+| `--lease-device` | `HOMESCREEN_LEASE_DEVICE` | `[view.backend.lease] device` | Which `wp_drm_lease_device_v1` when several are advertised (one per DRM node): index or node path |
+| `--lease-timeout-ms` | `HOMESCREEN_LEASE_TIMEOUT_MS` | `[view.backend.lease] timeout_ms` | Bound on the whole negotiation (default 5000) |
+
+The timeout is load-bearing, not cosmetic: the spec lets a compositor defer the
+DRM fd until it regains DRM master, so without a bound a VT-switched-away
+compositor would hang startup indefinitely. Every wait in the negotiation is
+bounded by it, including the roundtrips.
+
+The `drm_*` tuning knobs pass through unchanged for the egl tier, and
+`IVI_SW_DRM_MODE` / format / dither for the software tier — those describe how to
+drive a connector, which a lease does not change. `IVI_SW_SINK` is **not**
+consulted on the leased software path: the backend key already chose the sink.
+
+Failures are fatal by design. A leased backend that cannot get its lease has
+nothing to fall back to:
+
+```
+[E] [leased-drm] could not acquire a lease: no connectors offered for leasing
+```
+
+## Tests
+
+| Tier | Target | Needs |
+|---|---|---|
+| T1 — protocol, against a mock compositor | `homescreen_lease_client_ut_test_driver` | nothing (private socket in a temp `XDG_RUNTIME_DIR`) |
+| T2 — kernel-real lease | `homescreen_leased_drm_vkms_ut_test_driver` | vkms + DRM master |
+
+T1 covers the negotiation state machine end to end: grant, denial, both
+revocation timings, connector/device selection and its ambiguous and not-found
+variants, the deferred-enumeration deadline, and fd-leak gates (LeakSanitizer
+tracks memory, not descriptors).
+
+T2 makes a genuine lease with `drmModeCreateLease` and feeds it to the real code,
+which is the only way to reach these paths on a desktop — no compositor here will
+offer a connector. It **skips itself** without vkms + DRM master, so it is safe to
+run anywhere.
+
+Getting master for T2 is the awkward part. DRM grants master to the **first
+opener** of a node, and a running compositor takes it: wlroots hot-adds vkms via
+udev when the module loads, so `drmSetMaster` returns `EBUSY` even under root
+(and `EACCES` unprivileged, which misleadingly looks like a permissions problem).
+Run it from a **bare VT with no compositor**, where the test is the first opener
+and gets master implicitly:
+
+```bash
+sudo modprobe vkms
+# switch to a VT with no compositor running
+./homescreen_leased_drm_vkms_ut_test_driver
+```
+
+Alternatively pin the compositor away from vkms (`WLR_DRM_DEVICES`) or create a
+private device via `/sys/kernel/config/vkms`.

--- a/shell/backend/wayland_leased_drm/README.md
+++ b/shell/backend/wayland_leased_drm/README.md
@@ -43,9 +43,22 @@ cannot set it at runtime. Getting a lease from such a host needs one of: an EDID
 that trips the kernel's `EDID_QUIRK_NON_DESKTOP` list (`drm.edid_firmware=`), a
 compositor patch/config, or a compositor built for the job.
 
-Verify before assuming, with the lease client's own read-only path (it stops
-before `create_lease_request`, so it is safe against a live session) or with
-`wayland-info`.
+Ask the binary rather than assuming:
+
+```bash
+homescreen --lease-list-connectors        # no bundle required
+```
+
+It probes read-only (stopping before `create_lease_request`, so it is safe
+against a live session) and prints what the compositor will actually lease. Exit
+codes are scriptable, and separate the two failures that look identical from the
+outside:
+
+| exit | meaning |
+|---|---|
+| 0 | connectors listed |
+| 1 | reached a lease device, but it offers **nothing** — the non-desktop gate above |
+| 2 | no Wayland session, or the compositor has no drm-lease-v1 |
 
 ## Architecture
 

--- a/shell/backend/wayland_leased_drm/lease_client.cc
+++ b/shell/backend/wayland_leased_drm/lease_client.cc
@@ -20,6 +20,7 @@
 
 #include <cerrno>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <deque>
@@ -773,6 +774,97 @@ LeaseClient::Result LeaseClient::Probe(const LeaseConfig& cfg) {
   // kNone means "enumeration succeeded, see offers".
   res.error = res.offers.empty() ? LeaseError::kNoOffers : LeaseError::kNone;
   return res;
+}
+
+namespace {
+
+// Read "--flag=value" or "--flag value" out of argv.
+std::optional<std::string> ArgValue(int argc,
+                                    char** argv,
+                                    std::string_view flag) {
+  const std::string eq = std::string(flag) + "=";
+  for (int i = 1; i < argc; ++i) {
+    const std::string_view a = argv[i];
+    if (a == flag && i + 1 < argc) {
+      return std::string(argv[i + 1]);
+    }
+    if (a.rfind(eq, 0) == 0) {
+      return std::string(a.substr(eq.size()));
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+int MaybeListLeaseConnectors(int argc, char** argv) {
+  bool requested = false;
+  for (int i = 1; i < argc; ++i) {
+    if (std::string_view(argv[i]) == "--lease-list-connectors") {
+      requested = true;
+      break;
+    }
+  }
+  if (!requested) {
+    return -1;
+  }
+
+  LeaseConfig cfg;
+  cfg.device = ArgValue(argc, argv, "--lease-device");
+  if (const auto t = ArgValue(argc, argv, "--lease-timeout-ms")) {
+    const unsigned long ms = std::strtoul(t->c_str(), nullptr, 10);
+    if (ms > 0) {
+      cfg.timeout_ms = static_cast<uint32_t>(ms);
+    }
+  }
+
+  const auto res = LeaseClient::Probe(cfg);
+  if (res.error == LeaseError::kNone) {
+    std::printf("Leasable connectors offered by this compositor:\n");
+    for (const auto& o : res.offers) {
+      std::printf("  %-14s connector_id=%-5u %s\n", o.name.c_str(),
+                  o.connector_id, o.description.c_str());
+    }
+    std::printf(
+        "\nUse: --backend=wayland-leased-drm-egl --lease-connector=<name>\n");
+    return 0;
+  }
+
+  if (res.error == LeaseError::kNoOffers) {
+    // The interesting case, and the reason this tool exists. Say what is
+    // actually wrong -- the compositor is working, its policy is the problem --
+    // rather than leaving the operator to conclude their connector name is
+    // wrong.
+    std::printf(
+        "This compositor implements drm-lease-v1 but offers no connectors.\n"
+        "\n"
+        "That is the normal outcome on a desktop compositor, not a fault: the\n"
+        "wlroots family (Sway, labwc, niri, Wayfire, ...) only offers a\n"
+        "connector for leasing when its EDID carries the non-desktop flag --\n"
+        "the protocol comes from VR headsets. Every ordinary panel is claimed\n"
+        "by the compositor for its own compositing.\n"
+        "\n"
+        "Check with:  drm_info | grep -i non-desktop\n"
+        "A connector reporting non-desktop=0 will not be offered, and the\n"
+        "property is immutable -- it cannot be set at runtime.\n"
+        "\n"
+        "To get a lease you need one of:\n"
+        "  * an EDID that trips the kernel's non-desktop quirk list\n"
+        "    (drm.edid_firmware=<connector>:<file>)\n"
+        "  * a compositor patched or configured to offer desktop connectors\n"
+        "  * a compositor built for leasing\n");
+    return 1;
+  }
+
+  std::printf("No connectors could be listed: %s\n", ToString(res.error));
+  if (res.error == LeaseError::kNoLeaseDevice) {
+    std::printf(
+        "\nThe compositor advertises no wp_drm_lease_device_v1 global. Weston\n"
+        "(and AGL's Weston-derived compositors) do not implement "
+        "drm-lease-v1;\n"
+        "KWin, the wlroots family, Mutter, Hyprland and COSMIC do.\n");
+  }
+  return 2;
 }
 
 LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {

--- a/shell/backend/wayland_leased_drm/lease_client.cc
+++ b/shell/backend/wayland_leased_drm/lease_client.cc
@@ -508,14 +508,14 @@ bool OpenSession(Session& s, Clock::time_point deadline, LeaseError* err) {
     }
     return true;
   };
+  // No roundtrip after this. There used to be one, to "let the connector's own
+  // name/description/connector_id/done events land" -- but that is exactly the
+  // condition all_done blocks on, so by the time it ran nothing was
+  // outstanding and it cost a full sync + poll/read/dispatch cycle of startup
+  // latency, charged against the operator's lease-timeout-ms budget. Waiting on
+  // the predicate is strictly better than waiting a fixed round trip: it is
+  // what we actually need, and it cannot be too short.
   if (!DispatchUntil(s.display, all_done, deadline, &protocol_error)) {
-    *err = protocol_error ? LeaseError::kProtocolError : LeaseError::kTimeout;
-    return false;
-  }
-
-  // Each connector's own name/description/connector_id/done events follow the
-  // device's new_id; one more (bounded) roundtrip lets them land.
-  if (!BoundedRoundtrip(s.display, deadline, &protocol_error)) {
     *err = protocol_error ? LeaseError::kProtocolError : LeaseError::kTimeout;
     return false;
   }
@@ -789,9 +789,21 @@ LeaseClient::Result LeaseClient::Probe(const LeaseConfig& cfg) {
 namespace {
 
 // Read "--flag=value" or "--flag value" out of argv.
+// Read one --flag / --flag=value from argv, falling back to @p env_name.
+//
+// This deliberately does NOT go through Configuration::ParseArgcArgv, which is
+// the obvious objection to it: --lease-list-connectors runs before that parser
+// precisely so it works with no bundle, and the parser fatals ("No views
+// configured") without one -- which would break the tool exactly when it is
+// most needed, before a working config exists. What it must NOT do is disagree
+// with the parser about what the same flags mean, so the precedence here (CLI
+// wins, env fills) mirrors pick_string in configuration.cc. Any lease flag
+// added there needs a line here too, or the diagnostic quietly reports on a
+// different device than the backend will lease from.
 std::optional<std::string> ArgValue(int argc,
                                     char** argv,
-                                    std::string_view flag) {
+                                    std::string_view flag,
+                                    const char* env_name) {
   const std::string eq = std::string(flag) + "=";
   for (int i = 1; i < argc; ++i) {
     const std::string_view a = argv[i];
@@ -800,6 +812,11 @@ std::optional<std::string> ArgValue(int argc,
     }
     if (a.rfind(eq, 0) == 0) {
       return std::string(a.substr(eq.size()));
+    }
+  }
+  if (env_name != nullptr) {
+    if (const char* e = std::getenv(env_name); e != nullptr && *e != '\0') {
+      return std::string(e);
     }
   }
   return std::nullopt;
@@ -820,11 +837,24 @@ int MaybeListLeaseConnectors(int argc, char** argv) {
   }
 
   LeaseConfig cfg;
-  cfg.device = ArgValue(argc, argv, "--lease-device");
-  if (const auto t = ArgValue(argc, argv, "--lease-timeout-ms")) {
-    const unsigned long ms = std::strtoul(t->c_str(), nullptr, 10);
-    if (ms > 0) {
+  cfg.device =
+      ArgValue(argc, argv, "--lease-device", "HOMESCREEN_LEASE_DEVICE");
+  if (const auto t = ArgValue(argc, argv, "--lease-timeout-ms",
+                              "HOMESCREEN_LEASE_TIMEOUT_MS")) {
+    // Validated the way configuration.cc validates it, not with a bare strtoul:
+    // that accepted "5000abc" as 5000 and let a value above uint32 max through
+    // to be truncated. A diagnostic that silently reinterprets the operator's
+    // input is worse than one that refuses it.
+    char* end = nullptr;
+    const unsigned long long ms = std::strtoull(t->c_str(), &end, 10);
+    if (end != t->c_str() && *end == '\0' && ms > 0 &&
+        ms <= std::numeric_limits<uint32_t>::max()) {
       cfg.timeout_ms = static_cast<uint32_t>(ms);
+    } else {
+      std::fprintf(stderr,
+                   "--lease-timeout-ms='%s' must be an integer in 1..%u; using "
+                   "the default\n",
+                   t->c_str(), std::numeric_limits<uint32_t>::max());
     }
   }
 

--- a/shell/backend/wayland_leased_drm/lease_client.cc
+++ b/shell/backend/wayland_leased_drm/lease_client.cc
@@ -597,6 +597,18 @@ void LogOffers(const std::vector<LeaseOffer>& offers) {
 
 }  // namespace
 
+const char* ToString(RevokeCause c) {
+  switch (c) {
+    case RevokeCause::kFinished:
+      return "compositor lost DRM master (VT switch) or connector unplugged";
+    case RevokeCause::kConnectionLost:
+      return "compositor exited or crashed";
+    case RevokeCause::kMonitorFailure:
+      return "lease monitor failed";
+  }
+  return "unknown";
+}
+
 const char* ToString(LeaseError e) {
   switch (e) {
     case LeaseError::kNone:
@@ -633,6 +645,9 @@ const char* ToString(LeaseError e) {
 // protocol header.
 struct LeaseHold::Impl {
   wl_display* display = nullptr;
+  // From LeaseConfig::on_revoked. Read only under the LatchRevoked "once"
+  // guard, and set before the monitor thread starts, so it needs no lock.
+  std::function<void(RevokeCause)> on_revoked;
   std::unique_ptr<Device> device;
   std::unique_ptr<Lease> lease;
   std::thread monitor;
@@ -650,6 +665,42 @@ struct LeaseHold::Impl {
 constexpr int kMonitorFallbackTickMs = 200;
 
 LeaseHold::LeaseHold() : impl_(std::make_unique<Impl>()) {}
+
+void LeaseHold::LatchRevoked(const RevokeCause cause) {
+  // exchange, not store: every discovery path routes through here, and only the
+  // first may log or notify. Without this a connection that dies right after a
+  // `finished` would fire the policy twice.
+  if (revoked_.exchange(true, std::memory_order_acq_rel)) {
+    return;
+  }
+  switch (cause) {
+    case RevokeCause::kFinished:
+      // The protocol cannot say which of the two it was, so say both rather
+      // than guess: the operator actions differ completely.
+      ihs::log::warn(
+          "[leased-drm] lease revoked on connector '{}' (id {}): the "
+          "compositor "
+          "lost DRM master (a VT switch away) or the connector was unplugged. "
+          "Commits are gated from here.",
+          connector_name_, connector_id_);
+      break;
+    case RevokeCause::kConnectionLost:
+      ihs::log::error(
+          "[leased-drm] Wayland connection lost — the compositor exited or "
+          "crashed, so the lease died with its lessor. Connector '{}' (id {}).",
+          connector_name_, connector_id_);
+      break;
+    case RevokeCause::kMonitorFailure:
+      ihs::log::error(
+          "[leased-drm] lease monitor failed on connector '{}' (id {}); the "
+          "lease state is unknown, so it is treated as lost.",
+          connector_name_, connector_id_);
+      break;
+  }
+  if (impl_->on_revoked) {
+    impl_->on_revoked(cause);
+  }
+}
 
 LeaseHold::~LeaseHold() {
   // The monitor is dispatching on the display we are about to tear down, so it
@@ -816,6 +867,7 @@ LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
   // Hand the connection over; Session must not tear it down. Move the leased
   // device across FIRST, then release the rest while the display is still ours.
   hold->impl_->display = s.display;
+  hold->impl_->on_revoked = cfg.on_revoked;
   hold->impl_->lease = std::move(lease);
   for (auto& d : s.devices) {
     if (d.get() == dev) {
@@ -845,11 +897,9 @@ LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
   // fresh dispatch, and a dead lease produces no further events — so latch it
   // here or revoked() would stay false forever against dead KMS objects.
   if (hold->impl_->lease->finished) {
-    ihs::log::warn(
-        "[leased-drm] lease revoked before it could be used (finished arrived "
-        "with lease_fd) on connector '{}' (id {})",
-        hold->connector_name_, hold->connector_id_);
-    hold->revoked_.store(true, std::memory_order_release);
+    // Same dispatch batch as lease_fd — the monitor would never see another
+    // event to re-check on, so latch here, before it even starts.
+    hold->LatchRevoked(RevokeCause::kFinished);
   }
 
   // The event loop must stay alive for the process lifetime to observe
@@ -874,16 +924,7 @@ LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
       // be latched (see the pre-spawn check above), in which case no further
       // event will ever arrive to wake us.
       if (lease_obj->finished) {
-        if (!h->revoked_.exchange(true, std::memory_order_acq_rel)) {
-          // Per spec the causes are hot-unplug or the compositor losing DRM
-          // master (every VT switch away). We cannot tell them apart from this
-          // event alone; WS7 classifies and drives recovery. For now: latch
-          // revoked so renderers stop committing against dead KMS objects.
-          ihs::log::warn(
-              "[leased-drm] lease revoked (wp_drm_lease_v1.finished) on "
-              "connector '{}' (id {}) — commits gated",
-              h->connector_name_, h->connector_id_);
-        }
+        h->LatchRevoked(RevokeCause::kFinished);
         return;
       }
       wl_display_flush(display);
@@ -897,9 +938,8 @@ LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
         if (errno == EINTR) {
           continue;
         }
-        ihs::log::error("[leased-drm] monitor poll failed: {}",
-                        std::strerror(errno));
-        h->revoked_.store(true, std::memory_order_release);
+        ihs::log::error("[leased-drm] monitor poll: {}", std::strerror(errno));
+        h->LatchRevoked(RevokeCause::kMonitorFailure);
         return;
       }
       if (r == 0) {
@@ -912,12 +952,7 @@ LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
         continue;
       }
       if (wl_display_dispatch(display) < 0) {
-        // Connection death: the compositor exited or crashed. The lessor fd is
-        // gone, so the lease is already kernel-dead.
-        ihs::log::error(
-            "[leased-drm] Wayland connection lost — lease is revoked "
-            "(compositor exit/crash)");
-        h->revoked_.store(true, std::memory_order_release);
+        h->LatchRevoked(RevokeCause::kConnectionLost);
         return;
       }
     }

--- a/shell/backend/wayland_leased_drm/lease_client.cc
+++ b/shell/backend/wayland_leased_drm/lease_client.cc
@@ -900,8 +900,19 @@ LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
     return res;
   }
 
+  // Copy the offer NOW, by value. `conn` does not survive the dispatch below:
+  // wlroots withdraws a connector once it has been leased out and re-brackets
+  // the device's list with `done`, and both OnDone and OnConnector run
+  // PruneWithdrawn(), which erases the withdrawn Connector from the deque and
+  // frees it -- while we are still holding this raw pointer. Reading
+  // conn->offer afterwards is a heap-use-after-free (proven under ASan by
+  // ConnectorWithdrawnDuringGrantIsNotAUseAfterFree, which fails at exactly
+  // this read without this copy). Nothing below may dereference `conn` except
+  // GetProxy() before submit, which happens before any dispatch.
+  const LeaseOffer requested = conn->offer;
+
   ihs::log::info("[leased-drm] requesting connector '{}' (id {}) on {}",
-                 conn->offer.name, conn->offer.connector_id,
+                 requested.name, requested.connector_id,
                  dev->card_path.empty() ? "(unresolved)" : dev->card_path);
 
   // create_lease_request -> request_connector -> submit. `submit` destroys the
@@ -958,8 +969,10 @@ LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
   // Take ownership of the fd off the Lease: from here the LeaseHold closes it,
   // and ~Lease must not.
   hold->lease_fd_ = lease->ReleaseFd();
-  hold->connector_id_ = conn->offer.connector_id;
-  hold->connector_name_ = conn->offer.name;
+  // From the copy taken before the dispatch, not from `conn` -- which the
+  // compositor may have had us free by now (see the copy's comment).
+  hold->connector_id_ = requested.connector_id;
+  hold->connector_name_ = requested.name;
   // Derive the node path from the LEASE fd — the fd every renderer will use.
   hold->card_path_ = NodePathFromFd(hold->lease_fd_);
   if (hold->card_path_.empty()) {

--- a/shell/backend/wayland_leased_drm/lease_client.cc
+++ b/shell/backend/wayland_leased_drm/lease_client.cc
@@ -26,6 +26,7 @@
 #include <deque>
 #include <filesystem>
 #include <functional>
+#include <limits>
 #include <string_view>
 #include <system_error>
 #include <thread>
@@ -316,10 +317,19 @@ bool DispatchUntil(wl_display* display,
     const auto ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)
             .count();
+    // Clamp rather than cast. poll() takes an int and treats ANY negative value
+    // as "block forever", so a timeout above INT_MAX ms -- which the config
+    // surface accepts, being uint32_t -- would wrap negative and hang startup
+    // forever: the exact failure the deadline exists to prevent. Clamping caps
+    // one poll() at ~24.9 days; the while-loop re-checks the real deadline, so
+    // a longer timeout still expires correctly, just across more iterations.
+    const int poll_ms = ms > std::numeric_limits<int>::max()
+                            ? std::numeric_limits<int>::max()
+                            : static_cast<int>(ms);
 
     pollfd pfd{wl_display_get_fd(display),
                static_cast<short>(POLLIN | (want_write ? POLLOUT : 0)), 0};
-    const int r = poll(&pfd, 1, static_cast<int>(ms));
+    const int r = poll(&pfd, 1, poll_ms);
     if (r < 0) {
       wl_display_cancel_read(display);
       if (errno == EINTR) {

--- a/shell/backend/wayland_leased_drm/lease_client.cc
+++ b/shell/backend/wayland_leased_drm/lease_client.cc
@@ -173,13 +173,33 @@ class Device : public lease_proto::CWpDrmLeaseDeviceV1<Device> {
     if (id == nullptr) {
       return;
     }
+    // This object is dispatched for the process lifetime, and the compositor
+    // re-advertises leasable connectors on every VT switch back, hot-plug, and
+    // lease return. Without pruning, the deque and its live wl_proxy set would
+    // grow monotonically for days on an IVI unit until the compositor's
+    // per-client object table gives out. Prune here rather than in OnWithdrawn:
+    // that runs *on* the Connector being withdrawn, so destroying it there
+    // would free the object libwayland is currently dispatching into.
+    PruneWithdrawn();
     auto c = std::make_unique<Connector>();
     c->_SetProxy(id);
     connectors.emplace_back(std::move(c));
   }
 
-  void OnDone() override { done = true; }
+  void OnDone() override {
+    done = true;
+    PruneWithdrawn();
+  }
   void OnReleased() override { released = true; }
+
+  // Drop connectors the compositor has withdrawn. ~Connector sends
+  // wp_drm_lease_connector_v1.destroy and drops the proxy, which is the
+  // protocol-hygiene half of this.
+  void PruneWithdrawn() {
+    for (auto it = connectors.begin(); it != connectors.end();) {
+      it = (*it)->withdrawn ? connectors.erase(it) : it + 1;
+    }
+  }
 };
 
 // wp_drm_lease_request_v1 has no events; it exists only to carry
@@ -199,13 +219,35 @@ class Lease : public lease_proto::CWpDrmLeaseV1<Lease> {
   bool finished = false;
 
   ~Lease() override {
+    // The granted fd is ours until ReleaseFd() hands it to the LeaseHold. Close
+    // it otherwise, or any path that drops the Lease after lease_fd arrived --
+    // e.g. a protocol error dispatched in the SAME batch that delivered it --
+    // leaks the master fd outright.
+    CloseFd();
     // wp_drm_lease_v1.destroy IS a destructor request.
     if (GetProxy() != nullptr) {
       Destroy();
     }
   }
 
-  void OnLeaseFd(int32_t fd) override { lease_fd = fd; }
+  void CloseFd() noexcept {
+    if (lease_fd >= 0) {
+      close(lease_fd);
+      lease_fd = -1;
+    }
+  }
+
+  // Hand the fd to the caller; the Lease stops owning it.
+  [[nodiscard]] int ReleaseFd() noexcept { return std::exchange(lease_fd, -1); }
+
+  void OnLeaseFd(int32_t fd) override {
+    // The compositor is untrusted and this object is dispatched for the process
+    // lifetime. A repeat lease_fd (protocol-violating, but nothing stops it)
+    // must not drop the previous fd on the floor -- one leak per event walks
+    // the process to EMFILE. Same rule as Device::OnDrmFd.
+    CloseFd();
+    lease_fd = fd;
+  }
 
   // Either a denial (pre-grant) or a revocation (post-grant, at any time).
   void OnFinished() override { finished = true; }
@@ -436,10 +478,21 @@ bool OpenSession(Session& s, Clock::time_point deadline, LeaseError* err) {
     return false;
   }
 
+  // Gate on every connector's `done` as well as the device's. The device's
+  // `done` only brackets the connector *list*; each connector's own `done`
+  // brackets its name/description/connector_id, and a compositor is free to
+  // defer those (reading EDID is exactly what that event exists to bracket).
+  // Without this we could read an offer with an empty name and connector_id 0,
+  // then report kConnectorNotFound for a connector that was in fact offered.
   const auto all_done = [&s]() {
     for (const auto& d : s.devices) {
       if (!d->done) {
         return false;
+      }
+      for (const auto& c : d->connectors) {
+        if (!c->done && !c->withdrawn) {
+          return false;
+        }
       }
     }
     return true;
@@ -749,11 +802,13 @@ LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
   dev->CloseDrmFd();
 
   auto hold = std::unique_ptr<LeaseHold>(new LeaseHold());
-  hold->lease_fd_ = lease->lease_fd;
+  // Take ownership of the fd off the Lease: from here the LeaseHold closes it,
+  // and ~Lease must not.
+  hold->lease_fd_ = lease->ReleaseFd();
   hold->connector_id_ = conn->offer.connector_id;
   hold->connector_name_ = conn->offer.name;
   // Derive the node path from the LEASE fd — the fd every renderer will use.
-  hold->card_path_ = NodePathFromFd(lease->lease_fd);
+  hold->card_path_ = NodePathFromFd(hold->lease_fd_);
   if (hold->card_path_.empty()) {
     hold->card_path_ = dev->card_path;
   }

--- a/shell/backend/wayland_leased_drm/lease_client.cc
+++ b/shell/backend/wayland_leased_drm/lease_client.cc
@@ -1,0 +1,876 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/wayland_leased_drm/lease_client.h"
+
+#include "logging/logging.h"
+
+#include <cerrno>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <filesystem>
+#include <functional>
+#include <string_view>
+#include <system_error>
+#include <thread>
+#include <utility>
+
+extern "C" {
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include <xf86drm.h>
+}
+
+#include "wayland-protocols/drm_lease_v1_client.hpp"
+
+namespace homescreen {
+namespace {
+
+namespace lease_proto = drm_lease_v1::client;
+using Clock = std::chrono::steady_clock;
+
+// Bound on the wp_drm_lease_device_v1.release -> `released` handshake at
+// teardown. The compositor is required to answer, but teardown must not hang on
+// a wedged one: past this we destroy the proxy unilaterally.
+constexpr int kReleaseDrainMs = 250;
+
+// A live Wayland session = WAYLAND_DISPLAY set AND the socket actually exists
+// (the env var alone can be stale). Mirrors WaylandSessionAvailable() in
+// register_backends.cc; kept local so the lease client does not depend on the
+// registry translation unit. Later, hoist the pair into one shared helper.
+bool WaylandSessionAvailable() {
+  const char* wl = std::getenv("WAYLAND_DISPLAY");
+  if (wl == nullptr || *wl == '\0') {
+    return false;
+  }
+  std::error_code ec;
+  const std::filesystem::path sock(wl);
+  if (sock.is_absolute()) {
+    return std::filesystem::exists(sock, ec);
+  }
+  const char* xdg = std::getenv("XDG_RUNTIME_DIR");
+  if (xdg == nullptr || *xdg == '\0') {
+    return true;  // can't resolve the socket path; trust the env var
+  }
+  return std::filesystem::exists(std::filesystem::path(xdg) / sock, ec);
+}
+
+std::string NodePathFromFd(int fd) {
+  if (fd < 0) {
+    return {};
+  }
+  char* n = drmGetDeviceNameFromFd2(fd);
+  if (n == nullptr) {
+    return {};
+  }
+  std::string out(n);
+  free(n);
+  return out;
+}
+
+// ── proxies ────────────────────────────────────────────────────────────────
+//
+// wl::CProxy is a NON-owning handle and ~CProxyImpl is a defaulted no-op, so
+// every proxy this file creates must be destroyed explicitly. That is not just
+// a leak concern: _SetProxy installs `this` as the dispatcher's
+// `implementation` pointer, so a C++ object outliving its proxy leaves the
+// compositor able to dispatch an event into freed memory. Each class below
+// therefore destroys its own proxy in its destructor, which keeps object and
+// proxy lifetimes welded together no matter which path frees them.
+
+class Connector : public lease_proto::CWpDrmLeaseConnectorV1<Connector> {
+ public:
+  LeaseOffer offer;
+  bool done = false;
+  bool withdrawn = false;
+
+  ~Connector() override { DestroyProxy(); }
+
+  // wp_drm_lease_connector_v1.destroy IS a destructor request, so the generated
+  // Destroy() marshals it and destroys the proxy. Detach() then yields null
+  // here, making this idempotent.
+  void DestroyProxy() noexcept {
+    if (GetProxy() != nullptr) {
+      Destroy();
+    }
+  }
+
+  void OnName(const char* v) override { offer.name = v != nullptr ? v : ""; }
+  void OnDescription(const char* v) override {
+    offer.description = v != nullptr ? v : "";
+  }
+  void OnConnectorId(uint32_t v) override { offer.connector_id = v; }
+  void OnDone() override { done = true; }
+
+  // Post-grant this does NOT revoke: the spec states the lease status is
+  // unchanged and the client should merely destroy the object. Pre-grant it
+  // means the offer evaporated before we could request it.
+  void OnWithdrawn() override { withdrawn = true; }
+};
+
+class Device : public lease_proto::CWpDrmLeaseDeviceV1<Device> {
+ public:
+  uint32_t global_name = 0;
+  int drm_fd = -1;  // enumeration-only, NON-master; owned by us once dispatched
+  std::string card_path;
+  bool done = false;
+  bool released = false;
+
+  std::deque<std::unique_ptr<Connector>> connectors;
+
+  ~Device() override {
+    CloseDrmFd();
+    // Children first: their proxies are independent objects, and dropping them
+    // before the device keeps the teardown order obvious.
+    connectors.clear();
+    DestroyProxy();
+  }
+
+  void CloseDrmFd() noexcept {
+    if (drm_fd >= 0) {
+      close(drm_fd);
+      drm_fd = -1;
+    }
+  }
+
+  // Unlike the connector, wp_drm_lease_device_v1.release is NOT a destructor
+  // request (only the `released` event is), so the generated Release() marshals
+  // without destroying anything. Callers should prefer ReleaseAndDestroy();
+  // this is the unilateral fallback.
+  void DestroyProxy() noexcept {
+    if (wl_proxy* p = Detach()) {
+      wl_proxy_destroy(p);
+    }
+  }
+
+  void OnDrmFd(int32_t fd) override {
+    // The protocol permits repeat drm_fd events (e.g. after the compositor
+    // regains DRM master); each supersedes the last, so close the old one
+    // rather than dropping it on the floor.
+    CloseDrmFd();
+    drm_fd = fd;
+    card_path = NodePathFromFd(fd);
+  }
+
+  void OnConnector(wl_proxy* id) override {
+    if (id == nullptr) {
+      return;
+    }
+    auto c = std::make_unique<Connector>();
+    c->_SetProxy(id);
+    connectors.emplace_back(std::move(c));
+  }
+
+  void OnDone() override { done = true; }
+  void OnReleased() override { released = true; }
+};
+
+// wp_drm_lease_request_v1 has no events; it exists only to carry
+// request_connector + submit.
+class Request : public lease_proto::CWpDrmLeaseRequestV1<Request> {
+ public:
+  ~Request() override {
+    if (wl_proxy* p = Detach()) {
+      wl_proxy_destroy(p);
+    }
+  }
+};
+
+class Lease : public lease_proto::CWpDrmLeaseV1<Lease> {
+ public:
+  int lease_fd = -1;
+  bool finished = false;
+
+  ~Lease() override {
+    // wp_drm_lease_v1.destroy IS a destructor request.
+    if (GetProxy() != nullptr) {
+      Destroy();
+    }
+  }
+
+  void OnLeaseFd(int32_t fd) override { lease_fd = fd; }
+
+  // Either a denial (pre-grant) or a revocation (post-grant, at any time).
+  void OnFinished() override { finished = true; }
+};
+
+// The registry listener must outlive the registry proxy, so it has static
+// storage and its user_data points at a Session field — never at a stack local.
+struct RegistryScan {
+  struct Found {
+    uint32_t name;
+    uint32_t version;
+  };
+  std::vector<Found> found;
+};
+
+const wl_registry_listener kRegistryListener = {
+    [](void* ud, wl_registry*, uint32_t name, const char* iface, uint32_t ver) {
+      if (std::string_view(iface) ==
+          lease_proto::wp_drm_lease_device_v1_traits::interface_name) {
+        static_cast<RegistryScan*>(ud)->found.push_back({name, ver});
+      }
+    },
+    [](void*, wl_registry*, uint32_t) {},
+};
+
+// Dispatch until `pred` holds or the deadline passes. Returns false on timeout
+// or connection error. Uses poll() rather than wl_display_dispatch() so the
+// deadline is actually enforced — a bare dispatch would block indefinitely
+// against a compositor that has deferred drm_fd while it lacks DRM master.
+bool DispatchUntil(wl_display* display,
+                   const std::function<bool()>& pred,
+                   Clock::time_point deadline,
+                   bool* protocol_error) {
+  while (!pred()) {
+    while (wl_display_prepare_read(display) != 0) {
+      if (wl_display_dispatch_pending(display) < 0) {
+        *protocol_error = true;
+        return false;
+      }
+      if (pred()) {
+        return true;
+      }
+    }
+    // Read lock held from here: every exit below must read or cancel.
+
+    // A short write (EAGAIN) leaves requests queued. Poll for writability so we
+    // can flush the remainder — without POLLOUT the loop would never learn the
+    // socket drained and would stall to the deadline with `submit` unsent.
+    bool want_write = false;
+    if (wl_display_flush(display) < 0) {
+      if (errno == EAGAIN) {
+        want_write = true;
+      } else {
+        wl_display_cancel_read(display);
+        *protocol_error = true;
+        return false;
+      }
+    }
+
+    const auto now = Clock::now();
+    if (now >= deadline) {
+      wl_display_cancel_read(display);
+      return false;
+    }
+    const auto ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)
+            .count();
+
+    pollfd pfd{wl_display_get_fd(display),
+               static_cast<short>(POLLIN | (want_write ? POLLOUT : 0)), 0};
+    const int r = poll(&pfd, 1, static_cast<int>(ms));
+    if (r < 0) {
+      wl_display_cancel_read(display);
+      if (errno == EINTR) {
+        continue;
+      }
+      *protocol_error = true;
+      return false;
+    }
+    if (r == 0) {  // deadline expired
+      wl_display_cancel_read(display);
+      return false;
+    }
+    if ((pfd.revents & POLLIN) != 0) {
+      if (wl_display_read_events(display) < 0) {
+        *protocol_error = true;
+        return false;
+      }
+      if (wl_display_dispatch_pending(display) < 0) {
+        *protocol_error = true;
+        return false;
+      }
+      continue;
+    }
+    // No data to read.
+    wl_display_cancel_read(display);
+    if ((pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+      *protocol_error = true;
+      return false;
+    }
+    // POLLOUT only: loop round to re-flush the queued requests.
+  }
+  return true;
+}
+
+// Deadline-bounded wl_display_roundtrip. The stock roundtrip blocks forever,
+// which would defeat LeaseConfig::timeout_ms against a frozen compositor.
+bool BoundedRoundtrip(wl_display* display,
+                      Clock::time_point deadline,
+                      bool* protocol_error) {
+  wl_callback* cb = wl_display_sync(display);
+  if (cb == nullptr) {
+    *protocol_error = true;
+    return false;
+  }
+  bool done = false;
+  static const wl_callback_listener listener = {
+      [](void* ud, wl_callback*, uint32_t) { *static_cast<bool*>(ud) = true; },
+  };
+  wl_callback_add_listener(cb, &listener, &done);
+
+  const bool ok = DispatchUntil(
+      display, [&done]() { return done; }, deadline, protocol_error);
+  wl_callback_destroy(cb);
+  return ok;
+}
+
+// Connect, bind every advertised lease device, and let the initial enumeration
+// burst land. Owns the connection until a caller takes it over.
+struct Session {
+  wl_display* display = nullptr;
+  wl_registry* registry = nullptr;
+  RegistryScan scan;
+  std::deque<std::unique_ptr<Device>> devices;
+
+  // Destroy the registry as soon as enumeration is done: its listener's
+  // user_data points into this Session, so the proxy must never outlive it.
+  // Nothing post-negotiation needs registry events — revocation arrives on
+  // wp_drm_lease_v1.finished. Reacquire re-obtains one to see
+  // connector re-offers.
+  void CloseRegistry() {
+    if (registry != nullptr) {
+      wl_registry_destroy(registry);
+      registry = nullptr;
+    }
+  }
+
+  ~Session() {
+    CloseRegistry();
+    // Device/Connector destructors close the enumeration fd and destroy their
+    // proxies, so every error path is covered without per-path cleanup.
+    devices.clear();
+    if (display != nullptr) {
+      wl_display_disconnect(display);
+    }
+  }
+};
+
+// Politely hand a device back: release -> drain until `released` -> destroy.
+// Falls back to destroying the proxy outright if the compositor doesn't answer,
+// so this can never hang or leave a live dispatcher on a dying object.
+void ReleaseAndDestroy(Device& dev, wl_display* display) {
+  if (dev.GetProxy() == nullptr) {
+    return;
+  }
+  // Connectors belong to the device; drop them before releasing it.
+  dev.connectors.clear();
+  dev.CloseDrmFd();
+
+  dev.Release();
+  bool protocol_error = false;
+  const auto deadline =
+      Clock::now() + std::chrono::milliseconds(kReleaseDrainMs);
+  if (!DispatchUntil(
+          display, [&dev]() { return dev.released; }, deadline,
+          &protocol_error)) {
+    ihs::log::debug(
+        "[leased-drm] no `released` from compositor within {} ms; destroying "
+        "the device proxy anyway",
+        kReleaseDrainMs);
+  }
+  dev.DestroyProxy();
+}
+
+bool OpenSession(Session& s, Clock::time_point deadline, LeaseError* err) {
+  if (!WaylandSessionAvailable()) {
+    *err = LeaseError::kNoWaylandSession;
+    return false;
+  }
+  s.display = wl_display_connect(nullptr);
+  if (s.display == nullptr) {
+    *err = LeaseError::kConnectFailed;
+    return false;
+  }
+
+  s.registry = wl_display_get_registry(s.display);
+  wl_registry_add_listener(s.registry, &kRegistryListener, &s.scan);
+
+  // A failed roundtrip means the connection died — reporting that as
+  // kNoLeaseDevice would tell the operator to add compositor support that is
+  // already present, so surface it as the protocol error it is.
+  bool protocol_error = false;
+  if (!BoundedRoundtrip(s.display, deadline, &protocol_error)) {
+    *err = protocol_error ? LeaseError::kProtocolError : LeaseError::kTimeout;
+    return false;
+  }
+
+  if (s.scan.found.empty()) {
+    *err = LeaseError::kNoLeaseDevice;
+    return false;
+  }
+
+  // One global per DRM node — bind them all, then select (multi-GPU).
+  for (const auto& f : s.scan.found) {
+    auto* proxy = static_cast<wl_proxy*>(wl_registry_bind(
+        s.registry, f.name,
+        &lease_proto::wp_drm_lease_device_v1_traits::wl_iface(), 1));
+    if (proxy == nullptr) {
+      continue;
+    }
+    auto d = std::make_unique<Device>();
+    d->global_name = f.name;
+    d->_SetProxy(proxy);
+    s.devices.emplace_back(std::move(d));
+  }
+  if (s.devices.empty()) {
+    *err = LeaseError::kNoLeaseDevice;
+    return false;
+  }
+
+  const auto all_done = [&s]() {
+    for (const auto& d : s.devices) {
+      if (!d->done) {
+        return false;
+      }
+    }
+    return true;
+  };
+  if (!DispatchUntil(s.display, all_done, deadline, &protocol_error)) {
+    *err = protocol_error ? LeaseError::kProtocolError : LeaseError::kTimeout;
+    return false;
+  }
+
+  // Each connector's own name/description/connector_id/done events follow the
+  // device's new_id; one more (bounded) roundtrip lets them land.
+  if (!BoundedRoundtrip(s.display, deadline, &protocol_error)) {
+    *err = protocol_error ? LeaseError::kProtocolError : LeaseError::kTimeout;
+    return false;
+  }
+
+  *err = LeaseError::kNone;
+  return true;
+}
+
+std::vector<LeaseOffer> CollectOffers(const Session& s) {
+  std::vector<LeaseOffer> out;
+  for (const auto& d : s.devices) {
+    for (const auto& c : d->connectors) {
+      if (!c->withdrawn) {
+        out.push_back(c->offer);
+      }
+    }
+  }
+  return out;
+}
+
+// Either a decimal index into the advertised order, or a DRM node path matched
+// against the path derived from each device's enumeration drm_fd.
+Device* SelectDevice(const Session& s,
+                     const LeaseConfig& cfg,
+                     LeaseError* err) {
+  if (!cfg.device.has_value()) {
+    if (s.devices.size() == 1) {
+      return s.devices.front().get();
+    }
+    *err = LeaseError::kDeviceAmbiguous;
+    return nullptr;
+  }
+  const std::string& want = *cfg.device;
+
+  if (!want.empty() &&
+      want.find_first_not_of("0123456789") == std::string::npos) {
+    const auto idx =
+        static_cast<size_t>(std::strtoul(want.c_str(), nullptr, 10));
+    if (idx < s.devices.size()) {
+      return s.devices[idx].get();
+    }
+    *err = LeaseError::kDeviceNotFound;
+    return nullptr;
+  }
+
+  for (const auto& d : s.devices) {
+    if (!d->card_path.empty() && d->card_path == want) {
+      return d.get();
+    }
+  }
+  *err = LeaseError::kDeviceNotFound;
+  return nullptr;
+}
+
+Connector* SelectConnector(const Device& dev,
+                           const LeaseConfig& cfg,
+                           LeaseError* err) {
+  std::vector<Connector*> live;
+  for (const auto& c : dev.connectors) {
+    if (!c->withdrawn) {
+      live.push_back(c.get());
+    }
+  }
+  if (live.empty()) {
+    *err = LeaseError::kNoOffers;
+    return nullptr;
+  }
+  if (!cfg.connector.has_value()) {
+    if (live.size() == 1) {
+      return live.front();
+    }
+    *err = LeaseError::kConnectorAmbiguous;
+    return nullptr;
+  }
+  for (auto* c : live) {
+    if (c->offer.name == *cfg.connector) {
+      return c;
+    }
+  }
+  *err = LeaseError::kConnectorNotFound;
+  return nullptr;
+}
+
+void LogOffers(const std::vector<LeaseOffer>& offers) {
+  for (const auto& o : offers) {
+    ihs::log::info("[leased-drm]   offer: {} (connector_id {}) — {}", o.name,
+                   o.connector_id, o.description);
+  }
+}
+
+}  // namespace
+
+const char* ToString(LeaseError e) {
+  switch (e) {
+    case LeaseError::kNone:
+      return "ok";
+    case LeaseError::kNoWaylandSession:
+      return "no Wayland session";
+    case LeaseError::kConnectFailed:
+      return "wl_display_connect failed";
+    case LeaseError::kNoLeaseDevice:
+      return "compositor does not implement drm-lease-v1";
+    case LeaseError::kDeviceAmbiguous:
+      return "several lease devices advertised and none selected";
+    case LeaseError::kDeviceNotFound:
+      return "configured lease device not found";
+    case LeaseError::kNoOffers:
+      return "no connectors offered for leasing";
+    case LeaseError::kConnectorAmbiguous:
+      return "several connectors offered and none selected";
+    case LeaseError::kConnectorNotFound:
+      return "configured connector not offered";
+    case LeaseError::kDenied:
+      return "compositor denied the lease";
+    case LeaseError::kTimeout:
+      return "timed out negotiating the lease";
+    case LeaseError::kProtocolError:
+      return "Wayland protocol error";
+  }
+  return "unknown";
+}
+
+// ── LeaseHold ──────────────────────────────────────────────────────────────
+
+// Behind a pimpl so the header stays free of wayland-client.h and the generated
+// protocol header.
+struct LeaseHold::Impl {
+  wl_display* display = nullptr;
+  std::unique_ptr<Device> device;
+  std::unique_ptr<Lease> lease;
+  std::thread monitor;
+
+  // Teardown signal. `stop` is authoritative; stop_fd is only the wake-up
+  // mechanism that gets the monitor out of a blocking poll() promptly. If
+  // eventfd() fails we fall back to a polling tick, so teardown can never
+  // depend on the fd having been created — otherwise join() would hang forever.
+  std::atomic<bool> stop{false};
+  int stop_fd = -1;
+};
+
+// Poll tick used only when eventfd() was unavailable, so the monitor still
+// notices `stop` within a bounded time.
+constexpr int kMonitorFallbackTickMs = 200;
+
+LeaseHold::LeaseHold() : impl_(std::make_unique<Impl>()) {}
+
+LeaseHold::~LeaseHold() {
+  // The monitor is dispatching on the display we are about to tear down, so it
+  // must be stopped and joined first. Everything after this runs
+  // single-threaded.
+  if (impl_->monitor.joinable()) {
+    impl_->stop.store(true, std::memory_order_release);
+    if (impl_->stop_fd >= 0) {
+      const uint64_t one = 1;
+      [[maybe_unused]] const ssize_t w =
+          write(impl_->stop_fd, &one, sizeof(one));
+    }
+    impl_->monitor.join();
+  }
+  if (impl_->stop_fd >= 0) {
+    close(impl_->stop_fd);
+    impl_->stop_fd = -1;
+  }
+
+  // Teardown is destroy + close, NOT drmDropMaster: the lease fd is master over
+  // its object set by construction and the compositor is the lessor. Destroying
+  // the lease object is what tells it to drmModeRevokeLease and re-advertise
+  // the connector.
+  impl_->lease.reset();  // ~Lease sends destroy and drops the proxy
+  if (lease_fd_ >= 0) {
+    close(lease_fd_);
+    lease_fd_ = -1;
+  }
+  if (impl_->device && impl_->display != nullptr) {
+    ReleaseAndDestroy(*impl_->device, impl_->display);
+  }
+  impl_->device.reset();
+  if (impl_->display != nullptr) {
+    wl_display_flush(impl_->display);
+    wl_display_disconnect(impl_->display);
+    impl_->display = nullptr;
+  }
+}
+
+// ── LeaseClient ────────────────────────────────────────────────────────────
+
+LeaseClient::Result LeaseClient::Probe(const LeaseConfig& cfg) {
+  Result res;
+  Session s;
+  const auto deadline =
+      Clock::now() + std::chrono::milliseconds(cfg.timeout_ms);
+
+  if (!OpenSession(s, deadline, &res.error)) {
+    return res;
+  }
+  s.CloseRegistry();
+
+  res.offers = CollectOffers(s);
+  for (const auto& d : s.devices) {
+    ihs::log::info("[leased-drm] device[{}] node={} connectors={}",
+                   d->global_name,
+                   d->card_path.empty() ? "(unresolved)" : d->card_path,
+                   d->connectors.size());
+  }
+  LogOffers(res.offers);
+
+  // Hand every device back politely — a probe must leave the compositor's view
+  // exactly as it found it. ~Session would destroy the proxies regardless, but
+  // without the release handshake.
+  for (const auto& d : s.devices) {
+    ReleaseAndDestroy(*d, s.display);
+  }
+
+  // Probe never negotiates, so `hold` is always null and cannot signal success;
+  // kNone means "enumeration succeeded, see offers".
+  res.error = res.offers.empty() ? LeaseError::kNoOffers : LeaseError::kNone;
+  return res;
+}
+
+LeaseClient::Result LeaseClient::Acquire(const LeaseConfig& cfg) {
+  Result res;
+  Session s;
+  const auto deadline =
+      Clock::now() + std::chrono::milliseconds(cfg.timeout_ms);
+
+  if (!OpenSession(s, deadline, &res.error)) {
+    return res;
+  }
+  s.CloseRegistry();
+  res.offers = CollectOffers(s);
+
+  Device* dev = SelectDevice(s, cfg, &res.error);
+  if (dev == nullptr) {
+    LogOffers(res.offers);
+    return res;
+  }
+  Connector* conn = SelectConnector(*dev, cfg, &res.error);
+  if (conn == nullptr) {
+    LogOffers(res.offers);
+    return res;
+  }
+
+  ihs::log::info("[leased-drm] requesting connector '{}' (id {}) on {}",
+                 conn->offer.name, conn->offer.connector_id,
+                 dev->card_path.empty() ? "(unresolved)" : dev->card_path);
+
+  // create_lease_request -> request_connector -> submit. `submit` destroys the
+  // request object, so nothing may be sent on it afterwards. The requested set
+  // is only a suggestion: the compositor picks the final object set.
+  auto* req_proxy = wl::construct<
+      lease_proto::wp_drm_lease_request_v1_traits,
+      lease_proto::wp_drm_lease_device_v1_traits::Op::CreateLeaseRequest>(*dev);
+  if (req_proxy == nullptr) {
+    res.error = LeaseError::kProtocolError;
+    return res;
+  }
+  auto lease = std::make_unique<Lease>();
+  {
+    Request request;
+    // Attach, not _SetProxy: wp_drm_lease_request_v1 declares no events, so the
+    // generated class has no _Dispatch to install a dispatcher for.
+    request.Attach(req_proxy);
+    request.RequestConnector(conn->GetProxy());
+
+    auto* lease_proxy =
+        wl::construct<lease_proto::wp_drm_lease_v1_traits,
+                      lease_proto::wp_drm_lease_request_v1_traits::Op::Submit>(
+            request);
+    // submit consumed the request server-side; ~Request drops our proxy so it
+    // can't be reused (sending on it would be a protocol error).
+    if (lease_proxy == nullptr) {
+      res.error = LeaseError::kProtocolError;
+      return res;
+    }
+    lease->_SetProxy(lease_proxy);
+  }
+
+  // Terminal states: lease_fd (granted) or finished (denied).
+  bool protocol_error = false;
+  const auto settled = [&lease]() {
+    return lease->lease_fd >= 0 || lease->finished;
+  };
+  if (!DispatchUntil(s.display, settled, deadline, &protocol_error)) {
+    res.error =
+        protocol_error ? LeaseError::kProtocolError : LeaseError::kTimeout;
+    return res;
+  }
+  if (lease->lease_fd < 0) {
+    res.error = LeaseError::kDenied;
+    return res;
+  }
+
+  // Granted. The enumeration fd has served its purpose — the lease fd is the
+  // master one from here on.
+  dev->CloseDrmFd();
+
+  auto hold = std::unique_ptr<LeaseHold>(new LeaseHold());
+  hold->lease_fd_ = lease->lease_fd;
+  hold->connector_id_ = conn->offer.connector_id;
+  hold->connector_name_ = conn->offer.name;
+  // Derive the node path from the LEASE fd — the fd every renderer will use.
+  hold->card_path_ = NodePathFromFd(lease->lease_fd);
+  if (hold->card_path_.empty()) {
+    hold->card_path_ = dev->card_path;
+  }
+
+  // Hand the connection over; Session must not tear it down. Move the leased
+  // device across FIRST, then release the rest while the display is still ours.
+  hold->impl_->display = s.display;
+  hold->impl_->lease = std::move(lease);
+  for (auto& d : s.devices) {
+    if (d.get() == dev) {
+      hold->impl_->device = std::move(d);
+      break;
+    }
+  }
+  // Devices we did not lease from: hand them back properly. This must destroy
+  // their proxies, not merely free the C++ objects — the display now lives on
+  // the monitor thread, and a surviving proxy would dispatch `released` into
+  // freed memory.
+  for (auto& d : s.devices) {
+    if (d) {
+      ReleaseAndDestroy(*d, s.display);
+    }
+  }
+  s.devices.clear();
+  s.display = nullptr;
+
+  ihs::log::info(
+      "[leased-drm] lease granted: connector '{}' (id {}) fd={} node={}",
+      hold->connector_name_, hold->connector_id_, hold->lease_fd_,
+      hold->card_path_.empty() ? "(unresolved)" : hold->card_path_);
+
+  // `finished` may already have landed in the same dispatch batch as lease_fd
+  // (a VT switch arriving during startup). The monitor only re-reads it after a
+  // fresh dispatch, and a dead lease produces no further events — so latch it
+  // here or revoked() would stay false forever against dead KMS objects.
+  if (hold->impl_->lease->finished) {
+    ihs::log::warn(
+        "[leased-drm] lease revoked before it could be used (finished arrived "
+        "with lease_fd) on connector '{}' (id {})",
+        hold->connector_name_, hold->connector_id_);
+    hold->revoked_.store(true, std::memory_order_release);
+  }
+
+  // The event loop must stay alive for the process lifetime to observe
+  // `finished` — every VT switch away from the compositor is a revoke.
+  hold->impl_->stop_fd = eventfd(0, EFD_CLOEXEC);
+  LeaseHold* h = hold.get();
+  hold->impl_->monitor = std::thread([h]() {
+    wl_display* display = h->impl_->display;
+    Lease* lease_obj = h->impl_->lease.get();
+    const int stop_fd = h->impl_->stop_fd;
+
+    // Block indefinitely when the eventfd can wake us; otherwise tick so `stop`
+    // is still observed promptly.
+    const int poll_timeout = stop_fd >= 0 ? -1 : kMonitorFallbackTickMs;
+    const nfds_t nfds = stop_fd >= 0 ? 2 : 1;
+
+    for (;;) {
+      if (h->impl_->stop.load(std::memory_order_acquire)) {
+        return;  // orderly teardown
+      }
+      // Check before polling, not only after a dispatch: `finished` may already
+      // be latched (see the pre-spawn check above), in which case no further
+      // event will ever arrive to wake us.
+      if (lease_obj->finished) {
+        if (!h->revoked_.exchange(true, std::memory_order_acq_rel)) {
+          // Per spec the causes are hot-unplug or the compositor losing DRM
+          // master (every VT switch away). We cannot tell them apart from this
+          // event alone; WS7 classifies and drives recovery. For now: latch
+          // revoked so renderers stop committing against dead KMS objects.
+          ihs::log::warn(
+              "[leased-drm] lease revoked (wp_drm_lease_v1.finished) on "
+              "connector '{}' (id {}) — commits gated",
+              h->connector_name_, h->connector_id_);
+        }
+        return;
+      }
+      wl_display_flush(display);
+
+      pollfd pfds[2] = {
+          {wl_display_get_fd(display), POLLIN, 0},
+          {stop_fd, POLLIN, 0},
+      };
+      const int r = poll(pfds, nfds, poll_timeout);
+      if (r < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        ihs::log::error("[leased-drm] monitor poll failed: {}",
+                        std::strerror(errno));
+        h->revoked_.store(true, std::memory_order_release);
+        return;
+      }
+      if (r == 0) {
+        continue;  // fallback tick — re-check `stop` / `finished`
+      }
+      if (stop_fd >= 0 && (pfds[1].revents & POLLIN) != 0) {
+        return;  // orderly teardown
+      }
+      if ((pfds[0].revents & (POLLIN | POLLERR | POLLHUP)) == 0) {
+        continue;
+      }
+      if (wl_display_dispatch(display) < 0) {
+        // Connection death: the compositor exited or crashed. The lessor fd is
+        // gone, so the lease is already kernel-dead.
+        ihs::log::error(
+            "[leased-drm] Wayland connection lost — lease is revoked "
+            "(compositor exit/crash)");
+        h->revoked_.store(true, std::memory_order_release);
+        return;
+      }
+    }
+  });
+
+  res.error = LeaseError::kNone;
+  res.hold = std::move(hold);
+  return res;
+}
+
+}  // namespace homescreen

--- a/shell/backend/wayland_leased_drm/lease_client.h
+++ b/shell/backend/wayland_leased_drm/lease_client.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -42,6 +43,26 @@ struct LeaseOffer {
                             // restarts on the same boot
 };
 
+// Why a lease ended. Distinct because they demand different operator actions:
+// master-loss is routine and self-healing on VT return, a
+// hot-unplug needs someone to plug the panel back in, and a dead compositor is
+// a supervision problem.
+enum class RevokeCause {
+  // wp_drm_lease_v1.finished. The spec's causes are the compositor losing DRM
+  // master — i.e. every VT switch away, the common case — or a hot-unplug. The
+  // protocol carries no way to tell them apart; the connector's `withdrawn`
+  // event hints at unplug but is not sent for master-loss.
+  kFinished,
+  // The wl_display died: the compositor exited or crashed. The lessor's fd went
+  // with it, so the lease is already kernel-dead.
+  kConnectionLost,
+  // The monitor thread itself failed (poll error). Not a protocol event; the
+  // lease's true state is unknown, so it is treated as lost.
+  kMonitorFailure,
+};
+
+const char* ToString(RevokeCause c);
+
 struct LeaseConfig {
   // Selects the wp_drm_lease_device_v1 global when several are advertised (one
   // per DRM node). Either a decimal index into the advertised order, or a DRM
@@ -58,6 +79,21 @@ struct LeaseConfig {
   // compositor defer `drm_fd` until it regains DRM master, so without a
   // deadline a VT-switched-away compositor would hang startup indefinitely.
   uint32_t timeout_ms{5000};
+
+  // Called exactly once, when the lease is first observed revoked. Runs on the
+  // monitor thread — or inline on the caller's thread from Acquire() itself, if
+  // `finished` arrived in the same dispatch batch as `lease_fd`. It must be
+  // cheap and must not block: the monitor thread is what teardown joins.
+  //
+  // Passed here rather than set on the LeaseHold afterwards because Acquire()
+  // spawns the monitor before it returns — a setter would race the very first
+  // revocation, which is precisely the case worth handling.
+  //
+  // Null = latch revoked() and nothing else. The renderers' gates still fire,
+  // so the display stops updating and stays that way. That is a deliberate
+  // choice
+  // (`gate`), not a default to fall into: see the exit policy below.
+  std::function<void(RevokeCause)> on_revoked;
 };
 
 // Why a negotiation attempt ended without a lease. Distinct causes because they
@@ -120,6 +156,12 @@ class LeaseHold {
   struct Impl;
 
   LeaseHold();
+
+  // Latch revoked() and, the first time only, log the cause and run the
+  // LeaseConfig::on_revoked handler. Idempotent and safe from either the
+  // monitor thread or Acquire()'s own thread; every path that discovers a dead
+  // lease goes through here so the "once" and the logging cannot drift apart.
+  void LatchRevoked(RevokeCause cause);
 
   std::unique_ptr<Impl> impl_;
   int lease_fd_{-1};

--- a/shell/backend/wayland_leased_drm/lease_client.h
+++ b/shell/backend/wayland_leased_drm/lease_client.h
@@ -197,4 +197,21 @@ class LeaseClient {
   static Result Probe(const LeaseConfig& cfg);
 };
 
+// --lease-list-connectors handler. Scans @p argv; if the flag is absent returns
+// -1 and the caller carries on. Otherwise probes the compositor, prints what it
+// offers, and returns a process exit code.
+//
+// Takes raw argv rather than a Configuration because it must run before config
+// parsing: this is the tool you reach for when a leased backend will not start,
+// and it cannot require the bundle that the failing launch was trying to load.
+// It reads --lease-device and --lease-timeout-ms off argv for the same reason.
+//
+// Exit codes are meant to be scriptable, so "reached the compositor and it
+// offers nothing" is distinct from "no compositor" — on a wlroots host the
+// former is the normal outcome and the interesting one:
+//   0 — offers listed
+//   1 — reached a lease device, but zero connectors are offered
+//   2 — no Wayland session, or the compositor does not implement drm-lease-v1
+int MaybeListLeaseConnectors(int argc, char** argv);
+
 }  // namespace homescreen

--- a/shell/backend/wayland_leased_drm/lease_client.h
+++ b/shell/backend/wayland_leased_drm/lease_client.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace homescreen {
+
+// drm-lease-v1 client for the wayland-leased-drm backend family.
+//
+// The Wayland connection here is used ONLY to negotiate a DRM lease and to
+// watch for its revocation — this client never creates a wl_surface and takes
+// no input from the compositor (evdev does that). Negotiation is synchronous
+// with a deadline on the caller's thread; once granted, the wl_display moves to
+// a monitor thread that lives for the process lifetime so `finished` and
+// `withdrawn` are always observed.
+
+// A connector the compositor has advertised as available for leasing.
+struct LeaseOffer {
+  std::string name;  // e.g. "HDMI-A-1"; stable within a compositor session
+  std::string description;  // human-readable, from EDID
+  uint32_t connector_id{};  // kernel mode-object id; stable across compositor
+                            // restarts on the same boot
+};
+
+struct LeaseConfig {
+  // Selects the wp_drm_lease_device_v1 global when several are advertised (one
+  // per DRM node). Either a decimal index into the advertised order, or a DRM
+  // node path ("/dev/dri/card1") matched against the path derived from each
+  // device's enumeration drm_fd. Unset = the sole device; ambiguous + unset is
+  // a hard error.
+  std::optional<std::string> device;
+
+  // Connector to request, by name. Unset + exactly one offer = take it;
+  // unset + several offers is a hard error that lists what was offered.
+  std::optional<std::string> connector;
+
+  // Wall-clock bound on the whole negotiation. Load-bearing: the spec lets a
+  // compositor defer `drm_fd` until it regains DRM master, so without a
+  // deadline a VT-switched-away compositor would hang startup indefinitely.
+  uint32_t timeout_ms{5000};
+};
+
+// Why a negotiation attempt ended without a lease. Distinct causes because they
+// demand different operator actions.
+enum class LeaseError {
+  kNone,  // no error — see Result::error for what this means per call
+  kNoWaylandSession,    // WAYLAND_DISPLAY unset, or the socket doesn't exist
+  kConnectFailed,       // socket exists but wl_display_connect failed
+  kNoLeaseDevice,       // compositor does not implement drm-lease-v1
+  kDeviceAmbiguous,     // several devices advertised, none selected
+  kDeviceNotFound,      // the configured device index/path matched nothing
+  kNoOffers,            // device enumerated, but advertised zero connectors
+  kConnectorAmbiguous,  // several offers, none selected
+  kConnectorNotFound,   // the configured connector name matched no offer
+  kDenied,              // compositor sent `finished` instead of `lease_fd`
+  kTimeout,             // deadline hit before a terminal event
+  kProtocolError,       // wl_display error / EPIPE during negotiation
+};
+
+const char* ToString(LeaseError e);
+
+// A granted lease: the master fd plus the live Wayland connection that backs
+// it. Owning this object is what keeps the lease alive — destroying it sends
+// wp_drm_lease_v1.destroy, letting the compositor revoke and re-advertise the
+// connector.
+//
+// The monitor thread must outlive every backend built on the lease fd, so the
+// display in every family owns the LeaseHold.
+class LeaseHold {
+ public:
+  ~LeaseHold();
+
+  LeaseHold(const LeaseHold&) = delete;
+  LeaseHold& operator=(const LeaseHold&) = delete;
+
+  // DRM master fd over exactly the leased object set. The kernel filters this
+  // fd's resource view, so drmModeGetResources() on it returns only leased
+  // objects. Stays valid (as a render fd) even after revocation.
+  [[nodiscard]] int fd() const noexcept { return lease_fd_; }
+
+  [[nodiscard]] uint32_t connector_id() const noexcept { return connector_id_; }
+  [[nodiscard]] const std::string& connector_name() const noexcept {
+    return connector_name_;
+  }
+  // DRM node path derived from the lease fd, for logging and OutputProvider.
+  [[nodiscard]] const std::string& card_path() const noexcept {
+    return card_path_;
+  }
+
+  // Set by the monitor thread on wp_drm_lease_v1.finished (or connection
+  // death). Once true it never clears: reacquire builds a NEW LeaseHold.
+  // Renderers gate their commits on this — a revoked fd's KMS objects are gone
+  // and every ioctl naming them fails.
+  [[nodiscard]] bool revoked() const noexcept {
+    return revoked_.load(std::memory_order_acquire);
+  }
+
+ private:
+  friend class LeaseClient;
+  struct Impl;
+
+  LeaseHold();
+
+  std::unique_ptr<Impl> impl_;
+  int lease_fd_{-1};
+  uint32_t connector_id_{};
+  std::string connector_name_;
+  std::string card_path_;
+  std::atomic<bool> revoked_{false};
+};
+
+class LeaseClient {
+ public:
+  struct Result {
+    // Acquire(): non-null iff the lease was granted. Probe() never sets it —
+    // it does not negotiate, so use `error == kNone` to test a probe's success.
+    std::unique_ptr<LeaseHold> hold;
+    LeaseError error{};              // kNone = success
+    std::vector<LeaseOffer> offers;  // what was advertised, for diagnostics
+  };
+
+  // Negotiate a lease. Blocks on the caller's thread up to cfg.timeout_ms.
+  // On success spawns the monitor thread and hands back the hold, with
+  // error == kNone.
+  static Result Acquire(const LeaseConfig& cfg);
+
+  // Read-only enumeration: bind the lease devices, take the drm_fd, collect the
+  // connector offers, then release. Stops before create_lease_request, so it is
+  // safe to run against a live desktop session. Backs the lease-aware mode
+  // listing and `finished`-cause diagnostics.
+  //
+  // Returns error == kNone with `offers` populated on success (hold is always
+  // null). A probe that reaches a compositor advertising nothing returns
+  // kNoOffers.
+  static Result Probe(const LeaseConfig& cfg);
+};
+
+}  // namespace homescreen

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
+#include <limits>
 #include <string_view>
 
 #include "config/common.h"
@@ -245,6 +246,30 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
   if (v->at_path("backend.drm.device").is_string()) {
     instance.view.drm_device =
         v->at_path("backend.drm.device").as_string()->value_or("");
+  }
+  // [view.backend.lease] — wayland-leased-drm negotiation knobs. Kept under
+  // their own table rather than backend.drm.*: they select what to ask the
+  // compositor for, not how to drive a card we already own.
+  if (v->at_path("backend.lease.device").is_string()) {
+    instance.view.lease_device =
+        v->at_path("backend.lease.device").as_string()->value_or("");
+  }
+  if (v->at_path("backend.lease.connector").is_string()) {
+    instance.view.lease_connector =
+        v->at_path("backend.lease.connector").as_string()->value_or("");
+  }
+  if (v->at_path("backend.lease.timeout_ms").is_integer()) {
+    const int64_t ms = v->at_path("backend.lease.timeout_ms")
+                           .as_integer()
+                           ->value_or(int64_t{0});
+    if (ms > 0) {
+      instance.view.lease_timeout_ms = static_cast<uint32_t>(ms);
+    } else {
+      ihs::log::warn(
+          "[view.backend.lease] timeout_ms must be > 0 (got {}); using the "
+          "default",
+          ms);
+    }
   }
   if (v->at_path("backend.drm.connector").is_string()) {
     instance.view.drm_connector =
@@ -711,8 +736,30 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
     allocated->add_options("Backend")(
         "backend",
         "Active backend: wayland-egl|wayland-vulkan|drm-kms-egl|drm-kms-vulkan|"
-        "software (default: env-aware -- a Wayland session selects "
-        "wayland-egl, else drm-kms-egl)",
+        "software|wayland-leased-drm[-egl|-vulkan|-software] (default: "
+        "env-aware -- a Wayland session selects wayland-egl, else "
+        "drm-kms-egl). The bare name wayland-leased-drm picks the first "
+        "available leased tier; a leased backend never falls back to an "
+        "unleased one.",
+        cxxopts::value<std::string>());
+
+    // [view.backend.lease] (also settable via HOMESCREEN_LEASE_* env)
+    allocated->add_options("Lease")(
+        "lease-device",
+        "wayland-leased-drm: which wp_drm_lease_device_v1 to lease from when "
+        "several are advertised (one per DRM node) -- a decimal index or a "
+        "node "
+        "path (/dev/dri/card1). Default: the sole device; ambiguous is fatal.",
+        cxxopts::value<std::string>())(
+        "lease-connector",
+        "wayland-leased-drm: connector to request by name (e.g. HDMI-A-1). "
+        "Default: the sole offer; several offers with no choice is fatal.",
+        cxxopts::value<std::string>())(
+        "lease-timeout-ms",
+        "wayland-leased-drm: bound on the whole lease negotiation. Default "
+        "5000. The protocol lets a compositor defer the DRM fd until it "
+        "regains DRM master, so this is what stops a VT-switched-away "
+        "compositor hanging startup.",
         cxxopts::value<std::string>());
 
     // [view.backend.drm] (also settable via HOMESCREEN_DRM_* env)
@@ -769,8 +816,8 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
       // Requested help text is program output, not a log line: write it to
       // stdout directly (synchronous, unprefixed) rather than through the
       // async logger, which would send it to stderr with a timestamp/level.
-      const std::string help =
-          allocated->help({"", "Global", "View", "Shell", "Backend", "DRM"});
+      const std::string help = allocated->help(
+          {"", "Global", "View", "Shell", "Backend", "DRM", "Lease"});
       std::fputs(help.c_str(), stdout);
       std::fputc('\n', stdout);
       exit(EXIT_SUCCESS);
@@ -910,6 +957,26 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
     pick_string("drm-device", "HOMESCREEN_DRM_DEVICE", config.view.drm_device);
     pick_string("drm-connector", "HOMESCREEN_DRM_CONNECTOR",
                 config.view.drm_connector);
+    // wayland-leased-drm. Distinct from the drm-* keys above: those say how to
+    // drive a card we opened, these say what to ask the compositor to lease.
+    pick_string("lease-device", "HOMESCREEN_LEASE_DEVICE",
+                config.view.lease_device);
+    pick_string("lease-connector", "HOMESCREEN_LEASE_CONNECTOR",
+                config.view.lease_connector);
+    if (const char* e = std::getenv("HOMESCREEN_LEASE_TIMEOUT_MS");
+        e != nullptr && *e != '\0') {
+      char* end = nullptr;
+      const unsigned long ms = std::strtoul(e, &end, 10);
+      if (end != e && *end == '\0' && ms > 0 &&
+          ms <= std::numeric_limits<uint32_t>::max()) {
+        config.view.lease_timeout_ms = static_cast<uint32_t>(ms);
+      } else {
+        ihs::log::warn(
+            "HOMESCREEN_LEASE_TIMEOUT_MS='{}' is not a positive integer; "
+            "using the default",
+            e);
+      }
+    }
     pick_string("drm-mode", "HOMESCREEN_DRM_MODE", config.view.drm_mode);
     pick_string("drm-compositor", "HOMESCREEN_DRM_COMPOSITOR",
                 config.view.drm_compositor);

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -258,6 +258,10 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
     instance.view.lease_connector =
         v->at_path("backend.lease.connector").as_string()->value_or("");
   }
+  if (v->at_path("backend.lease.on_revoke").is_string()) {
+    instance.view.lease_on_revoke =
+        v->at_path("backend.lease.on_revoke").as_string()->value_or("");
+  }
   if (v->at_path("backend.lease.timeout_ms").is_integer()) {
     const int64_t ms = v->at_path("backend.lease.timeout_ms")
                            .as_integer()
@@ -755,6 +759,13 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
         "wayland-leased-drm: connector to request by name (e.g. HDMI-A-1). "
         "Default: the sole offer; several offers with no choice is fatal.",
         cxxopts::value<std::string>())(
+        "lease-on-revoke",
+        "wayland-leased-drm: what to do when the compositor revokes the lease "
+        "(it does so on every VT switch away from it, not just on error). "
+        "exit (default) = log the cause and exit non-zero so a supervisor "
+        "restarts and renegotiates; gate = keep running with a frozen panel "
+        "(debugging only, nothing recovers). reacquire is not implemented yet.",
+        cxxopts::value<std::string>())(
         "lease-timeout-ms",
         "wayland-leased-drm: bound on the whole lease negotiation. Default "
         "5000. The protocol lets a compositor defer the DRM fd until it "
@@ -963,6 +974,8 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
                 config.view.lease_device);
     pick_string("lease-connector", "HOMESCREEN_LEASE_CONNECTOR",
                 config.view.lease_connector);
+    pick_string("lease-on-revoke", "HOMESCREEN_LEASE_ON_REVOKE",
+                config.view.lease_on_revoke);
     if (const char* e = std::getenv("HOMESCREEN_LEASE_TIMEOUT_MS");
         e != nullptr && *e != '\0') {
       char* end = nullptr;

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -266,13 +266,17 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
     const int64_t ms = v->at_path("backend.lease.timeout_ms")
                            .as_integer()
                            ->value_or(int64_t{0});
-    if (ms > 0) {
+    // The upper bound is not pedantry: TOML integers are int64_t, so without it
+    // a value that is a multiple of 2^32 truncates to 0 -- an already-expired
+    // deadline that fails the lease instantly and blames the compositor in the
+    // log. Matches the bound HOMESCREEN_LEASE_TIMEOUT_MS enforces.
+    if (ms > 0 && ms <= std::numeric_limits<uint32_t>::max()) {
       instance.view.lease_timeout_ms = static_cast<uint32_t>(ms);
     } else {
       ihs::log::warn(
-          "[view.backend.lease] timeout_ms must be > 0 (got {}); using the "
-          "default",
-          ms);
+          "[view.backend.lease] timeout_ms must be in 1..{} (got {}); using "
+          "the default",
+          std::numeric_limits<uint32_t>::max(), ms);
     }
   }
   if (v->at_path("backend.drm.connector").is_string()) {
@@ -976,20 +980,37 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
                 config.view.lease_connector);
     pick_string("lease-on-revoke", "HOMESCREEN_LEASE_ON_REVOKE",
                 config.view.lease_on_revoke);
-    if (const char* e = std::getenv("HOMESCREEN_LEASE_TIMEOUT_MS");
-        e != nullptr && *e != '\0') {
-      char* end = nullptr;
-      const unsigned long ms = std::strtoul(e, &end, 10);
-      if (end != e && *end == '\0' && ms > 0 &&
-          ms <= std::numeric_limits<uint32_t>::max()) {
-        config.view.lease_timeout_ms = static_cast<uint32_t>(ms);
-      } else {
-        ihs::log::warn(
-            "HOMESCREEN_LEASE_TIMEOUT_MS='{}' is not a positive integer; "
-            "using the default",
-            e);
+    // Same CLI-wins-then-env precedence as pick_string, but parsed as a bounded
+    // uint32. Written as a lambda over both sources rather than an env-only
+    // block: --lease-timeout-ms was registered as a flag and read from nowhere,
+    // so it parsed, was discarded, and the default silently applied while the
+    // help text advertised otherwise.
+    auto pick_timeout_ms = [&](const char* cli_name, const char* env_name,
+                               std::optional<uint32_t>& out) {
+      const auto parse = [&](const std::string& s, const char* source) {
+        char* end = nullptr;
+        const unsigned long long ms = std::strtoull(s.c_str(), &end, 10);
+        if (end != s.c_str() && *end == '\0' && ms > 0 &&
+            ms <= std::numeric_limits<uint32_t>::max()) {
+          out = static_cast<uint32_t>(ms);
+          return true;
+        }
+        ihs::log::warn("{}='{}' must be an integer in 1..{}; using the default",
+                       source, s, std::numeric_limits<uint32_t>::max());
+        return false;
+      };
+      if (result.count(cli_name) != 0U) {
+        const auto v = result[cli_name].as<std::string>();
+        if (!v.empty() && parse(v, cli_name)) {
+          return;
+        }
       }
-    }
+      if (const char* e = std::getenv(env_name); e != nullptr && *e != '\0') {
+        parse(e, env_name);
+      }
+    };
+    pick_timeout_ms("lease-timeout-ms", "HOMESCREEN_LEASE_TIMEOUT_MS",
+                    config.view.lease_timeout_ms);
     pick_string("drm-mode", "HOMESCREEN_DRM_MODE", config.view.drm_mode);
     pick_string("drm-compositor", "HOMESCREEN_DRM_COMPOSITOR",
                 config.view.drm_compositor);

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -113,9 +113,22 @@ class Configuration {
       //                     defer drm_fd until it regains DRM master, so
       //                     without a bound a VT-switched-away compositor would
       //                     hang startup.
+      //   lease_on_revoke : what to do when the compositor revokes the lease —
+      //                     which it does on every VT switch away from it, not
+      //                     only on error.
+      //                       "exit" (default) — log the cause and exit
+      //                         non-zero, so a supervisor (systemd) restarts
+      //                         and renegotiates from scratch. The honest
+      //                         default until reacquire-in-place exists.
+      //                       "gate"           — stop committing and keep
+      //                         running with a frozen panel. Only useful for
+      //                         debugging a revocation, since nothing recovers.
+      //                       "reacquire"      — not implemented yet;
+      //                         accepted and warned about, treated as "exit".
       std::optional<std::string> lease_device;
       std::optional<std::string> lease_connector;
       std::optional<uint32_t> lease_timeout_ms;
+      std::optional<std::string> lease_on_revoke;
       // Wayland compositor-protocol shell selection: "auto" (default) | "xdg" |
       // "agl" | "ivi" | "simple". The Display reads it from the first view.
       std::optional<std::string> shell;

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -89,12 +89,33 @@ class Configuration {
       std::optional<int> drm_rotation;
       // Backend selection when several backends are compiled into one binary.
       // Accepts a full registry key (wayland-egl | wayland-vulkan | drm-kms-egl
-      // | drm-kms-vulkan | software) or, for back-compat, an "egl" | "vulkan"
-      // renderer-family hint. Empty/unset = the sole compiled backend. Set per
-      // bundle under [view] in the bundle's TOML, or process-wide via
+      // | drm-kms-vulkan | software | wayland-leased-drm-{egl,vulkan,software})
+      // or, for back-compat, an "egl" | "vulkan" renderer-family hint. The bare
+      // family name "wayland-leased-drm" is also accepted and resolves to the
+      // first available leased tier. Empty/unset = the sole compiled backend.
+      // Set per bundle under [view] in the bundle's TOML, or process-wide via
       // --backend. One process drives one backend today, so the first bundle's
       // value wins.
       std::optional<std::string> backend;
+
+      // wayland-leased-drm knobs. All optional; see LeaseConfig in
+      // backend/wayland_leased_drm/lease_client.h for the semantics.
+      //   lease_device    : which wp_drm_lease_device_v1 to lease from when the
+      //                     compositor advertises several (one per DRM node) —
+      //                     a decimal index or a node path ("/dev/dri/card1").
+      //                     Unset = the sole device; ambiguous + unset is
+      //                     fatal.
+      //   lease_connector : connector to request, by name ("HDMI-A-1"). Unset +
+      //                     exactly one offer takes it; unset + several is
+      //                     fatal and lists what was offered.
+      //   lease_timeout_ms: wall-clock bound on the whole negotiation. Unset =
+      //                     5000. Load-bearing: the spec lets a compositor
+      //                     defer drm_fd until it regains DRM master, so
+      //                     without a bound a VT-switched-away compositor would
+      //                     hang startup.
+      std::optional<std::string> lease_device;
+      std::optional<std::string> lease_connector;
+      std::optional<uint32_t> lease_timeout_ms;
       // Wayland compositor-protocol shell selection: "auto" (default) | "xdg" |
       // "agl" | "ivi" | "simple". The Display reads it from the first view.
       std::optional<std::string> shell;

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -211,6 +211,61 @@ DrmDisplay::DrmDisplay(int32_t width,
   }
 }
 
+DrmDisplay::DrmDisplay(AdoptFd,
+                       int32_t width,
+                       int32_t height,
+                       double refresh_rate_hz,
+                       int fd,
+                       std::string device_path,
+                       std::shared_ptr<void> fd_owner,
+                       bool no_seat)
+    // Delegate so the seat/session wiring stays in one place; only the device
+    // acquisition differs on this path.
+    : DrmDisplay(width,
+                 height,
+                 refresh_rate_hz,
+                 std::move(device_path),
+                 no_seat) {
+  adopted_fd_ = true;
+  fd_owner_ = std::move(fd_owner);
+
+  // Adopt up front so SharedDevice() short-circuits: no libseat TakeDevice, no
+  // direct open, no drmSetMaster, no foreground-VT guard. The lease fd is
+  // already master over its object set by construction.
+  //
+  // from_fd borrows: the fd stays owned by fd_owner_ (the LeaseHold), which is
+  // also what returns the lease. drm_master_ stays false so ~DrmDisplay does
+  // not drmDropMaster a lease we never took master on -- returning it is the
+  // lessor's business, driven by destroying the wp_drm_lease_v1 object.
+  drm_dev_.emplace(drm::Device::from_fd(fd));
+
+  // The lease fd's resource view is kernel-filtered to the leased objects, but
+  // output_provider_ re-opens the card by path and so sees the whole card.
+  // Seed it with what we actually hold, straight from the kernel: asking the
+  // lease fd is authoritative in a way that trusting our own lease request is
+  // not -- the requested connector set is only a suggestion, and the compositor
+  // picks the final object set (and may pick differently on every grant).
+  if (drmModeRes* res = drmModeGetResources(fd); res != nullptr) {
+    std::vector<uint32_t> leased(
+        res->connectors,
+        res->connectors + static_cast<size_t>(res->count_connectors));
+    ihs::log::info(
+        "[DrmDisplay] adopted lease fd on {}: {} leased connector(s)",
+        device_path_, leased.size());
+    output_provider_.SetConnectorFilter(std::move(leased));
+    drmModeFreeResources(res);
+  } else {
+    // Enumeration failing on a fd we were just handed means the lease is
+    // already dead (revoked between grant and here) or the fd is not a DRM
+    // node. Leave the filter empty but say so -- an unfiltered provider would
+    // silently advertise the whole card.
+    ihs::log::error(
+        "[DrmDisplay] drmModeGetResources on the adopted lease fd failed: {}. "
+        "Outputs are NOT filtered to the lease.",
+        std::strerror(errno));
+  }
+}
+
 DrmDisplay::~DrmDisplay() {
   // Stop the per-card flip reader first -- it runs its own thread and holds the
   // fd via flip_descriptor_, so it must be torn down before the fd is closed.

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -217,15 +217,18 @@ DrmDisplay::DrmDisplay(AdoptFd,
                        double refresh_rate_hz,
                        int fd,
                        std::string device_path,
-                       std::shared_ptr<void> fd_owner,
-                       bool no_seat)
-    // Delegate so the seat/session wiring stays in one place; only the device
-    // acquisition differs on this path.
+                       std::shared_ptr<void> fd_owner)
+    // Delegate for the width/height/seat wiring, but always with no_seat:
+    // libseat's TakeControl would fight the compositor, which already holds the
+    // session controller on the seat we are leasing from -- producing spurious
+    // session errors on every leased startup. The compositor owns the VT and
+    // the session; we own one connector. Input therefore comes from direct
+    // evdev; see the desktop-host hazard that creates.
     : DrmDisplay(width,
                  height,
                  refresh_rate_hz,
                  std::move(device_path),
-                 no_seat) {
+                 /*no_seat=*/true) {
   adopted_fd_ = true;
   fd_owner_ = std::move(fd_owner);
 
@@ -239,29 +242,33 @@ DrmDisplay::DrmDisplay(AdoptFd,
   // lessor's business, driven by destroying the wp_drm_lease_v1 object.
   drm_dev_.emplace(drm::Device::from_fd(fd));
 
-  // The lease fd's resource view is kernel-filtered to the leased objects, but
-  // output_provider_ re-opens the card by path and so sees the whole card.
-  // Seed it with what we actually hold, straight from the kernel: asking the
-  // lease fd is authoritative in a way that trusting our own lease request is
-  // not -- the requested connector set is only a suggestion, and the compositor
-  // picks the final object set (and may pick differently on every grant).
+  // Enumerate outputs through the lease fd rather than by re-opening the card.
+  // Two reasons, and both matter:
+  //   - Scope: the kernel filters this fd to the leased objects, so the
+  //     provider advertises exactly what we hold. Opening the card by path
+  //     would show the whole card, and `[view.output]` would happily validate
+  //     against a connector the compositor is still scanning out on.
+  //   - Permission: a leased client uses a lease precisely because it may not
+  //     be able to open /dev/dri/cardN at all. Opening by path would fail with
+  //     EACCES on a locked-down target and a display holding a perfectly good
+  //     lease would advertise no outputs.
+  output_provider_.SetEnumerationFd(fd);
+
   if (drmModeRes* res = drmModeGetResources(fd); res != nullptr) {
-    std::vector<uint32_t> leased(
-        res->connectors,
-        res->connectors + static_cast<size_t>(res->count_connectors));
     ihs::log::info(
         "[DrmDisplay] adopted lease fd on {}: {} leased connector(s)",
-        device_path_, leased.size());
-    output_provider_.SetConnectorFilter(std::move(leased));
+        device_path_, res->count_connectors);
     drmModeFreeResources(res);
   } else {
-    // Enumeration failing on a fd we were just handed means the lease is
+    // Enumeration failing on an fd we were just handed means the lease is
     // already dead (revoked between grant and here) or the fd is not a DRM
-    // node. Leave the filter empty but say so -- an unfiltered provider would
-    // silently advertise the whole card.
+    // node. Nothing to disable -- the provider enumerates through this same fd
+    // and will come back empty, which is the fail-closed answer -- but say so,
+    // because "no outputs" otherwise looks like a config error.
     ihs::log::error(
         "[DrmDisplay] drmModeGetResources on the adopted lease fd failed: {}. "
-        "Outputs are NOT filtered to the lease.",
+        "The lease is dead or the fd is not a DRM node; this display will "
+        "advertise no outputs.",
         std::strerror(errno));
   }
 }

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -217,7 +217,9 @@ DrmDisplay::DrmDisplay(AdoptFd,
                        double refresh_rate_hz,
                        int fd,
                        std::string device_path,
-                       std::shared_ptr<void> fd_owner)
+                       std::shared_ptr<void> fd_owner,
+                       uint32_t connector_id,
+                       std::function<bool()> revoked)
     // Delegate for the width/height/seat wiring, but always with no_seat:
     // libseat's TakeControl would fight the compositor, which already holds the
     // session controller on the seat we are leasing from -- producing spurious
@@ -231,6 +233,8 @@ DrmDisplay::DrmDisplay(AdoptFd,
                  /*no_seat=*/true) {
   adopted_fd_ = true;
   fd_owner_ = std::move(fd_owner);
+  lease_connector_id_ = connector_id;
+  lease_revoked_ = std::move(revoked);
 
   // Adopt up front so SharedDevice() short-circuits: no libseat TakeDevice, no
   // direct open, no drmSetMaster, no foreground-VT guard. The lease fd is

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -62,15 +62,20 @@ class DrmDisplay final : public IDisplay {
   // register_backends.cc casts to DrmDisplay*, so staying the same concrete
   // type keeps the DRM-EGL backend factory reusable as-is.
   //
-  // Differs from the path above in three ways, all because the compositor —
+  // Differs from the path above in four ways, all because the compositor —
   // not us — is the lessor:
   //   - the fd is already master over its leased object set, so there is no
   //     drmSetMaster and no foreground-VT guard (the compositor owns the VT);
   //   - teardown must NOT drmDropMaster: the lease is returned by destroying
   //     the wp_drm_lease_v1 object, which is @p fd_owner's job;
-  //   - the kernel filters this fd's resource view to the leased objects, so
-  //     the output provider is filtered to match (it re-opens the card
-  //     unfiltered and would otherwise advertise connectors we do not hold).
+  //   - outputs are enumerated through the lease fd, whose resource view the
+  //     kernel filters to the leased objects — re-opening the card by path
+  //     would both show connectors we do not hold and require permissions a
+  //     leased client may not have;
+  //   - no libseat session is taken: the compositor already holds the session
+  //     controller for this seat, so input falls back to direct evdev.
+  //     There is deliberately no no_seat knob here — the answer
+  //     is always "no seat".
   //
   // @p fd is borrowed: drm::Device::from_fd does not close it. @p fd_owner is
   // the opaque keep-alive that does own it (the LeaseHold) and must outlive
@@ -82,8 +87,7 @@ class DrmDisplay final : public IDisplay {
              double refresh_rate_hz,
              int fd,
              std::string device_path,
-             std::shared_ptr<void> fd_owner,
-             bool no_seat = false);
+             std::shared_ptr<void> fd_owner);
 
   ~DrmDisplay() override;
 

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -81,13 +82,26 @@ class DrmDisplay final : public IDisplay {
   // the opaque keep-alive that does own it (the LeaseHold) and must outlive
   // this display; it is held so the lease cannot be dropped while a backend is
   // still scanning out on the fd.
+  //
+  // @p connector_id is the leased connector the backend must drive. A lease may
+  // contain more than one -- the requested set is only a suggestion and the
+  // compositor picks the final set -- so a backend that instead takes "the
+  // first connected connector" can light up the wrong panel and leave the
+  // requested one dark. 0 falls back to that heuristic.
+  //
+  // @p revoked is polled by the backends' commit paths: once the lease is
+  // revoked its KMS objects are gone from the fd's view and every commit naming
+  // them fails, so frames are dropped rather than spraying ioctl errors
+  // forever. Null = never gated.
   DrmDisplay(AdoptFd,
              int32_t width,
              int32_t height,
              double refresh_rate_hz,
              int fd,
              std::string device_path,
-             std::shared_ptr<void> fd_owner);
+             std::shared_ptr<void> fd_owner,
+             uint32_t connector_id,
+             std::function<bool()> revoked);
 
   ~DrmDisplay() override;
 
@@ -102,6 +116,20 @@ class DrmDisplay final : public IDisplay {
   // required — but it makes the backend's own lifetime self-evident instead of
   // resting on an ordering invariant documented elsewhere.
   [[nodiscard]] std::shared_ptr<void> fd_owner() const { return fd_owner_; }
+
+  // The leased connector the backend must drive; 0 on every non-adopted path
+  // (and on a lease that named none), meaning "first connected with a mode".
+  [[nodiscard]] uint32_t lease_connector_id() const {
+    return lease_connector_id_;
+  }
+
+  // Revocation gate for the backends' commit paths; empty on every non-adopted
+  // path, where there is no lease to lose. Copied by value into a backend, so
+  // it must stay callable for that backend's lifetime -- it captures the
+  // LeaseHold share, which fd_owner_ also holds.
+  [[nodiscard]] std::function<bool()> lease_revoked() const {
+    return lease_revoked_;
+  }
 
   // Process-wide libseat session. Null when no seat backend is available
   // (no logind/seatd/builtin), when drm-cxx was built without libseat, or
@@ -266,6 +294,11 @@ class DrmDisplay final : public IDisplay {
   // lease client (the display only needs the fd to stay valid, not to know what
   // keeps it so). Null on every non-adopted path.
   std::shared_ptr<void> fd_owner_;
+
+  // The leased connector to drive, and the lease's revocation gate. Both are
+  // inert (0 / empty) on every non-adopted path. See the accessors.
+  uint32_t lease_connector_id_ = 0;
+  std::function<bool()> lease_revoked_;
 
   // Enumerates this card's connectors as outputs (libdrm only, no master).
   homescreen::DrmOutputProvider output_provider_;

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -96,6 +96,13 @@ class DrmDisplay final : public IDisplay {
   // handoff, mode-object ownership — must branch on this.
   [[nodiscard]] bool adopted_fd() const { return adopted_fd_; }
 
+  // The adopted fd's owner (the LeaseHold), for a backend that wants to hold it
+  // too. Null on every non-adopted path. This display already outlives its
+  // backends, so a backend taking a share is belt-and-braces rather than
+  // required — but it makes the backend's own lifetime self-evident instead of
+  // resting on an ordering invariant documented elsewhere.
+  [[nodiscard]] std::shared_ptr<void> fd_owner() const { return fd_owner_; }
+
   // Process-wide libseat session. Null when no seat backend is available
   // (no logind/seatd/builtin), when drm-cxx was built without libseat, or
   // when --drm-no-seat forced the direct-open path.

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -53,7 +53,44 @@ class DrmDisplay final : public IDisplay {
              double refresh_rate_hz,
              std::string device_path,
              bool no_seat = false);
+
+  // Tag for the adopted-fd construction path below.
+  struct AdoptFd {};
+
+  // wayland-leased-drm: build around a DRM fd we did not open — the master fd
+  // from wp_drm_lease_v1.lease_fd. A tag rather than a subclass because
+  // register_backends.cc casts to DrmDisplay*, so staying the same concrete
+  // type keeps the DRM-EGL backend factory reusable as-is.
+  //
+  // Differs from the path above in three ways, all because the compositor —
+  // not us — is the lessor:
+  //   - the fd is already master over its leased object set, so there is no
+  //     drmSetMaster and no foreground-VT guard (the compositor owns the VT);
+  //   - teardown must NOT drmDropMaster: the lease is returned by destroying
+  //     the wp_drm_lease_v1 object, which is @p fd_owner's job;
+  //   - the kernel filters this fd's resource view to the leased objects, so
+  //     the output provider is filtered to match (it re-opens the card
+  //     unfiltered and would otherwise advertise connectors we do not hold).
+  //
+  // @p fd is borrowed: drm::Device::from_fd does not close it. @p fd_owner is
+  // the opaque keep-alive that does own it (the LeaseHold) and must outlive
+  // this display; it is held so the lease cannot be dropped while a backend is
+  // still scanning out on the fd.
+  DrmDisplay(AdoptFd,
+             int32_t width,
+             int32_t height,
+             double refresh_rate_hz,
+             int fd,
+             std::string device_path,
+             std::shared_ptr<void> fd_owner,
+             bool no_seat = false);
+
   ~DrmDisplay() override;
+
+  // True when built through the adopted-fd path (a DRM lease). Callers that
+  // would otherwise assume this process is the master — VT guards, master
+  // handoff, mode-object ownership — must branch on this.
+  [[nodiscard]] bool adopted_fd() const { return adopted_fd_; }
 
   // Process-wide libseat session. Null when no seat backend is available
   // (no logind/seatd/builtin), when drm-cxx was built without libseat, or
@@ -205,6 +242,19 @@ class DrmDisplay final : public IDisplay {
   // --drm-no-seat: skip the foreground-VT guard on the direct-open path when
   // SharedDevice() falls back (no libseat session).
   bool no_seat_;
+
+  // True when drm_dev_ wraps a borrowed fd (a DRM lease) rather than one this
+  // display opened. Gates the master bookkeeping off: we never took master, so
+  // the destructor must never drop it.
+  bool adopted_fd_ = false;
+
+  // Keeps the adopted fd's owner (the LeaseHold) alive for at least as long as
+  // drm_dev_, which only borrows the fd — drm::Device::from_fd does not close
+  // it. Declared BEFORE drm_dev_ so it is destroyed AFTER it: the Device must
+  // go while its fd is still open. Opaque so this header stays free of the
+  // lease client (the display only needs the fd to stay valid, not to know what
+  // keeps it so). Null on every non-adopted path.
+  std::shared_ptr<void> fd_owner_;
 
   // Enumerates this card's connectors as outputs (libdrm only, no master).
   homescreen::DrmOutputProvider output_provider_;

--- a/shell/display/drm_output_provider.cc
+++ b/shell/display/drm_output_provider.cc
@@ -16,6 +16,7 @@
 
 #include "display/drm_output_provider.h"
 
+#include <algorithm>
 #include <utility>
 
 #include <drm-cxx/core/device.hpp>
@@ -27,6 +28,11 @@ namespace homescreen {
 
 DrmOutputProvider::DrmOutputProvider(std::string device_path)
     : device_path_(std::move(device_path)) {}
+
+void DrmOutputProvider::SetConnectorFilter(
+    std::vector<uint32_t> connector_ids) {
+  connector_filter_ = std::move(connector_ids);
+}
 
 std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
   std::vector<OutputInfo> outputs;
@@ -47,6 +53,15 @@ std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
 
   outputs.reserve(connectors->size());
   for (const auto& connector : *connectors) {
+    // On a lease, this open() sees the whole card while we only hold a subset;
+    // drop anything outside the lease so callers cannot bind to a connector the
+    // compositor still owns.
+    if (!connector_filter_.empty() &&
+        std::find(connector_filter_.begin(), connector_filter_.end(),
+                  connector.connector_id) == connector_filter_.end()) {
+      continue;
+    }
+
     OutputInfo info;
     info.name = connector.name();
     info.connected = connector.connected;

--- a/shell/display/drm_output_provider.cc
+++ b/shell/display/drm_output_provider.cc
@@ -29,19 +29,28 @@ namespace homescreen {
 DrmOutputProvider::DrmOutputProvider(std::string device_path)
     : device_path_(std::move(device_path)) {}
 
-void DrmOutputProvider::SetConnectorFilter(
-    std::vector<uint32_t> connector_ids) {
-  connector_filter_ = std::move(connector_ids);
+void DrmOutputProvider::SetEnumerationFd(int fd) {
+  enumeration_fd_ = fd;
 }
 
 std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
   std::vector<OutputInfo> outputs;
 
-  auto dev = drm::Device::open(device_path_);
-  if (!dev) {
-    ihs::log::warn("[DrmOutputProvider] open('{}'): {}", device_path_,
-                   dev.error().message());
-    return outputs;
+  // Prefer a supplied fd (a DRM lease) over opening the card: it is both the
+  // correctly-scoped view (the kernel filters it to the leased objects) and the
+  // only handle a leased client is guaranteed to have. from_fd borrows -- the
+  // fd stays owned by whoever supplied it.
+  std::optional<drm::Device> dev;
+  if (enumeration_fd_ >= 0) {
+    dev.emplace(drm::Device::from_fd(enumeration_fd_));
+  } else {
+    auto opened = drm::Device::open(device_path_);
+    if (!opened) {
+      ihs::log::warn("[DrmOutputProvider] open('{}'): {}", device_path_,
+                     opened.error().message());
+      return outputs;
+    }
+    dev.emplace(std::move(*opened));
   }
 
   auto connectors = drm::display::query_connector_modes(*dev);
@@ -53,15 +62,6 @@ std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
 
   outputs.reserve(connectors->size());
   for (const auto& connector : *connectors) {
-    // On a lease, this open() sees the whole card while we only hold a subset;
-    // drop anything outside the lease so callers cannot bind to a connector the
-    // compositor still owns.
-    if (!connector_filter_.empty() &&
-        std::find(connector_filter_.begin(), connector_filter_.end(),
-                  connector.connector_id) == connector_filter_.end()) {
-      continue;
-    }
-
     OutputInfo info;
     info.name = connector.name();
     info.connected = connector.connected;

--- a/shell/display/drm_output_provider.h
+++ b/shell/display/drm_output_provider.h
@@ -39,20 +39,31 @@ class DrmOutputProvider final : public IOutputProvider {
   void SetOutputListener(IOutputListener* listener) override;
   [[nodiscard]] bool SupportsHotplug() const override;
 
-  // Restrict enumeration to these connector ids. Needed by wayland-leased-drm:
-  // this provider re-opens the card as a plain non-master fd, whose resource
-  // view is the WHOLE card -- unlike the lease fd, which the kernel filters to
-  // the leased objects. Without the filter a leased display would advertise
-  // connectors it does not hold, and `[view.output]` validation would "succeed"
-  // against one the compositor still owns. Empty (the default) = no filtering.
-  void SetConnectorFilter(std::vector<uint32_t> connector_ids);
+  // Enumerate through @p fd instead of opening device_path_. Needed by
+  // wayland-leased-drm, for two reasons:
+  //
+  //   - Scope. The kernel filters a lease fd's resource view to the leased
+  //     objects, so enumerating through it yields exactly the connectors we
+  //     hold. Opening the card by path yields the WHOLE card, so a leased
+  //     display would advertise connectors the compositor still owns and
+  //     `[view.output]` validation would "succeed" against one of them.
+  //   - Permission. The point of drm-lease-v1 is that an unprivileged client
+  //     can drive a connector *without* being able to open the DRM node. On a
+  //     locked-down target the open() here fails with EACCES, enumeration comes
+  //     back empty, and a display holding a perfectly good lease advertises no
+  //     outputs at all.
+  //
+  // @p fd is borrowed and must outlive this provider (the display holds the
+  // LeaseHold that owns it). -1 (the default) restores the open-by-path path.
+  void SetEnumerationFd(int fd);
 
  private:
-  // The card this provider enumerates (e.g. "/dev/dri/card1").
+  // The card this provider enumerates (e.g. "/dev/dri/card1"). Unused when
+  // enumeration_fd_ is set, except for diagnostics.
   std::string device_path_;
 
-  // Connector-id allowlist; empty = enumerate everything on the card.
-  std::vector<uint32_t> connector_filter_;
+  // Borrowed fd to enumerate through; -1 = open device_path_ instead.
+  int enumeration_fd_{-1};
 
   // Set by SetOutputListener; consumed once the hotplug monitor is wired.
   IOutputListener* listener_ = nullptr;

--- a/shell/display/drm_output_provider.h
+++ b/shell/display/drm_output_provider.h
@@ -39,9 +39,20 @@ class DrmOutputProvider final : public IOutputProvider {
   void SetOutputListener(IOutputListener* listener) override;
   [[nodiscard]] bool SupportsHotplug() const override;
 
+  // Restrict enumeration to these connector ids. Needed by wayland-leased-drm:
+  // this provider re-opens the card as a plain non-master fd, whose resource
+  // view is the WHOLE card -- unlike the lease fd, which the kernel filters to
+  // the leased objects. Without the filter a leased display would advertise
+  // connectors it does not hold, and `[view.output]` validation would "succeed"
+  // against one the compositor still owns. Empty (the default) = no filtering.
+  void SetConnectorFilter(std::vector<uint32_t> connector_ids);
+
  private:
   // The card this provider enumerates (e.g. "/dev/dri/card1").
   std::string device_path_;
+
+  // Connector-id allowlist; empty = enumerate everything on the card.
+  std::vector<uint32_t> connector_filter_;
 
   // Set by SetOutputListener; consumed once the hotplug monitor is wired.
   IOutputListener* listener_ = nullptr;

--- a/shell/display/software_display.h
+++ b/shell/display/software_display.h
@@ -16,7 +16,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <memory>
+#include <optional>
 
 #include "display/idisplay.h"
 
@@ -83,6 +86,28 @@ class SoftwareDisplay final : public IDisplay {
 
   [[nodiscard]] bool HasRepeatTimer() const override { return false; }
 
+  // wayland-leased-drm: everything the backend needs to build a DrmDumbSink on
+  // a leased DRM fd, when this display was made for a lease.
+  //
+  // Deliberately not a LeaseHold: this header stays free of the lease client,
+  // which the software tier otherwise has no reason to know about. The display
+  // holds it because the descriptor's make_display/make_backend pair is the
+  // only seam between negotiating the lease and building the sink -- and
+  // because `owner` must outlive the sink either way.
+  struct LeasedScanout {
+    int fd = -1;                    // borrowed; owned by `owner`
+    uint32_t connector_id = 0;      // the connector to drive, from the lease
+    std::function<bool()> revoked;  // polled by the sink's Present() gate
+    std::shared_ptr<void> owner;    // the LeaseHold; closes fd and returns the
+                                    // lease when the display goes
+  };
+  void SetLeasedScanout(LeasedScanout scanout) {
+    leased_scanout_ = std::move(scanout);
+  }
+  [[nodiscard]] const std::optional<LeasedScanout>& leased_scanout() const {
+    return leased_scanout_;
+  }
+
  private:
   int32_t width_;
   int32_t height_;
@@ -90,4 +115,5 @@ class SoftwareDisplay final : public IDisplay {
   FlutterDesktopViewControllerState* view_controller_state_ = nullptr;
   std::unique_ptr<homescreen::ISeat> seat_;
   std::shared_ptr<SoftwareCursor> cursor_;
+  std::optional<LeasedScanout> leased_scanout_;
 };

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -24,6 +24,9 @@
 
 #include "app.h"
 #include "backend/register_backends.h"
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM
+#include "backend/wayland_leased_drm/lease_client.h"
+#endif
 #include "configuration/configuration.h"
 #include "ihs/config.h"
 #include "logging/logger.hpp"
@@ -151,6 +154,27 @@ void PublishIhsConfig(const std::vector<Configuration::Config>& configs) {
  */
 int main(const int argc, char** argv) {
   IHS_LOGGING_START("IHSC", "ivi-homescreen Flutter runtime");
+
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM
+  // --lease-list-connectors: ask the compositor what it will actually lease.
+  //
+  // Handled here, off raw argv and ahead of config parsing, because it must
+  // work with no bundle: it is the first thing to run when a leased backend
+  // refuses to start, and demanding an app bundle to answer "what do you
+  // offer?" would be absurd. (--drm-list-modes sits after parsing and does
+  // require one.)
+  //
+  // This exists because "the compositor implements drm-lease-v1" and "the
+  // compositor will lease you a connector" are different facts, and only the
+  // second one matters. wlroots offers a connector only when its EDID carries
+  // the non-desktop flag, so the usual outcome on a desktop is a device that
+  // advertises itself and offers nothing — indistinguishable, without this,
+  // from a misconfigured connector name.
+  if (const int rc = homescreen::MaybeListLeaseConnectors(argc, argv);
+      rc >= 0) {
+    return rc;
+  }
+#endif
 
   const auto configs = Configuration::ParseArgcArgv(argc, argv);
   assert(!configs.empty());

--- a/shell/wayland/protocols/drm-lease-v1.xml
+++ b/shell/wayland/protocols/drm-lease-v1.xml
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="drm_lease_v1">
+  <copyright>
+    Copyright © 2018 NXP
+    Copyright © 2019 Status Research &amp; Development GmbH.
+    Copyright © 2021 Xaver Hugl
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="wp_drm_lease_device_v1" version="1">
+    <description summary="lease device">
+      This protocol is used by Wayland compositors which act as Direct
+      Rendering Manager (DRM) masters to lease DRM resources to Wayland
+      clients.
+
+      The compositor will advertise one wp_drm_lease_device_v1 global for each
+      DRM node. Some time after a client binds to the wp_drm_lease_device_v1
+      global, the compositor will send a drm_fd event followed by zero, one or
+      more connector events. After all currently available connectors have been
+      sent, the compositor will send a wp_drm_lease_device_v1.done event.
+
+      When the list of connectors available for lease changes the compositor
+      will send wp_drm_lease_device_v1.connector events for added connectors and
+      wp_drm_lease_connector_v1.withdrawn events for removed connectors,
+      followed by a wp_drm_lease_device_v1.done event.
+
+      The compositor will indicate when a device is gone by removing the global
+      via a wl_registry.global_remove event. Upon receiving this event, the
+      client should destroy any matching wp_drm_lease_device_v1 object.
+
+      To destroy a wp_drm_lease_device_v1 object, the client must first issue
+      a release request. Upon receiving this request, the compositor will
+      immediately send a released event and destroy the object. The client must
+      continue to process and discard drm_fd and connector events until it
+      receives the released event. Upon receiving the released event, the
+      client can safely cleanup any client-side resources.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    </description>
+
+    <request name="create_lease_request">
+      <description summary="create a lease request object">
+        Creates a lease request object.
+
+        See the documentation for wp_drm_lease_request_v1 for details.
+      </description>
+      <arg name="id" type="new_id" interface="wp_drm_lease_request_v1" />
+    </request>
+
+    <request name="release">
+      <description summary="release this object">
+        Indicates the client no longer wishes to use this object. In response
+        the compositor will immediately send the released event and destroy
+        this object. It can however not guarantee that the client won't receive
+        connector events before the released event. The client must not send any
+        requests after this one, doing so will raise a wl_display error.
+        Existing connectors, lease request and leases will not be affected.
+      </description>
+    </request>
+
+    <event name="drm_fd">
+      <description summary="open a non-master fd for this DRM node">
+        The compositor will send this event when the wp_drm_lease_device_v1
+        global is bound, although there are no guarantees as to how long this
+        takes - the compositor might need to wait until regaining DRM master.
+        The included fd is a non-master DRM file descriptor opened for this
+        device and the compositor must not authenticate it.
+        The purpose of this event is to give the client the ability to
+        query DRM and discover information which may help them pick the
+        appropriate DRM device or select the appropriate connectors therein.
+      </description>
+      <arg name="fd" type="fd" summary="DRM file descriptor" />
+    </event>
+
+    <event name="connector">
+      <description summary="advertise connectors available for leases">
+        The compositor will use this event to advertise connectors available for
+        lease by clients. This object may be passed into a lease request to
+        indicate the client would like to lease that connector, see
+        wp_drm_lease_request_v1.request_connector for details. While the
+        compositor will make a best effort to not send disconnected connectors,
+        no guarantees can be made.
+
+        The compositor must send the drm_fd event before sending connectors.
+        After the drm_fd event it will send all available connectors but may
+        send additional connectors at any time.
+      </description>
+      <arg name="id" type="new_id" interface="wp_drm_lease_connector_v1" />
+    </event>
+
+    <event name="done">
+      <description summary="signals grouping of connectors">
+        The compositor will send this event to indicate that it has sent all
+        currently available connectors after the client binds to the global or
+        when it updates the connector list, for example on hotplug, drm master
+        change or when a leased connector becomes available again. It will
+        similarly send this event to group wp_drm_lease_connector_v1.withdrawn
+        events of connectors of this device.
+      </description>
+    </event>
+
+    <event name="released" type="destructor">
+      <description summary="the compositor has finished using the device">
+        This event is sent in response to the release request and indicates
+        that the compositor is done sending connector events.
+        The compositor will destroy this object immediately after sending the
+        event and it will become invalid. The client should release any
+        resources associated with this device after receiving this event.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="wp_drm_lease_connector_v1" version="1">
+    <description summary="a leasable DRM connector">
+      Represents a DRM connector which is available for lease. These objects are
+      created via wp_drm_lease_device_v1.connector events, and should be passed
+      to lease requests via wp_drm_lease_request_v1.request_connector.
+      Immediately after the wp_drm_lease_connector_v1 object is created the
+      compositor will send a name, a description, a connector_id and a done
+      event. When the description is updated the compositor will send a
+      description event followed by a done event.
+    </description>
+
+    <event name="name">
+      <description summary="name">
+        The compositor sends this event once the connector is created to
+        indicate the name of this connector. This will not change for the
+        duration of the Wayland session, but is not guaranteed to be consistent
+        between sessions.
+
+        If the compositor supports wl_output version 4 and this connector
+        corresponds to a wl_output, the compositor should use the same name as
+        for the wl_output.
+      </description>
+      <arg name="name" type="string" summary="connector name" />
+    </event>
+
+    <event name="description">
+      <description summary="description">
+        The compositor sends this event once the connector is created to provide
+        a human-readable description for this connector, which may be presented
+        to the user. The compositor may send this event multiple times over the
+        lifetime of this object to reflect changes in the description.
+      </description>
+      <arg name="description" type="string" summary="connector description" />
+    </event>
+
+    <event name="connector_id">
+      <description summary="connector_id">
+        The compositor sends this event once the connector is created to
+        indicate the DRM object ID which represents the underlying connector
+        that is being offered. Note that the final lease may include additional
+        object IDs, such as CRTCs and planes.
+      </description>
+      <arg name="connector_id" type="uint" summary="DRM connector ID" />
+    </event>
+
+    <event name="done">
+      <description summary="all properties have been sent">
+        This event is sent after all properties of a connector have been sent.
+        This allows changes to the properties to be seen as atomic even if they
+        happen via multiple events.
+      </description>
+    </event>
+
+    <event name="withdrawn">
+      <description summary="lease offer withdrawn">
+        Sent to indicate that the compositor will no longer honor requests for
+        DRM leases which include this connector. The client may still issue a
+        lease request including this connector, but the compositor will send
+        wp_drm_lease_v1.finished without issuing a lease fd. Compositors are
+        encouraged to send this event when they lose access to connector, for
+        example when the connector is hot-unplugged, when the connector gets
+        leased to a client or when the compositor loses DRM master.
+
+        If a client holds a lease for the connector, the status of the lease
+        remains the same. The client should destroy the object after receiving
+        this event.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy connector">
+        The client may send this request to indicate that it will not use this
+        connector. Clients are encouraged to send this after receiving the
+        "withdrawn" event so that the server can release the resources
+        associated with this connector offer. Neither existing lease requests
+        nor leases will be affected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="wp_drm_lease_request_v1" version="1">
+    <description summary="DRM lease request">
+      A client that wishes to lease DRM resources will attach the list of
+      connectors advertised with wp_drm_lease_device_v1.connector that they
+      wish to lease, then use wp_drm_lease_request_v1.submit to submit the
+      request.
+    </description>
+
+    <enum name="error">
+      <entry name="wrong_device" value="0"
+             summary="requested a connector from a different lease device"/>
+      <entry name="duplicate_connector" value="1"
+             summary="requested a connector twice"/>
+      <entry name="empty_lease" value="2"
+             summary="requested a lease without requesting a connector"/>
+    </enum>
+
+    <request name="request_connector">
+      <description summary="request a connector for this lease">
+        Indicates that the client would like to lease the given connector.
+        This is only used as a suggestion, the compositor may choose to
+        include any resources in the lease it issues, or change the set of
+        leased resources at any time. Compositors are however encouraged to
+        include the requested connector and other resources necessary
+        to drive the connected output in the lease.
+
+        Requesting a connector that was created from a different lease device
+        than this lease request raises the wrong_device error. Requesting a
+        connector twice will raise the duplicate_connector error.
+      </description>
+      <arg name="connector" type="object"
+           interface="wp_drm_lease_connector_v1" />
+    </request>
+
+    <request name="submit" type="destructor">
+      <description summary="submit the lease request">
+        Submits the lease request and creates a new wp_drm_lease_v1 object.
+        After calling submit the compositor will immediately destroy this
+        object, issuing any more requests will cause a wl_display error.
+        The compositor doesn't make any guarantees about the events of the
+        lease object, clients cannot expect an immediate response.
+        Not requesting any connectors before submitting the lease request
+        will raise the empty_lease error.
+      </description>
+      <arg name="id" type="new_id" interface="wp_drm_lease_v1" />
+    </request>
+  </interface>
+
+  <interface name="wp_drm_lease_v1" version="1">
+    <description summary="a DRM lease">
+      A DRM lease object is used to transfer the DRM file descriptor to the
+      client and manage the lifetime of the lease.
+
+      Some time after the wp_drm_lease_v1 object is created, the compositor
+      will reply with the lease request's result. If the lease request is
+      granted, the compositor will send a lease_fd event. If the lease request
+      is denied, the compositor will send a finished event without a lease_fd
+      event.
+    </description>
+
+    <event name="lease_fd">
+      <description summary="shares the DRM file descriptor">
+        This event returns a file descriptor suitable for use with DRM-related
+        ioctls. The client should use drmModeGetLease to enumerate the DRM
+        objects which have been leased to them. The compositor guarantees it
+        will not use the leased DRM objects itself until it sends the finished
+        event. If the compositor cannot or will not grant a lease for the
+        requested connectors, it will not send this event, instead sending the
+        finished event.
+
+        The compositor will send this event at most once during this objects
+        lifetime.
+      </description>
+      <arg name="leased_fd" type="fd" summary="leased DRM file descriptor" />
+    </event>
+
+    <event name="finished">
+      <description summary="sent when the lease has been revoked">
+        The compositor uses this event to either reject a lease request, or if
+        it previously sent a lease_fd, to notify the client that the lease has
+        been revoked. If the client requires a new lease, they should destroy
+        this object and submit a new lease request. The compositor will send
+        no further events for this object after sending the finish event.
+        Compositors should revoke the lease when any of the leased resources
+        become unavailable, namely when a hot-unplug occurs or when the
+        compositor loses DRM master. Compositors may advertise the connector
+        for leasing again, if the resource is available, by sending the
+        connector event through the wp_drm_lease_device_v1 interface.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroys the lease object">
+        The client should send this to indicate that it no longer wishes to use
+        this lease. The compositor should use drmModeRevokeLease on the
+        appropriate file descriptor, if necessary.
+
+        Upon destruction, the compositor should advertise the connector for
+        leasing again by sending the connector event through the
+        wp_drm_lease_device_v1 interface.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -77,6 +77,17 @@ add_subdirectory(output_resolver-test)
 # Needs no GPU/compositor, so it runs anywhere the lease client is built.
 if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
     add_subdirectory(lease_client-test)
+    # T2 — kernel-real lease on vkms. Skips itself without vkms + DRM master, so
+    # it is safe to build and run everywhere; it only does real work under sudo.
+    #
+    # Needs both halves of the leased scanout path it drives: the software sink
+    # (BUILD_SOFTWARE_SINK_DRM) and the output provider, whose drm-cxx only
+    # exists once a DRM-KMS backend pulls in cmake/drm_kms.cmake. Configure e.g.
+    #   -DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_SOFTWARE=ON \
+    #   -DBUILD_BACKEND_DRM_KMS_EGL=ON -DBUILD_UNIT_TESTS=ON
+    if (BUILD_SOFTWARE_SINK_DRM AND TARGET drm-cxx)
+        add_subdirectory(leased_drm_vkms-test)
+    endif ()
 endif ()
 add_subdirectory(timer-test)
 add_subdirectory(watchdog-test)

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -73,6 +73,11 @@ add_subdirectory(flutter_view-test)
 add_subdirectory(app-test)
 add_subdirectory(configuration-test-case)
 add_subdirectory(output_resolver-test)
+# T1 — drives the real LeaseClient against a mock drm-lease-v1 compositor.
+# Needs no GPU/compositor, so it runs anywhere the lease client is built.
+if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
+    add_subdirectory(lease_client-test)
+endif ()
 add_subdirectory(timer-test)
 add_subdirectory(watchdog-test)
 add_subdirectory(wake_event_fd-test)

--- a/test/unit_test/lease_client-test/CMakeLists.txt
+++ b/test/unit_test/lease_client-test/CMakeLists.txt
@@ -1,0 +1,54 @@
+# T1 — LeaseClient unit tier (CI, no hardware).
+#
+# Deliberately does NOT use TYPICAL_TEST_SOURCES: the lease client has no
+# dependency on the shell, the engine, or a renderer, and compiling the whole
+# shell in would drag the Flutter engine into a test that only needs a socket.
+# Only the unit under test plus the mock compositor are built here, which is
+# also what lets this run on any CI box with no GPU and no compositor.
+set(TESTCASE_NAME "homescreen_lease_client_ut_test_driver")
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(WL_SERVER REQUIRED IMPORTED_TARGET wayland-server)
+if (NOT TARGET PkgConfig::DRM)
+    pkg_check_modules(DRM REQUIRED IMPORTED_TARGET libdrm)
+endif ()
+
+add_executable(
+        ${TESTCASE_NAME}
+        ${PROJECT_SOURCE_DIR}/shell/backend/wayland_leased_drm/lease_client.cc
+        test_case_lease_client.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_include_directories(
+        ${TESTCASE_NAME}
+        PRIVATE
+        ${PROJECT_SOURCE_DIR}/shell
+        ${PROJECT_SOURCE_DIR}/shared/include
+        ${CMAKE_BINARY_DIR}/shared/include
+        ${CMAKE_BINARY_DIR}/shell
+)
+
+# The generated drm-lease client header is attached to the shell target by
+# ivi_wayland_protocols(); depend on the same codegen so this target can build
+# standalone (e.g. `ninja <testcase>` without building the shell first).
+add_dependencies(${TESTCASE_NAME} wlcxxgen_wayland_protocols_drm_lease_v1_client_hpp)
+
+target_link_libraries(
+        ${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        wayland-cxx::wayland-cxx
+        PkgConfig::WAYLAND_CXX_RUNTIME
+        PkgConfig::WL_SERVER
+        PkgConfig::DRM
+        ivi_homescreen::ihs_shared
+        Threads::Threads
+        toolchain::toolchain
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/lease_client-test/test_case_lease_client.cc
+++ b/test/unit_test/lease_client-test/test_case_lease_client.cc
@@ -1,0 +1,553 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// LeaseClient against a mock drm-lease-v1 compositor.
+//
+// A hand-rolled libwayland *server* (correct by construction: it uses the raw
+// server API) implements wp_drm_lease_device_v1 / _connector_v1 / _request_v1 /
+// _lease_v1; the client under test is the real homescreen::LeaseClient. It runs
+// on a private socket in a temp XDG_RUNTIME_DIR, so no compositor, GPU, or
+// leasable connector is needed — which is the point: on real wlroots hosts
+// nothing is offered unless a connector's EDID carries the non-desktop flag, so
+// the grant / monitor / teardown paths are unreachable outside this tier.
+//
+// The interface tables come from the generated *client* header, which emits
+// them (EMIT_INTERFACE_TABLES); a wl_interface is direction-agnostic.
+
+#include "backend/wayland_leased_drm/lease_client.h"
+
+#include "wayland-protocols/drm_lease_v1_client.hpp"
+
+extern "C" {
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <wayland-server-core.h>
+}
+
+#include <cerrno>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+namespace proto = drm_lease_v1::client;
+using homescreen::LeaseClient;
+using homescreen::LeaseConfig;
+using homescreen::LeaseError;
+
+// Event opcodes, taken from the generated traits so a protocol change can't
+// silently desync the mock from the client.
+constexpr uint32_t kDevDrmFd = proto::wp_drm_lease_device_v1_traits::Evt::DrmFd;
+constexpr uint32_t kDevConnector =
+    proto::wp_drm_lease_device_v1_traits::Evt::Connector;
+constexpr uint32_t kDevDone = proto::wp_drm_lease_device_v1_traits::Evt::Done;
+constexpr uint32_t kDevReleased =
+    proto::wp_drm_lease_device_v1_traits::Evt::Released;
+
+constexpr uint32_t kConnName =
+    proto::wp_drm_lease_connector_v1_traits::Evt::Name;
+constexpr uint32_t kConnDescription =
+    proto::wp_drm_lease_connector_v1_traits::Evt::Description;
+constexpr uint32_t kConnConnectorId =
+    proto::wp_drm_lease_connector_v1_traits::Evt::ConnectorId;
+constexpr uint32_t kConnDone =
+    proto::wp_drm_lease_connector_v1_traits::Evt::Done;
+
+constexpr uint32_t kLeaseFd = proto::wp_drm_lease_v1_traits::Evt::LeaseFd;
+constexpr uint32_t kLeaseFinished =
+    proto::wp_drm_lease_v1_traits::Evt::Finished;
+
+int MakeDummyFd() {
+  // Stands in for the DRM fd. drmGetDeviceNameFromFd2() on it fails, so the
+  // client reports the node as "(unresolved)" — which is fine here; resolving a
+  // real node is the vkms tier's job, not this one's.
+  const int fd = memfd_create("lease-test", MFD_CLOEXEC);
+  EXPECT_GE(fd, 0);
+  return fd;
+}
+
+// What the mock should do when a lease is submitted.
+enum class GrantPolicy {
+  kGrant,                 // lease_fd
+  kDeny,                  // finished, no lease_fd
+  kGrantThenFinishNow,    // lease_fd + finished in the same flush
+  kGrantThenFinishLater,  // lease_fd, then finished ~50 ms on
+};
+
+struct ConnectorSpec {
+  std::string name;
+  std::string description;
+  uint32_t connector_id;
+};
+
+struct DeviceSpec {
+  std::vector<ConnectorSpec> connectors;
+};
+
+struct MockConfig {
+  std::vector<DeviceSpec> devices{{{{"HDMI-A-1", "mock panel", 42}}}};
+  GrantPolicy policy = GrantPolicy::kGrant;
+  bool send_drm_fd = true;  // false = defer forever (compositor lacks master)
+  bool send_device_done = true;
+};
+
+// ── mock compositor ────────────────────────────────────────────────────────
+
+class MockCompositor {
+ public:
+  explicit MockCompositor(MockConfig cfg) : cfg_(std::move(cfg)) {
+    // Hermetic runtime dir so the test never touches the developer's session.
+    char tmpl[] = "/tmp/ivi-lease-test-XXXXXX";
+    runtime_dir_ = mkdtemp(tmpl);
+    EXPECT_FALSE(runtime_dir_.empty());
+    prev_xdg_ = GetEnvOr("XDG_RUNTIME_DIR");
+    prev_wl_ = GetEnvOr("WAYLAND_DISPLAY");
+    setenv("XDG_RUNTIME_DIR", runtime_dir_.c_str(), 1);
+
+    display_ = wl_display_create();
+    EXPECT_NE(display_, nullptr);
+    const char* sock = wl_display_add_socket_auto(display_);
+    EXPECT_NE(sock, nullptr);
+    socket_name_ = sock != nullptr ? sock : "";
+    setenv("WAYLAND_DISPLAY", socket_name_.c_str(), 1);
+
+    for (size_t i = 0; i < cfg_.devices.size(); ++i) {
+      wl_global_create(display_,
+                       &proto::wp_drm_lease_device_v1_traits::wl_iface(), 1,
+                       this, &MockCompositor::BindDevice);
+    }
+    thread_ = std::thread([this] { wl_display_run(display_); });
+  }
+
+  ~MockCompositor() {
+    wl_display_terminate(display_);
+    if (thread_.joinable()) {
+      thread_.join();
+    }
+    wl_display_destroy(display_);
+    RestoreEnv("XDG_RUNTIME_DIR", prev_xdg_);
+    RestoreEnv("WAYLAND_DISPLAY", prev_wl_);
+    std::error_code ec;
+    std::filesystem::remove_all(runtime_dir_, ec);
+  }
+
+  MockCompositor(const MockCompositor&) = delete;
+  MockCompositor& operator=(const MockCompositor&) = delete;
+
+ private:
+  static std::string GetEnvOr(const char* k) {
+    const char* v = getenv(k);
+    return v != nullptr ? std::string(v) : std::string();
+  }
+  static void RestoreEnv(const char* k, const std::string& v) {
+    if (v.empty()) {
+      unsetenv(k);
+    } else {
+      setenv(k, v.c_str(), 1);
+    }
+  }
+
+  // Per-bound-device state.
+  struct DeviceCtx {
+    MockCompositor* self;
+    size_t index;
+  };
+
+  static void BindDevice(wl_client* client,
+                         void* data,
+                         uint32_t version,
+                         uint32_t id) {
+    auto* self = static_cast<MockCompositor*>(data);
+    // Which spec this bind maps to: globals are created in order, and the
+    // client binds them in advertisement order.
+    const size_t index = self->bind_count_++;
+
+    wl_resource* res = wl_resource_create(
+        client, &proto::wp_drm_lease_device_v1_traits::wl_iface(),
+        static_cast<int>(version), id);
+    auto* ctx = new DeviceCtx{self, index};
+    wl_resource_set_implementation(res, &kDeviceImpl, ctx,
+                                   &MockCompositor::DestroyDeviceCtx);
+
+    if (self->cfg_.send_drm_fd) {
+      const int fd = MakeDummyFd();
+      wl_resource_post_event(res, kDevDrmFd, fd);
+      // libwayland takes ownership of an 'h' arg and closes it once sent.
+    }
+
+    if (index < self->cfg_.devices.size()) {
+      for (const auto& c : self->cfg_.devices[index].connectors) {
+        wl_resource* cr = wl_resource_create(
+            client, &proto::wp_drm_lease_connector_v1_traits::wl_iface(), 1, 0);
+        wl_resource_set_implementation(cr, &kConnectorImpl, nullptr, nullptr);
+        wl_resource_post_event(res, kDevConnector, cr);
+        wl_resource_post_event(cr, kConnName, c.name.c_str());
+        wl_resource_post_event(cr, kConnDescription, c.description.c_str());
+        wl_resource_post_event(cr, kConnConnectorId, c.connector_id);
+        wl_resource_post_event(cr, kConnDone);
+      }
+    }
+    if (self->cfg_.send_device_done) {
+      wl_resource_post_event(res, kDevDone);
+    }
+  }
+
+  static void DestroyDeviceCtx(wl_resource* res) {
+    delete static_cast<DeviceCtx*>(wl_resource_get_user_data(res));
+  }
+
+  // wp_drm_lease_device_v1
+  static void DeviceCreateLeaseRequest(wl_client* client,
+                                       wl_resource* dev,
+                                       uint32_t id) {
+    auto* ctx = static_cast<DeviceCtx*>(wl_resource_get_user_data(dev));
+    wl_resource* req = wl_resource_create(
+        client, &proto::wp_drm_lease_request_v1_traits::wl_iface(), 1, id);
+    wl_resource_set_implementation(req, &kRequestImpl, ctx->self, nullptr);
+  }
+  static void DeviceRelease(wl_client* /*client*/, wl_resource* dev) {
+    // The `released` event is the destructor — answer, then drop the resource.
+    // The client drains for exactly this before destroying its proxy.
+    wl_resource_post_event(dev, kDevReleased);
+    wl_resource_destroy(dev);
+  }
+  static constexpr struct {
+    void (*create_lease_request)(wl_client*, wl_resource*, uint32_t);
+    void (*release)(wl_client*, wl_resource*);
+  } kDeviceImpl{&MockCompositor::DeviceCreateLeaseRequest,
+                &MockCompositor::DeviceRelease};
+
+  // wp_drm_lease_connector_v1
+  static void ConnectorDestroy(wl_client* /*client*/, wl_resource* r) {
+    wl_resource_destroy(r);
+  }
+  static constexpr struct {
+    void (*destroy)(wl_client*, wl_resource*);
+  } kConnectorImpl{&MockCompositor::ConnectorDestroy};
+
+  // wp_drm_lease_request_v1
+  static void RequestConnector(wl_client* /*client*/,
+                               wl_resource* /*req*/,
+                               wl_resource* /*connector*/) {}
+
+  // wl_display_destroy does not reap a still-armed timer source, so the source
+  // owns itself: it fires once, removes itself, and frees its context.
+  struct FinishCtx {
+    wl_resource* lease;
+    wl_event_source* src;
+  };
+
+  static int FinishLater(void* data) {
+    auto* ctx = static_cast<FinishCtx*>(data);
+    wl_resource_post_event(ctx->lease, kLeaseFinished);
+    wl_client_flush(wl_resource_get_client(ctx->lease));
+    wl_event_source_remove(ctx->src);
+    delete ctx;
+    return 0;
+  }
+
+  static void RequestSubmit(wl_client* client, wl_resource* req, uint32_t id) {
+    auto* self = static_cast<MockCompositor*>(wl_resource_get_user_data(req));
+    wl_resource* lease = wl_resource_create(
+        client, &proto::wp_drm_lease_v1_traits::wl_iface(), 1, id);
+    wl_resource_set_implementation(lease, &kLeaseImpl, nullptr, nullptr);
+    // submit is a destructor request: the request object is gone server-side.
+    wl_resource_destroy(req);
+
+    switch (self->cfg_.policy) {
+      case GrantPolicy::kDeny:
+        wl_resource_post_event(lease, kLeaseFinished);
+        break;
+      case GrantPolicy::kGrant:
+        wl_resource_post_event(lease, kLeaseFd, MakeDummyFd());
+        break;
+      case GrantPolicy::kGrantThenFinishNow:
+        wl_resource_post_event(lease, kLeaseFd, MakeDummyFd());
+        wl_resource_post_event(lease, kLeaseFinished);
+        break;
+      case GrantPolicy::kGrantThenFinishLater: {
+        wl_resource_post_event(lease, kLeaseFd, MakeDummyFd());
+        auto* ctx = new FinishCtx{lease, nullptr};
+        ctx->src =
+            wl_event_loop_add_timer(wl_display_get_event_loop(self->display_),
+                                    &MockCompositor::FinishLater, ctx);
+        wl_event_source_timer_update(ctx->src, 50);
+        break;
+      }
+    }
+  }
+  static constexpr struct {
+    void (*request_connector)(wl_client*, wl_resource*, wl_resource*);
+    void (*submit)(wl_client*, wl_resource*, uint32_t);
+  } kRequestImpl{&MockCompositor::RequestConnector,
+                 &MockCompositor::RequestSubmit};
+
+  // wp_drm_lease_v1
+  static void LeaseDestroy(wl_client* /*client*/, wl_resource* r) {
+    wl_resource_destroy(r);
+  }
+  static constexpr struct {
+    void (*destroy)(wl_client*, wl_resource*);
+  } kLeaseImpl{&MockCompositor::LeaseDestroy};
+
+  MockConfig cfg_;
+  wl_display* display_ = nullptr;
+  std::thread thread_;
+  std::string runtime_dir_;
+  std::string socket_name_;
+  std::string prev_xdg_;
+  std::string prev_wl_;
+  std::atomic<size_t> bind_count_{0};
+};
+
+LeaseConfig Cfg(uint32_t timeout_ms = 2000) {
+  LeaseConfig c;
+  c.timeout_ms = timeout_ms;
+  return c;
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+TEST(LeaseClient, GrantsALeaseAndReportsTheConnector) {
+  MockCompositor mock{MockConfig{}};
+
+  auto res = LeaseClient::Acquire(Cfg());
+
+  ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+  EXPECT_EQ(res.error, LeaseError::kNone);
+  EXPECT_EQ(res.hold->connector_name(), "HDMI-A-1");
+  EXPECT_EQ(res.hold->connector_id(), 42u);
+  EXPECT_GE(res.hold->fd(), 0);
+  EXPECT_FALSE(res.hold->revoked());
+  ASSERT_EQ(res.offers.size(), 1u);
+  EXPECT_EQ(res.offers[0].description, "mock panel");
+}
+
+TEST(LeaseClient, TeardownReleasesCleanly) {
+  MockCompositor mock{MockConfig{}};
+  auto res = LeaseClient::Acquire(Cfg());
+  ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+  const int fd = res.hold->fd();
+  EXPECT_GE(fd, 0);
+
+  // Exercises ~LeaseHold: stop+join the monitor, destroy the lease, close the
+  // fd, run the release -> released handshake, disconnect. Must not hang.
+  res.hold.reset();
+
+  // The lease fd is ours and must be closed by the destructor.
+  EXPECT_EQ(fcntl(fd, F_GETFD), -1);
+  EXPECT_EQ(errno, EBADF);
+}
+
+TEST(LeaseClient, DenialIsReportedAsDenied) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kDeny;
+  MockCompositor mock{cfg};
+
+  auto res = LeaseClient::Acquire(Cfg());
+
+  EXPECT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kDenied);
+}
+
+// The reviewer's scenario: lease_fd and finished land in the same dispatch
+// batch, so the monitor never sees a fresh event. revoked() must still latch.
+TEST(LeaseClient, FinishedInSameBatchAsGrantStillLatchesRevoked) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kGrantThenFinishNow;
+  MockCompositor mock{cfg};
+
+  auto res = LeaseClient::Acquire(Cfg());
+
+  ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+  EXPECT_TRUE(res.hold->revoked())
+      << "finished arrived with lease_fd but revoked() never latched";
+}
+
+// Revocation after the grant must be seen by the monitor thread.
+TEST(LeaseClient, MonitorLatchesRevokedOnLaterFinished) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kGrantThenFinishLater;
+  MockCompositor mock{cfg};
+
+  auto res = LeaseClient::Acquire(Cfg());
+  ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!res.hold->revoked() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  EXPECT_TRUE(res.hold->revoked()) << "monitor thread never observed finished";
+}
+
+TEST(LeaseClient, NoConnectorsOfferedIsReported) {
+  MockConfig cfg;
+  cfg.devices = {DeviceSpec{{}}};  // device advertises zero connectors
+  MockCompositor mock{cfg};
+
+  auto res = LeaseClient::Acquire(Cfg());
+
+  EXPECT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kNoOffers);
+  EXPECT_TRUE(res.offers.empty());
+}
+
+TEST(LeaseClient, SeveralConnectorsWithNoSelectionIsAmbiguous) {
+  MockConfig cfg;
+  cfg.devices = {DeviceSpec{{{"HDMI-A-1", "a", 42}, {"DP-1", "b", 43}}}};
+  MockCompositor mock{cfg};
+
+  auto res = LeaseClient::Acquire(Cfg());
+
+  EXPECT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kConnectorAmbiguous);
+  EXPECT_EQ(res.offers.size(), 2u);
+}
+
+TEST(LeaseClient, SelectsTheNamedConnector) {
+  MockConfig cfg;
+  cfg.devices = {DeviceSpec{{{"HDMI-A-1", "a", 42}, {"DP-1", "b", 43}}}};
+  MockCompositor mock{cfg};
+
+  LeaseConfig c = Cfg();
+  c.connector = "DP-1";
+  auto res = LeaseClient::Acquire(c);
+
+  ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+  EXPECT_EQ(res.hold->connector_name(), "DP-1");
+  EXPECT_EQ(res.hold->connector_id(), 43u);
+}
+
+TEST(LeaseClient, UnknownConnectorNameIsReported) {
+  MockCompositor mock{MockConfig{}};
+
+  LeaseConfig c = Cfg();
+  c.connector = "VGA-9";
+  auto res = LeaseClient::Acquire(c);
+
+  EXPECT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kConnectorNotFound);
+}
+
+TEST(LeaseClient, SeveralDevicesWithNoSelectionIsAmbiguous) {
+  MockConfig cfg;
+  cfg.devices = {DeviceSpec{{{"HDMI-A-1", "a", 42}}},
+                 DeviceSpec{{{"DP-1", "b", 43}}}};
+  MockCompositor mock{cfg};
+
+  auto res = LeaseClient::Acquire(Cfg());
+
+  EXPECT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kDeviceAmbiguous);
+}
+
+TEST(LeaseClient, DeviceSelectableByIndex) {
+  MockConfig cfg;
+  cfg.devices = {DeviceSpec{{{"HDMI-A-1", "a", 42}}},
+                 DeviceSpec{{{"DP-1", "b", 43}}}};
+  MockCompositor mock{cfg};
+
+  LeaseConfig c = Cfg();
+  c.device = "1";
+  auto res = LeaseClient::Acquire(c);
+
+  ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+  EXPECT_EQ(res.hold->connector_name(), "DP-1");
+}
+
+TEST(LeaseClient, UnknownDeviceIndexIsReported) {
+  MockCompositor mock{MockConfig{}};
+
+  LeaseConfig c = Cfg();
+  c.device = "7";
+  auto res = LeaseClient::Acquire(c);
+
+  EXPECT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kDeviceNotFound);
+}
+
+// The spec lets a compositor defer drm_fd until it regains DRM master. Without
+// a bound deadline this would hang startup forever, so the timeout is
+// load-bearing rather than cosmetic.
+TEST(LeaseClient, DeferredEnumerationHitsTheDeadlineInsteadOfHanging) {
+  MockConfig cfg;
+  cfg.send_device_done = false;  // never completes enumeration
+  MockCompositor mock{cfg};
+
+  const auto start = std::chrono::steady_clock::now();
+  auto res = LeaseClient::Acquire(Cfg(300));
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kTimeout);
+  EXPECT_GE(elapsed, std::chrono::milliseconds(250));
+  EXPECT_LT(elapsed, std::chrono::seconds(5)) << "deadline did not bind";
+}
+
+TEST(LeaseClient, ProbeEnumeratesWithoutLeasing) {
+  MockCompositor mock{MockConfig{}};
+
+  auto res = LeaseClient::Probe(Cfg());
+
+  EXPECT_EQ(res.hold, nullptr);  // Probe never negotiates
+  EXPECT_EQ(res.error, LeaseError::kNone) << homescreen::ToString(res.error);
+  ASSERT_EQ(res.offers.size(), 1u);
+  EXPECT_EQ(res.offers[0].name, "HDMI-A-1");
+  EXPECT_EQ(res.offers[0].connector_id, 42u);
+}
+
+TEST(LeaseClient, ProbeWithNoOffersIsDistinctFromSuccess) {
+  MockConfig cfg;
+  cfg.devices = {DeviceSpec{{}}};
+  MockCompositor mock{cfg};
+
+  auto res = LeaseClient::Probe(Cfg());
+
+  EXPECT_EQ(res.error, LeaseError::kNoOffers);
+  EXPECT_TRUE(res.offers.empty());
+}
+
+// No mock at all: a stale WAYLAND_DISPLAY must not be trusted.
+TEST(LeaseClient, StaleWaylandDisplayIsNotASession) {
+  const char* prev = getenv("WAYLAND_DISPLAY");
+  const std::string saved = prev != nullptr ? prev : "";
+  setenv("WAYLAND_DISPLAY", "ivi-lease-test-nonexistent", 1);
+
+  auto res = LeaseClient::Acquire(Cfg(200));
+
+  EXPECT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kNoWaylandSession);
+
+  if (saved.empty()) {
+    unsetenv("WAYLAND_DISPLAY");
+  } else {
+    setenv("WAYLAND_DISPLAY", saved.c_str(), 1);
+  }
+}
+
+}  // namespace

--- a/test/unit_test/lease_client-test/test_case_lease_client.cc
+++ b/test/unit_test/lease_client-test/test_case_lease_client.cc
@@ -532,6 +532,77 @@ TEST(LeaseClient, MonitorLatchesRevokedOnLaterFinished) {
   EXPECT_TRUE(res.hold->revoked()) << "monitor thread never observed finished";
 }
 
+// The revocation policy hook. The shell's `exit` policy installs a handler that
+// terminates the process, so the handler is injectable precisely to keep it out
+// of the library — these tests observe it instead of exiting.
+TEST(LeaseClient, OnRevokedFiresOnceWithTheCauseWhenFinishedArrivesLater) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kGrantThenFinishLater;
+  MockCompositor mock{cfg};
+
+  std::atomic<int> calls{0};
+  std::atomic<homescreen::RevokeCause> seen{
+      homescreen::RevokeCause::kMonitorFailure};
+  LeaseConfig c = Cfg();
+  c.on_revoked = [&](homescreen::RevokeCause cause) {
+    seen.store(cause);
+    calls.fetch_add(1);
+  };
+
+  auto res = LeaseClient::Acquire(c);
+  ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (calls.load() == 0 && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+  EXPECT_EQ(calls.load(), 1);
+  EXPECT_EQ(seen.load(), homescreen::RevokeCause::kFinished);
+  EXPECT_TRUE(res.hold->revoked());
+
+  // Teardown must not fire it again: the handler is "once", and a policy that
+  // exits the process would be catastrophic to re-run while tearing down.
+  res.hold.reset();
+  EXPECT_EQ(calls.load(), 1);
+}
+
+// The same-batch case: `finished` arrives with lease_fd, so the monitor thread
+// never sees a fresh event. Acquire() must fire the handler itself.
+TEST(LeaseClient, OnRevokedFiresWhenFinishedArrivesInTheGrantBatch) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kGrantThenFinishNow;
+  MockCompositor mock{cfg};
+
+  std::atomic<int> calls{0};
+  LeaseConfig c = Cfg();
+  c.on_revoked = [&](homescreen::RevokeCause) { calls.fetch_add(1); };
+
+  auto res = LeaseClient::Acquire(c);
+  ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+  EXPECT_TRUE(res.hold->revoked());
+  EXPECT_EQ(calls.load(), 1) << "handler must fire even though the monitor "
+                                "thread will never see another event";
+}
+
+// A denial is not a revocation: no lease was ever held, so the policy must not
+// fire. Otherwise `exit` would turn a recoverable config error into a crash
+// loop with a misleading cause.
+TEST(LeaseClient, OnRevokedDoesNotFireOnDenial) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kDeny;
+  MockCompositor mock{cfg};
+
+  std::atomic<int> calls{0};
+  LeaseConfig c = Cfg();
+  c.on_revoked = [&](homescreen::RevokeCause) { calls.fetch_add(1); };
+
+  auto res = LeaseClient::Acquire(c);
+  ASSERT_EQ(res.hold, nullptr);
+  EXPECT_EQ(res.error, LeaseError::kDenied);
+  EXPECT_EQ(calls.load(), 0);
+}
+
 TEST(LeaseClient, NoConnectorsOfferedIsReported) {
   MockConfig cfg;
   cfg.devices = {DeviceSpec{{}}};  // device advertises zero connectors

--- a/test/unit_test/lease_client-test/test_case_lease_client.cc
+++ b/test/unit_test/lease_client-test/test_case_lease_client.cc
@@ -730,6 +730,38 @@ TEST(LeaseClient, ProbeWithNoOffersIsDistinctFromSuccess) {
   EXPECT_TRUE(res.offers.empty());
 }
 
+// --lease-list-connectors. Its exit codes are meant to be scriptable, so pin
+// them: an operator (or CI) has to be able to tell "the compositor offers
+// nothing" apart from "there is no compositor", because on a wlroots host the
+// former is the normal outcome and the one that needs explaining.
+TEST(LeaseListConnectors, AbsentFlagDefersToNormalStartup) {
+  char a0[] = "homescreen";
+  char a1[] = "--backend=software";
+  char* argv[] = {a0, a1};
+  EXPECT_EQ(homescreen::MaybeListLeaseConnectors(2, argv), -1)
+      << "without the flag it must not intercept startup";
+}
+
+TEST(LeaseListConnectors, ListsOffersAndSucceeds) {
+  MockCompositor mock{MockConfig{}};
+  char a0[] = "homescreen";
+  char a1[] = "--lease-list-connectors";
+  char* argv[] = {a0, a1};
+  EXPECT_EQ(homescreen::MaybeListLeaseConnectors(2, argv), 0);
+}
+
+TEST(LeaseListConnectors, NoOffersIsDistinctFromNoCompositor) {
+  MockConfig cfg;
+  cfg.devices = {DeviceSpec{{}}};  // advertises the device, offers nothing
+  MockCompositor mock{cfg};
+  char a0[] = "homescreen";
+  char a1[] = "--lease-list-connectors";
+  char* argv[] = {a0, a1};
+  EXPECT_EQ(homescreen::MaybeListLeaseConnectors(2, argv), 1)
+      << "a reachable compositor offering nothing must not look like an absent "
+         "one";
+}
+
 // No mock at all: a stale WAYLAND_DISPLAY must not be trusted.
 TEST(LeaseClient, StaleWaylandDisplayIsNotASession) {
   const char* prev = getenv("WAYLAND_DISPLAY");

--- a/test/unit_test/lease_client-test/test_case_lease_client.cc
+++ b/test/unit_test/lease_client-test/test_case_lease_client.cc
@@ -77,6 +77,8 @@ constexpr uint32_t kConnConnectorId =
     proto::wp_drm_lease_connector_v1_traits::Evt::ConnectorId;
 constexpr uint32_t kConnDone =
     proto::wp_drm_lease_connector_v1_traits::Evt::Done;
+constexpr uint32_t kConnWithdrawn =
+    proto::wp_drm_lease_connector_v1_traits::Evt::Withdrawn;
 
 constexpr uint32_t kLeaseFd = proto::wp_drm_lease_v1_traits::Evt::LeaseFd;
 constexpr uint32_t kLeaseFinished =
@@ -118,6 +120,11 @@ enum class GrantPolicy {
   kGrantThenFinishNow,    // lease_fd + finished in the same flush
   kGrantThenFinishLater,  // lease_fd, then finished ~50 ms on
   kGrantTwice,            // lease_fd twice — a misbehaving/hostile compositor
+  // What wlroots actually does: a connector that has been leased out is no
+  // longer leasable, so it is withdrawn and the device re-brackets its list
+  // with `done`. Sent in the same flush as lease_fd, so the client sees all
+  // three in the dispatch it runs while waiting for the grant.
+  kGrantThenWithdrawConnector,
 };
 
 struct ConnectorSpec {
@@ -258,6 +265,10 @@ class MockCompositor {
         wl_resource_post_event(cr, kConnDescription, c.description.c_str());
         wl_resource_post_event(cr, kConnConnectorId, c.connector_id);
         wl_resource_post_event(cr, kConnDone);
+        // Retained so a policy can withdraw them later; the device resource is
+        // the parent, so these do not outlive the client connection.
+        self->connector_res_.push_back(cr);
+        self->device_res_ = res;
       }
     }
     if (self->cfg_.send_device_done) {
@@ -344,6 +355,15 @@ class MockCompositor {
         PostFdAndClose(lease, kLeaseFd);
         PostFdAndClose(lease, kLeaseFd);
         break;
+      case GrantPolicy::kGrantThenWithdrawConnector:
+        PostFdAndClose(lease, kLeaseFd);
+        for (wl_resource* cr : self->connector_res_) {
+          wl_resource_post_event(cr, kConnWithdrawn);
+        }
+        if (self->device_res_ != nullptr) {
+          wl_resource_post_event(self->device_res_, kDevDone);
+        }
+        break;
       case GrantPolicy::kGrantThenFinishLater: {
         PostFdAndClose(lease, kLeaseFd);
         auto* ctx = new FinishCtx{lease, nullptr};
@@ -370,6 +390,12 @@ class MockCompositor {
   } kLeaseImpl{&MockCompositor::LeaseDestroy};
 
   MockConfig cfg_;
+
+  // Connector/device resources from the most recent bind, so a grant policy can
+  // withdraw a connector after leasing it out. Non-owning: libwayland destroys
+  // them with the client connection.
+  std::vector<wl_resource*> connector_res_;
+  wl_resource* device_res_ = nullptr;
   wl_display* display_ = nullptr;
   std::thread thread_;
   std::string runtime_dir_;
@@ -778,6 +804,45 @@ TEST(LeaseClient, StaleWaylandDisplayIsNotASession) {
   } else {
     setenv("WAYLAND_DISPLAY", saved.c_str(), 1);
   }
+}
+
+// A compositor that withdraws the connector it just leased out -- which is what
+// wlroots does, since a leased connector is no longer leasable -- must not take
+// the client's cached Connector* out from under it.
+//
+// Acquire() caches the selected Connector*, submits, then dispatches waiting
+// for lease_fd. Both wp_drm_lease_device_v1.done and a subsequent .connector
+// run PruneWithdrawn(), which erases the withdrawn Connector from the device's
+// deque and frees it -- while Acquire still holds a raw pointer it reads
+// afterwards to populate the hold's connector_id/name. The withdraw carries no
+// lease meaning here (the spec says the lease status is unchanged post-grant
+// and the client should merely destroy the object), so this must be a clean
+// grant.
+//
+// Built as an ASan regression test: without the fix the reads after the
+// dispatch are a heap-use-after-free, which ASan aborts on. Unsanitized, the
+// freed offer usually still holds plausible bytes, so the failure is a garbage
+// connector_id rather than a crash -- which is exactly why the assertions below
+// check the values, not just survival.
+TEST(LeaseClient, ConnectorWithdrawnDuringGrantIsNotAUseAfterFree) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kGrantThenWithdrawConnector;
+  cfg.devices = {{{{"HDMI-A-1", "mock panel", 42}}}};
+  MockCompositor mock(std::move(cfg));
+
+  auto res = LeaseClient::Acquire(Cfg(2000));
+
+  ASSERT_NE(res.hold, nullptr)
+      << "withdrawing the connector after granting must not fail the lease: "
+         "the spec leaves the lease status unchanged";
+  // The identity must survive the withdraw. A UAF read here typically yields 0
+  // or garbage rather than crashing.
+  EXPECT_EQ(res.hold->connector_id(), 42u)
+      << "connector_id was read from a Connector freed by PruneWithdrawn";
+  EXPECT_EQ(res.hold->connector_name(), "HDMI-A-1")
+      << "connector_name was read from a Connector freed by PruneWithdrawn";
+  EXPECT_FALSE(res.hold->revoked())
+      << "a post-grant withdraw is not a revocation";
 }
 
 }  // namespace

--- a/test/unit_test/lease_client-test/test_case_lease_client.cc
+++ b/test/unit_test/lease_client-test/test_case_lease_client.cc
@@ -47,6 +47,7 @@ extern "C" {
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <filesystem>
 #include <string>
 #include <thread>
@@ -90,12 +91,33 @@ int MakeDummyFd() {
   return fd;
 }
 
+// Post an fd event and drop our copy: the sender keeps ownership of an 'h'
+// argument, so the mock must close what it created.
+void PostFdAndClose(wl_resource* res, uint32_t opcode) {
+  const int fd = MakeDummyFd();
+  wl_resource_post_event(res, opcode, fd);
+  close(fd);
+}
+
+// Number of fds this process currently holds. Used to gate fd leaks, which
+// LeakSanitizer cannot see -- it tracks memory, not descriptors.
+size_t CountOpenFds() {
+  size_t n = 0;
+  std::error_code ec;
+  for (auto it = std::filesystem::directory_iterator("/proc/self/fd", ec);
+       !ec && it != std::filesystem::directory_iterator(); it.increment(ec)) {
+    ++n;
+  }
+  return n;
+}
+
 // What the mock should do when a lease is submitted.
 enum class GrantPolicy {
   kGrant,                 // lease_fd
   kDeny,                  // finished, no lease_fd
   kGrantThenFinishNow,    // lease_fd + finished in the same flush
   kGrantThenFinishLater,  // lease_fd, then finished ~50 ms on
+  kGrantTwice,            // lease_fd twice — a misbehaving/hostile compositor
 };
 
 struct ConnectorSpec {
@@ -122,8 +144,17 @@ class MockCompositor {
   explicit MockCompositor(MockConfig cfg) : cfg_(std::move(cfg)) {
     // Hermetic runtime dir so the test never touches the developer's session.
     char tmpl[] = "/tmp/ivi-lease-test-XXXXXX";
-    runtime_dir_ = mkdtemp(tmpl);
-    EXPECT_FALSE(runtime_dir_.empty());
+    // mkdtemp returns null on failure (/tmp full or read-only in a constrained
+    // CI container); constructing a std::string from it would segfault inside
+    // this constructor. ADD_FAILURE rather than ASSERT_*: the latter expands to
+    // a value-returning `return`, which is ill-formed in a constructor. The
+    // early return leaves display_ null, which the destructor tolerates.
+    const char* dir = mkdtemp(tmpl);
+    if (dir == nullptr) {
+      ADD_FAILURE() << "mkdtemp failed: " << std::strerror(errno);
+      return;
+    }
+    runtime_dir_ = dir;
     prev_xdg_ = GetEnvOr("XDG_RUNTIME_DIR");
     prev_wl_ = GetEnvOr("WAYLAND_DISPLAY");
     setenv("XDG_RUNTIME_DIR", runtime_dir_.c_str(), 1);
@@ -135,24 +166,37 @@ class MockCompositor {
     socket_name_ = sock != nullptr ? sock : "";
     setenv("WAYLAND_DISPLAY", socket_name_.c_str(), 1);
 
+    // One global per device spec, each carrying its own index. NOT a running
+    // bind counter: every client connection binds every global, so a counter
+    // would only be correct for the first client and would silently advertise
+    // no connectors to the second.
     for (size_t i = 0; i < cfg_.devices.size(); ++i) {
+      global_ctxs_.push_back(GlobalCtx{this, i});
       wl_global_create(display_,
                        &proto::wp_drm_lease_device_v1_traits::wl_iface(), 1,
-                       this, &MockCompositor::BindDevice);
+                       &global_ctxs_.back(), &MockCompositor::BindDevice);
     }
     thread_ = std::thread([this] { wl_display_run(display_); });
   }
 
+  // Tolerates a half-constructed mock: the constructor bails out early if
+  // mkdtemp or wl_display_create fails, leaving these null/empty.
   ~MockCompositor() {
-    wl_display_terminate(display_);
+    if (display_ != nullptr) {
+      wl_display_terminate(display_);
+    }
     if (thread_.joinable()) {
       thread_.join();
     }
-    wl_display_destroy(display_);
+    if (display_ != nullptr) {
+      wl_display_destroy(display_);
+    }
     RestoreEnv("XDG_RUNTIME_DIR", prev_xdg_);
     RestoreEnv("WAYLAND_DISPLAY", prev_wl_);
-    std::error_code ec;
-    std::filesystem::remove_all(runtime_dir_, ec);
+    if (!runtime_dir_.empty()) {
+      std::error_code ec;
+      std::filesystem::remove_all(runtime_dir_, ec);
+    }
   }
 
   MockCompositor(const MockCompositor&) = delete;
@@ -171,20 +215,21 @@ class MockCompositor {
     }
   }
 
-  // Per-bound-device state.
-  struct DeviceCtx {
+  // Identifies which device spec a global (and each resource bound from it)
+  // corresponds to.
+  struct GlobalCtx {
     MockCompositor* self;
     size_t index;
   };
+  using DeviceCtx = GlobalCtx;
 
   static void BindDevice(wl_client* client,
                          void* data,
                          uint32_t version,
                          uint32_t id) {
-    auto* self = static_cast<MockCompositor*>(data);
-    // Which spec this bind maps to: globals are created in order, and the
-    // client binds them in advertisement order.
-    const size_t index = self->bind_count_++;
+    auto* gctx = static_cast<GlobalCtx*>(data);
+    auto* self = gctx->self;
+    const size_t index = gctx->index;
 
     wl_resource* res = wl_resource_create(
         client, &proto::wp_drm_lease_device_v1_traits::wl_iface(),
@@ -196,7 +241,11 @@ class MockCompositor {
     if (self->cfg_.send_drm_fd) {
       const int fd = MakeDummyFd();
       wl_resource_post_event(res, kDevDrmFd, fd);
-      // libwayland takes ownership of an 'h' arg and closes it once sent.
+      // The sender keeps ownership of an 'h' argument: libwayland dups it into
+      // the connection's out-buffer and does NOT close the original. Verified
+      // empirically -- without this close the mock leaked one memfd per bind,
+      // which the fd-growth gates below then (correctly) blamed on the client.
+      close(fd);
     }
 
     if (index < self->cfg_.devices.size()) {
@@ -283,14 +332,20 @@ class MockCompositor {
         wl_resource_post_event(lease, kLeaseFinished);
         break;
       case GrantPolicy::kGrant:
-        wl_resource_post_event(lease, kLeaseFd, MakeDummyFd());
+        PostFdAndClose(lease, kLeaseFd);
         break;
       case GrantPolicy::kGrantThenFinishNow:
-        wl_resource_post_event(lease, kLeaseFd, MakeDummyFd());
+        PostFdAndClose(lease, kLeaseFd);
         wl_resource_post_event(lease, kLeaseFinished);
         break;
+      case GrantPolicy::kGrantTwice:
+        // Protocol-violating, but nothing on the wire stops a compositor doing
+        // it, and the client must not drop the superseded fd on the floor.
+        PostFdAndClose(lease, kLeaseFd);
+        PostFdAndClose(lease, kLeaseFd);
+        break;
       case GrantPolicy::kGrantThenFinishLater: {
-        wl_resource_post_event(lease, kLeaseFd, MakeDummyFd());
+        PostFdAndClose(lease, kLeaseFd);
         auto* ctx = new FinishCtx{lease, nullptr};
         ctx->src =
             wl_event_loop_add_timer(wl_display_get_event_loop(self->display_),
@@ -321,7 +376,9 @@ class MockCompositor {
   std::string socket_name_;
   std::string prev_xdg_;
   std::string prev_wl_;
-  std::atomic<size_t> bind_count_{0};
+  // Stable addresses for wl_global_create's user data; deque never reallocates
+  // its elements.
+  std::deque<GlobalCtx> global_ctxs_;
 };
 
 LeaseConfig Cfg(uint32_t timeout_ms = 2000) {
@@ -361,6 +418,76 @@ TEST(LeaseClient, TeardownReleasesCleanly) {
   // The lease fd is ours and must be closed by the destructor.
   EXPECT_EQ(fcntl(fd, F_GETFD), -1);
   EXPECT_EQ(errno, EBADF);
+}
+
+// fd-leak gates. LeakSanitizer tracks memory, not descriptors, so these are the
+// only thing standing between an fd leak and EMFILE on a long-running unit.
+//
+// Measured as GROWTH across repeated cycles rather than an absolute
+// before/after delta: the mock server shares this process, and it reaps each
+// client's accepted socket asynchronously on its own thread, so a single
+// cycle's count is both offset and racy. A real leak is per-cycle and dominates
+// that noise; a constant offset does not.
+constexpr int kFdCycles = 8;
+constexpr size_t kFdSlack = 2;  // server-side reaping lag
+
+// The mock server reaps a disconnected client's socket on its own event-loop
+// thread, so give it a moment to catch up before counting — otherwise its
+// backlog of unreaped sockets is indistinguishable from a client-side leak.
+void SettleServer() {
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+}
+
+size_t FdGrowthOverCycles(const std::function<void()>& cycle) {
+  cycle();  // warm up: first pass allocates the steady-state structures
+  SettleServer();
+  const size_t before = CountOpenFds();
+  for (int i = 0; i < kFdCycles; ++i) {
+    cycle();
+  }
+  SettleServer();
+  const size_t after = CountOpenFds();
+  return after > before ? after - before : 0;
+}
+
+TEST(LeaseClient, GrantAndTeardownLeakNoFds) {
+  MockCompositor mock{MockConfig{}};
+  const size_t growth = FdGrowthOverCycles([] {
+    auto res = LeaseClient::Acquire(Cfg());
+    ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+  });
+  EXPECT_LE(growth, kFdSlack) << "fds grew by " << growth << " across "
+                              << kFdCycles << " grant/teardown cycles";
+}
+
+// A compositor that re-sends lease_fd must not leak the superseded descriptor.
+// Unfixed, OnLeaseFd clobbers the field and one fd escapes per event — a
+// hostile compositor could loop this to drive the embedder to EMFILE.
+TEST(LeaseClient, RepeatedLeaseFdDoesNotLeakTheSupersededFd) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kGrantTwice;
+  MockCompositor mock{cfg};
+  const size_t growth = FdGrowthOverCycles([] {
+    auto res = LeaseClient::Acquire(Cfg());
+    ASSERT_NE(res.hold, nullptr) << homescreen::ToString(res.error);
+    EXPECT_GE(res.hold->fd(), 0);
+  });
+  EXPECT_LE(growth, kFdSlack)
+      << "fds grew by " << growth << " across " << kFdCycles
+      << " cycles — the superseded lease_fd is leaking";
+}
+
+// A denial must not leak the enumeration fd either.
+TEST(LeaseClient, DenialLeaksNoFds) {
+  MockConfig cfg;
+  cfg.policy = GrantPolicy::kDeny;
+  MockCompositor mock{cfg};
+  const size_t growth = FdGrowthOverCycles([] {
+    auto res = LeaseClient::Acquire(Cfg());
+    ASSERT_EQ(res.hold, nullptr);
+  });
+  EXPECT_LE(growth, kFdSlack) << "fds grew by " << growth << " across "
+                              << kFdCycles << " denied cycles";
 }
 
 TEST(LeaseClient, DenialIsReportedAsDenied) {

--- a/test/unit_test/leased_drm_vkms-test/CMakeLists.txt
+++ b/test/unit_test/leased_drm_vkms-test/CMakeLists.txt
@@ -1,0 +1,53 @@
+# T2 — kernel-real DRM lease on vkms (no compositor).
+#
+# Unlike the T1 lease-client tier, this one follows the standard
+# TYPICAL_TEST_SOURCES pattern: it drives DrmDumbSink, which is genuinely wired
+# into the shell (vsync provider, profiling, task runner), so building it
+# standalone would mean re-listing half the shell by hand.
+#
+# Every case skips (not fails) without vkms + DRM master, so this is safe to
+# build and run unprivileged and in CI; it only does real work under `sudo`.
+set(TESTCASE_NAME "homescreen_leased_drm_vkms_ut_test_driver")
+set(TESTCASE_CC test_case_leased_drm_vkms.cc;)
+
+add_executable(
+        ${TESTCASE_NAME}
+        ${TYPICAL_TEST_SOURCES}
+        ${TESTCASE_CC}
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+# TYPICAL_TEST_SOURCES now carries lease_client.cc, which includes the generated
+# drm-lease client header. The header is attached to the shell target by
+# ivi_wayland_protocols(), so without this the test only builds when the shell
+# happened to be built first.
+if (TARGET wlcxxgen_wayland_protocols_drm_lease_v1_client_hpp)
+    add_dependencies(${TESTCASE_NAME}
+            wlcxxgen_wayland_protocols_drm_lease_v1_client_hpp)
+endif ()
+
+target_compile_definitions(
+        ${TESTCASE_NAME}
+        PRIVATE
+        ${TYPICAL_TEST_DEFINITIONS}
+)
+
+target_include_directories(
+        ${TESTCASE_NAME}
+        PRIVATE
+        ${TYPICAL_TEST_INC_DIRS}
+)
+
+target_link_libraries(
+        ${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        ${TYPICAL_TEST_LINK_LIBS}
+        toolchain::toolchain
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/leased_drm_vkms-test/test_case_leased_drm_vkms.cc
+++ b/test/unit_test/leased_drm_vkms-test/test_case_leased_drm_vkms.cc
@@ -288,6 +288,66 @@ TEST(LeasedDrmVkms, RevokedLeaseLosesItsObjectsButKeepsTheFd) {
   }
 }
 
+// The one kernel-behaviour claim the whole EGL
+// recovery design rests on, and the reason egl's lease_on_revoke default is
+// `exit` until this is evidenced: "leases partition mode objects only. GEM
+// allocation, prime export/import and render ioctls were never lease-scoped, so
+// a revoked lease fd remains a functional render fd."
+//
+// If that is false, the egl tier is unimplementable as written -- it keeps
+// GBM/EGL and the engine's GL context on the OLD fd across a reacquire and
+// rebuilds only the KMS side. So this is worth pinning against a real kernel
+// rather than reasoning about.
+TEST(LeasedDrmVkms, RevokedLeaseFdIsStillAFunctionalRenderFd) {
+  REQUIRE_VKMS_LEASE(v);
+
+  // Baseline: GEM alloc + prime export work on the live lease fd.
+  uint32_t handle = 0;
+  uint32_t pitch = 0;
+  uint64_t size = 0;
+  ASSERT_EQ(drmModeCreateDumbBuffer(v.lease_fd(), 64, 64, 32, 0, &handle,
+                                    &pitch, &size),
+            0)
+      << "dumb alloc on a live lease fd: " << std::strerror(errno);
+  int prime_fd = -1;
+  const int pre_prime =
+      drmPrimeHandleToFD(v.lease_fd(), handle, DRM_CLOEXEC, &prime_fd);
+  if (prime_fd >= 0) {
+    ::close(prime_fd);
+    prime_fd = -1;
+  }
+  ASSERT_EQ(drmModeDestroyDumbBuffer(v.lease_fd(), handle), 0);
+
+  // Now revoke, and retry exactly the same operations on the same fd.
+  ASSERT_EQ(drmModeRevokeLease(v.card_fd(), v.lessee_id()), 0)
+      << std::strerror(errno);
+
+  // The KMS objects are gone -- that much is already covered above.
+  uint32_t post_handle = 0;
+  const int gem_rc = drmModeCreateDumbBuffer(v.lease_fd(), 64, 64, 32, 0,
+                                             &post_handle, &pitch, &size);
+  EXPECT_EQ(gem_rc, 0) << "GEM alloc FAILED on a revoked lease fd ("
+                       << std::strerror(errno)
+                       << ") — the render-fd claim fails, and the egl "
+                          "recovery tier needs redesigning";
+
+  if (gem_rc == 0) {
+    const int post_prime =
+        drmPrimeHandleToFD(v.lease_fd(), post_handle, DRM_CLOEXEC, &prime_fd);
+    EXPECT_EQ(post_prime, 0)
+        << "prime export FAILED on a revoked lease fd (" << std::strerror(errno)
+        << ") — the render-fd claim fails";
+    if (pre_prime == 0) {
+      EXPECT_EQ(post_prime, 0)
+          << "prime export worked before revocation but not after";
+    }
+    if (prime_fd >= 0) {
+      ::close(prime_fd);
+    }
+    EXPECT_EQ(drmModeDestroyDumbBuffer(v.lease_fd(), post_handle), 0);
+  }
+}
+
 // A sink built on a revoked lease must fail to construct rather than spray
 // ioctl errors.
 TEST(LeasedDrmVkms, DumbSinkRefusesARevokedLease) {

--- a/test/unit_test/leased_drm_vkms-test/test_case_leased_drm_vkms.cc
+++ b/test/unit_test/leased_drm_vkms-test/test_case_leased_drm_vkms.cc
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Kernel-real DRM lease, no compositor.
+//
+// The mock tier proves the drm-lease-v1 *protocol* but hands out a memfd:
+// nothing there is a DRM object, so every consumer of the lease fd (the adopted
+// DrmDisplay, the leased DrmDumbSink) goes untested. This tier closes that gap
+// from the other side: it makes a genuine lease with drmModeCreateLease on a
+// vkms master fd and feeds it to the real code. No compositor is involved,
+// which also sidesteps the reason none of this is reachable on a desktop --
+// wlroots only offers a connector for leasing when its EDID carries the
+// non-desktop flag, and vkms's Virtual-1 does not.
+//
+// Requirements, both checked at runtime with GTEST_SKIP rather than a failure:
+//   - vkms loaded            (sudo modprobe vkms)
+//   - DRM master on its node (root: DRM grants master to the first opener, and
+//                             on a logind seat that is logind, so an
+//                             unprivileged process gets a non-master fd and
+//                             drmSetMaster returns EACCES)
+//
+//   sudo ./homescreen_leased_drm_vkms_ut_test_driver
+
+#include "backend/software/drm_dumb_sink.h"
+#include "display/drm_output_provider.h"
+
+extern "C" {
+#include <fcntl.h>
+#include <unistd.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+}
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+// A vkms card, mastered, with a lease carved out of it. Everything is skipped
+// rather than failed when the environment can't supply that.
+class VkmsLease {
+ public:
+  bool Setup() {
+    for (int i = 0; i < 8; ++i) {
+      const std::string path = "/dev/dri/card" + std::to_string(i);
+      const int fd = ::open(path.c_str(), O_RDWR | O_CLOEXEC);
+      if (fd < 0) {
+        continue;
+      }
+      drmVersionPtr v = drmGetVersion(fd);
+      const bool is_vkms =
+          v != nullptr && v->name != nullptr && std::string(v->name) == "vkms";
+      if (v != nullptr) {
+        drmFreeVersion(v);
+      }
+      if (!is_vkms) {
+        ::close(fd);
+        continue;
+      }
+      card_path_ = path;
+      card_fd_ = fd;
+      break;
+    }
+    if (card_fd_ < 0) {
+      skip_reason_ = "no vkms node found (sudo modprobe vkms)";
+      return false;
+    }
+
+    // DRM hands master to the first opener; on a logind seat that is logind, so
+    // an unprivileged process lands here with a non-master fd.
+    if (drmIsMaster(card_fd_) == 0 && drmSetMaster(card_fd_) != 0) {
+      skip_reason_ = std::string("not DRM master on ") + card_path_ + " (" +
+                     std::strerror(errno) +
+                     ") — run this binary as root, e.g. `sudo " +
+                     "./homescreen_leased_drm_vkms_ut_test_driver`";
+      return false;
+    }
+
+    drmModeRes* res = drmModeGetResources(card_fd_);
+    if (res == nullptr) {
+      skip_reason_ = "drmModeGetResources failed on vkms";
+      return false;
+    }
+    card_connectors_ = res->count_connectors;
+    for (int i = 0; i < res->count_connectors; ++i) {
+      drmModeConnector* c = drmModeGetConnector(card_fd_, res->connectors[i]);
+      if (c != nullptr && c->connection == DRM_MODE_CONNECTED &&
+          c->count_modes > 0) {
+        connector_id_ = c->connector_id;
+        drmModeFreeConnector(c);
+        break;
+      }
+      if (c != nullptr) {
+        drmModeFreeConnector(c);
+      }
+    }
+    if (res->count_crtcs > 0) {
+      crtc_id_ = res->crtcs[0];
+    }
+    drmModeFreeResources(res);
+    if (connector_id_ == 0 || crtc_id_ == 0) {
+      skip_reason_ = "vkms exposed no connected connector + crtc";
+      return false;
+    }
+
+    uint32_t objects[2] = {connector_id_, crtc_id_};
+    uint32_t lessee = 0;
+    lease_fd_ = drmModeCreateLease(card_fd_, objects, 2, O_CLOEXEC, &lessee);
+    if (lease_fd_ < 0) {
+      skip_reason_ =
+          std::string("drmModeCreateLease: ") + std::strerror(-lease_fd_);
+      return false;
+    }
+    lessee_id_ = lessee;
+    return true;
+  }
+
+  ~VkmsLease() {
+    if (lease_fd_ >= 0) {
+      ::close(lease_fd_);
+    }
+    if (card_fd_ >= 0) {
+      ::close(card_fd_);
+    }
+  }
+
+  [[nodiscard]] const std::string& skip_reason() const { return skip_reason_; }
+  [[nodiscard]] int card_fd() const { return card_fd_; }
+  [[nodiscard]] int lease_fd() const { return lease_fd_; }
+  [[nodiscard]] uint32_t connector_id() const { return connector_id_; }
+  [[nodiscard]] uint32_t lessee_id() const { return lessee_id_; }
+  [[nodiscard]] const std::string& card_path() const { return card_path_; }
+  [[nodiscard]] int card_connectors() const { return card_connectors_; }
+
+ private:
+  std::string skip_reason_{};
+  std::string card_path_{};
+  int card_fd_ = -1;
+  int lease_fd_ = -1;
+  uint32_t connector_id_ = 0;
+  uint32_t crtc_id_ = 0;
+  uint32_t lessee_id_ = 0;
+  int card_connectors_ = 0;
+};
+
+// Print the reason as well as skipping: gtest does not surface a GTEST_SKIP
+// message on the console, and a silent skip tells an operator nothing about
+// what their environment is missing.
+#define REQUIRE_VKMS_LEASE(v)                                       \
+  VkmsLease v;                                                      \
+  if (!(v).Setup()) {                                               \
+    std::cout << "[   SKIP   ] " << (v).skip_reason() << std::endl; \
+    GTEST_SKIP() << (v).skip_reason();                              \
+  }
+
+// The invariant the whole design rests on: the kernel filters a lease
+// fd's resource view to the leased objects. Every "by construction" claim in
+// the leased display and sink depends on this being true, and nothing has ever
+// checked it against a real kernel.
+TEST(LeasedDrmVkms, LeaseFdResourceViewIsKernelFiltered) {
+  REQUIRE_VKMS_LEASE(v);
+
+  drmModeRes* lres = drmModeGetResources(v.lease_fd());
+  ASSERT_NE(lres, nullptr) << std::strerror(errno);
+  EXPECT_EQ(lres->count_connectors, 1)
+      << "lease fd should see exactly the leased connector";
+  if (lres->count_connectors == 1) {
+    EXPECT_EQ(lres->connectors[0], v.connector_id());
+  }
+  drmModeFreeResources(lres);
+
+  EXPECT_NE(drmIsMaster(v.lease_fd()), 0)
+      << "a lease fd is master over its object set by construction";
+}
+
+// DrmOutputProvider must enumerate through the supplied fd, not by re-opening
+// the card: that is both the correctly-scoped view and the only handle a leased
+// client is guaranteed to hold.
+TEST(LeasedDrmVkms, OutputProviderEnumeratesThroughTheLeaseFd) {
+  REQUIRE_VKMS_LEASE(v);
+
+  homescreen::DrmOutputProvider provider(v.card_path());
+  provider.SetEnumerationFd(v.lease_fd());
+  const auto outputs = provider.EnumerateOutputs();
+
+  ASSERT_EQ(outputs.size(), 1u)
+      << "expected exactly the leased connector, got " << outputs.size();
+  EXPECT_EQ(outputs[0].handle, v.connector_id());
+  EXPECT_TRUE(outputs[0].connected);
+  EXPECT_GT(outputs[0].width_px, 0);
+  EXPECT_GT(outputs[0].height_px, 0);
+}
+
+// Without the fd it falls back to opening the card, which sees everything --
+// this is the failure mode the fd path exists to prevent, pinned so a
+// regression is loud.
+TEST(LeasedDrmVkms, OutputProviderWithoutFdSeesTheWholeCard) {
+  REQUIRE_VKMS_LEASE(v);
+
+  homescreen::DrmOutputProvider provider(v.card_path());
+  const auto outputs = provider.EnumerateOutputs();
+  EXPECT_EQ(static_cast<int>(outputs.size()), v.card_connectors())
+      << "open-by-path should see the whole card, not the lease";
+}
+
+// The leased software tier, end to end on a real lease: probe, mode-pick,
+// dumb-buffer alloc and modeset all against KMS objects we hold by lease.
+TEST(LeasedDrmVkms, DumbSinkDrivesALeasedConnector) {
+  REQUIRE_VKMS_LEASE(v);
+
+  auto sink = DrmDumbSink::Create(v.lease_fd(), /*fd_owner=*/nullptr,
+                                  v.connector_id(), /*revoked=*/nullptr);
+  ASSERT_NE(sink, nullptr) << "the sink could not drive the leased connector";
+
+  const auto native = sink->NativeSize();
+  ASSERT_TRUE(native.has_value());
+  EXPECT_GT(native->first, 0u);
+  EXPECT_GT(native->second, 0u);
+  EXPECT_GT(sink->refresh_rate_hz(), 0.0);
+}
+
+// Pinning a connector that is not in the lease must fail rather than silently
+// falling back to another panel.
+TEST(LeasedDrmVkms, DumbSinkRefusesAConnectorOutsideTheLease) {
+  REQUIRE_VKMS_LEASE(v);
+
+  auto sink = DrmDumbSink::Create(v.lease_fd(), /*fd_owner=*/nullptr,
+                                  /*connector_id=*/0xBADC0DE,
+                                  /*revoked=*/nullptr);
+  EXPECT_EQ(sink, nullptr)
+      << "a connector outside the lease must not silently resolve to another";
+}
+
+// The sink must not close a borrowed lease fd: the LeaseHold owns it.
+TEST(LeasedDrmVkms, DumbSinkDoesNotCloseTheBorrowedLeaseFd) {
+  REQUIRE_VKMS_LEASE(v);
+
+  {
+    auto sink =
+        DrmDumbSink::Create(v.lease_fd(), nullptr, v.connector_id(), nullptr);
+    ASSERT_NE(sink, nullptr);
+  }
+  // Still ours, still usable — a double close would have made this EBADF.
+  EXPECT_NE(fcntl(v.lease_fd(), F_GETFD), -1)
+      << "the sink closed a borrowed fd: " << std::strerror(errno);
+}
+
+// Revocation: what the kernel actually does to a live lessee, and whether the
+// gate added for it holds. This checks the claim -- "the fd stays open and
+// valid; ioctls naming the vanished objects fail" -- checked rather than
+// assumed.
+TEST(LeasedDrmVkms, RevokedLeaseLosesItsObjectsButKeepsTheFd) {
+  REQUIRE_VKMS_LEASE(v);
+
+  ASSERT_EQ(drmModeRevokeLease(v.card_fd(), v.lessee_id()), 0)
+      << std::strerror(errno);
+
+  // The fd survives revocation...
+  EXPECT_NE(fcntl(v.lease_fd(), F_GETFD), -1)
+      << "the lease fd should stay open after revocation";
+
+  // ...but its KMS objects are gone, which is exactly why Present() must gate.
+  drmModeRes* lres = drmModeGetResources(v.lease_fd());
+  if (lres != nullptr) {
+    EXPECT_EQ(lres->count_connectors, 0)
+        << "a revoked lease should expose no connectors";
+    drmModeFreeResources(lres);
+  }
+}
+
+// A sink built on a revoked lease must fail to construct rather than spray
+// ioctl errors.
+TEST(LeasedDrmVkms, DumbSinkRefusesARevokedLease) {
+  REQUIRE_VKMS_LEASE(v);
+
+  ASSERT_EQ(drmModeRevokeLease(v.card_fd(), v.lessee_id()), 0)
+      << std::strerror(errno);
+
+  auto sink =
+      DrmDumbSink::Create(v.lease_fd(), nullptr, v.connector_id(), nullptr);
+  EXPECT_EQ(sink, nullptr) << "a revoked lease has no KMS objects to drive";
+}
+
+}  // namespace


### PR DESCRIPTION
Adds a `wayland-leased-drm` backend family: it acquires exclusive control of one or more display connectors from a running Wayland compositor via the `drm-lease-v1` staging protocol, then scans out through one of three existing present paths on the leased fd — no `wl_surface`, no compositor-composited path. Target use cases are instrument-cluster / HUD panels leased from a primary IVI compositor, and any deployment where one process must own a connector while a compositor owns the rest of the card.

Acquisition and rendering are kept orthogonal: the lease only changes how the DRM fd is obtained, so the three tiers reuse the existing `drm_kms_egl`, `drm_kms_vulkan`, and software dumb-sink backends unchanged apart from taking an injected fd.

## Read this first — two honest caveats

1. **The two GPU tiers have never drawn a leased frame.** All `wayland-leased-drm-egl` / `-vulkan` wiring is verified by build and fail-fast paths only. vkms — the one kernel-real test substrate — exposes no render node, so the integration suite structurally cannot host either GPU tier, and compositor-side non-desktop gating (see below) means no compositor on hand will grant a lease. Runtime proof needs HIL on real hardware. **The software tier is the only one with runtime coverage, and it is the solid one.**
2. **`drm-lease-v1` support in a compositor is necessary but not sufficient for deployment.** The wlroots family offers a connector for leasing only when its EDID carries the non-desktop flag, which is immutable; an ordinary panel is never offered. This is why a real-compositor integration test is not yet schedulable, and why the mock-compositor + vkms tiers exist in the form they do.

## Does it affect existing (non-leased) builds?

No. Leasing is **default-OFF** (`BUILD_BACKEND_WAYLAND_LEASED_DRM=OFF`), so a normal build does not compile any of it. The shared files this touches are inert when leasing is off: the changed `DiscoverScanoutTarget` overload has no non-leased caller; the new `DrmConfig` fields default to `0`/empty with their branches skipped on direct builds; the `ResolveKeyForConfig` change is gated behind the `wayland-leased-drm` key prefix; and the config additions live entirely under the `backend.lease.*` handlers.

Verified across five build configurations (default wayland-egl+vulkan, leased+both-GPU, leased+egl+software, leased+vulkan, direct-drm-egl-only) — all clean.

## What's here

- **`LeaseClient`** — a standalone drm-lease-v1 client: bounded-deadline negotiation on the caller thread, then a monitor thread for revocation. Non-owning-proxy lifetimes handled explicitly (the wayland-cxx `CProxy` is non-owning).
- **Adopted-fd `DrmDisplay`** and fd injection into all three present paths; the lease fd is borrowed, the `LeaseHold` owns it and outlives every backend.
- **Revocation policy** (`lease_on_revoke = exit` (default) | `gate`): all three tiers gate their present path on revocation and park the vsync source rather than spinning against dead KMS objects.
- **Connector pinning**: all three tiers drive the leased `connector_id` (a lease may contain several connectors; "first connected" would light the wrong panel).
- **Diagnostics**: `--lease-list-connectors` reports what a compositor will actually lease, no bundle needed.
- **Tests**: T1 (26 cases) against a hand-rolled mock compositor, clean under ASan/UBSan/LSan; T2 (9 cases) a kernel-real lease on vkms, including evidence that a revoked lease fd stays a functional render fd.

## Reviewed

The last six commits are a workflow code review of the branch (10 findings, all fixed). The headline was that the leased path had been fully wired only for the software tier; the egl/vulkan tiers had silently dropped the connector pin and the revocation gate, the family resolver had a fail-open that could run an unleased backend, and there was a use-after-free on a connector withdrawn mid-grant — **reproduced under ASan** before the fix and now guarded by a regression test. A lease-timeout config cluster (flag never read; two overflow-to-hang paths) was fixed in the same pass.

## Not yet done

Lease-loss *reacquire* (rebuild-in-place) is not implemented — it is blocked on a rasterizer-quiescence design decision that applies to every tier, so today the `exit` policy hands revocation to a supervisor. Input hardening and the HIL / soak test tiers are also future work.
