### PR TITLE
Vulkan backends: enable device features + expose the device for platform-view engines

### DIFF
--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -1836,11 +1836,17 @@ bool VulkanDrmBackend::GetVulkanContext(BackendVulkanContext* out) const {
   out->device = device_;
   out->queue = graphics_queue_;
   out->queue_family_index = graphics_queue_family_;
-  // Raw loader: this backend does not yet interpose vkQueue* through a shared-
-  // queue lock the way WaylandVulkanBackend does (QueueInterposer), so a
-  // plugin's submits and the compositor's share the one graphics queue without
-  // serialization (issue #208) — benign in practice; an interposed loader is a
-  // follow-up.
+  // KNOWN CONTRACT GAP (issue #208): this hands back the raw loader, but
+  // ihs/platform_view.h requires get_instance_proc_addr to be an INTERPOSED
+  // loader that serializes vkQueueSubmit/vkQueuePresentKHR on the shared
+  // graphics queue (as WaylandVulkanBackend does via QueueInterposer). This
+  // backend has no queue mutex yet, so a plugin resolving through this loader
+  // would submit unsynchronized against the compositor/engine — undefined
+  // behavior per the Vulkan external-synchronization rules. Latent today (no
+  // Vulkan-on-DRM plugin is wired to this ABI), but it MUST be interposed
+  // before one is. Fixing it means adding a queue mutex, wrapping this
+  // backend's own submit/present sites in it, and returning the interposed
+  // loader here and to the engine — tracked under #208.
   out->get_instance_proc_addr =
       reinterpret_cast<void*>(d().vkGetInstanceProcAddr);
   out->device_extensions = enabled_device_extensions_.data();

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -1616,6 +1616,14 @@ bool VulkanDrmBackend::CreateLogicalDevice(std::string& refusal_reason) {
   VkPhysicalDeviceTimelineSemaphoreFeatures timeline_supported{};
   timeline_supported.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+  // Also probe pipelineCreationCacheControl: a platform-view engine that adopts
+  // this device (e.g. the Mapbox Maps SDK) creates its pipeline cache with
+  // EXTERNALLY_SYNCHRONIZED, which needs this feature to be valid.
+  VkPhysicalDevicePipelineCreationCacheControlFeatures
+      cache_control_supported{};
+  cache_control_supported.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
+  timeline_supported.pNext = &cache_control_supported;
   VkPhysicalDeviceSynchronization2Features sync2_supported{};
   sync2_supported.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
@@ -1650,6 +1658,12 @@ bool VulkanDrmBackend::CreateLogicalDevice(std::string& refusal_reason) {
   queue_info.pQueuePriorities = &priority;
 
   VkPhysicalDeviceFeatures device_features{};
+  // A platform-view engine that adopts this device creates anisotropic samplers
+  // and uses dual-source blending; enable those when the device offers them so
+  // such an engine renders validation-clean. Harmless to the compositor.
+  device_features.samplerAnisotropy = features2.features.samplerAnisotropy;
+  device_features.dualSrcBlend = features2.features.dualSrcBlend;
+
   VkDeviceCreateInfo device_info{};
   device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
   device_info.pNext = &sync2_enable;
@@ -1659,6 +1673,34 @@ bool VulkanDrmBackend::CreateLogicalDevice(std::string& refusal_reason) {
       static_cast<uint32_t>(enabled_device_extensions_.size());
   device_info.ppEnabledExtensionNames = enabled_device_extensions_.data();
   device_info.pEnabledFeatures = &device_features;
+
+  // Enable pipelineCreationCacheControl (and its extension) when the device
+  // offers both, so an adopting engine's externally-synchronized pipeline cache
+  // is valid. Declared at function scope so it outlives vkCreateDevice.
+  VkPhysicalDevicePipelineCreationCacheControlFeatures cache_control_enable{};
+  cache_control_enable.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
+  if (cache_control_supported.pipelineCreationCacheControl == VK_TRUE) {
+    uint32_t ext_count = 0;
+    d().vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
+                                             &ext_count, nullptr);
+    std::vector<VkExtensionProperties> avail(ext_count);
+    if (ext_count > 0) {
+      d().vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
+                                               &ext_count, avail.data());
+    }
+    if (HasExt(avail, VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME)) {
+      enabled_device_extensions_.push_back(
+          VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME);
+      // push_back may reallocate, so refresh the pointer/count on device_info.
+      device_info.enabledExtensionCount =
+          static_cast<uint32_t>(enabled_device_extensions_.size());
+      device_info.ppEnabledExtensionNames = enabled_device_extensions_.data();
+      cache_control_enable.pipelineCreationCacheControl = VK_TRUE;
+      cache_control_enable.pNext = const_cast<void*>(device_info.pNext);
+      device_info.pNext = &cache_control_enable;
+    }
+  }
 
   if (d().vkCreateDevice(physical_device_, &device_info, nullptr, &device_) !=
       VK_SUCCESS) {

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -1827,6 +1827,27 @@ bool VulkanDrmBackend::TextureClearCurrent() {
   return false;
 }
 
+bool VulkanDrmBackend::GetVulkanContext(BackendVulkanContext* out) const {
+  if (out == nullptr || device_ == VK_NULL_HANDLE) {
+    return false;
+  }
+  out->instance = instance_;
+  out->physical_device = physical_device_;
+  out->device = device_;
+  out->queue = graphics_queue_;
+  out->queue_family_index = graphics_queue_family_;
+  // Raw loader: this backend does not yet interpose vkQueue* through a shared-
+  // queue lock the way WaylandVulkanBackend does (QueueInterposer), so a
+  // plugin's submits and the compositor's share the one graphics queue without
+  // serialization (issue #208) — benign in practice; an interposed loader is a
+  // follow-up.
+  out->get_instance_proc_addr =
+      reinterpret_cast<void*>(d().vkGetInstanceProcAddr);
+  out->device_extensions = enabled_device_extensions_.data();
+  out->device_extension_count = enabled_device_extensions_.size();
+  return true;
+}
+
 FlutterRendererConfig VulkanDrmBackend::GetRenderConfig() {
   FlutterRendererConfig config{};
   config.type = kVulkan;

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -118,6 +118,12 @@ class VulkanDrmBackend final : public Backend {
   FlutterRendererConfig GetRenderConfig() override;
   FlutterCompositor GetCompositorConfig() override;
 
+  // Expose the backend's Vulkan device to the ihs_pv platform-view host so a
+  // plugin (e.g. the Mapbox Maps SDK) can adopt the shared device, render into
+  // an exported dma-buf, and submit it for zero-copy import — the same seam
+  // WaylandVulkanBackend provides.
+  bool GetVulkanContext(BackendVulkanContext* out) const override;
+
   // Vsync: drive Flutter's frame scheduling from the real page-flip event
   // instead of its wall-clock fallback, so frames align to the connector's
   // refresh (and the raster thread no longer blocks in WaitForFlip). Returns a

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -754,16 +754,29 @@ void WaylandVulkanBackend::createLogicalDevice() {
 
   // Enable pipelineCreationCacheControl when the extension was selected, so a
   // platform-view engine's externally-synchronized pipeline cache is valid.
+  // The extension being advertised does not guarantee the feature bit, so
+  // query it via vkGetPhysicalDeviceFeatures2 and only chain it when the
+  // device reports support — requesting an unsupported feature can fail
+  // vkCreateDevice.
   VkPhysicalDevicePipelineCreationCacheControlFeatures cache_control{};
   cache_control.sType =
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
   for (const char* ext : enabled_device_extensions_) {
     if (strcmp(ext, VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME) ==
         0) {
-      cache_control.pipelineCreationCacheControl = VK_TRUE;
-      // chain ahead of any prior struct (pNext on the create info is const)
-      cache_control.pNext = const_cast<void*>(device_info.pNext);
-      device_info.pNext = &cache_control;
+      VkPhysicalDevicePipelineCreationCacheControlFeatures cache_supported{};
+      cache_supported.sType =
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
+      VkPhysicalDeviceFeatures2 features2{};
+      features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+      features2.pNext = &cache_supported;
+      d().vkGetPhysicalDeviceFeatures2(physical_device_, &features2);
+      if (cache_supported.pipelineCreationCacheControl == VK_TRUE) {
+        cache_control.pipelineCreationCacheControl = VK_TRUE;
+        // chain ahead of any prior struct (pNext on the create info is const)
+        cache_control.pNext = const_cast<void*>(device_info.pNext);
+        device_info.pNext = &cache_control;
+      }
       break;
     }
   }

--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -627,6 +627,12 @@ void WaylandVulkanBackend::findPhysicalDevice() {
               VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
               VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
               VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+              // Lets a platform-view engine (e.g. the Mapbox Maps SDK) create a
+              // pipeline cache with EXTERNALLY_SYNCHRONIZED on
+              // this 1.1-targeted device without a validation error. Core in
+              // Vulkan 1.3; enabled as an extension here when advertised.
+              // Harmless otherwise.
+              VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME,
               VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME}) {
           if (strcmp(want, extensionName) == 0) {
             supported_extensions.push_back(want);
@@ -713,6 +719,16 @@ void WaylandVulkanBackend::createLogicalDevice() {
   queue_info.pQueuePriorities = &priority;
 
   VkPhysicalDeviceFeatures device_features{};
+  {
+    // The Mapbox Maps SDK (and other platform-view engines) create anisotropic
+    // samplers and use dual-source blending; enable those features when the
+    // device offers them so such an engine stays validation-clean. Both are
+    // widely supported and harmless to the rest of the compositor.
+    VkPhysicalDeviceFeatures supported{};
+    d().vkGetPhysicalDeviceFeatures(physical_device_, &supported);
+    device_features.samplerAnisotropy = supported.samplerAnisotropy;
+    device_features.dualSrcBlend = supported.dualSrcBlend;
+  }
   VkDeviceCreateInfo device_info{};
   device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
   device_info.queueCreateInfoCount = 1;
@@ -732,6 +748,22 @@ void WaylandVulkanBackend::createLogicalDevice() {
     if (strcmp(ext, VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME) == 0) {
       timeline_feature.timelineSemaphore = VK_TRUE;
       device_info.pNext = &timeline_feature;
+      break;
+    }
+  }
+
+  // Enable pipelineCreationCacheControl when the extension was selected, so a
+  // platform-view engine's externally-synchronized pipeline cache is valid.
+  VkPhysicalDevicePipelineCreationCacheControlFeatures cache_control{};
+  cache_control.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
+  for (const char* ext : enabled_device_extensions_) {
+    if (strcmp(ext, VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME) ==
+        0) {
+      cache_control.pipelineCreationCacheControl = VK_TRUE;
+      // chain ahead of any prior struct (pNext on the create info is const)
+      cache_control.pNext = const_cast<void*>(device_info.pNext);
+      device_info.pNext = &cache_control;
       break;
     }
   }


### PR DESCRIPTION
## What

Enable the Vulkan device features that a platform-view engine adopting the backend's shared device needs, on **both** Vulkan backends, and expose the device to the ihs_pv platform-view host on the DRM/KMS Vulkan backend.

Motivated by integrating the Mapbox Maps Embedded SDK as an `ihs_pv` platform view (renders headlessly into an exported dma-buf the compositor imports zero-copy), but the changes are engine-agnostic — any platform-view engine that adopts the shared `VkDevice` benefits.

## Commits

1. **wayland_vulkan: enable device features platform-view engines need** — enable `samplerAnisotropy`, `dualSrcBlend`, and `VK_EXT_pipeline_creation_cache_control` on the logical device when the physical device advertises them. Without these, an adopting engine's anisotropic samplers, dual-source blending, and externally-synchronized pipeline cache trip validation errors.
2. **drm_kms_vulkan: enable device features platform-view engines need** — the same three features on the DRM/KMS Vulkan backend, matching its feature-chain style.
3. **drm_kms_vulkan: expose the Vulkan device to the platform-view host** — implement `VulkanDrmBackend::GetVulkanContext` (mirroring `WaylandVulkanBackend`). Without it the ihs_pv host reported "vulkan off" and every dma-buf producer went inert; with it a plugin adopts the shared device, renders into an exported dma-buf, and the compositor imports and composites it.

## Safety

Every feature is enabled **only when the physical device advertises it** — `samplerAnisotropy`/`dualSrcBlend` are read from the already-queried `features2`; the cache-control extension is appended only when both its feature bit and the extension are present. A device lacking any of them is unaffected (no refusal, no behavior change for other backends or plugins).

`GetVulkanContext` uses the raw instance-proc loader for now (no shared-queue interposer on the DRM Vulkan backend yet — issue #208); a follow-up can add the locking trampolines the Wayland Vulkan backend uses.

## Validation

- **wayland_vulkan** — HW-validated on amdgpu (RADV): a quad of Mapbox map platform views renders tiles, steady-state 0 VUIDs.
- **drm_kms_vulkan** — validated headlessly on vkms: the quad's four producers come up (host reports "vulkan ready"), render, and present to the KMS plane. Real-hardware KMS validation to follow.