### PR TITLE
platform-views: sample planar YUV through an external image

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -999,9 +999,11 @@ void DrmCompositor::CompositeLayerIntoFbo(GLuint target_fbo,
                                           GLsizei dst_w,
                                           GLsizei dst_h,
                                           bool blend,
-                                          bool flip_y) const {
+                                          bool flip_y,
+                                          bool external) const {
   gl_compositor_->CompositeToFbo(target_fbo, src_fbo, src_tex, src_w, src_h,
-                                 dst_x, dst_y, dst_w, dst_h, blend, flip_y);
+                                 dst_x, dst_y, dst_w, dst_h, blend, flip_y,
+                                 external);
 }
 
 // ─── GL fallback (no plane allocator) ────────────────────────────────────
@@ -1073,8 +1075,9 @@ bool DrmCompositor::PresentViaGlFallback(const FlutterLayer** layers,
           // GlFallback writes into FBO 0 (gbm_surface, standard GL NDC).
           // Flip only when the surface reports top-first storage.
           const bool flip_y = surface_sp->TextureIsTopFirst();
+          const bool external = surface_sp->TextureIsExternalOes();
           gl_compositor_->CompositeToDefault(0, tex, sw, sh, dx, dy, dw, dh,
-                                             blend, flip_y);
+                                             blend, flip_y, external);
           composited_any = true;
         }
       }
@@ -1237,20 +1240,22 @@ bool DrmCompositor::PresentFramed(const FlutterLayer** layers,
             ihs::log::debug(
                 "[DrmCompositor] framed layer[{}] PV id={} tex={} "
                 "src={}x{} offset=({:.1f},{:.1f}) size={:.1f}x{:.1f} "
-                "blend={} flip_y={} top_first={}",
+                "blend={} flip_y={} top_first={} external={}",
                 i, layer->platform_view->identifier, tex,
                 surface_sp->GetGlTextureWidth(),
                 surface_sp->GetGlTextureHeight(), layer->offset.x,
                 layer->offset.y, layer->size.width, layer->size.height, blend,
-                flip_y, surface_sp->TextureIsTopFirst());
+                flip_y, surface_sp->TextureIsTopFirst(),
+                surface_sp->TextureIsExternalOes());
           }
-          CompositeLayerIntoFbo(
-              comp.fbo, /*src_fbo=*/0, tex, surface_sp->GetGlTextureWidth(),
-              surface_sp->GetGlTextureHeight(),
-              static_cast<GLint>(layer->offset.x),
-              static_cast<GLint>(layer->offset.y),
-              static_cast<GLsizei>(layer->size.width),
-              static_cast<GLsizei>(layer->size.height), blend, flip_y);
+          CompositeLayerIntoFbo(comp.fbo, /*src_fbo=*/0, tex,
+                                surface_sp->GetGlTextureWidth(),
+                                surface_sp->GetGlTextureHeight(),
+                                static_cast<GLint>(layer->offset.x),
+                                static_cast<GLint>(layer->offset.y),
+                                static_cast<GLsizei>(layer->size.width),
+                                static_cast<GLsizei>(layer->size.height), blend,
+                                flip_y, surface_sp->TextureIsExternalOes());
           composited_any = true;
           if (backend_->cfg_.debug_backend) {
             const auto cx =
@@ -2031,7 +2036,8 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
                 static_cast<GLint>(flutter->offset.x),
                 static_cast<GLint>(flutter->offset.y),
                 static_cast<GLsizei>(flutter->size.width),
-                static_cast<GLsizei>(flutter->size.height), blend, flip_y);
+                static_cast<GLsizei>(flutter->size.height), blend, flip_y,
+                surface_sp->TextureIsExternalOes());
             any_composited = true;
           }
         }

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -274,7 +274,11 @@ class DrmCompositor : public IFlipSink {
                              GLsizei dst_w,
                              GLsizei dst_h,
                              bool blend,
-                             bool flip_y = false) const;
+                             bool flip_y = false,
+                             // Planar YUV imports are bound to
+                             // GL_TEXTURE_EXTERNAL_OES and need the external
+                             // sampler; see ICompositorSurface.
+                             bool external = false) const;
 
   bool WaitForPendingFlip() const;
 

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -275,7 +275,7 @@ class DrmCompositor : public IFlipSink {
                              GLsizei dst_h,
                              bool blend,
                              bool flip_y = false,
-                             // Planar YUV imports are bound to
+                             // YUV imports (planar or packed) are bound to
                              // GL_TEXTURE_EXTERNAL_OES and need the external
                              // sampler; see ICompositorSurface.
                              bool external = false) const;

--- a/shell/backend/gl_extensions.h
+++ b/shell/backend/gl_extensions.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Toyota Connected North America
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef SHELL_BACKEND_GL_EXTENSIONS_H_
+#define SHELL_BACKEND_GL_EXTENSIONS_H_
+
+#include <cstring>
+#include <string_view>
+
+namespace ihs::gl {
+
+// Whether @name appears as a whole, space-delimited token in a GL/EGL
+// extension string. An exact match rather than a substring: a substring test
+// accepts, say, GL_OES_EGL_image_external_essl3 as the base
+// GL_OES_EGL_image_external and leads a caller to use a feature the driver does
+// not have.
+inline bool ExtensionSupported(const char* extensions, const char* name) {
+  if (extensions == nullptr || name == nullptr) {
+    return false;
+  }
+  const size_t name_len = std::strlen(name);
+  const std::string_view sv(extensions);
+  size_t pos = 0;
+  while ((pos = sv.find(name, pos)) != std::string_view::npos) {
+    const bool left_ok = (pos == 0) || (sv[pos - 1] == ' ');
+    const size_t end = pos + name_len;
+    const bool right_ok = (end == sv.size()) || (sv[end] == ' ');
+    if (left_ok && right_ok) {
+      return true;
+    }
+    pos = end;
+  }
+  return false;
+}
+
+}  // namespace ihs::gl
+
+#endif  // SHELL_BACKEND_GL_EXTENSIONS_H_

--- a/shell/backend/wayland_egl/gl_caps.cc
+++ b/shell/backend/wayland_egl/gl_caps.cc
@@ -20,29 +20,11 @@
 #include <cstring>
 #include <string_view>
 
+#include "backend/gl_extensions.h"
 #include "backend/gl_process_resolver.h"
 #include "logging.h"
 
 namespace {
-
-bool ExtensionSupported(const char* extensions, const char* name) {
-  if (!extensions || !name) {
-    return false;
-  }
-  const size_t name_len = std::strlen(name);
-  const std::string_view sv(extensions);
-  size_t pos = 0;
-  while ((pos = sv.find(name, pos)) != std::string_view::npos) {
-    const bool left_ok = (pos == 0) || (sv[pos - 1] == ' ');
-    const size_t end = pos + name_len;
-    const bool right_ok = (end == sv.size()) || (sv[end] == ' ');
-    if (left_ok && right_ok) {
-      return true;
-    }
-    pos = end;
-  }
-  return false;
-}
 
 void* Resolve(const char* name) {
   return GlProcessResolver::GetInstance().process_resolver(name);
@@ -83,9 +65,10 @@ void GlCaps::Probe() {
 
   const char* exts = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
 
-  has_rgb8_rgba8 = is_es3 || ExtensionSupported(exts, "GL_OES_rgb8_rgba8");
-  has_packed_depth_stencil =
-      is_es3 || ExtensionSupported(exts, "GL_OES_packed_depth_stencil");
+  has_rgb8_rgba8 =
+      is_es3 || ihs::gl::ExtensionSupported(exts, "GL_OES_rgb8_rgba8");
+  has_packed_depth_stencil = is_es3 || ihs::gl::ExtensionSupported(
+                                           exts, "GL_OES_packed_depth_stencil");
 
   // Resolve blit_framebuffer.
   blit_framebuffer = nullptr;
@@ -93,12 +76,13 @@ void GlCaps::Probe() {
     blit_framebuffer =
         reinterpret_cast<BlitFramebufferFn>(Resolve("glBlitFramebuffer"));
   }
-  if (!blit_framebuffer && ExtensionSupported(exts, "GL_NV_framebuffer_blit")) {
+  if (!blit_framebuffer &&
+      ihs::gl::ExtensionSupported(exts, "GL_NV_framebuffer_blit")) {
     blit_framebuffer =
         reinterpret_cast<BlitFramebufferFn>(Resolve("glBlitFramebufferNV"));
   }
   if (!blit_framebuffer &&
-      ExtensionSupported(exts, "GL_ANGLE_framebuffer_blit")) {
+      ihs::gl::ExtensionSupported(exts, "GL_ANGLE_framebuffer_blit")) {
     blit_framebuffer =
         reinterpret_cast<BlitFramebufferFn>(Resolve("glBlitFramebufferANGLE"));
   }
@@ -112,13 +96,13 @@ void GlCaps::Probe() {
             Resolve("glRenderbufferStorageMultisample"));
   }
   if (!renderbuffer_storage_multisample &&
-      ExtensionSupported(exts, "GL_ANGLE_framebuffer_multisample")) {
+      ihs::gl::ExtensionSupported(exts, "GL_ANGLE_framebuffer_multisample")) {
     renderbuffer_storage_multisample =
         reinterpret_cast<RenderbufferStorageMultisampleFn>(
             Resolve("glRenderbufferStorageMultisampleANGLE"));
   }
   if (!renderbuffer_storage_multisample &&
-      ExtensionSupported(exts, "GL_NV_framebuffer_multisample")) {
+      ihs::gl::ExtensionSupported(exts, "GL_NV_framebuffer_multisample")) {
     renderbuffer_storage_multisample =
         reinterpret_cast<RenderbufferStorageMultisampleFn>(
             Resolve("glRenderbufferStorageMultisampleNV"));

--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -18,6 +18,9 @@
 #include "logging/logging.h"
 
 #include <array>
+#include <cstring>
+#include <string>
+#include <string_view>
 
 #include "backend/wayland_egl/gl_caps.h"
 #include "logging.h"

--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -200,8 +200,8 @@ void GlCompositor::BuildExternalProgram() {
   const auto* exts = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
   if (!ExtensionSupported(exts, "GL_OES_EGL_image_external")) {
     ihs::log::warn(
-        "GlCompositor: GL_OES_EGL_image_external absent; planar YUV "
-        "platform-view frames cannot be sampled");
+        "GlCompositor: GL_OES_EGL_image_external absent; YUV platform-view "
+        "frames (planar or packed) cannot be sampled");
     return;
   }
   const GLuint vs = CompileShader(GL_VERTEX_SHADER, kVertSrc);

--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/wayland_egl/gl_compositor.h"
+#include "backend/gl_extensions.h"
 #include "logging/logging.h"
 
 #include <array>
@@ -64,28 +65,6 @@ constexpr char kFragSrcExternal[] =
     "void main() {\n"
     "  gl_FragColor = texture2D(u_tex, v_uv);\n"
     "}\n";
-
-// Exact, space-delimited match. A substring search would accept
-// GL_OES_EGL_image_external_essl3 as the base extension and go on to compile a
-// shader the driver cannot link.
-bool ExtensionSupported(const char* extensions, const char* name) {
-  if (extensions == nullptr || name == nullptr) {
-    return false;
-  }
-  const size_t name_len = std::strlen(name);
-  const std::string_view sv(extensions);
-  size_t pos = 0;
-  while ((pos = sv.find(name, pos)) != std::string_view::npos) {
-    const bool left_ok = (pos == 0) || (sv[pos - 1] == ' ');
-    const size_t end = pos + name_len;
-    const bool right_ok = (end == sv.size()) || (sv[end] == ' ');
-    if (left_ok && right_ok) {
-      return true;
-    }
-    pos = end;
-  }
-  return false;
-}
 
 GLuint CompileShader(GLenum type, const char* src) {
   const GLuint s = glCreateShader(type);
@@ -198,10 +177,10 @@ void GlCompositor::BuildExternalProgram() {
   // Optional: a driver without the extension keeps the packed-format path, and
   // a planar frame is then simply not composited rather than mis-sampled.
   const auto* exts = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
-  if (!ExtensionSupported(exts, "GL_OES_EGL_image_external")) {
-    ihs::log::warn(
-        "GlCompositor: GL_OES_EGL_image_external absent; YUV platform-view "
-        "frames (planar or packed) cannot be sampled");
+  if (!ihs::gl::ExtensionSupported(exts, "GL_OES_EGL_image_external")) {
+    // Left unbuilt, not an error: a context that never presents a YUV
+    // platform-view frame does not need it. The one warning, if a frame does
+    // arrive, is emitted where the composite is refused.
     return;
   }
   const GLuint vs = CompileShader(GL_VERTEX_SHADER, kVertSrc);
@@ -393,7 +372,17 @@ void GlCompositor::CompositeViaQuad(GLuint src_color_tex,
     return;
   }
   if (external && program_external_ == 0) {
-    return;  // no external sampler; better blank than the luma plane in red
+    // Blank rather than the luma plane in red. Warn once: the driver lacks
+    // GL_OES_EGL_image_external and a YUV frame has now actually reached here.
+    static bool warned = false;
+    if (!warned) {
+      warned = true;
+      ihs::log::warn(
+          "GlCompositor: a YUV platform-view frame needs "
+          "GL_OES_EGL_image_external, which this context lacks; it will not be "
+          "composited");
+    }
+    return;
   }
   // The external path is rare (one platform-view layer), so it does not join
   // the frame-batched fast path: it sets its own program and state and leaves

--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -18,6 +18,8 @@
 #include "backend/gl_extensions.h"
 #include "logging/logging.h"
 
+#include <GLES2/gl2ext.h>  // GL_TEXTURE_EXTERNAL_OES
+
 #include <array>
 #include <cstring>
 #include <string>

--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -62,6 +62,28 @@ constexpr char kFragSrcExternal[] =
     "  gl_FragColor = texture2D(u_tex, v_uv);\n"
     "}\n";
 
+// Exact, space-delimited match. A substring search would accept
+// GL_OES_EGL_image_external_essl3 as the base extension and go on to compile a
+// shader the driver cannot link.
+bool ExtensionSupported(const char* extensions, const char* name) {
+  if (extensions == nullptr || name == nullptr) {
+    return false;
+  }
+  const size_t name_len = std::strlen(name);
+  const std::string_view sv(extensions);
+  size_t pos = 0;
+  while ((pos = sv.find(name, pos)) != std::string_view::npos) {
+    const bool left_ok = (pos == 0) || (sv[pos - 1] == ' ');
+    const size_t end = pos + name_len;
+    const bool right_ok = (end == sv.size()) || (sv[end] == ' ');
+    if (left_ok && right_ok) {
+      return true;
+    }
+    pos = end;
+  }
+  return false;
+}
+
 GLuint CompileShader(GLenum type, const char* src) {
   const GLuint s = glCreateShader(type);
   glShaderSource(s, 1, &src, nullptr);
@@ -92,6 +114,9 @@ GlCompositor::~GlCompositor() {
   }
   if (program_) {
     glDeleteProgram(program_);
+  }
+  if (program_external_) {
+    glDeleteProgram(program_external_);
   }
 }
 
@@ -170,9 +195,7 @@ void GlCompositor::BuildExternalProgram() {
   // Optional: a driver without the extension keeps the packed-format path, and
   // a planar frame is then simply not composited rather than mis-sampled.
   const auto* exts = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
-  if (exts == nullptr ||
-      std::string_view(exts).find("GL_OES_EGL_image_external") ==
-          std::string_view::npos) {
+  if (!ExtensionSupported(exts, "GL_OES_EGL_image_external")) {
     ihs::log::warn(
         "GlCompositor: GL_OES_EGL_image_external absent; planar YUV "
         "platform-view frames cannot be sampled");
@@ -283,6 +306,13 @@ void GlCompositor::CompositeViaQuadExternal(GLuint tex,
     TearDownPersistentQuadState();
     persistent_state_emitted_ = false;
   }
+  // Same baseline the batched path establishes: anything left enabled by the
+  // caller could clip or discard this draw.
+  glDisable(GL_DEPTH_TEST);
+  glDisable(GL_STENCIL_TEST);
+  glDisable(GL_SCISSOR_TEST);
+  glDisable(GL_CULL_FACE);
+
   glUseProgram(program_external_);
   glActiveTexture(GL_TEXTURE0);
   if (uni_tex_external_ >= 0) {
@@ -325,6 +355,13 @@ void GlCompositor::CompositeViaQuadExternal(GLuint tex,
   }
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glUseProgram(0);
+  // Blend is left off rather than as this draw wanted it. This path clears
+  // persistent_state_emitted_, so EndFrame will not tear anything down, and an
+  // enabled blend would leak into the rest of the present and the next frame.
+  if (blend) {
+    glDisable(GL_BLEND);
+  }
+  blend_enabled_ = false;
   bound_tex_ = 0;
 }
 

--- a/shell/backend/wayland_egl/gl_compositor.cc
+++ b/shell/backend/wayland_egl/gl_compositor.cc
@@ -48,6 +48,20 @@ constexpr char kFragSrc[] =
     "  gl_FragColor = texture2D(u_tex, v_uv);\n"
     "}\n";
 
+// The same quad, sampling an external image. A dma-buf holding planar YUV can
+// only be sampled through samplerExternalOES, which is what applies the
+// colour-space conversion; the driver picks BT.601/709 from the image. Built
+// only when the context advertises the extension, so a driver without it keeps
+// working for packed formats.
+constexpr char kFragSrcExternal[] =
+    "#extension GL_OES_EGL_image_external : require\n"
+    "precision mediump float;\n"
+    "varying vec2 v_uv;\n"
+    "uniform samplerExternalOES u_tex;\n"
+    "void main() {\n"
+    "  gl_FragColor = texture2D(u_tex, v_uv);\n"
+    "}\n";
+
 GLuint CompileShader(GLenum type, const char* src) {
   const GLuint s = glCreateShader(type);
   glShaderSource(s, 1, &src, nullptr);
@@ -122,6 +136,7 @@ bool GlCompositor::EnsureQuad() {
   attr_pos_ = glGetAttribLocation(program_, "a_pos");
   attr_uv_ = glGetAttribLocation(program_, "a_uv");
   uni_tex_ = glGetUniformLocation(program_, "u_tex");
+  BuildExternalProgram();
   uni_uv_y_scale_ = glGetUniformLocation(program_, "u_uv_y_scale");
   uni_uv_y_offset_ = glGetUniformLocation(program_, "u_uv_y_offset");
 
@@ -149,6 +164,58 @@ bool GlCompositor::EnsureQuad() {
   glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts.data(), GL_STATIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   return true;
+}
+
+void GlCompositor::BuildExternalProgram() {
+  // Optional: a driver without the extension keeps the packed-format path, and
+  // a planar frame is then simply not composited rather than mis-sampled.
+  const auto* exts = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
+  if (exts == nullptr ||
+      std::string_view(exts).find("GL_OES_EGL_image_external") ==
+          std::string_view::npos) {
+    ihs::log::warn(
+        "GlCompositor: GL_OES_EGL_image_external absent; planar YUV "
+        "platform-view frames cannot be sampled");
+    return;
+  }
+  const GLuint vs = CompileShader(GL_VERTEX_SHADER, kVertSrc);
+  const GLuint fs = CompileShader(GL_FRAGMENT_SHADER, kFragSrcExternal);
+  if (!vs || !fs) {
+    if (vs) {
+      glDeleteShader(vs);
+    }
+    if (fs) {
+      glDeleteShader(fs);
+    }
+    return;
+  }
+  program_external_ = glCreateProgram();
+  glAttachShader(program_external_, vs);
+  glAttachShader(program_external_, fs);
+  glLinkProgram(program_external_);
+  glDeleteShader(vs);
+  glDeleteShader(fs);
+  GLint ok = 0;
+  glGetProgramiv(program_external_, GL_LINK_STATUS, &ok);
+  if (!ok) {
+    GLint len = 0;
+    glGetProgramiv(program_external_, GL_INFO_LOG_LENGTH, &len);
+    std::string log(static_cast<size_t>(len > 0 ? len : 0), '\0');
+    if (len > 0) {
+      glGetProgramInfoLog(program_external_, len, nullptr, log.data());
+    }
+    ihs::log::error("GlCompositor: external program link failed: {}", log);
+    glDeleteProgram(program_external_);
+    program_external_ = 0;
+    return;
+  }
+  attr_pos_external_ = glGetAttribLocation(program_external_, "a_pos");
+  attr_uv_external_ = glGetAttribLocation(program_external_, "a_uv");
+  uni_tex_external_ = glGetUniformLocation(program_external_, "u_tex");
+  uni_uv_y_scale_external_ =
+      glGetUniformLocation(program_external_, "u_uv_y_scale");
+  uni_uv_y_offset_external_ =
+      glGetUniformLocation(program_external_, "u_uv_y_offset");
 }
 
 void GlCompositor::EmitPersistentQuadState() {
@@ -203,6 +270,64 @@ void GlCompositor::TearDownPersistentQuadState() {
   bound_tex_ = 0;
 }
 
+void GlCompositor::CompositeViaQuadExternal(GLuint tex,
+                                            GLint dst_x,
+                                            GLint dst_y,
+                                            GLsizei dst_w,
+                                            GLsizei dst_h,
+                                            bool blend,
+                                            bool flip_y) {
+  // Self-contained: this program has its own attribute and uniform locations,
+  // so it cannot ride the batched state emitted for the sampler2D program.
+  if (persistent_state_emitted_) {
+    TearDownPersistentQuadState();
+    persistent_state_emitted_ = false;
+  }
+  glUseProgram(program_external_);
+  glActiveTexture(GL_TEXTURE0);
+  if (uni_tex_external_ >= 0) {
+    glUniform1i(uni_tex_external_, 0);
+  }
+  if (uni_uv_y_scale_external_ >= 0) {
+    glUniform1f(uni_uv_y_scale_external_, flip_y ? -1.f : 1.f);
+  }
+  if (uni_uv_y_offset_external_ >= 0) {
+    glUniform1f(uni_uv_y_offset_external_, flip_y ? 1.f : 0.f);
+  }
+  if (blend) {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+  } else {
+    glDisable(GL_BLEND);
+  }
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_);
+  if (attr_pos_external_ >= 0) {
+    glEnableVertexAttribArray(static_cast<GLuint>(attr_pos_external_));
+    glVertexAttribPointer(static_cast<GLuint>(attr_pos_external_), 2, GL_FLOAT,
+                          GL_FALSE, 4 * sizeof(GLfloat), nullptr);
+  }
+  if (attr_uv_external_ >= 0) {
+    glEnableVertexAttribArray(static_cast<GLuint>(attr_uv_external_));
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    glVertexAttribPointer(static_cast<GLuint>(attr_uv_external_), 2, GL_FLOAT,
+                          GL_FALSE, 4 * sizeof(GLfloat),
+                          reinterpret_cast<const void*>(2 * sizeof(GLfloat)));
+  }
+  glViewport(dst_x, dst_y, dst_w, dst_h);
+  glBindTexture(GL_TEXTURE_EXTERNAL_OES, tex);
+  glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+  glBindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
+  if (attr_pos_external_ >= 0) {
+    glDisableVertexAttribArray(static_cast<GLuint>(attr_pos_external_));
+  }
+  if (attr_uv_external_ >= 0) {
+    glDisableVertexAttribArray(static_cast<GLuint>(attr_uv_external_));
+  }
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glUseProgram(0);
+  bound_tex_ = 0;
+}
+
 void GlCompositor::BeginFrame() {
   frame_open_ = true;
   persistent_state_emitted_ = false;
@@ -222,8 +347,20 @@ void GlCompositor::CompositeViaQuad(GLuint src_color_tex,
                                     GLsizei dst_w,
                                     GLsizei dst_h,
                                     bool blend,
-                                    bool flip_y) {
+                                    bool flip_y,
+                                    bool external) {
   if (!EnsureQuad()) {
+    return;
+  }
+  if (external && program_external_ == 0) {
+    return;  // no external sampler; better blank than the luma plane in red
+  }
+  // The external path is rare (one platform-view layer), so it does not join
+  // the frame-batched fast path: it sets its own program and state and leaves
+  // the batched baseline to be re-emitted for the next 2D layer.
+  if (external) {
+    CompositeViaQuadExternal(src_color_tex, dst_x, dst_y, dst_w, dst_h, blend,
+                             flip_y);
     return;
   }
 
@@ -324,15 +461,18 @@ void GlCompositor::CompositeToFbo(GLuint dst_fbo,
                                   GLsizei dst_w,
                                   GLsizei dst_h,
                                   bool blend,
-                                  bool flip_y) {
+                                  bool flip_y,
+                                  bool external) {
   // Blit can't alpha-blend, so overlay layers must take the quad path.
   // Also skip blit when there is no source FBO to read from (e.g. raw
   // platform-view textures with no associated FBO) — falling through to
   // the quad path handles that case via sampler.
   // glBlitFramebuffer flips vertically when dstY1 < dstY0; we use that for
   // GL-native-origin sources that need to land top-down.
-  if (!blend && src_fbo != 0 && caps_ && caps_->has_blit_framebuffer &&
-      caps_->blit_framebuffer) {
+  // An external texture has no FBO to read from and must go through its own
+  // sampler, so it never takes the blit path.
+  if (!external && !blend && src_fbo != 0 && caps_ &&
+      caps_->has_blit_framebuffer && caps_->blit_framebuffer) {
     glBindFramebuffer(kReadFramebuffer, src_fbo);
     glBindFramebuffer(kDrawFramebuffer, dst_fbo);
     const GLint dst_y0 = flip_y ? dst_y + dst_h : dst_y;
@@ -344,6 +484,7 @@ void GlCompositor::CompositeToFbo(GLuint dst_fbo,
   }
   // Quad path draws into whatever FBO is currently bound.
   glBindFramebuffer(GL_FRAMEBUFFER, dst_fbo);
-  CompositeViaQuad(src_color_tex, dst_x, dst_y, dst_w, dst_h, blend, flip_y);
+  CompositeViaQuad(src_color_tex, dst_x, dst_y, dst_w, dst_h, blend, flip_y,
+                   external);
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }

--- a/shell/backend/wayland_egl/gl_compositor.h
+++ b/shell/backend/wayland_egl/gl_compositor.h
@@ -129,9 +129,9 @@ class GlCompositor {
   GLuint bound_tex_{0};
 
   bool EnsureQuad();
-  // Links the samplerExternalOES variant of the quad program, used for planar
-  // YUV platform-view frames. Leaves program_external_ at 0 when the driver
-  // lacks GL_OES_EGL_image_external.
+  // Links the samplerExternalOES variant of the quad program, used for YUV
+  // platform-view frames (planar or packed). Leaves program_external_ at 0 when
+  // the driver lacks GL_OES_EGL_image_external.
   void BuildExternalProgram();
   void CompositeViaQuadExternal(GLuint tex,
                                 GLint dst_x,

--- a/shell/backend/wayland_egl/gl_compositor.h
+++ b/shell/backend/wayland_egl/gl_compositor.h
@@ -73,7 +73,8 @@ class GlCompositor {
                       GLsizei dst_w,
                       GLsizei dst_h,
                       bool blend = false,
-                      bool flip_y = false);
+                      bool flip_y = false,
+                      bool external = false);
 
   // Thin wrapper: composite into the default framebuffer (FBO 0).
   void CompositeToDefault(GLuint src_fbo,
@@ -85,9 +86,10 @@ class GlCompositor {
                           GLsizei dst_w,
                           GLsizei dst_h,
                           bool blend = false,
-                          bool flip_y = false) {
+                          bool flip_y = false,
+                          bool external = false) {
     CompositeToFbo(0, src_fbo, src_color_tex, src_w, src_h, dst_x, dst_y, dst_w,
-                   dst_h, blend, flip_y);
+                   dst_h, blend, flip_y, external);
   }
 
   /**
@@ -127,16 +129,40 @@ class GlCompositor {
   GLuint bound_tex_{0};
 
   bool EnsureQuad();
+  // Links the samplerExternalOES variant of the quad program, used for planar
+  // YUV platform-view frames. Leaves program_external_ at 0 when the driver
+  // lacks GL_OES_EGL_image_external.
+  void BuildExternalProgram();
+  void CompositeViaQuadExternal(GLuint tex,
+                                GLint dst_x,
+                                GLint dst_y,
+                                GLsizei dst_w,
+                                GLsizei dst_h,
+                                bool blend,
+                                bool flip_y);
+  // @external selects the samplerExternalOES program and the
+  // GL_TEXTURE_EXTERNAL_OES bind target, which planar YUV requires.
   void CompositeViaQuad(GLuint src_color_tex,
                         GLint dst_x,
                         GLint dst_y,
                         GLsizei dst_w,
                         GLsizei dst_h,
                         bool blend,
-                        bool flip_y);
+                        bool flip_y,
+                        bool external);
   void EmitPersistentQuadState();
   void TearDownPersistentQuadState();
 
   GLint uni_uv_y_scale_{-1};
   GLint uni_uv_y_offset_{-1};
+
+  // The external-sampler variant. A planar YUV dma-buf is bound to
+  // GL_TEXTURE_EXTERNAL_OES and can only be read through this program;
+  // sampling it with the sampler2D one yields the luma plane in red.
+  GLuint program_external_{0};
+  GLint attr_pos_external_{-1};
+  GLint attr_uv_external_{-1};
+  GLint uni_tex_external_{-1};
+  GLint uni_uv_y_scale_external_{-1};
+  GLint uni_uv_y_offset_external_{-1};
 };

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -977,7 +977,10 @@ bool WaylandEglBackend::PresentLayers(const FlutterLayer** layers,
           // dmabuf, pre-flipped YUV shader) opt into a sampler V-invert by
           // overriding ICompositorSurface::TextureIsTopFirst() → true.
           const bool flip_y = surface.TextureIsTopFirst();
-          if (!blend && m_gl_caps.has_blit_framebuffer) {
+          // An external texture cannot be attached to an FBO or blitted; it
+          // has to go through the external sampler.
+          const bool external = surface.TextureIsExternalOes();
+          if (!external && !blend && m_gl_caps.has_blit_framebuffer) {
             if (!m_texture_blit_fbo_) {
               glGenFramebuffers(1, &m_texture_blit_fbo_);
             }
@@ -989,7 +992,7 @@ bool WaylandEglBackend::PresentLayers(const FlutterLayer** layers,
                                                 flip_y);
           } else {
             m_gl_compositor->CompositeToDefault(0, tex, sw, sh, dx, dy, dw, dh,
-                                                blend, flip_y);
+                                                blend, flip_y, external);
           }
           composited_any = true;
         }

--- a/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
+++ b/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
@@ -29,6 +29,8 @@
 
 #include <drm_fourcc.h>
 
+#include "backend/gl_extensions.h"
+
 #include "logging/logging.h"
 
 namespace {
@@ -57,31 +59,9 @@ constexpr std::array<PlaneAttribs, 4> kPlaneAttribs{{
      EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT},
 }};
 
-// Formats whose planes carry Y and chroma separately, or subsampled packed
-// YUV. These need the external sampler; packed RGB does not.
-// Exact, space-delimited match; see the note in gl_compositor.cc.
-bool ExtensionSupported(const char* extensions, const char* name) {
-  if (extensions == nullptr || name == nullptr) {
-    return false;
-  }
-  const size_t name_len = std::strlen(name);
-  const std::string_view sv(extensions);
-  size_t pos = 0;
-  while ((pos = sv.find(name, pos)) != std::string_view::npos) {
-    const bool left_ok = (pos == 0) || (sv[pos - 1] == ' ');
-    const size_t end = pos + name_len;
-    const bool right_ok = (end == sv.size()) || (sv[end] == ' ');
-    if (left_ok && right_ok) {
-      return true;
-    }
-    pos = end;
-  }
-  return false;
-}
-
 // Queried once with a context current, which Import guarantees.
 bool HasExternalImage() {
-  static const bool supported = ExtensionSupported(
+  static const bool supported = ihs::gl::ExtensionSupported(
       reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS)),
       "GL_OES_EGL_image_external");
   return supported;

--- a/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
+++ b/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
@@ -87,7 +87,10 @@ bool HasExternalImage() {
   return supported;
 }
 
-bool IsPlanarYuv(uint32_t fourcc) {
+// True for YUV formats that must be sampled through GL_TEXTURE_EXTERNAL_OES so
+// the driver applies the YUV->RGB conversion — planar (NV12, ...) and packed
+// (YUYV/UYVY) alike. Packed RGB returns false and stays on GL_TEXTURE_2D.
+bool NeedsExternalOes(uint32_t fourcc) {
   switch (fourcc) {
     case DRM_FORMAT_NV12:
     case DRM_FORMAT_NV21:
@@ -187,7 +190,7 @@ bool EglDmabufImporter::Import(const IhsFrame& frame,
         eglGetError());
     return false;
   }
-  const bool external = IsPlanarYuv(frame.format.fourcc);
+  const bool external = NeedsExternalOes(frame.format.fourcc);
   if (external && !HasExternalImage()) {
     // Binding to a target the context does not implement raises
     // GL_INVALID_ENUM and would otherwise return a half-built texture. Undo

--- a/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
+++ b/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
@@ -24,6 +24,9 @@
 #include <EGL/eglext.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+#include <cstring>
+#include <string_view>
+
 #include <drm_fourcc.h>
 
 #include "logging/logging.h"
@@ -56,6 +59,34 @@ constexpr std::array<PlaneAttribs, 4> kPlaneAttribs{{
 
 // Formats whose planes carry Y and chroma separately, or subsampled packed
 // YUV. These need the external sampler; packed RGB does not.
+// Exact, space-delimited match; see the note in gl_compositor.cc.
+bool ExtensionSupported(const char* extensions, const char* name) {
+  if (extensions == nullptr || name == nullptr) {
+    return false;
+  }
+  const size_t name_len = std::strlen(name);
+  const std::string_view sv(extensions);
+  size_t pos = 0;
+  while ((pos = sv.find(name, pos)) != std::string_view::npos) {
+    const bool left_ok = (pos == 0) || (sv[pos - 1] == ' ');
+    const size_t end = pos + name_len;
+    const bool right_ok = (end == sv.size()) || (sv[end] == ' ');
+    if (left_ok && right_ok) {
+      return true;
+    }
+    pos = end;
+  }
+  return false;
+}
+
+// Queried once with a context current, which Import guarantees.
+bool HasExternalImage() {
+  static const bool supported = ExtensionSupported(
+      reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS)),
+      "GL_OES_EGL_image_external");
+  return supported;
+}
+
 bool IsPlanarYuv(uint32_t fourcc) {
   switch (fourcc) {
     case DRM_FORMAT_NV12:
@@ -156,6 +187,23 @@ bool EglDmabufImporter::Import(const IhsFrame& frame,
         eglGetError());
     return false;
   }
+  const bool external = IsPlanarYuv(frame.format.fourcc);
+  if (external && !HasExternalImage()) {
+    // Binding to a target the context does not implement raises
+    // GL_INVALID_ENUM and would otherwise return a half-built texture. Undo
+    // the image and report failure, which leaves the plane fds to the caller
+    // as the contract says.
+    auto destroy = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(destroy_image_);
+    if (destroy != nullptr) {
+      destroy(static_cast<EGLDisplay>(egl_display_), image);
+    }
+    ihs::log::error(
+        "[EglDmabufImporter] planar fourcc=0x{:x} needs "
+        "GL_OES_EGL_image_external, which this context lacks",
+        frame.format.fourcc);
+    return false;
+  }
+
   for (uint32_t p = 0; p < planes; ++p) {
     close(frame.plane_fd[p]);  // EGL dup'd them
   }
@@ -163,7 +211,6 @@ bool EglDmabufImporter::Import(const IhsFrame& frame,
   // A YUV image carries its colour conversion in the sampler, which only
   // GL_TEXTURE_EXTERNAL_OES provides. Bound as GL_TEXTURE_2D the driver
   // exposes the first plane alone, so a plain sampler2D reads luma into red.
-  const bool external = IsPlanarYuv(frame.format.fourcc);
   const GLenum target = external ? GL_TEXTURE_EXTERNAL_OES : GL_TEXTURE_2D;
 
   GLuint tex = 0;

--- a/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
+++ b/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
@@ -54,6 +54,26 @@ constexpr std::array<PlaneAttribs, 4> kPlaneAttribs{{
      EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT},
 }};
 
+// Formats whose planes carry Y and chroma separately, or subsampled packed
+// YUV. These need the external sampler; packed RGB does not.
+bool IsPlanarYuv(uint32_t fourcc) {
+  switch (fourcc) {
+    case DRM_FORMAT_NV12:
+    case DRM_FORMAT_NV21:
+    case DRM_FORMAT_NV16:
+    case DRM_FORMAT_NV61:
+    case DRM_FORMAT_YUV420:
+    case DRM_FORMAT_YVU420:
+    case DRM_FORMAT_YUV422:
+    case DRM_FORMAT_YUV444:
+    case DRM_FORMAT_P010:
+    case DRM_FORMAT_YUYV:
+    case DRM_FORMAT_UYVY:
+      return true;
+    default:
+      return false;
+  }
+}
 }  // namespace
 
 bool EglDmabufImporter::Init(void* egl_display) {
@@ -140,22 +160,31 @@ bool EglDmabufImporter::Import(const IhsFrame& frame,
     close(frame.plane_fd[p]);  // EGL dup'd them
   }
 
+  // A YUV image carries its colour conversion in the sampler, which only
+  // GL_TEXTURE_EXTERNAL_OES provides. Bound as GL_TEXTURE_2D the driver
+  // exposes the first plane alone, so a plain sampler2D reads luma into red.
+  const bool external = IsPlanarYuv(frame.format.fourcc);
+  const GLenum target = external ? GL_TEXTURE_EXTERNAL_OES : GL_TEXTURE_2D;
+
   GLuint tex = 0;
   glGenTextures(1, &tex);
-  glBindTexture(GL_TEXTURE_2D, tex);
+  glBindTexture(target, tex);
   auto image_target = reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(
       image_target_texture_);
-  image_target(GL_TEXTURE_2D, static_cast<GLeglImageOES>(image));
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  glBindTexture(GL_TEXTURE_2D, 0);
+  image_target(target, static_cast<GLeglImageOES>(image));
+  glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  // External textures support only CLAMP_TO_EDGE and no mipmaps; the same
+  // settings suit the 2D path, so there is one set for both.
+  glTexParameteri(target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glBindTexture(target, 0);
 
   out->texture = tex;
   out->egl_image = image;
   out->width = frame.width;
   out->height = frame.height;
+  out->external = external;
   return true;
 }
 

--- a/shell/platform/homescreen/platform_views/egl_dmabuf_import.h
+++ b/shell/platform/homescreen/platform_views/egl_dmabuf_import.h
@@ -42,10 +42,11 @@ class EglDmabufImporter {
     void* egl_image{nullptr};  // EGLImageKHR
     uint32_t width{0};
     uint32_t height{0};
-    // Which target the texture is bound to. A planar YUV image must be
-    // GL_TEXTURE_EXTERNAL_OES so the driver does the YUV->RGB conversion;
-    // sampling one as GL_TEXTURE_2D yields the luma plane alone. Packed RGB
-    // stays on GL_TEXTURE_2D, which every GLES context supports.
+    // Which target the texture is bound to. A YUV image — planar (NV12, ...) or
+    // packed (YUYV/UYVY) — must be GL_TEXTURE_EXTERNAL_OES so the driver does
+    // the YUV->RGB conversion; sampling one as GL_TEXTURE_2D yields raw/luma
+    // data. Packed RGB stays on GL_TEXTURE_2D, which every GLES context
+    // supports.
     bool external{false};
   };
 
@@ -68,10 +69,10 @@ class EglDmabufImporter {
   // so they are closed here). On failure the fds are left for the caller to
   // close.
   //
-  // Packed formats are bound as GL_TEXTURE_2D; planar YUV as
-  // GL_TEXTURE_EXTERNAL_OES, which is what applies the colour conversion.
-  // ImportedTexture::external says which, and the caller must sample with a
-  // matching sampler. GL context must be current.
+  // YUV formats — planar (NV12, ...) or packed (YUYV/UYVY) — are bound as
+  // GL_TEXTURE_EXTERNAL_OES, which is what applies the color conversion; packed
+  // RGB stays GL_TEXTURE_2D. ImportedTexture::external says which, and the
+  // caller must sample with a matching sampler. GL context must be current.
   bool Import(const IhsFrame& frame, ImportedTexture* out) const;
 
   void Destroy(ImportedTexture* out) const;

--- a/shell/platform/homescreen/platform_views/egl_dmabuf_import.h
+++ b/shell/platform/homescreen/platform_views/egl_dmabuf_import.h
@@ -38,10 +38,15 @@
 class EglDmabufImporter {
  public:
   struct ImportedTexture {
-    unsigned int texture{0};   // GLuint (GL_TEXTURE_2D), 0 = unset
+    unsigned int texture{0};   // GLuint, 0 = unset
     void* egl_image{nullptr};  // EGLImageKHR
     uint32_t width{0};
     uint32_t height{0};
+    // Which target the texture is bound to. A planar YUV image must be
+    // GL_TEXTURE_EXTERNAL_OES so the driver does the YUV->RGB conversion;
+    // sampling one as GL_TEXTURE_2D yields the luma plane alone. Packed RGB
+    // stays on GL_TEXTURE_2D, which every GLES context supports.
+    bool external{false};
   };
 
   EglDmabufImporter() = default;
@@ -58,12 +63,15 @@ class EglDmabufImporter {
            image_target_texture_ != nullptr;
   }
 
-  // Import @frame's dma-buf planes into a GL_TEXTURE_2D in @out. On success the
+  // Import @frame's dma-buf planes into a texture in @out. On success the
   // texture owns the import; @frame.plane_fd[*] are consumed (EGL dup's them,
   // so they are closed here). On failure the fds are left for the caller to
-  // close. Single/multi-plane packed formats bound as GL_TEXTURE_2D (the map's
-  // RGBA path); planar YUV → GL_TEXTURE_EXTERNAL_OES is a follow-up. GL context
-  // must be current.
+  // close.
+  //
+  // Packed formats are bound as GL_TEXTURE_2D; planar YUV as
+  // GL_TEXTURE_EXTERNAL_OES, which is what applies the colour conversion.
+  // ImportedTexture::external says which, and the caller must sample with a
+  // matching sampler. GL context must be current.
   bool Import(const IhsFrame& frame, ImportedTexture* out) const;
 
   void Destroy(ImportedTexture* out) const;

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -252,6 +252,9 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // thread — the GL context is current here — then returns it. 0 until the
   // first frame. Defined out of line (needs g_egl_importer + CloseFrameFds).
   [[nodiscard]] uint32_t GetGlTextureName() const override;
+  [[nodiscard]] bool TextureIsExternalOes() const override {
+    return current_egl != nullptr && current_egl->external;
+  }
   [[nodiscard]] int32_t GetGlTextureWidth() const override {
     const std::lock_guard<std::mutex> lock(mutex);
     return current_egl != nullptr ? static_cast<int32_t>(current_egl->width)

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -253,6 +253,7 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // first frame. Defined out of line (needs g_egl_importer + CloseFrameFds).
   [[nodiscard]] uint32_t GetGlTextureName() const override;
   [[nodiscard]] bool TextureIsExternalOes() const override {
+    const std::lock_guard<std::mutex> lock(mutex);
     return current_egl != nullptr && current_egl->external;
   }
   [[nodiscard]] int32_t GetGlTextureWidth() const override {

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -115,6 +115,16 @@ class ICompositorSurface {
   [[nodiscard]] virtual bool TextureIsTopFirst() const { return false; }
 
   /**
+   * @brief Whether GetGlTextureName() is bound to GL_TEXTURE_EXTERNAL_OES.
+   *
+   * True for a planar YUV dma-buf import, which can only be sampled through
+   * samplerExternalOES — that is where the colour conversion happens. Sampling
+   * such a texture as GL_TEXTURE_2D yields the luma plane alone. Packed
+   * formats stay on GL_TEXTURE_2D and leave this false.
+   */
+  [[nodiscard]] virtual bool TextureIsExternalOes() const { return false; }
+
+  /**
    * @brief Expose a Vulkan platform-view image the compositor can blit.
    *
    * The Vulkan counterpart to @c GetGlTextureName: a plugin that rendered into

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -117,10 +117,11 @@ class ICompositorSurface {
   /**
    * @brief Whether GetGlTextureName() is bound to GL_TEXTURE_EXTERNAL_OES.
    *
-   * True for a planar YUV dma-buf import, which can only be sampled through
-   * samplerExternalOES — that is where the colour conversion happens. Sampling
-   * such a texture as GL_TEXTURE_2D yields the luma plane alone. Packed
-   * formats stay on GL_TEXTURE_2D and leave this false.
+   * True for a YUV dma-buf import — planar (e.g. NV12) or packed (e.g.
+   * YUYV/UYVY) — which is sampled through samplerExternalOES, where the driver
+   * does the YUV->RGB conversion. Sampling such a texture as GL_TEXTURE_2D
+   * yields raw/luma data. Packed RGB(A) formats stay on GL_TEXTURE_2D and leave
+   * this false.
    */
   [[nodiscard]] virtual bool TextureIsExternalOes() const { return false; }
 


### PR DESCRIPTION
## The problem

`EglDmabufImporter::Import` bound every dma-buf to `GL_TEXTURE_2D`, and `GlCompositor` sampled it with a `sampler2D`. For a planar YUV image that is the wrong target: the driver exposes the first plane alone and applies no colour conversion, so the frame arrives as `(Y, 0, 0, 1)`.

A hardware-decoded NV12 video frame reaching a platform view therefore rendered as a red luma ramp — geometry, stride and motion all correct, colour absent.

`egl_dmabuf_import.h` already recorded the gap: *"planar YUV → GL_TEXTURE_EXTERNAL_OES is a follow-up."* This is that follow-up.

## The change

- `IsPlanarYuv()` covers NV12/NV21/NV16/NV61, YUV420/YVU420/YUV422/YUV444, P010, YUYV, UYVY. Those import into `GL_TEXTURE_EXTERNAL_OES`; everything else keeps `GL_TEXTURE_2D`.
- `ImportedTexture::external` records which, surfaced as `ICompositorSurface::TextureIsExternalOes()` alongside the existing `TextureIsTopFirst()`.
- `GlCompositor` gains a `samplerExternalOES` program and selects it per draw.
- Wired for `wayland-egl` and for all three platform-view composite paths in `drm_compositor.cc`.

Three details worth review attention:

**Optional by construction.** The external program is built only when the context advertises `GL_OES_EGL_image_external`; otherwise `program_external_` stays 0 and a planar frame is left undrawn rather than mis-sampled. Packed formats are unaffected either way.

**No FBO path.** An external texture cannot be attached to an FBO, so both backends skip the blit fast path when `external` is set.

**Not batched.** The external draw sets up and tears down its own state. It has its own attribute and uniform locations and cannot ride the persistent quad state emitted for the `sampler2D` program, so it is deliberately outside that fast path — one platform-view layer per frame, so the saving would not have been meaningful.

The `external` flag is a **trailing default parameter** on `CompositeToFbo`/`CompositeToDefault`/`CompositeViaQuad`/`CompositeLayerIntoFbo`. That keeps every existing call site untouched, at the cost that a new caller can silently omit it. Happy to make it explicit instead if you would rather.

## Testing

A hardware-decoded WebRTC H.264 stream delivered to a platform view as NV12 dma-bufs, via an out-of-tree plugin implementing `IhsPvFactory`:

| | before | after |
|---|---|---|
| AMD desktop, `wayland-egl` | red luma ramp | correct greyscale |
| Raspberry Pi 4, `drm-kms-egl` | — | correct greyscale |

The Pi decodes through `bcm2835-codec` (`/dev/video10`) straight to dma-bufs, so the frame reaches the compositor without a copy.

## Out of scope

`DmabufVulkanImporter` needs a `VkSamplerYcbcrConversion` for the same reason; a planar frame on a Vulkan backend still samples as luma. Not addressed here.

## Two things noticed while working on this, not fixed here

- `HostSubmit` copies the caller's frame with `pending_egl.frame = *frame` without consulting `frame->struct_size`. A plugin built against an older header has a smaller object, so that reads past the end of it — and what lands in the trailing `buffer_id` is then used as the import-cache key. The field exists for exactly this case.
- `*out_release_fence_fd = -1` is still marked a follow-up. A producer that would retire buffers on the release fence instead falls back to a depth window, holding more of its pool than it needs to.

Happy to open issues for either.