### PR TITLE
drm: scan out platform-view dma-bufs on KMS overlay planes

### DIFF
--- a/shell/backend/backend.h
+++ b/shell/backend/backend.h
@@ -48,6 +48,9 @@ struct BackendEglContext {
   void* share_context;  // EGLContext suitable as share_context for a
                         // plugin-owned context that uploads GL objects
                         // visible on the raster thread.
+  void* gbm_device;     // struct gbm_device* on a gbm/DRM backend (NULL on a
+                        // Wayland EGL backend). Lets a platform view allocate a
+                        // scanout-capable buffer it can export as a dma-buf.
 };
 
 // Carries the Vulkan handle set a plugin needs to render into a VkImage using

--- a/shell/backend/drm_kms_egl/drm_backend.cc
+++ b/shell/backend/drm_kms_egl/drm_backend.cc
@@ -1988,5 +1988,6 @@ bool DrmBackend::GetEglContext(BackendEglContext* out) const {
   out->display = egl_display_;
   out->config = egl_config_;
   out->share_context = egl_context_;
+  out->gbm_device = gbm_device_;
   return true;
 }

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2397,11 +2397,18 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       // reached it yet).
       surface->OnResize(static_cast<int32_t>(fl->size.width),
                         static_cast<int32_t>(fl->size.height));
-      ICompositorSurface::Dmabuf db;
-      if (!surface->GetDmabuf(&db)) {
-        // GL-only surface, or no dma-buf frame ready this present: route
-        // the whole frame through GL composition (which samples the
-        // surface's GL texture / Vulkan image).
+      // Only pull (and dup) a dma-buf for a NEW platform view — one that will
+      // build an ExternalDmaBufSource below. An existing scene layer keeps its
+      // source (the reuse path in the add loop), so calling GetDmabuf for it
+      // every frame would dup+close an fd for nothing. find_by_identity_tag
+      // reflects last frame's layers; this PV is present, so it survives the
+      // prune and the add loop finds it too.
+      ICompositorSurface::Dmabuf db{};
+      if (scene_->find_by_identity_tag(surface.get()) == nullptr &&
+          !surface->GetDmabuf(&db)) {
+        // New platform view with no dma-buf (GL-only surface, or none ready
+        // this present): route the whole frame through GL composition, which
+        // samples the surface's GL texture / Vulkan image.
         return PresentViaGlFallback(layers, layer_count);
       }
       frame_layers.push_back({fl, nullptr, nullptr, surface.get(), db});
@@ -2439,7 +2446,10 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   // in CRTC coordinates; the non-framed path has no letterbox so
   // FlutterLayer.offset is already CRTC-relative.
   //
-  // z_index is each layer's position in Flutter's array = its z-order.
+  // z_index is each engaged layer's position in frame_layers, which is built
+  // in Flutter's layer order — so it preserves the relative z-order (any
+  // skipped null/unsupported layers just compact the numbering, which is fine:
+  // only relative order matters for stacking).
   // Every non-primary layer (backing stores AND platform views) gets an
   // explicit plane zpos so the whole overlay stack shares one Flutter-order
   // scheme (leaving BS overlays unset let them float in z relative to the
@@ -2502,14 +2512,32 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     } else {
       // ── Platform view: wrap the dma-buf as a scene buffer source ──
       if (auto* layer = scene_->find_by_identity_tag(fl.pv_tag)) {
-        // Only geometry / stacking are updated here — the scene layer keeps
-        // its existing ExternalDmaBufSource. That is correct for the current
-        // producer, whose buffer content is static once submitted (a resize
-        // re-stretches a solid color, no visible change). A producer that
-        // cycles buffer *content* per frame (a decoder, a camera) needs
-        // LayerScene::replace_source() driven by a buffer ring here — the
-        // dynamic-producer follow-up; without it such a plane would scan out
-        // the first frame indefinitely.
+        // Reused layer: swap in this frame's dma-buf so a per-frame producer
+        // (a decoder, a camera) scans out fresh content instead of the first
+        // frame forever. replace_source retires the displaced source only once
+        // its in-flight buffers release (with their release fences), so nothing
+        // is freed while the kernel may still scan it. ExternalDmaBufSource
+        // dups the fds and does its own AddFB2WithModifiers; the pv_fd_closer
+        // closes our dup at scope exit.
+        const auto& db = fl.pv_db;
+        const uint32_t np = db.plane_count;
+        std::array<drm::scene::ExternalPlaneInfo, 4> planes{};
+        for (uint32_t p = 0; p < np && p < 4; ++p) {
+          planes[p] =
+              drm::scene::ExternalPlaneInfo{db.fd, db.offset[p], db.stride[p]};
+        }
+        auto src = drm::scene::ExternalDmaBufSource::create(
+            backend_->device(), db.width, db.height, db.fourcc, db.modifier,
+            drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(), np));
+        if (src) {
+          if (auto r = scene_->replace_source(layer->handle(),
+                                              std::move(src.value()));
+              !r) {
+            ihs::log::warn(
+                "[DrmCompositor] LayerScene::replace_source (pv): {}",
+                r.error().message());
+          }
+        }  // else: keep the existing source rather than tear the layer down
         layer->set_dst_rect_if_changed(dst_rect);
         layer->set_zpos_if_changed(overlay_zpos);  // restack on reorder
         ++pv_reused;

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -39,6 +39,7 @@
 #include <xf86drmMode.h>
 
 #include <drm-cxx/core/format.hpp>
+#include <drm-cxx/scene/external_dma_buf_source.hpp>
 
 #include "backend/drm_kms_egl/driver_probe.h"
 #include "backend/drm_kms_egl/drm_backend.h"
@@ -2323,111 +2324,228 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   }
   const uint64_t t1 = profile ? NsNow() : 0;
 
-  // Pre-scan: any platform-view layer forces the whole frame through
-  // the GL composite path. Platform-view→LayerBufferSource plumbing
-  // (Tier-2 wrappers over ExternalDmaBufSource / GstAppsinkSource) is
-  // not wired in this revision; routing PVs through GL keeps the
-  // current visual behaviour intact while BS layers benefit from the
-  // scene allocator.
-  for (size_t i = 0; i < layer_count; ++i) {
-    const FlutterLayer* fl = layers[i];
-    if (fl && fl->type == kFlutterLayerContentTypePlatformView) {
-      return PresentViaGlFallback(layers, layer_count);
-    }
-  }
-
   // Walk the FlutterLayer[] in z-order (Flutter's convention: layer 0
-  // is bottom). Sync scene_'s layer set against the current frame's
-  // batons: add new, update dst_rect on existing, remove any scene
-  // layer whose baton didn't appear this frame.
+  // is bottom). Sync scene_'s layer set against the current frame: add
+  // new, update geometry/zpos on existing, remove any scene layer whose
+  // tag didn't appear this frame. Backing stores are keyed by their
+  // StoreBaton; platform views by their ICompositorSurface pointer. A
+  // platform view that exports a dma-buf goes onto a KMS overlay plane
+  // via ExternalDmaBufSource; one that can't (GL-only, or no frame yet)
+  // drops the whole frame to GL composition — the same all-or-nothing
+  // rule the backing-store overflow uses below.
   struct FrameLayer {
     const FlutterLayer* flutter;
-    GbmBackingStore* store;
-    StoreBaton* baton;
+    StoreBaton* baton;                 // non-null for backing-store layers
+    GbmBackingStore* store;            // non-null for backing-store layers
+    void* pv_tag;                      // PV surface* identity tag (null for BS)
+    ICompositorSurface::Dmabuf pv_db;  // PV frame (valid when pv_tag != null)
   };
   std::vector<FrameLayer> frame_layers;
   frame_layers.reserve(layer_count);
 
-  // Track this frame's batons for the stale-layer prune below. Linear
-  // scan; engaged layer count is single-digit in practice.
+  // Per-frame prune keys — two tag spaces (BS batons, PV surface ptrs).
   std::vector<StoreBaton*> frame_batons;
+  std::vector<void*> frame_pv_tags;
   frame_batons.reserve(layer_count);
+  frame_pv_tags.reserve(layer_count);
 
   for (size_t i = 0; i < layer_count; ++i) {
     const FlutterLayer* fl = layers[i];
-    if (!fl || fl->type != kFlutterLayerContentTypeBackingStore ||
-        !fl->backing_store) {
+    if (!fl) {
       continue;
     }
-    auto* baton = static_cast<StoreBaton*>(fl->backing_store->user_data);
-    if (!baton || !baton->store) {
-      continue;
-    }
-    frame_layers.push_back({fl, baton->store, baton});
-    frame_batons.push_back(baton);
-  }
-
-  // Prune scene layers whose batons are not in this frame's set. The
-  // scene retains layers across commits; without this step, a layer
-  // for a backing store Flutter dropped from its layer tree (without
-  // collecting it yet) would still be acquired by the next commit
-  // with stale dst_rect.
-  for (auto it = scene_layer_batons_.begin();
-       it != scene_layer_batons_.end();) {
-    StoreBaton* baton = *it;
-    const bool still_present =
-        std::find(frame_batons.begin(), frame_batons.end(), baton) !=
-        frame_batons.end();
-    if (!still_present) {
-      if (auto* layer = scene_->find_by_identity_tag(baton)) {
-        scene_->remove_layer(layer->handle());
+    if (fl->type == kFlutterLayerContentTypeBackingStore && fl->backing_store) {
+      auto* baton = static_cast<StoreBaton*>(fl->backing_store->user_data);
+      if (!baton || !baton->store) {
+        continue;
       }
-      it = scene_layer_batons_.erase(it);
-    } else {
-      ++it;
+      frame_layers.push_back({fl, baton, baton->store, nullptr, {}});
+      frame_batons.push_back(baton);
+    } else if (fl->type == kFlutterLayerContentTypePlatformView &&
+               fl->platform_view) {
+      std::shared_ptr<ICompositorSurface> surface;
+      {
+        const std::lock_guard<std::mutex> lock(surfaces_mu_);
+        if (auto it = surfaces_.find(fl->platform_view->identifier);
+            it != surfaces_.end()) {
+          surface = it->second;
+        }
+      }
+      if (!surface) {
+        // No registered surface for this view id this frame — nothing to
+        // place; fall back so the frame stays well-formed.
+        return PresentViaGlFallback(layers, layer_count);
+      }
+      // The producer renders at this size; feed it the laid-out extent
+      // before pulling its frame (the create/resize channel may not have
+      // reached it yet).
+      surface->OnResize(static_cast<int32_t>(fl->size.width),
+                        static_cast<int32_t>(fl->size.height));
+      ICompositorSurface::Dmabuf db;
+      if (!surface->GetDmabuf(&db)) {
+        // GL-only surface, or no dma-buf frame ready this present: route
+        // the whole frame through GL composition (which samples the
+        // surface's GL texture / Vulkan image).
+        return PresentViaGlFallback(layers, layer_count);
+      }
+      frame_layers.push_back({fl, nullptr, nullptr, surface.get(), db});
+      frame_pv_tags.push_back(surface.get());
     }
   }
 
-  // Add new layers; update dst_rect on existing ones. dst_rect is in
-  // CRTC coordinates; the non-framed path has no letterbox so
+  // Prune scene layers whose tag is not in this frame's set. The scene
+  // retains layers across commits; without this a layer for a store /
+  // view Flutter dropped from its tree (without collecting it yet) would
+  // still be acquired by the next commit with stale geometry. Two tag
+  // spaces (BS batons, PV surface ptrs), so the prune runs over both.
+  const auto prune = [&](auto& tags, const auto& present) -> int {
+    int pruned = 0;
+    for (auto it = tags.begin(); it != tags.end();) {
+      const bool still_present =
+          std::find(present.begin(), present.end(), *it) != present.end();
+      if (!still_present) {
+        if (auto* layer =
+                scene_->find_by_identity_tag(static_cast<void*>(*it))) {
+          scene_->remove_layer(layer->handle());
+        }
+        it = tags.erase(it);
+        ++pruned;
+      } else {
+        ++it;
+      }
+    }
+    return pruned;
+  };
+  const int bs_pruned = prune(scene_layer_batons_, frame_batons);
+  const int pv_pruned = prune(scene_pv_tags_, frame_pv_tags);
+
+  // Add new layers; update geometry/zpos on existing ones. dst_rect is
+  // in CRTC coordinates; the non-framed path has no letterbox so
   // FlutterLayer.offset is already CRTC-relative.
+  //
+  // z_index is each layer's position in Flutter's array = its z-order.
+  // Write it as the plane zpos for EVERY non-primary layer (backing
+  // stores AND platform views) so the whole overlay stack shares one
+  // Flutter-order z scheme; leaving BS overlays unset let them float in z
+  // relative to the PVs. The first layer (z_index 0, the UI/primary
+  // backing store) is left unset — its plane's zpos is immutable on some
+  // drivers, and writing zpos=N matching the primary mis-screens overlays.
+  int bs_reused = 0, bs_new = 0, pv_reused = 0, pv_new = 0;
+  int z_index = -1;
   for (auto& fl : frame_layers) {
+    ++z_index;
+    const bool is_ui = (z_index == 0);
     drm::scene::Rect dst_rect{
         static_cast<int32_t>(fl.flutter->offset.x),
         static_cast<int32_t>(fl.flutter->offset.y),
         static_cast<uint32_t>(fl.flutter->size.width),
         static_cast<uint32_t>(fl.flutter->size.height),
     };
-    auto* layer = scene_->find_by_identity_tag(fl.baton);
-    if (layer) {
-      layer->set_dst_rect_if_changed(dst_rect);
-      continue;
+
+    if (fl.pv_tag == nullptr) {
+      // ── Backing store: hand the pre-built scene_source to the scene ──
+      if (auto* layer = scene_->find_by_identity_tag(fl.baton)) {
+        layer->set_dst_rect_if_changed(dst_rect);
+        if (!is_ui) {
+          layer->set_zpos_if_changed(z_index);
+        }
+        ++bs_reused;
+        continue;
+      }
+      ++bs_new;
+      // CreateBackingStore pre-built the scene_source; nullptr would only
+      // happen if the store predated scene_ construction, which can't
+      // happen on the non-framed path (scene_ is built before any Present).
+      if (!fl.baton->scene_source) {
+        ihs::log::warn(
+            "[DrmCompositor] LayerScene: baton lacks scene_source; routing "
+            "frame through GL fallback");
+        return PresentViaGlFallback(layers, layer_count);
+      }
+      drm::scene::LayerDesc desc{};
+      desc.source = std::move(fl.baton->scene_source);
+      desc.display.dst_rect = dst_rect;
+      desc.display.rotation = DRM_MODE_ROTATE_0 | DRM_MODE_REFLECT_Y;
+      // Non-UI backing stores get a Flutter-order zpos too, matching the PVs.
+      if (!is_ui) {
+        desc.display.zpos = z_index;
+      }
+      desc.content_type = is_ui ? drm::planes::ContentType::UI
+                                : drm::planes::ContentType::Generic;
+      desc.identity_tag = fl.baton;
+      auto handle = scene_->add_layer(std::move(desc));
+      if (!handle) {
+        ihs::log::warn("[DrmCompositor] LayerScene::add_layer (bs): {}",
+                       handle.error().message());
+        return PresentViaGlFallback(layers, layer_count);
+      }
+      scene_layer_batons_.push_back(fl.baton);
+    } else {
+      // ── Platform view: wrap the dma-buf as a scene buffer source ──
+      if (auto* layer = scene_->find_by_identity_tag(fl.pv_tag)) {
+        // The current producer submits a static buffer, so only geometry /
+        // stacking change. A producer that cycles buffers per frame would
+        // replace_source() here (or drive an external_dma_buf ring) —
+        // deferred to the video-producer work.
+        layer->set_dst_rect_if_changed(dst_rect);
+        layer->set_zpos_if_changed(z_index);  // restack on widget-tree reorder
+        ++pv_reused;
+        continue;
+      }
+      ++pv_new;
+      const auto& db = fl.pv_db;
+      const uint32_t np = db.plane_count ? db.plane_count : 1;
+      std::array<drm::scene::ExternalPlaneInfo, 4> planes{};
+      for (uint32_t p = 0; p < np && p < 4; ++p) {
+        planes[p] =
+            drm::scene::ExternalPlaneInfo{db.fd, db.offset[p], db.stride[p]};
+      }
+      // ExternalDmaBufSource dups the fds and does its own
+      // AddFB2WithModifiers; the producer keeps ownership of the originals.
+      auto src = drm::scene::ExternalDmaBufSource::create(
+          backend_->device(), db.width, db.height, db.fourcc, db.modifier,
+          drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(), np));
+      if (!src) {
+        ihs::log::warn(
+            "[DrmCompositor] ExternalDmaBufSource::create (pv): {}; routing "
+            "through GL fallback",
+            src.error().message());
+        return PresentViaGlFallback(layers, layer_count);
+      }
+      drm::scene::LayerDesc desc{};
+      desc.source = std::move(src.value());
+      desc.display.dst_rect = dst_rect;
+      // Producer hands scanout-oriented (top-down) pixels — no REFLECT_Y,
+      // unlike GL backing stores.
+      desc.display.rotation = DRM_MODE_ROTATE_0;
+      desc.display.zpos = z_index;
+      desc.content_type = drm::planes::ContentType::Generic;
+      desc.identity_tag = fl.pv_tag;
+      auto handle = scene_->add_layer(std::move(desc));
+      if (!handle) {
+        ihs::log::warn("[DrmCompositor] LayerScene::add_layer (pv): {}",
+                       handle.error().message());
+        return PresentViaGlFallback(layers, layer_count);
+      }
+      scene_pv_tags_.push_back(fl.pv_tag);
+      if (backend_->cfg_.debug_backend) {
+        ihs::log::debug(
+            "[DrmCompositor] platform-view scene layer added: {}x{} "
+            "fmt=0x{:08x} mod=0x{:016x} dst=({},{} {}x{})",
+            db.width, db.height, db.fourcc, db.modifier,
+            static_cast<int32_t>(fl.flutter->offset.x),
+            static_cast<int32_t>(fl.flutter->offset.y),
+            static_cast<uint32_t>(fl.flutter->size.width),
+            static_cast<uint32_t>(fl.flutter->size.height));
+      }
     }
-    // First sight: hand the scene_source wrapper to the scene.
-    // CreateBackingStore pre-built it; nullptr would only happen if
-    // the store predated the scene_ construction, which can't happen
-    // on the non-framed path (scene_ is built before any Present).
-    if (!fl.baton->scene_source) {
-      ihs::log::warn(
-          "[DrmCompositor] LayerScene: baton lacks scene_source; routing "
-          "frame through GL fallback");
-      return PresentViaGlFallback(layers, layer_count);
-    }
-    drm::scene::LayerDesc desc{};
-    desc.source = std::move(fl.baton->scene_source);
-    desc.display.dst_rect = dst_rect;
-    desc.display.rotation = DRM_MODE_ROTATE_0 | DRM_MODE_REFLECT_Y;
-    desc.content_type = (&fl == &frame_layers.front())
-                            ? drm::planes::ContentType::UI
-                            : drm::planes::ContentType::Generic;
-    desc.identity_tag = fl.baton;
-    auto handle = scene_->add_layer(std::move(desc));
-    if (!handle) {
-      ihs::log::warn("[DrmCompositor] LayerScene::add_layer: {}",
-                     handle.error().message());
-      return PresentViaGlFallback(layers, layer_count);
-    }
-    scene_layer_batons_.push_back(fl.baton);
+  }
+  if (backend_->cfg_.debug_backend &&
+      (bs_new || pv_new || bs_pruned || pv_pruned)) {
+    ihs::log::debug(
+        "[pv-churn] bs: reused={} new={} pruned={} | pv: reused={} new={} "
+        "pruned={}",
+        bs_reused, bs_new, bs_pruned, pv_reused, pv_new, pv_pruned);
   }
 
   // TEST_ONLY probe: if any layer would land in the composition

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2349,6 +2349,22 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   frame_batons.reserve(layer_count);
   frame_pv_tags.reserve(layer_count);
 
+  // GetDmabuf hands back an owned (dup'd) fd per platform view; close them on
+  // every exit path (each GL-fallback return below, and the normal exit).
+  // ExternalDmaBufSource::create dups again for the KMS framebuffer, so closing
+  // after the scene layer is built is correct.
+  struct PvFdCloser {
+    std::vector<FrameLayer>& fls;
+    ~PvFdCloser() {
+      for (auto& fl : fls) {
+        if (fl.pv_tag != nullptr && fl.pv_db.fd >= 0) {
+          ::close(fl.pv_db.fd);
+          fl.pv_db.fd = -1;
+        }
+      }
+    }
+  } pv_fd_closer{frame_layers};
+
   for (size_t i = 0; i < layer_count; ++i) {
     const FlutterLayer* fl = layers[i];
     if (!fl) {

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2440,17 +2440,20 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   // FlutterLayer.offset is already CRTC-relative.
   //
   // z_index is each layer's position in Flutter's array = its z-order.
-  // Write it as the plane zpos for EVERY non-primary layer (backing
-  // stores AND platform views) so the whole overlay stack shares one
-  // Flutter-order z scheme; leaving BS overlays unset let them float in z
-  // relative to the PVs. The first layer (z_index 0, the UI/primary
-  // backing store) is left unset — its plane's zpos is immutable on some
-  // drivers, and writing zpos=N matching the primary mis-screens overlays.
+  // Every non-primary layer (backing stores AND platform views) gets an
+  // explicit plane zpos so the whole overlay stack shares one Flutter-order
+  // scheme (leaving BS overlays unset let them float in z relative to the
+  // PVs). The zpos is primary_zpos_ + z_index, NOT the raw index: on drivers
+  // where the primary plane's zpos is not 0 (e.g. amdgpu primary zpos=2), a
+  // raw zpos=1 would sit below the primary and invert stacking. The first
+  // layer (z_index 0, the UI/primary backing store) is left unset — it lands
+  // on the primary plane, whose zpos is immutable on some drivers.
   int bs_reused = 0, bs_new = 0, pv_reused = 0, pv_new = 0;
   int z_index = -1;
   for (auto& fl : frame_layers) {
     ++z_index;
     const bool is_ui = (z_index == 0);
+    const int overlay_zpos = static_cast<int>(primary_zpos_) + z_index;
     drm::scene::Rect dst_rect{
         static_cast<int32_t>(fl.flutter->offset.x),
         static_cast<int32_t>(fl.flutter->offset.y),
@@ -2463,7 +2466,7 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       if (auto* layer = scene_->find_by_identity_tag(fl.baton)) {
         layer->set_dst_rect_if_changed(dst_rect);
         if (!is_ui) {
-          layer->set_zpos_if_changed(z_index);
+          layer->set_zpos_if_changed(overlay_zpos);
         }
         ++bs_reused;
         continue;
@@ -2484,7 +2487,7 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       desc.display.rotation = DRM_MODE_ROTATE_0 | DRM_MODE_REFLECT_Y;
       // Non-UI backing stores get a Flutter-order zpos too, matching the PVs.
       if (!is_ui) {
-        desc.display.zpos = z_index;
+        desc.display.zpos = overlay_zpos;
       }
       desc.content_type = is_ui ? drm::planes::ContentType::UI
                                 : drm::planes::ContentType::Generic;
@@ -2499,18 +2502,24 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     } else {
       // ── Platform view: wrap the dma-buf as a scene buffer source ──
       if (auto* layer = scene_->find_by_identity_tag(fl.pv_tag)) {
-        // The current producer submits a static buffer, so only geometry /
-        // stacking change. A producer that cycles buffers per frame would
-        // replace_source() here (or drive an external_dma_buf ring) —
-        // deferred to the video-producer work.
+        // Only geometry / stacking are updated here — the scene layer keeps
+        // its existing ExternalDmaBufSource. That is correct for the current
+        // producer, whose buffer content is static once submitted (a resize
+        // re-stretches a solid color, no visible change). A producer that
+        // cycles buffer *content* per frame (a decoder, a camera) needs
+        // LayerScene::replace_source() driven by a buffer ring here — the
+        // dynamic-producer follow-up; without it such a plane would scan out
+        // the first frame indefinitely.
         layer->set_dst_rect_if_changed(dst_rect);
-        layer->set_zpos_if_changed(z_index);  // restack on widget-tree reorder
+        layer->set_zpos_if_changed(overlay_zpos);  // restack on reorder
         ++pv_reused;
         continue;
       }
       ++pv_new;
       const auto& db = fl.pv_db;
-      const uint32_t np = db.plane_count ? db.plane_count : 1;
+      // GetDmabuf guarantees a valid single-handle plane set (1..4 planes); it
+      // returns false rather than a zero-plane frame.
+      const uint32_t np = db.plane_count;
       std::array<drm::scene::ExternalPlaneInfo, 4> planes{};
       for (uint32_t p = 0; p < np && p < 4; ++p) {
         planes[p] =
@@ -2534,7 +2543,7 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       // Producer hands scanout-oriented (top-down) pixels — no REFLECT_Y,
       // unlike GL backing stores.
       desc.display.rotation = DRM_MODE_ROTATE_0;
-      desc.display.zpos = z_index;
+      desc.display.zpos = overlay_zpos;
       desc.content_type = drm::planes::ContentType::Generic;
       desc.identity_tag = fl.pv_tag;
       auto handle = scene_->add_layer(std::move(desc));

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -451,6 +451,12 @@ class DrmCompositor : public IFlipSink {
   // than any hashing for that size.
   std::vector<StoreBaton*> scene_layer_batons_;
 
+  // Sibling prune list for platform-view scene layers, keyed by the
+  // ICompositorSurface pointer (its scene identity_tag). Same rationale as
+  // scene_layer_batons_ — the scene retains layers across commits, so a PV
+  // that vanished from the frame must be pruned by tag.
+  std::vector<void*> scene_pv_tags_;
+
   // DRM plane id of an externally-managed cursor to reserve from the
   // scene allocator's disable-unused pass. Set by ReserveCursorPlane()
   // (from DrmBackend, once the cursor exists); applied to scene_ each

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -630,6 +630,9 @@ bool WaylandEglBackend::GetEglContext(BackendEglContext* out) const {
   // share_context transitively shares GL objects with Flutter's raster
   // context.
   out->share_context = GetTextureContext();
+  // No gbm on a Wayland EGL backend — platform views present via wl_surface /
+  // GL texture, not a KMS plane, so there is no scanout buffer to export.
+  out->gbm_device = nullptr;
   return out->display != EGL_NO_DISPLAY && out->share_context != EGL_NO_CONTEXT;
 }
 

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -252,12 +252,13 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
 
   // Direct-scanout seam for the DRM compositor: expose the latest submitted
   // frame's dma-buf so it can be placed on a KMS overlay plane instead of being
-  // GL-composited. A pure read of the frame stashed by HostSubmit; the returned
-  // fd is borrowed (owned by pending_egl — valid until the next submit
-  // supersedes it, or GetGlTextureName imports and closes it). The compositor
-  // must therefore plane-route XOR GL-import a given surface in one present so
-  // the two paths never both consume the frame. Producers submit top-down
-  // pixels (no REFLECT_Y), so the plane scans the buffer out as-is.
+  // GL-composited. Reads the frame stashed by HostSubmit and returns a *dup* of
+  // its dma-buf fd — owned by the caller, which must close it. Duping under the
+  // lock keeps the fd valid even if a concurrent HostSubmit supersedes and
+  // closes the plugin's original before the compositor imports it. The
+  // compositor still plane-routes XOR GL-imports a given surface per present so
+  // the two paths don't both consume a frame. Producers submit top-down pixels
+  // (no REFLECT_Y), so the plane scans the buffer out as-is.
   [[nodiscard]] bool GetDmabuf(Dmabuf* out) const override {
     const std::lock_guard<std::mutex> lock(mutex);
     if (out == nullptr || !pending_egl.valid) {
@@ -267,19 +268,25 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     if (f.plane_count == 0 || f.plane_fd[0] < 0) {
       return false;
     }
-    out->fd = f.plane_fd[0];
+    const int dup_fd = ::dup(f.plane_fd[0]);
+    if (dup_fd < 0) {
+      return false;
+    }
+    out->fd = dup_fd;  // owned by the caller
     out->fourcc = f.format.fourcc;
     out->modifier = f.format.modifier;
     out->width = f.width;
     out->height = f.height;
-    out->plane_count = f.plane_count;
-    for (uint32_t i = 0; i < f.plane_count && i < 4; ++i) {
+    // A single-handle multi-planar layout shares one fd across planes; clamp to
+    // the 4 the descriptor holds (a DRM fourcc has at most 4 planes).
+    out->plane_count = f.plane_count < 4 ? f.plane_count : 4;
+    for (uint32_t i = 0; i < out->plane_count; ++i) {
       out->offset[i] = f.plane_offset[i];
       out->stride[i] = f.plane_stride[i];
     }
-    // Borrowed; -1 on the implicit-sync path. The compositor dups it for the
-    // atomic commit's IN_FENCE_FD when >= 0.
-    out->acquire_fence_fd = pending_acquire_fd;
+    // The DRM scene path is implicit-sync today and does not consume an acquire
+    // fence; leave it unset until explicit-sync IN_FENCE wiring lands.
+    out->acquire_fence_fd = -1;
     return true;
   }
 #endif

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -249,6 +249,39 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // Imported dma-bufs are top-first (row 0 is the top), so the EGL compositor
   // must V-flip when sampling into its bottom-first framebuffer.
   [[nodiscard]] bool TextureIsTopFirst() const override { return true; }
+
+  // Direct-scanout seam for the DRM compositor: expose the latest submitted
+  // frame's dma-buf so it can be placed on a KMS overlay plane instead of being
+  // GL-composited. A pure read of the frame stashed by HostSubmit; the returned
+  // fd is borrowed (owned by pending_egl — valid until the next submit
+  // supersedes it, or GetGlTextureName imports and closes it). The compositor
+  // must therefore plane-route XOR GL-import a given surface in one present so
+  // the two paths never both consume the frame. Producers submit top-down
+  // pixels (no REFLECT_Y), so the plane scans the buffer out as-is.
+  [[nodiscard]] bool GetDmabuf(Dmabuf* out) const override {
+    const std::lock_guard<std::mutex> lock(mutex);
+    if (out == nullptr || !pending_egl.valid) {
+      return false;
+    }
+    const IhsFrame& f = pending_egl.frame;
+    if (f.plane_count == 0 || f.plane_fd[0] < 0) {
+      return false;
+    }
+    out->fd = f.plane_fd[0];
+    out->fourcc = f.format.fourcc;
+    out->modifier = f.format.modifier;
+    out->width = f.width;
+    out->height = f.height;
+    out->plane_count = f.plane_count;
+    for (uint32_t i = 0; i < f.plane_count && i < 4; ++i) {
+      out->offset[i] = f.plane_offset[i];
+      out->stride[i] = f.plane_stride[i];
+    }
+    // Borrowed; -1 on the implicit-sync path. The compositor dups it for the
+    // atomic commit's IN_FENCE_FD when >= 0.
+    out->acquire_fence_fd = pending_acquire_fd;
+    return true;
+  }
 #endif
 
   // The image is an imported dma-buf the plugin rewrites; the compositor
@@ -592,7 +625,7 @@ int HostEglContext(void* user_data, IhsEglContext* out) {
   out->egl_display = egl.display;
   out->egl_context = egl.share_context;
   out->egl_config = egl.config;
-  out->gbm_device = nullptr;
+  out->gbm_device = egl.gbm_device;
   return IHS_PV_OK;
 }
 

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -268,6 +268,17 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     if (f.plane_count == 0 || f.plane_fd[0] < 0) {
       return false;
     }
+    // The Dmabuf descriptor carries a single fd shared across planes (the
+    // v4l2 / libcamera / Chromium single-handle layout). A genuine per-plane-fd
+    // frame can't be represented here, so bail — the caller falls back to the
+    // GL import path, which handles multiple fds. Clamp to the 4 planes the
+    // descriptor holds (a DRM fourcc has at most 4).
+    const uint32_t np = f.plane_count < 4 ? f.plane_count : 4;
+    for (uint32_t i = 1; i < np; ++i) {
+      if (f.plane_fd[i] != f.plane_fd[0]) {
+        return false;
+      }
+    }
     const int dup_fd = ::dup(f.plane_fd[0]);
     if (dup_fd < 0) {
       return false;
@@ -277,10 +288,8 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     out->modifier = f.format.modifier;
     out->width = f.width;
     out->height = f.height;
-    // A single-handle multi-planar layout shares one fd across planes; clamp to
-    // the 4 the descriptor holds (a DRM fourcc has at most 4 planes).
-    out->plane_count = f.plane_count < 4 ? f.plane_count : 4;
-    for (uint32_t i = 0; i < out->plane_count; ++i) {
+    out->plane_count = np;
+    for (uint32_t i = 0; i < np; ++i) {
       out->offset[i] = f.plane_offset[i];
       out->stride[i] = f.plane_stride[i];
     }
@@ -595,6 +604,14 @@ int HostQueryCapabilities(void* user_data, IhsPvCapabilities* out) {
     BackendEglContext egl{};
     if (backend->GetEglContext(&egl)) {
       out->kinds |= IHS_PV_KIND_TEXTURE_DMABUF_IMPORT;
+      // The DRM-KMS-EGL backend (gbm_device set; wayland-egl leaves it null)
+      // runs the plane compositor, which can scan out a submitted dma-buf
+      // directly on a KMS overlay plane — offer the zero-copy DRM_PLANE kind.
+      // The scene path falls back to GL if a plane can't be allocated for a
+      // given frame, so advertising it never hard-fails a view.
+      if (egl.gbm_device != nullptr) {
+        out->kinds |= IHS_PV_KIND_DRM_PLANE;
+      }
     }
 #endif
   }

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -259,6 +259,14 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // compositor still plane-routes XOR GL-imports a given surface per present so
   // the two paths don't both consume a frame. Producers submit top-down pixels
   // (no REFLECT_Y), so the plane scans the buffer out as-is.
+  //
+  // A GL fallback for a frame (no overlay plane fits) imports the stashed frame
+  // via GetGlTextureName, which consumes it — so GetDmabuf then returns false
+  // until the producer submits again. A continuous producer resumes direct
+  // scanout on its next submit; a static producer stays GL-composited (still
+  // correct, just not zero-copy) until it resubmits. Retaining the dma-buf
+  // across a GL import so a static producer returns to scanout is part of the
+  // dynamic-producer follow-up.
   [[nodiscard]] bool GetDmabuf(Dmabuf* out) const override {
     const std::lock_guard<std::mutex> lock(mutex);
     if (out == nullptr || !pending_egl.valid) {

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -152,9 +152,10 @@ class ICompositorSurface {
    * (YUV) frames fill @c plane_count entries of @c offset / @c stride, all
    * sharing one @c fd (the common single-handle layout v4l2/libcamera and
    * Chromium's accelerated paint produce). @c fourcc is a @c DRM_FORMAT_* code
-   * and @c modifier a @c DRM_FORMAT_MOD_* value (@c DRM_FORMAT_MOD_INVALID for
-   * an unmodified linear buffer). @c width / @c height are the source extent in
-   * pixels; the plane scales this to the layer's destination rect.
+   * and @c modifier a @c DRM_FORMAT_MOD_* value — @c DRM_FORMAT_MOD_LINEAR (0)
+   * for a plain linear buffer, @c DRM_FORMAT_MOD_INVALID only when the modifier
+   * is unknown/unspecified (let the importer infer). @c width / @c height are
+   * the source extent in pixels; the plane scales this to the layer's dst rect.
    *
    * @c acquire_fence_fd, when >= 0, is a sync_file naming when the producer's
    * writes complete — intended for the atomic commit's @c IN_FENCE_FD so

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -156,10 +156,12 @@ class ICompositorSurface {
    * an unmodified linear buffer). @c width / @c height are the source extent in
    * pixels; the plane scales this to the layer's destination rect.
    *
-   * @c acquire_fence_fd, when >= 0, is a sync_file the compositor hands to the
-   * atomic commit as @c IN_FENCE_FD so scanout waits for the producer's writes,
-   * tear-free without a CPU stall. Ownership stays with the surface; the
-   * compositor dups it if it needs to outlive the call.
+   * @c acquire_fence_fd, when >= 0, is a sync_file naming when the producer's
+   * writes complete — intended for the atomic commit's @c IN_FENCE_FD so
+   * scanout is tear-free without a CPU stall. Not every present path consumes
+   * it yet: the DRM scene path is implicit-sync today and ignores it (leave it
+   * -1 for an implicit-sync producer). When a path does consume it, ownership
+   * stays with the surface and the compositor dups it.
    */
   struct Dmabuf {
     int fd{-1};
@@ -182,9 +184,10 @@ class ICompositorSurface {
    * geometry drives the Layer Crtc and Src rects, which drive the plane)
    * instead of GL-compositing it. Returns false (default) for GL-only surfaces,
    * or when no dma-buf frame is ready this present — the compositor falls back
-   * to the @c GetGlTextureName / @c GetVulkanImage path. Buffer ownership stays
-   * with the surface; the returned @c fd must remain valid until the next
-   * present.
+   * to the @c GetGlTextureName / @c GetVulkanImage path. The returned @c fd is
+   * owned by the caller (an implementation may dup its internal handle to make
+   * it robust against a concurrent producer superseding the frame); the caller
+   * closes it once it has imported the buffer.
    */
   [[nodiscard]] virtual bool GetDmabuf(Dmabuf* /*out*/) const { return false; }
 

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -146,6 +146,49 @@ class ICompositorSurface {
   virtual void SetVulkanImageLayout(uint32_t /*layout*/) {}
 
   /**
+   * @brief A single dma-buf frame a surface can hand to a KMS overlay plane.
+   *
+   * Plain data so this header stays free of DRM/GBM includes. Multi-planar
+   * (YUV) frames fill @c plane_count entries of @c offset / @c stride, all
+   * sharing one @c fd (the common single-handle layout v4l2/libcamera and
+   * Chromium's accelerated paint produce). @c fourcc is a @c DRM_FORMAT_* code
+   * and @c modifier a @c DRM_FORMAT_MOD_* value (@c DRM_FORMAT_MOD_INVALID for
+   * an unmodified linear buffer). @c width / @c height are the source extent in
+   * pixels; the plane scales this to the layer's destination rect.
+   *
+   * @c acquire_fence_fd, when >= 0, is a sync_file the compositor hands to the
+   * atomic commit as @c IN_FENCE_FD so scanout waits for the producer's writes,
+   * tear-free without a CPU stall. Ownership stays with the surface; the
+   * compositor dups it if it needs to outlive the call.
+   */
+  struct Dmabuf {
+    int fd{-1};
+    uint32_t fourcc{0};
+    uint64_t modifier{0};
+    uint32_t width{0};
+    uint32_t height{0};
+    uint32_t plane_count{0};
+    uint32_t offset[4]{};
+    uint32_t stride[4]{};
+    int acquire_fence_fd{-1};
+  };
+
+  /**
+   * @brief Expose the surface's latest frame as a dma-buf for direct scanout.
+   *
+   * A surface that produced a frame into a dma-buf (a video decoder, a camera,
+   * a Vulkan/GL plugin that exported its image) fills @p out and returns true;
+   * the compositor then routes it onto a KMS overlay plane (the FlutterLayer
+   * geometry drives the Layer Crtc and Src rects, which drive the plane)
+   * instead of GL-compositing it. Returns false (default) for GL-only surfaces,
+   * or when no dma-buf frame is ready this present — the compositor falls back
+   * to the @c GetGlTextureName / @c GetVulkanImage path. Buffer ownership stays
+   * with the surface; the returned @c fd must remain valid until the next
+   * present.
+   */
+  [[nodiscard]] virtual bool GetDmabuf(Dmabuf* /*out*/) const { return false; }
+
+  /**
    * @brief Whether the Vulkan image is a dma-buf the producer rewrites on
    * another agent's queue, so the compositor must take ownership of it before
    * reading and hand it back after.


### PR DESCRIPTION
## What

On drm-kms-egl the DRM compositor previously forced any frame containing a
platform view through the GL composite path, which assembled the frame but never
placed the view — an `ihs_pv`-submitted dma-buf never reached scanout. This
routes it onto a KMS overlay plane instead.

- `ICompositorSurface` gains a `Dmabuf` accessor (`GetDmabuf`); the ihs_pv host's
  `IhsPluginView` implements it as a pure read of the frame it already retains
  from the last submit. The compositor plane-routes XOR GL-imports a surface per
  frame so the two paths never both consume the frame.
- `PresentLayersViaScene` wraps each platform view's dma-buf in an
  `ExternalDmaBufSource` scene layer at the Flutter layer rect, and writes the
  Flutter-array position as the plane zpos on every non-primary layer so the
  overlay stack shares one z scheme. A view with no dma-buf, or a layer the
  allocator can't place, falls back to GL composition.
- The EGL context now carries `gbm_device`, so a GL/dma-buf producer on a DRM
  backend can allocate a scanout-capable buffer.

## Dependencies

Bumps drm-cxx to **v2.0.1** for the allocator warm-start stability fix — it keeps
each view on its plane across Flutter's per-frame backing-store re-splits;
without it, mousing over reshuffles the overlay planes (flicker).

Pairs with the in-tree ihs_pv producer in ivi-homescreen-plugins that exercises
this path (linked below).

## Validation

HW-validated on Raspberry Pi 4 (vc4), drm-kms-egl: solid-color platform-view
boxes direct-scanout onto KMS overlay planes (`LayerScene commit total=14
assigned=14 composited=0`), zero GL fallback across 146 interactive frames,
stable and flicker-free under mouse interaction.
