### PR TITLE
drm-kms-egl: wire explicit sync for platform-view scanout

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -40,6 +40,7 @@
 
 #include <drm-cxx/core/format.hpp>
 #include <drm-cxx/scene/external_dma_buf_source.hpp>
+#include <drm-cxx/sync/fence.hpp>
 
 #include "backend/drm_kms_egl/driver_probe.h"
 #include "backend/drm_kms_egl/drm_backend.h"
@@ -2361,6 +2362,16 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
           ::close(fl.pv_db.fd);
           fl.pv_db.fd = -1;
         }
+        // Close the producer's acquire fence. drm::sync::SyncFence::import_fd
+        // (used by set_acquire_fence below) DUPS the fd rather than taking
+        // ownership, so this original is always ours to close — the same
+        // pattern vulkan_drm_backend.cc follows (it also ::close()s its fd
+        // after import_fd). Also covers the paths where the source failed to
+        // build.
+        if (fl.pv_tag != nullptr && fl.pv_db.acquire_fence_fd >= 0) {
+          ::close(fl.pv_db.acquire_fence_fd);
+          fl.pv_db.acquire_fence_fd = -1;
+        }
       }
     }
   } pv_fd_closer{frame_layers};
@@ -2539,6 +2550,22 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
               drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(),
                                                              np));
           if (src) {
+            // Explicit sync: the producer's acquire fence rides the plane's
+            // IN_FENCE_FD (scene CPU-waits as a fallback). import_fd dups, so
+            // PvFdCloser still closes our original fd.
+            if (db.acquire_fence_fd >= 0) {
+              if (auto f = drm::sync::SyncFence::import_fd(db.acquire_fence_fd);
+                  f) {
+                src.value()->set_acquire_fence(std::move(f.value()));
+              } else {
+                // Fall back to implicit sync for this frame (the producer
+                // synced, or scanout may tear); log so it's diagnosable.
+                ihs::log::warn(
+                    "[DrmCompositor] pv acquire-fence import failed ({}); "
+                    "implicit sync this frame",
+                    f.error().message());
+              }
+            }
             if (auto r = scene_->replace_source(layer->handle(),
                                                 std::move(src.value()));
                 !r) {
@@ -2580,6 +2607,20 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
             "through GL fallback",
             src.error().message());
         return PresentViaGlFallback(layers, layer_count);
+      }
+      // Explicit sync: hand the producer's acquire fence to the source so the
+      // scene wires it to the plane's IN_FENCE_FD (CPU-wait fallback).
+      // import_fd dups, so PvFdCloser still closes our original fd.
+      if (db.acquire_fence_fd >= 0) {
+        if (auto f = drm::sync::SyncFence::import_fd(db.acquire_fence_fd); f) {
+          src.value()->set_acquire_fence(std::move(f.value()));
+        } else {
+          // Fall back to implicit sync for this frame; log so it's diagnosable.
+          ihs::log::warn(
+              "[DrmCompositor] pv acquire-fence import failed ({}); implicit "
+              "sync this frame",
+              f.error().message());
+        }
       }
       drm::scene::LayerDesc desc{};
       desc.source = std::move(src.value());

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -29,8 +29,10 @@
 // instead.
 #if BUILD_COMPOSITOR
 
+#include <poll.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <map>
@@ -175,6 +177,12 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   struct PendingEglFrame {
     bool valid{false};
     IhsFrame frame{};  // owns the plane fds until imported / superseded
+    // Producer's acquire fence (sync_file fd) for this frame's writes.
+    // GetDmabuf hands the DRM scene path a dup for the plane's IN_FENCE_FD and
+    // this copy stays owned here; it is closed on a superseding submit, on
+    // dispose, or by the GL-fallback wait in GetGlTextureName. -1 when the
+    // producer synced before submit.
+    int acquire_fence_fd{-1};
   };
   mutable PendingEglFrame pending_egl;
   mutable std::map<uint32_t, EglDmabufImporter::ImportedTexture> buffers_egl;
@@ -315,9 +323,25 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
       out->offset[i] = f.plane_offset[i];
       out->stride[i] = f.plane_stride[i];
     }
-    // The DRM scene path is implicit-sync today and does not consume an acquire
-    // fence; leave it unset until explicit-sync IN_FENCE wiring lands.
+    // Explicit sync: hand the producer's acquire fence to the DRM scene path,
+    // which wires it to the plane's IN_FENCE_FD (or CPU-waits as a fallback).
+    // Per the ICompositorSurface::Dmabuf contract the surface keeps ownership
+    // and the compositor gets a dup; retaining it here also lets the GL-texture
+    // fallback (GetGlTextureName) still wait on the fence if this present later
+    // falls back after GetDmabuf. The surface's copy is closed on the next
+    // superseding submit, on dispose, or by the fallback wait. -1 when the
+    // producer synced before submit.
     out->acquire_fence_fd = -1;
+    if (pending_egl.acquire_fence_fd >= 0) {
+      out->acquire_fence_fd = ::dup(pending_egl.acquire_fence_fd);
+      if (out->acquire_fence_fd < 0) {
+        // Fall back to implicit sync for this frame; log so it's diagnosable.
+        ihs::log::warn(
+            "[ihs_pv] dup(acquire_fence) failed (errno={}); implicit sync "
+            "this frame",
+            errno);
+      }
+    }
     dmabuf_delivered_seq = submit_seq;
     return true;
   }
@@ -416,6 +440,10 @@ IhsPluginView::~IhsPluginView() {
         close(pending_egl.frame.plane_fd[i]);
       }
     }
+    if (pending_egl.acquire_fence_fd >= 0) {
+      close(pending_egl.acquire_fence_fd);
+      pending_egl.acquire_fence_fd = -1;
+    }
     pending_egl.valid = false;
   }
   // Same deferred free for the GL imports (glDeleteTextures needs the GL
@@ -454,8 +482,43 @@ void CloseFrameFds(const IhsFrame* frame) {
 // calls us with the context current, caching per ring buffer like the Vulkan
 // path.
 uint32_t IhsPluginView::GetGlTextureName() const {
-  const std::lock_guard<std::mutex> lock(mutex);
+  std::unique_lock<std::mutex> lock(mutex);
   if (pending_egl.valid) {
+    // The GL-texture fallback samples the buffer directly with no plane
+    // IN_FENCE_FD, so block until the producer's writes complete before
+    // sampling, then release the fence. Only reached when direct scanout is
+    // unavailable (the fence otherwise rides the plane's IN_FENCE_FD via
+    // GetDmabuf), so this wait is off the hot path. Drop the lock across the
+    // (bounded) wait so a wedged fence can't block HostSubmit or dispose; take
+    // ownership of the fd first so a superseding submit won't close it, and
+    // loop so a frame that arrived while unlocked is also waited on — we never
+    // sample ahead of the producer. On timeout/error we sample best-effort but
+    // warn.
+    while (pending_egl.valid && pending_egl.acquire_fence_fd >= 0) {
+      const int fence = pending_egl.acquire_fence_fd;
+      pending_egl.acquire_fence_fd = -1;
+      lock.unlock();
+      pollfd pfd{fence, POLLIN, 0};
+      int pr = 0;
+      while ((pr = ::poll(&pfd, 1, 1000)) < 0 && errno == EINTR) {
+      }
+      // Only POLLIN means the fence signalled; poll() can also wake on
+      // POLLERR/POLLHUP/POLLNVAL (>0 with no POLLIN), which is a failure, not a
+      // signal. Sample best-effort either way, but warn.
+      if (pr <= 0 || (pfd.revents & POLLIN) == 0) {
+        ihs::log::warn(
+            "[ihs_pv] GL-fallback acquire-fence wait {} (fd={}, "
+            "revents=0x{:x});"
+            " sampling anyway — frame may tear",
+            pr == 0 ? "timed out" : "failed", fence, pfd.revents);
+      }
+      close(fence);
+      lock.lock();
+    }
+    // The view may have been disposed while the lock was dropped for the wait.
+    if (!pending_egl.valid) {
+      return current_egl != nullptr ? current_egl->texture : 0;
+    }
     // Margin (in submits) before a resize-replaced import is destroyed; the
     // compositor samples GetGlTextureName synchronously here, so GL's own
     // deferred deletion already covers in-flight draws — the margin is safety.
@@ -731,19 +794,21 @@ int HostSubmit(void* user_data,
   if (!vulkan_ready && g_egl_importer.ready()) {
     // EGL backend: GL import is context-affine, so only stash the frame here
     // (on the plugin's thread); GetGlTextureName imports it on the raster
-    // thread. The EGL backends composite the texture without an explicit
-    // acquire wait, so the producer must have finished rendering before submit
-    // — close the acquire fence (a GL fence wait on this path is a follow-up).
-    if (acquire_fence_fd >= 0) {
-      close(acquire_fence_fd);
-    }
+    // thread. The DRM scene path (GetDmabuf) forwards the acquire fence to the
+    // plane's IN_FENCE_FD for explicit sync; the GL-texture fallback has no
+    // plane fence, so GetGlTextureName CPU-waits on it before sampling. Stash
+    // the fence with the frame for both.
     const std::lock_guard<std::mutex> lock(v->mutex);
     ++v->submit_seq;
     if (v->pending_egl.valid) {
       CloseFrameFds(&v->pending_egl.frame);  // superseded before import
+      if (v->pending_egl.acquire_fence_fd >= 0) {
+        close(v->pending_egl.acquire_fence_fd);
+      }
     }
     v->pending_egl.frame = *frame;       // take ownership of the plane fds
     v->pending_egl.frame.hdr = nullptr;  // do not retain the plugin's hdr ptr
+    v->pending_egl.acquire_fence_fd = acquire_fence_fd;  // ownership moves here
     v->pending_egl.valid = true;
     return IHS_PV_OK;
   }


### PR DESCRIPTION
## Summary

Wires explicit synchronization for platform-view direct scanout on `drm_kms_egl`. A producer's acquire fence now rides the overlay plane's `IN_FENCE_FD`, so the display waits on the producer's GPU work instead of the producer stalling on a CPU fence before submit — removing the per-frame stall that showed up as juddery pans with a live map producer.

## Changes

- **Host** (`platform_view_host.cc`): stash the producer's acquire fence with the pending frame instead of closing it, and forward it to the DRM scene path via `GetDmabuf`. The GL-texture fallback (no explicit plane sync) poll-waits on the fence before sampling, then releases it.
- **Compositor** (`drm_compositor.cc`): hand the fence to `ExternalDmaBufSource::set_acquire_fence` on both the new-layer and reused-layer paths (`import_fd` dups, so `PvFdCloser` still closes the original).
- **drm-cxx** bump to include the matching `acquire()` fix ([drm-cxx#230](https://github.com/jwinarske/drm-cxx/pull/230), merged): `acquire()` now hands back a dup of the fence rather than moving it out, so it survives the scene's test + real commit passes and actually reaches the plane's `IN_FENCE_FD`.

## Validation

HW-validated on a Raspberry Pi 4 (vc4) with a MapLibre GL dma-buf producer through `drm_kms_egl`, rebased onto current `v2.0` (incl. #331):

- `DRM_CXX_FENCE_DEBUG=1` → `in_fences_armed=1 in_fence_cpu_waits=0` (the acquire fence reaches the plane's `IN_FENCE_FD`, not a CPU-wait fallback)
- 0 errors, steady scanout, on-panel pans smooth and consistent
- `clang-tidy-19` clean on both changed TUs (host build with all backends); `clang-format-19` clean

## Follow-ups

- Release-fence backpressure (producer↔compositor) — currently a fixed-depth ring
- Producer vsync pacing
