### PR TITLE
wayland-leased-drm: gate direct-evdev input, default off under a host session

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,16 @@ Usage:
                               compositor defer the DRM fd until it regains DRM 
                               master, so this is what stops a VT-switched-away 
                               compositor hanging startup.
+      --lease-input arg       wayland-leased-drm: whether to read input from 
+                              raw evdev. A leased client has no wl_surface, so 
+                              libinput on /dev/input/event* is its only input 
+                              source, and it is ungrabbed -- on a host with a 
+                              live Wayland session that duplicates every 
+                              keystroke into this process and the session 
+                              compositor. auto (default) = read evdev on an 
+                              embedded target but disable it when a Wayland 
+                              session is detected; on = always read evdev; off 
+                              = never.
 ```
 
 <!-- END CLI-REFERENCE -->
@@ -363,6 +373,7 @@ annotated all-keys file see
 | `[view.backend.drm]` | `stage_cursor` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.lease]` | `connector` | `string` | `(sole offer)` | `e.g. HDMI-A-1` | leased |
 | `[view.backend.lease]` | `device` | `string` | `(sole device)` | `index or /dev/dri/cardN` | leased |
+| `[view.backend.lease]` | `input` | `string` | `auto` | `auto\|on\|off` | leased |
 | `[view.backend.lease]` | `on_revoke` | `string` | `exit` | `exit\|gate` | leased |
 | `[view.backend.lease]` | `timeout_ms` | `int` | `5000` | `> 0` | leased |
 | `[view.output]` | `drm_connector` | `string` | `(none)` | `e.g. HDMI-A-1` | drm |

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -183,6 +183,10 @@
   # type=string default=(sole device) values=index or /dev/dri/cardN applies=leased
   device =
 
+  # Whether to read input from raw evdev. A leased client has no wl_surface, so ungrabbed libinput is its only input source; under a host Wayland session that duplicates events into both this process and the compositor. auto disables it when a session is detected, on forces it (embedded-under-compositor), off never reads evdev.
+  # type=string default=auto values=auto|on|off applies=leased
+  input =
+
   # On revocation (every VT switch away from the compositor is one): exit non-zero so a supervisor restarts and renegotiates, or gate and keep running with a frozen panel (debugging only).
   # type=string default=exit values=exit|gate applies=leased
   on_revoke =

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -83,6 +83,7 @@ META = {
     "backend.lease.connector": ("(sole offer)", "e.g. HDMI-A-1", "leased", "Connector to request by name; several offers with no choice is fatal."),
     "backend.lease.timeout_ms": ("5000", "> 0", "leased", "Bound on the whole lease negotiation; a compositor may defer the DRM fd until it regains DRM master."),
     "backend.lease.on_revoke": ("exit", "exit|gate", "leased", "On revocation (every VT switch away from the compositor is one): exit non-zero so a supervisor restarts and renegotiates, or gate and keep running with a frozen panel (debugging only)."),
+    "backend.lease.input": ("auto", "auto|on|off", "leased", "Whether to read input from raw evdev. A leased client has no wl_surface, so ungrabbed libinput is its only input source; under a host Wayland session that duplicates events into both this process and the compositor. auto disables it when a session is detected, on forces it (embedded-under-compositor), off never reads evdev."),
 
     # [view.backend.drm] — DRM/software only
     "backend.drm.device": ("(rank-pick)", "/dev/dri/cardN", "drm/sw", "DRM device node."),

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -48,6 +48,7 @@
 #endif
 #if BUILD_BACKEND_WAYLAND_LEASED_DRM
 #include "backend/wayland_leased_drm/lease_client.h"
+#include "backend/wayland_leased_drm/leased_input_policy.h"
 #endif
 #if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
 #include "display/drm_device_resolver.h"  // ResolveDrmDevice
@@ -83,6 +84,13 @@
 #endif
 #if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
 #include "wayland/display.h"
+#endif
+
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM
+// Defined near WaylandSessionAvailable() (which it needs); declared here
+// because the leased make_display factories in the anonymous namespace below
+// call it.
+static bool ResolveLeasedInputEnabled(const Configuration::Config& config);
 #endif
 
 namespace {
@@ -234,10 +242,15 @@ std::shared_ptr<IDisplay> MakeLeasedDrmDisplay(
   // display -- the DRM backend factories take everything else from it too. The
   // gate captures the hold by value: fd_owner_ holds the same share, so the
   // callable cannot outlive what it reads.
-  return std::make_shared<DrmDisplay>(
+  auto display = std::make_shared<DrmDisplay>(
       DrmDisplay::AdoptFd{}, static_cast<int32_t>(w), static_cast<int32_t>(h),
       60.0, fd, std::move(card), hold, hold->connector_id(),
       [hold] { return hold->revoked(); });
+  // Gate direct-evdev input on the leased-input policy (see
+  // ResolveLeasedInputEnabled). Set before StartEvents(), which FlutterView
+  // calls later.
+  display->SetInputEnabled(ResolveLeasedInputEnabled(configs[0]));
+  return display;
 }
 #endif
 
@@ -306,6 +319,11 @@ std::shared_ptr<IDisplay> MakeLeasedSoftwareDisplay(
   auto display = MakeSoftwareDisplay(configs);
   auto* sw = dynamic_cast<SoftwareDisplay*>(display.get());
   assert(sw != nullptr);
+  // Same leased-input policy as the DRM tiers: the seat is already constructed
+  // (MakeSoftwareDisplay wires it unless IVI_SW_INPUT=none), but gating
+  // StartEvents keeps libinput from opening devices when a host Wayland session
+  // is present. Set before StartEvents().
+  sw->SetInputEnabled(ResolveLeasedInputEnabled(configs[0]));
   SoftwareDisplay::LeasedScanout scanout;
   scanout.fd = hold->fd();
   scanout.connector_id = hold->connector_id();
@@ -834,6 +852,56 @@ static bool WaylandSessionAvailable() {
   }
   return std::filesystem::exists(std::filesystem::path(xdg) / sock, ec);
 }
+
+#if BUILD_BACKEND_WAYLAND_LEASED_DRM
+// Decide whether a leased backend should read input from raw evdev.
+//
+// A leased client has no wl_surface, so the compositor delivers it no input --
+// its only source is libinput on /dev/input/event*, and those reads are NOT
+// grabbed. On a host with a live Wayland session that means every keystroke and
+// pointer event reaches BOTH this process and the session compositor: input is
+// duplicated, not stolen. `lease_input` sets the policy:
+//   off  -> never read evdev.
+//   on   -> always read evdev (embedded-under-compositor, where the operator
+//           has partitioned input devices and wants this panel to have some).
+//   auto -> read evdev on an embedded target, but disable it when a host
+//           Wayland session is detected, warning why. The default.
+//
+// The policy itself (the decision table) lives in leased_input_policy.h so it
+// can be unit-tested without this file's dependency graph; this wrapper does
+// the config read, session detection, and logging around it.
+static bool ResolveLeasedInputEnabled(const Configuration::Config& config) {
+  const std::string mode = config.view.lease_input.value_or("auto");
+  if (homescreen::IsUnrecognizedLeasedInputMode(mode)) {
+    ihs::log::warn(
+        "[leased-drm] lease_input='{}' unrecognized (auto|on|off); using auto",
+        mode);
+  }
+  const homescreen::LeasedInputDecision decision =
+      homescreen::DecideLeasedInput(mode, WaylandSessionAvailable());
+  switch (decision) {
+    case homescreen::LeasedInputDecision::kDisabledByConfig:
+      ihs::log::info("[leased-drm] input disabled (lease_input=off)");
+      break;
+    case homescreen::LeasedInputDecision::kDisabledUnderSession: {
+      const char* wl = std::getenv("WAYLAND_DISPLAY");
+      ihs::log::warn(
+          "[leased-drm] a Wayland session is present (WAYLAND_DISPLAY={}); "
+          "disabling direct evdev input so it is not duplicated into both this "
+          "homescreen and the session compositor -- this process has no "
+          "wl_surface and its libinput reads are ungrabbed. Set lease_input=on "
+          "to force input on (embedded-under-compositor with partitioned input "
+          "devices).",
+          wl != nullptr ? wl : "");
+      break;
+    }
+    case homescreen::LeasedInputDecision::kForcedOn:
+    case homescreen::LeasedInputDecision::kEnabledAuto:
+      break;
+  }
+  return homescreen::LeasedInputEnabled(decision);
+}
+#endif
 
 std::string ResolveKeyForConfig(const backend::BackendRegistry& reg,
                                 const Configuration::Config& config) {

--- a/shell/backend/wayland_leased_drm/README.md
+++ b/shell/backend/wayland_leased_drm/README.md
@@ -106,6 +106,17 @@ The compositor, not this process, is the lessor:
   `wp_drm_lease_v1` object, which lets the compositor revoke and re-advertise.
 - **No libseat session.** The compositor already holds the session controller for
   the seat; taking it would fight. Input falls back to direct evdev.
+- **Input can be duplicated, and defaults to off under a host session.** A leased
+  client has no `wl_surface`, so the compositor delivers it no input — its only
+  source is libinput on `/dev/input/event*`, and those reads are *ungrabbed*. On
+  a host with a live Wayland session that means every keystroke and pointer event
+  reaches **both** this process and the session compositor (input is duplicated,
+  not stolen). `lease_input` controls it: `auto` (default) reads evdev on an
+  embedded target — no `WAYLAND_DISPLAY` — but disables it when a host session is
+  detected, warning why; `on` forces evdev even under a session (an embedded box
+  running its own compositor, with input devices partitioned between them); `off`
+  never reads evdev. `--drm-no-seat` does **not** affect this — it bypasses
+  libseat, not input.
 - **Outputs are enumerated through the lease fd**, whose resource view the kernel
   filters to the leased objects. Re-opening the card by path would both show
   connectors we do not hold *and* require permissions a leased client may not
@@ -183,6 +194,7 @@ homescreen --backend=wayland-leased-drm-egl --lease-connector=HDMI-A-1 -b <bundl
 | `--lease-connector` | `HOMESCREEN_LEASE_CONNECTOR` | `[view.backend.lease] connector` | Connector to request by name. Unset + one offer takes it; unset + several is fatal and lists them |
 | `--lease-device` | `HOMESCREEN_LEASE_DEVICE` | `[view.backend.lease] device` | Which `wp_drm_lease_device_v1` when several are advertised (one per DRM node): index or node path |
 | `--lease-timeout-ms` | `HOMESCREEN_LEASE_TIMEOUT_MS` | `[view.backend.lease] timeout_ms` | Bound on the whole negotiation (default 5000) |
+| `--lease-input` | `HOMESCREEN_LEASE_INPUT` | `[view.backend.lease] input` | Read input from raw evdev: `auto` (default; on for embedded, off under a host Wayland session), `on` (force), `off` (never). See the input-duplication note above |
 
 The timeout is load-bearing, not cosmetic: the spec lets a compositor defer the
 DRM fd until it regains DRM master, so without a bound a VT-switched-away

--- a/shell/backend/wayland_leased_drm/leased_input_policy.h
+++ b/shell/backend/wayland_leased_drm/leased_input_policy.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace homescreen {
+
+// Whether a leased backend reads input from raw evdev, and why.
+//
+// A leased client has no wl_surface, so the compositor delivers it no input and
+// its only source is libinput on /dev/input/event*. Those reads are ungrabbed:
+// on a host with a live Wayland session every event reaches BOTH this process
+// and the session compositor (input is duplicated, not stolen). This is the
+// pure policy that decides what to do about it; session detection, logging, and
+// the config read live in register_backends.cc, which is why this stays a
+// dependency-free header (so the decision can be unit-tested directly).
+enum class LeasedInputDecision {
+  kEnabledAuto,           // auto + no host session: an embedded target.
+  kForcedOn,              // lease_input=on: read evdev even under a session.
+  kDisabledByConfig,      // lease_input=off.
+  kDisabledUnderSession,  // auto + a host session is present.
+};
+
+// True when the decision means "start the seat / open input devices".
+[[nodiscard]] inline bool LeasedInputEnabled(LeasedInputDecision d) {
+  return d == LeasedInputDecision::kEnabledAuto ||
+         d == LeasedInputDecision::kForcedOn;
+}
+
+// Classify a lease_input mode string. Recognized: off|none|false|0 (disable),
+// on|yes|true|1 (force on). Anything else -- including "auto", empty, and
+// unrecognized values -- is auto: enabled on an embedded target, disabled when
+// a host session is present. @p session_present is WaylandSessionAvailable().
+[[nodiscard]] inline LeasedInputDecision DecideLeasedInput(
+    std::string_view mode,
+    bool session_present) {
+  if (mode == "off" || mode == "none" || mode == "false" || mode == "0") {
+    return LeasedInputDecision::kDisabledByConfig;
+  }
+  if (mode == "on" || mode == "yes" || mode == "true" || mode == "1") {
+    return LeasedInputDecision::kForcedOn;
+  }
+  return session_present ? LeasedInputDecision::kDisabledUnderSession
+                         : LeasedInputDecision::kEnabledAuto;
+}
+
+// True when @p mode is neither a recognized on/off value nor "auto"/empty --
+// i.e. a typo the caller should warn about before falling back to auto.
+[[nodiscard]] inline bool IsUnrecognizedLeasedInputMode(std::string_view mode) {
+  return DecideLeasedInput(mode, /*session_present=*/false) ==
+             LeasedInputDecision::kEnabledAuto &&
+         !(mode.empty() || mode == "auto");
+}
+
+}  // namespace homescreen

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -262,6 +262,10 @@ void Configuration::get_view_parameters(toml::table* v, Config& instance) {
     instance.view.lease_on_revoke =
         v->at_path("backend.lease.on_revoke").as_string()->value_or("");
   }
+  if (v->at_path("backend.lease.input").is_string()) {
+    instance.view.lease_input =
+        v->at_path("backend.lease.input").as_string()->value_or("");
+  }
   if (v->at_path("backend.lease.timeout_ms").is_integer()) {
     const int64_t ms = v->at_path("backend.lease.timeout_ms")
                            .as_integer()
@@ -797,6 +801,16 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
         "5000. The protocol lets a compositor defer the DRM fd until it "
         "regains DRM master, so this is what stops a VT-switched-away "
         "compositor hanging startup.",
+        cxxopts::value<std::string>())(
+        "lease-input",
+        "wayland-leased-drm: whether to read input from raw evdev. A leased "
+        "client has no wl_surface, so libinput on /dev/input/event* is its "
+        "only "
+        "input source, and it is ungrabbed -- on a host with a live Wayland "
+        "session that duplicates every keystroke into this process and the "
+        "session compositor. auto (default) = read evdev on an embedded target "
+        "but disable it when a Wayland session is detected; on = always read "
+        "evdev; off = never.",
         cxxopts::value<std::string>());
 
     // [view.backend.drm] (also settable via HOMESCREEN_DRM_* env)
@@ -1002,6 +1016,8 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
                 config.view.lease_connector);
     pick_string("lease-on-revoke", "HOMESCREEN_LEASE_ON_REVOKE",
                 config.view.lease_on_revoke);
+    pick_string("lease-input", "HOMESCREEN_LEASE_INPUT",
+                config.view.lease_input);
     // Same CLI-wins-then-env precedence as pick_string, but parsed as a bounded
     // uint32. Written as a lambda over both sources rather than an env-only
     // block: --lease-timeout-ms was registered as a flag and read from nowhere,

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -125,10 +125,26 @@ class Configuration {
       //                         debugging a revocation, since nothing recovers.
       //                       "reacquire"      — not implemented yet;
       //                         accepted and warned about, treated as "exit".
+      //   lease_input     : whether the leased backend reads input from raw
+      //                     evdev. A leased client has no wl_surface, so the
+      //                     compositor delivers it no input — its only source
+      //                     is libinput on /dev/input/event*, ungrabbed, which
+      //                     on a host with a live Wayland session duplicates
+      //                     every keystroke into both this process and the
+      //                     session compositor.
+      //                       "auto" (default) — read evdev on an embedded
+      //                         target (no WAYLAND_DISPLAY), but disable it
+      //                         when a host Wayland session is detected,
+      //                         warning why.
+      //                       "on"             — always read evdev, even under
+      //                         a host session
+      //                         (embedded-under-compositor).
+      //                       "off"            — never read evdev.
       std::optional<std::string> lease_device;
       std::optional<std::string> lease_connector;
       std::optional<uint32_t> lease_timeout_ms;
       std::optional<std::string> lease_on_revoke;
+      std::optional<std::string> lease_input;
       // Wayland compositor-protocol shell selection: "auto" (default) | "xdg" |
       // "agl" | "ivi" | "simple". The Display reads it from the first view.
       std::optional<std::string> shell;

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -466,6 +466,12 @@ std::vector<uint32_t> DrmDisplay::ReservedPlanes() const {
 }
 
 void DrmDisplay::StartEvents() {
+  if (!input_enabled_) {
+    // Seat left unstarted on purpose (SetInputEnabled(false)) — libinput never
+    // opens /dev/input/event*. The leased factory does this when a host Wayland
+    // session is present; the reason was logged there.
+    return;
+  }
   if (seat_) {
     seat_->Start();
   }

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -192,6 +192,13 @@ class DrmDisplay final : public IDisplay {
   void StopEvents() override;
   [[nodiscard]] int PollEvents() const override { return 0; }
 
+  // Gate the input seat. When false, StartEvents() does not start the seat, so
+  // libinput never opens /dev/input/event*. Default true. The leased factory
+  // sets it false when a host Wayland session is present (wayland-leased-drm
+  // has no wl_surface, so its evdev reads would duplicate input into both this
+  // process and the session compositor). Must be called before StartEvents().
+  void SetInputEnabled(bool enabled) { input_enabled_ = enabled; }
+
   void SetViewControllerState(
       FlutterDesktopViewControllerState* state) override;
 
@@ -316,6 +323,11 @@ class DrmDisplay final : public IDisplay {
   // is there so a Wayland-client + DRM-rendering configuration can swap in
   // a WaylandSeat without changing this class.
   std::unique_ptr<homescreen::ISeat> seat_;
+
+  // When false, StartEvents() leaves seat_ unstarted so libinput never opens
+  // input devices. See SetInputEnabled(). Default true (path-opened tiers read
+  // input as before).
+  bool input_enabled_ = true;
 
   // Arm the async_wait for the next PAGE_FLIP_EVENT; re-armed after every
   // drain.

--- a/shell/display/software_display.cc
+++ b/shell/display/software_display.cc
@@ -98,6 +98,12 @@ bool SoftwareDisplay::ActivateSystemCursor(const int32_t /*device*/,
 }
 
 void SoftwareDisplay::StartEvents() {
+  if (!input_enabled_) {
+    // Seat left unstarted on purpose (SetInputEnabled(false)) — libinput never
+    // opens /dev/input/event*. The leased-software factory does this when a
+    // host Wayland session is present; the reason was logged there.
+    return;
+  }
   if (seat_) {
     seat_->Start();
   }

--- a/shell/display/software_display.h
+++ b/shell/display/software_display.h
@@ -59,6 +59,14 @@ class SoftwareDisplay final : public IDisplay {
     return cursor_;
   }
 
+  // Gate the input seat. When false, StartEvents() leaves the seat unstarted,
+  // so libinput never opens /dev/input/event*. Default true. The leased-
+  // software factory sets it false when a host Wayland session is present --
+  // the leased path has no wl_surface, so its ungrabbed evdev reads would
+  // duplicate input into both this process and the session compositor. Must be
+  // called before StartEvents().
+  void SetInputEnabled(bool enabled) { input_enabled_ = enabled; }
+
   void StartEvents() override;
   void StopEvents() override;
   [[nodiscard]] int PollEvents() const override { return 0; }
@@ -114,6 +122,9 @@ class SoftwareDisplay final : public IDisplay {
   double refresh_rate_hz_;
   FlutterDesktopViewControllerState* view_controller_state_ = nullptr;
   std::unique_ptr<homescreen::ISeat> seat_;
+  // When false, StartEvents() leaves seat_ unstarted (see SetInputEnabled()).
+  // Default true.
+  bool input_enabled_ = true;
   std::shared_ptr<SoftwareCursor> cursor_;
   std::optional<LeasedScanout> leased_scanout_;
 };

--- a/test/unit_test/lease_client-test/test_case_lease_client.cc
+++ b/test/unit_test/lease_client-test/test_case_lease_client.cc
@@ -28,6 +28,7 @@
 // them (EMIT_INTERFACE_TABLES); a wl_interface is direction-agnostic.
 
 #include "backend/wayland_leased_drm/lease_client.h"
+#include "backend/wayland_leased_drm/leased_input_policy.h"
 
 #include "wayland-protocols/drm_lease_v1_client.hpp"
 
@@ -843,6 +844,76 @@ TEST(LeaseClient, ConnectorWithdrawnDuringGrantIsNotAUseAfterFree) {
       << "connector_name was read from a Connector freed by PruneWithdrawn";
   EXPECT_FALSE(res.hold->revoked())
       << "a post-grant withdraw is not a revocation";
+}
+
+// ── lease_input policy (WS8) ────────────────────────────────────────────────
+//
+// A leased client has no wl_surface, so its only input is ungrabbed libinput on
+// /dev/input/event*; under a host Wayland session that duplicates every event
+// into both this process and the session compositor. DecideLeasedInput encodes
+// the policy: off disables, on forces on, auto disables only when a session is
+// present.
+using homescreen::DecideLeasedInput;
+using homescreen::IsUnrecognizedLeasedInputMode;
+using homescreen::LeasedInputDecision;
+using homescreen::LeasedInputEnabled;
+
+TEST(LeasedInputPolicy, OffAlwaysDisables) {
+  for (const char* m : {"off", "none", "false", "0"}) {
+    EXPECT_EQ(DecideLeasedInput(m, /*session=*/true),
+              LeasedInputDecision::kDisabledByConfig)
+        << m << " under a session";
+    EXPECT_EQ(DecideLeasedInput(m, /*session=*/false),
+              LeasedInputDecision::kDisabledByConfig)
+        << m << " with no session";
+    EXPECT_FALSE(LeasedInputEnabled(DecideLeasedInput(m, false))) << m;
+  }
+}
+
+TEST(LeasedInputPolicy, OnAlwaysEnablesEvenUnderASession) {
+  for (const char* m : {"on", "yes", "true", "1"}) {
+    EXPECT_EQ(DecideLeasedInput(m, /*session=*/true),
+              LeasedInputDecision::kForcedOn)
+        << m << " must override the session check";
+    EXPECT_TRUE(LeasedInputEnabled(DecideLeasedInput(m, true))) << m;
+  }
+}
+
+TEST(LeasedInputPolicy, AutoDisablesUnderASessionEnablesWithout) {
+  // The whole point: safe on a dev host, live on an embedded target.
+  for (const char* m : {"auto", "", "typo"}) {
+    EXPECT_EQ(DecideLeasedInput(m, /*session=*/true),
+              LeasedInputDecision::kDisabledUnderSession)
+        << "'" << m << "' + session should disable";
+    EXPECT_FALSE(LeasedInputEnabled(DecideLeasedInput(m, true))) << m;
+    EXPECT_EQ(DecideLeasedInput(m, /*session=*/false),
+              LeasedInputDecision::kEnabledAuto)
+        << "'" << m << "' + no session should enable";
+    EXPECT_TRUE(LeasedInputEnabled(DecideLeasedInput(m, false))) << m;
+  }
+}
+
+TEST(LeasedInputPolicy, UnrecognizedModeIsFlaggedButFallsBackToAuto) {
+  EXPECT_TRUE(IsUnrecognizedLeasedInputMode("typo"));
+  EXPECT_FALSE(IsUnrecognizedLeasedInputMode("auto"));
+  EXPECT_FALSE(IsUnrecognizedLeasedInputMode(""));
+  EXPECT_FALSE(IsUnrecognizedLeasedInputMode("off"));
+  EXPECT_FALSE(IsUnrecognizedLeasedInputMode("on"));
+
+  // Every spelling the gate accepts, so a correct config never warns.
+  for (const char* m : {"yes", "true", "1", "none", "false", "0"}) {
+    EXPECT_FALSE(IsUnrecognizedLeasedInputMode(m)) << m;
+  }
+
+  // Matching is case-sensitive: "Off" is not "off". It is reported and treated
+  // as auto rather than silently disabling input, which is the safer way to be
+  // wrong -- but it is a real way to mis-write the key, so pin the behavior.
+  for (const char* m : {"Off", "ON", "Auto"}) {
+    EXPECT_TRUE(IsUnrecognizedLeasedInputMode(m)) << m;
+    EXPECT_EQ(DecideLeasedInput(m, /*session=*/true),
+              LeasedInputDecision::kDisabledUnderSession)
+        << m;
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Input hardening for the `wayland-leased-drm` backend family (the input workstream from the leased-drm design).

## The problem

A leased backend has no `wl_surface`, so the compositor delivers it no input — its only source is libinput on `/dev/input/event*`, and those reads are **not** grabbed. On a host with a live Wayland session that means every keystroke and pointer event reaches **both** this process and the session compositor: input is *duplicated, not stolen*. Until now there was no way to stop it — the seat was built and started unconditionally, and only the software tier had any input gate at all (`IVI_SW_INPUT=none`).

## What this adds

A `lease_input` policy, resolved once per leased `make_display`:

- **`auto`** (default) — read evdev on an embedded target, but **disable it and warn** when a host Wayland session is detected (`WAYLAND_DISPLAY` set + socket live).
- **`on`** — always read evdev, even under a session (embedded-under-compositor, where input devices are partitioned between the two).
- **`off`** — never read evdev.

Auto defaults **off** under a detected session so a developer's keyboard is not silently duplicated on a workstation; an embedded target has no `WAYLAND_DISPLAY` and is unaffected. Config surface mirrors the other lease knobs: `--lease-input`, `HOMESCREEN_LEASE_INPUT`, `[view.backend.lease] input`.

## Design

- **Gate mechanism:** `DrmDisplay` and `SoftwareDisplay` gain `SetInputEnabled()`; when false, `StartEvents()` leaves the seat unstarted, so libinput never opens a device (both seats open in `Start()`, not their constructors — verified). Default true, so the direct / path-opened tiers are **unchanged**; only the leased factories set it.
- **Testable policy:** the decision table lives in a dependency-free `leased_input_policy.h` pure function so it is unit-testable without the backend graph; `register_backends` does the config read, session detection, and logging around it. Four cases were added to the existing lease-client test suite (no new test target).

## Correction to a prior assumption

The leased-drm docs claimed `--drm-no-seat` was the dev-host input recipe. It is not — `--drm-no-seat` bypasses *libseat*, not input, and the leased path already runs as `no_seat`. `lease_input` is the actual knob; the README is corrected here.

## Verification

- Builds clean: leased+egl+software, leased+vulkan, and default-Wayland (the shared `DrmDisplay`/`SoftwareDisplay`/`configuration.cc` changes are inert on the direct and non-DRM paths).
- Tests: lease-client suite 30/30 (26 existing + 4 new policy cases), vkms suite 9/9.
- clang-tidy (scoped) applies nothing; clang-format clean; config reference regenerated and in sync.

## Runtime caveat (read before merging)

The full leased-input path **past a granted lease** is not runtime-exercised here — it needs a leasing compositor or root+vkms, neither available in this environment (wlroots offers a connector only when its EDID carries the non-desktop flag; the local session offers none). So the **policy** is proven by the unit tests and the **gate** by construction, not by a live leased frame. This is the same runtime-proof gap the leased GPU tiers already carry; it closes with HIL on real leasing hardware.
