### PR TITLE
drm-kms-egl: scan out platform-view dma-bufs on a vc4 overlay plane

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2397,15 +2397,18 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       // reached it yet).
       surface->OnResize(static_cast<int32_t>(fl->size.width),
                         static_cast<int32_t>(fl->size.height));
-      // Only pull (and dup) a dma-buf for a NEW platform view — one that will
-      // build an ExternalDmaBufSource below. An existing scene layer keeps its
-      // source (the reuse path in the add loop), so calling GetDmabuf for it
-      // every frame would dup+close an fd for nothing. find_by_identity_tag
-      // reflects last frame's layers; this PV is present, so it survives the
-      // prune and the add loop finds it too.
+      // Pull this present's dma-buf for every platform view, new or reused: a
+      // per-frame producer (a decoder, a camera) hands a fresh buffer each
+      // present, and the reuse path in the add loop swaps it in via
+      // replace_source. GetDmabuf is deliver-once (keyed on the producer's
+      // submit_seq), so on a present with no new frame it returns false and the
+      // layer keeps its current source. find_by_identity_tag reflects last
+      // frame's layers; this PV survives the prune and the add loop finds it.
       ICompositorSurface::Dmabuf db{};
-      if (scene_->find_by_identity_tag(surface.get()) == nullptr &&
-          !surface->GetDmabuf(&db)) {
+      const bool is_new =
+          scene_->find_by_identity_tag(surface.get()) == nullptr;
+      const bool have_db = surface->GetDmabuf(&db);
+      if (is_new && !have_db) {
         // New platform view with no dma-buf (GL-only surface, or none ready
         // this present): route the whole frame through GL composition, which
         // samples the surface's GL texture / Vulkan image.
@@ -2520,24 +2523,36 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
         // dups the fds and does its own AddFB2WithModifiers; the pv_fd_closer
         // closes our dup at scope exit.
         const auto& db = fl.pv_db;
-        const uint32_t np = db.plane_count;
-        std::array<drm::scene::ExternalPlaneInfo, 4> planes{};
-        for (uint32_t p = 0; p < np && p < 4; ++p) {
-          planes[p] =
-              drm::scene::ExternalPlaneInfo{db.fd, db.offset[p], db.stride[p]};
-        }
-        auto src = drm::scene::ExternalDmaBufSource::create(
-            backend_->device(), db.width, db.height, db.fourcc, db.modifier,
-            drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(), np));
-        if (src) {
-          if (auto r = scene_->replace_source(layer->handle(),
-                                              std::move(src.value()));
-              !r) {
-            ihs::log::warn(
-                "[DrmCompositor] LayerScene::replace_source (pv): {}",
-                r.error().message());
+        // GetDmabuf is deliver-once: a valid descriptor here means a fresh
+        // frame this present. When it's empty (fd < 0 — the producer had no new
+        // frame), keep the source already on the plane rather than tearing the
+        // layer down, so the last frame holds until the next one arrives.
+        if (db.fd >= 0 && db.plane_count > 0) {
+          const uint32_t np = db.plane_count;
+          std::array<drm::scene::ExternalPlaneInfo, 4> planes{};
+          for (uint32_t p = 0; p < np && p < 4; ++p) {
+            planes[p] = drm::scene::ExternalPlaneInfo{db.fd, db.offset[p],
+                                                      db.stride[p]};
           }
-        }  // else: keep the existing source rather than tear the layer down
+          auto src = drm::scene::ExternalDmaBufSource::create(
+              backend_->device(), db.width, db.height, db.fourcc, db.modifier,
+              drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(),
+                                                             np));
+          if (src) {
+            if (auto r = scene_->replace_source(layer->handle(),
+                                                std::move(src.value()));
+                !r) {
+              ihs::log::warn(
+                  "[DrmCompositor] LayerScene::replace_source (pv): {}",
+                  r.error().message());
+            }
+          } else {
+            ihs::log::warn(
+                "[DrmCompositor] pv ExternalDmaBufSource::create failed: "
+                "{}x{} fourcc=0x{:08x} mod=0x{:016x} planes={}",
+                db.width, db.height, db.fourcc, db.modifier, np);
+          }
+        }
         layer->set_dst_rect_if_changed(dst_rect);
         layer->set_zpos_if_changed(overlay_zpos);  // restack on reorder
         ++pv_reused;

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2548,9 +2548,10 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
             }
           } else {
             ihs::log::warn(
-                "[DrmCompositor] pv ExternalDmaBufSource::create failed: "
-                "{}x{} fourcc=0x{:08x} mod=0x{:016x} planes={}",
-                db.width, db.height, db.fourcc, db.modifier, np);
+                "[DrmCompositor] pv ExternalDmaBufSource::create failed "
+                "({}): {}x{} fourcc=0x{:08x} mod=0x{:016x} planes={}",
+                src.error().message(), db.width, db.height, db.fourcc,
+                db.modifier, np);
           }
         }
         layer->set_dst_rect_if_changed(dst_rect);

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -137,6 +137,14 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // Common retire clock for both import paths (incremented on every submit).
   uint64_t submit_seq{0};
 
+  // Deliver-once guard for the direct-scanout path: the submit_seq last handed
+  // to GetDmabuf. The compositor commits faster than a 30fps producer submits,
+  // so a reused overlay layer polls GetDmabuf every present; without this it
+  // would re-import the same buffer each time, churning AddFB2/retire for no
+  // new content. Set when GetDmabuf hands out a frame; a fresh submit bumps
+  // submit_seq past it, re-arming delivery.
+  mutable uint64_t dmabuf_delivered_seq{0};
+
 #if IVI_HAVE_VULKAN
   // A resize re-creates a ring slot's dma-buf at a new size, replacing the
   // cached import. The old import can't be destroyed at once — a compositor
@@ -272,6 +280,11 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     if (out == nullptr || !pending_egl.valid) {
       return false;
     }
+    // Hand each submitted frame to the scanout path at most once — the reuse
+    // branch polls this every present but only wants a fresh buffer.
+    if (dmabuf_delivered_seq == submit_seq) {
+      return false;
+    }
     const IhsFrame& f = pending_egl.frame;
     if (f.plane_count == 0 || f.plane_fd[0] < 0) {
       return false;
@@ -287,6 +300,7 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
         return false;
       }
     }
+
     const int dup_fd = ::dup(f.plane_fd[0]);
     if (dup_fd < 0) {
       return false;
@@ -304,6 +318,7 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     // The DRM scene path is implicit-sync today and does not consume an acquire
     // fence; leave it unset until explicit-sync IN_FENCE wiring lands.
     out->acquire_fence_fd = -1;
+    dmabuf_delivered_seq = submit_seq;
     return true;
   }
 #endif


### PR DESCRIPTION
## What

Route a platform view's decoded dma-buf onto a KMS overlay plane via the
LayerScene instead of GL-compositing it, and keep it live: a per-frame
producer (a video decoder, a camera) scans out fresh content each present.

## Changes

- **platform_view_host** — `GetDmabuf` hands each submitted frame to the
  scanout path once (keyed on `submit_seq`), duping the plane fd under the
  lock so a concurrent producer supersede can't invalidate it before the
  compositor imports it.
- **drm_compositor** — advertise `IHS_PV_KIND_DRM_PLANE` from the DRM-KMS-EGL
  backend when a `gbm_device` is present; pull a fresh dma-buf for *every*
  platform view each present (not just new ones) and swap it into the reused
  scene layer with `replace_source`. A new view with no dma-buf ready still
  routes the frame through GL composition.

## Testing

Validated on a Raspberry Pi 4 driving a 1280x1440@60 HDMI output, with a live
H.264 WebRTC stream decoded by the bcm2835 V4L2 stateful decoder to NV12
dma-buf and handed to a platform view. Confirmed `granted_kind=2` (DRM plane),
tear-free vsync-locked scanout at matched frame rates, and correct color.

## Known limitations (follow-ups)

- The release path is implicit-sync: a wide producer CAPTURE-buffer margin
  bounds the reuse window until explicit `IN_FENCE` release-sync lands.
- A sub-refresh source (e.g. 30fps on a 60Hz panel) shows frame-pacing judder;
  vblank-genlocked playout is a separate change.