### PR TITLE
emb: enable BUILD_COMPOSITOR for the raspberry-pi drm-kms-egl target

### DIFF
--- a/.emb/raspberry-pi.emb.yaml
+++ b/.emb/raspberry-pi.emb.yaml
@@ -91,6 +91,11 @@ cross:
           BUILD_BACKEND_WAYLAND_VULKAN: 'OFF'
           BUILD_BACKEND_DRM_KMS_EGL: 'ON'
           BUILD_BACKEND_SOFTWARE: 'OFF'
+          # The DRM compositor + LayerScene plane path (and platform-view
+          # plugins) live in the drm-kms-egl backend; without this the
+          # FlutterCompositor API compiles out and native/platform-view
+          # content never reaches a KMS plane. (drm-kms-vulkan sets it too.)
+          BUILD_COMPOSITOR: 'ON'
         drm-kms-vulkan:
           BUILD_BACKEND_WAYLAND_EGL: 'OFF'
           BUILD_BACKEND_WAYLAND_VULKAN: 'OFF'


### PR DESCRIPTION
## What

Enable `BUILD_COMPOSITOR` for the raspberry-pi `drm-kms-egl` cross target in `.emb/raspberry-pi.emb.yaml`.

## Why

The `drm-kms-egl` target built with `BUILD_COMPOSITOR` unset, so the `FlutterCompositor` API — the DRM compositor and its `LayerScene` KMS-plane path, plus any platform-view plugin — compiled out. Native / platform-view content then never reached a KMS plane at runtime. Only `drm-kms-vulkan` set it; this brings `drm-kms-egl` in line.

## Notes

Stacked on #326 (base branch is `jw/bump-wayland-cxx-drm-cxx`); the diff here is only the 5-line yaml change. GitHub will retarget this to `v2.0` when #326 merges.
