### PR TITLE
ihs_shared: add the ihs_location_* shared location service

### DIFF
--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -80,6 +80,14 @@ jobs:
           export LD_LIBRARY_PATH="$PWD/prefix/lib:$PWD/prefix/lib64:$PWD/prefix/lib/x86_64-linux-gnu"
           ctest --test-dir sbuild --output-on-failure
 
+      - name: Location gpsd TPV parser unit test
+        # Standalone: compiles the internal provider source directly (ParseTpv
+        # is not part of the installed C ABI), so no prefix / gpsd is needed.
+        run: |
+          cmake -S shared/tests/location -B lbuild -G Ninja
+          cmake --build lbuild
+          ctest --test-dir lbuild --output-on-failure
+
   # Producer-latency regression guard for the shell logging path. Links the
   # installed libihs_shared (real cross-.so FFI) and asserts the per-call cost
   # stays within a same-machine ratio of raw fmt formatting, so a future change

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -136,17 +136,17 @@ endif ()
 
 # Location service (the ihs_location_* C ABI): the gpsd and geoclue providers
 # and their gpsd-primary/geoclue-fallback combiner. geoclue talks D-Bus through
-# sd-bus (libsystemd) — present wherever systemd is, and in the cross sysroots,
-# so no dependency to stage.
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(IHS_SYSTEMD REQUIRED IMPORTED_TARGET libsystemd)
+# sd-bus, which it loads from libsystemd.so.0 at runtime via dlopen — exactly as
+# the DLT sink loads libdlt — so ihs_shared keeps no build- or link-time
+# dependency on libsystemd; only libdl (for dlopen) is needed.
 target_sources(ihs_shared PRIVATE
         src/location/location_api.cc
         src/location/gpsd_provider.cc
         src/location/geoclue_provider.cc
         src/location/fallback_location_provider.cc
+        src/location/sd_bus_dynamic.cc
 )
-target_link_libraries(ihs_shared PRIVATE PkgConfig::IHS_SYSTEMD)
+target_link_libraries(ihs_shared PRIVATE ${CMAKE_DL_LIBS})
 
 #
 # Install + CMake package export

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -134,6 +134,20 @@ if (ENABLE_DLT)
     target_link_libraries(ihs_shared PRIVATE ${CMAKE_DL_LIBS})
 endif ()
 
+# Location service (the ihs_location_* C ABI): the gpsd and geoclue providers
+# and their gpsd-primary/geoclue-fallback combiner. geoclue talks D-Bus through
+# sd-bus (libsystemd) — present wherever systemd is, and in the cross sysroots,
+# so no dependency to stage.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(IHS_SYSTEMD REQUIRED IMPORTED_TARGET libsystemd)
+target_sources(ihs_shared PRIVATE
+        src/location/location_api.cc
+        src/location/gpsd_provider.cc
+        src/location/geoclue_provider.cc
+        src/location/fallback_location_provider.cc
+)
+target_link_libraries(ihs_shared PRIVATE PkgConfig::IHS_SYSTEMD)
+
 #
 # Install + CMake package export
 #

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * ihs_location: a shared location service fronting gpsd and geoclue.
+ *
+ * A single acquisition service any consumer (a map's puck, a compass widget, a
+ * navigation plugin, Dart via FFI) can poll for the device's position, so the
+ * providers live once in this .so rather than being re-implemented per plugin.
+ * The service runs its backend(s) on their own worker threads; consumers poll
+ * ihs_location_latest() and use ihs_location_generation() to notice new fixes.
+ */
+
+#ifndef IHS_LOCATION_H_
+#define IHS_LOCATION_H_
+
+#include <stdint.h>
+
+#include "ihs/ihs_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* One location fix. bearing_deg/speed_mps are meaningful only when the backend
+ * supplies them (has_bearing / a non-negative speed). */
+typedef struct IhsPosition {
+  double latitude;
+  double longitude;
+  double bearing_deg;  /* course over ground, degrees */
+  double speed_mps;    /* ground speed, meters/second */
+  int32_t mode;        /* gpsd-style fix mode: <2 no fix, 2 = 2D, 3 = 3D */
+  int32_t has_bearing; /* 0/1 */
+} IhsPosition;
+
+/* Which backend(s) the service acquires from. */
+typedef enum IhsLocationSource {
+  IHS_LOCATION_GPSD = 0,    /* gpsd JSON socket */
+  IHS_LOCATION_GEOCLUE = 1, /* geoclue over D-Bus */
+  IHS_LOCATION_AUTO = 2,    /* gpsd primary, geoclue fallback */
+} IhsLocationSource;
+
+/* Opaque handle to a running location service. */
+typedef struct IhsLocationService IhsLocationService;
+
+/*
+ * Start acquiring from @source. @config is an optional backend hint (may be
+ * NULL): for gpsd, "host:port" (default 127.0.0.1:2947); for geoclue, a D-Bus
+ * address (default the system bus); ignored for IHS_LOCATION_AUTO. Returns NULL
+ * only on allocation failure — a backend that has no fix yet (or is not
+ * present) still returns a handle and simply reports no fix until one arrives.
+ */
+IHS_EXPORT IhsLocationService* ihs_location_start(IhsLocationSource source,
+                                                  const char* config);
+
+/*
+ * Copy the most recent fix into @out. Returns 1 if a valid fix exists, else 0
+ * (in which case @out is left unchanged).
+ */
+IHS_EXPORT int ihs_location_latest(IhsLocationService* service,
+                                   IhsPosition* out);
+
+/*
+ * A monotonic counter bumped on each new fix, so a consumer can tell whether
+ * the fix changed since it last looked without comparing timestamps. 0 before
+ * any fix (and for a NULL service).
+ */
+IHS_EXPORT uint64_t ihs_location_generation(IhsLocationService* service);
+
+/* Stop acquiring and free @service; the handle is invalid afterwards. */
+IHS_EXPORT void ihs_location_stop(IhsLocationService* service);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* IHS_LOCATION_H_ */

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -35,13 +35,12 @@
 extern "C" {
 #endif
 
-/* One location fix. bearing_deg/speed_mps are meaningful only when the backend
- * supplies them (has_bearing / a non-negative speed). */
+/* One location fix. */
 typedef struct IhsPosition {
   double latitude;
   double longitude;
-  double bearing_deg;  /* course over ground, degrees */
-  double speed_mps;    /* ground speed, meters/second */
+  double bearing_deg;  /* course over ground, degrees; valid iff has_bearing */
+  double speed_mps;    /* ground speed, meters/second; < 0 means unknown */
   int32_t mode;        /* gpsd-style fix mode: <2 no fix, 2 = 2D, 3 = 3D */
   int32_t has_bearing; /* 0/1 */
 } IhsPosition;
@@ -59,9 +58,10 @@ typedef struct IhsLocationService IhsLocationService;
 /*
  * Start acquiring from @source. @config is an optional backend hint (may be
  * NULL): for gpsd, "host:port" (default 127.0.0.1:2947); for geoclue, a D-Bus
- * address (default the system bus); ignored for IHS_LOCATION_AUTO. Returns NULL
- * only on allocation failure — a backend that has no fix yet (or is not
- * present) still returns a handle and simply reports no fix until one arrives.
+ * address, or the literal "user" to use the session bus (default the system
+ * bus); ignored for IHS_LOCATION_AUTO. Returns NULL only on failure — a backend
+ * with no fix yet (or that is not present) still returns a handle and simply
+ * reports no fix until one arrives.
  */
 IHS_EXPORT IhsLocationService* ihs_location_start(IhsLocationSource source,
                                                   const char* config);

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -57,11 +57,12 @@ typedef struct IhsLocationService IhsLocationService;
 
 /*
  * Start acquiring from @source. @config is an optional backend hint (may be
- * NULL): for gpsd, "host:port" (default 127.0.0.1:2947); for geoclue, a D-Bus
- * address, or the literal "user" to use the session bus (default the system
- * bus); ignored for IHS_LOCATION_AUTO. Returns NULL only on failure — a backend
- * with no fix yet (or that is not present) still returns a handle and simply
- * reports no fix until one arrives.
+ * NULL): for gpsd, a numeric IPv4 "host:port" (default 127.0.0.1:2947 — host
+ * names are not resolved); for geoclue, a D-Bus address, or the literal "user"
+ * to use the session bus (default the system bus); ignored for
+ * IHS_LOCATION_AUTO. Returns NULL on failure — a backend with no fix yet (or
+ * that is not present) still returns a handle and simply reports no fix until
+ * one arrives.
  */
 IHS_EXPORT IhsLocationService* ihs_location_start(IhsLocationSource source,
                                                   const char* config);

--- a/shared/src/location/fallback_location_provider.cc
+++ b/shared/src/location/fallback_location_provider.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "fallback_location_provider.hpp"
+
+#include <utility>
+
+namespace ihs::location {
+
+FallbackLocationProvider::FallbackLocationProvider(
+    std::unique_ptr<ILocationProvider> primary,
+    std::unique_ptr<ILocationProvider> fallback,
+    std::chrono::steady_clock::duration primary_stale)
+    : primary_(std::move(primary)),
+      fallback_(std::move(fallback)),
+      primary_stale_(primary_stale) {}
+
+bool FallbackLocationProvider::Start() {
+  bool ok = false;
+  if (primary_) {
+    ok = primary_->Start() || ok;
+  }
+  if (fallback_) {
+    ok = fallback_->Start() || ok;
+  }
+  return ok;
+}
+
+void FallbackLocationProvider::Stop() {
+  if (primary_) {
+    primary_->Stop();
+  }
+  if (fallback_) {
+    fallback_->Stop();
+  }
+}
+
+bool FallbackLocationProvider::Latest(Position& out) {
+  if (primary_) {
+    const uint64_t g = primary_->generation();
+    if (g != primary_seen_gen_) {
+      primary_seen_gen_ = g;
+      primary_ever_ = true;
+      primary_last_change_ = std::chrono::steady_clock::now();
+    }
+    Position pp;
+    const bool fresh = primary_ever_ && (std::chrono::steady_clock::now() -
+                                         primary_last_change_) < primary_stale_;
+    if (fresh && primary_->Latest(pp)) {
+      out = pp;
+      return true;
+    }
+  }
+  return fallback_ && fallback_->Latest(out);
+}
+
+uint64_t FallbackLocationProvider::generation() const {
+  // Monotonic across both children: any new fix from either bumps this, so the
+  // consumer re-evaluates (Latest() then picks the right source).
+  return (primary_ ? primary_->generation() : 0) +
+         (fallback_ ? fallback_->generation() : 0);
+}
+
+}  // namespace ihs::location

--- a/shared/src/location/fallback_location_provider.hpp
+++ b/shared/src/location/fallback_location_provider.hpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_FALLBACK_LOCATION_PROVIDER_H_
+#define IHS_LOC_FALLBACK_LOCATION_PROVIDER_H_
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+
+#include "location.hpp"
+
+namespace ihs::location {
+
+// Combines a primary and a fallback provider: reports the primary's fix while
+// the primary is producing FRESH fixes, and the fallback's otherwise. This is
+// the design's "gpsd primary + geoclue fallback" — gpsd is authoritative when
+// it has signal, and geoclue (network / Wi-Fi) fills in when gpsd goes quiet or
+// was never present. Freshness is judged by how recently the primary's
+// generation last advanced.
+//
+// Both children run their own worker threads; this object only reads them, and
+// Latest()/generation() are called on the consumer (engine) thread, so its own
+// bookkeeping needs no lock.
+class FallbackLocationProvider final : public ILocationProvider {
+ public:
+  FallbackLocationProvider(std::unique_ptr<ILocationProvider> primary,
+                           std::unique_ptr<ILocationProvider> fallback,
+                           std::chrono::steady_clock::duration primary_stale =
+                               std::chrono::seconds(5));
+  ~FallbackLocationProvider() override =
+      default;  // children stop in their dtors
+
+  bool Start() override;
+  void Stop() override;
+  bool Latest(Position& out) override;
+  [[nodiscard]] uint64_t generation() const override;
+
+ private:
+  std::unique_ptr<ILocationProvider> primary_;
+  std::unique_ptr<ILocationProvider> fallback_;
+  const std::chrono::steady_clock::duration primary_stale_;
+
+  // Consumer-thread only (Latest()): track when the primary last advanced so a
+  // stale primary yields to the fallback.
+  uint64_t primary_seen_gen_ = 0;
+  bool primary_ever_ = false;
+  std::chrono::steady_clock::time_point primary_last_change_;
+};
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_FALLBACK_LOCATION_PROVIDER_H_

--- a/shared/src/location/geoclue_provider.cc
+++ b/shared/src/location/geoclue_provider.cc
@@ -131,6 +131,10 @@ void GeoclueProvider::OnLocationObject(const char* location_path) {
   }
   sd_->error_free(&err);
 
+  if (!ValidLatLon(lat, lon)) {
+    return;  // ignore a malformed geoclue reply rather than publish NaN/range
+  }
+
   const double heading = ReadDouble(sd_, bus_, location_path, "Heading");
   const double speed = ReadDouble(sd_, bus_, location_path, "Speed");
 

--- a/shared/src/location/geoclue_provider.cc
+++ b/shared/src/location/geoclue_provider.cc
@@ -174,7 +174,9 @@ bool GeoclueProvider::Setup() {
       r = sd_->set_address(bus_, bus_address_.c_str());
     }
     if (r >= 0) {
-      sd_->set_bus_client(bus_, 1);
+      r = sd_->set_bus_client(bus_, 1);
+    }
+    if (r >= 0) {
       r = sd_->start(bus_);
     }
   }

--- a/shared/src/location/geoclue_provider.cc
+++ b/shared/src/location/geoclue_provider.cc
@@ -201,14 +201,15 @@ bool GeoclueProvider::Setup() {
     return false;
   }
 
-  // Identify + request accuracy before starting (both required by geoclue).
-  // Check each return and reset the shared error on failure, so a first failure
-  // neither leaks nor leaves a stale error for the next call.
+  // Identify + request accuracy before starting. geoclue requires both, so a
+  // failure is fatal: fail Setup() and let the retry loop try again rather than
+  // run a client that can never receive fixes.
   if (sd_->set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
                         "DesktopId", &err, "s", desktop_id_.c_str()) < 0) {
     std::fprintf(stderr, "[ihs.location] geoclue: set DesktopId failed: %s\n",
                  err.message ? err.message : "?");
     sd_->error_free(&err);
+    return false;
   }
   if (sd_->set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
                         "RequestedAccuracyLevel", &err, "u",
@@ -218,6 +219,7 @@ bool GeoclueProvider::Setup() {
         "[ihs.location] geoclue: set RequestedAccuracyLevel failed: %s\n",
         err.message ? err.message : "?");
     sd_->error_free(&err);
+    return false;
   }
 
   // Fixes arrive via LocationUpdated(old, new).

--- a/shared/src/location/geoclue_provider.cc
+++ b/shared/src/location/geoclue_provider.cc
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "geoclue_provider.hpp"
+
+#include <systemd/sd-bus.h>
+
+#include <chrono>
+#include <cstdio>
+#include <thread>
+#include <utility>
+
+namespace ihs::location {
+
+namespace {
+
+constexpr char kGeoclue[] = "org.freedesktop.GeoClue2";
+constexpr char kManagerPath[] = "/org/freedesktop/GeoClue2/Manager";
+constexpr char kManagerIface[] = "org.freedesktop.GeoClue2.Manager";
+constexpr char kClientIface[] = "org.freedesktop.GeoClue2.Client";
+constexpr char kLocationIface[] = "org.freedesktop.GeoClue2.Location";
+
+// GClueAccuracyLevel: 0 none, 1 country, 4 city, 5 neighborhood, 6 street,
+// 8 exact. Request street-level; geoclue clamps to what it can provide.
+constexpr uint32_t kAccuracyStreet = 6;
+
+double ReadDouble(sd_bus* bus, const char* path, const char* member) {
+  sd_bus_error err = SD_BUS_ERROR_NULL;
+  double v = -1.0;
+  if (sd_bus_get_property_trivial(bus, kGeoclue, path, kLocationIface, member,
+                                  &err, 'd', &v) < 0) {
+    v = -1.0;
+  }
+  sd_bus_error_free(&err);
+  return v;
+}
+
+// sd-bus signal handler for Client.LocationUpdated(old, new); reads the new
+// Location object path and hands it to the provider.
+int LocationUpdatedCb(sd_bus_message* m, void* userdata, sd_bus_error* /*e*/) {
+  const char* old_path = nullptr;
+  const char* new_path = nullptr;
+  if (sd_bus_message_read(m, "oo", &old_path, &new_path) < 0 ||
+      new_path == nullptr) {
+    return 0;
+  }
+  static_cast<GeoclueProvider*>(userdata)->OnLocationObject(new_path);
+  return 0;
+}
+
+}  // namespace
+
+GeoclueProvider::GeoclueProvider(std::string desktop_id,
+                                 std::string bus_address)
+    : desktop_id_(std::move(desktop_id)),
+      bus_address_(std::move(bus_address)) {}
+
+GeoclueProvider::~GeoclueProvider() {
+  StopWorker();
+}
+
+bool GeoclueProvider::Start() {
+  bool expected = false;
+  if (!running_.compare_exchange_strong(expected, true)) {
+    return true;  // already started
+  }
+  thread_ = std::thread([this] { Run(); });
+  return true;
+}
+
+void GeoclueProvider::Stop() {
+  StopWorker();
+}
+
+void GeoclueProvider::StopWorker() {
+  if (!running_.exchange(false)) {
+    return;  // already stopped
+  }
+  // The worker blocks in sd_bus_wait for at most 200 ms, then re-checks
+  // running_, so the join returns promptly.
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+bool GeoclueProvider::Latest(Position& out) {
+  const std::lock_guard<std::mutex> lock(mu_);
+  if (!have_fix_) {
+    return false;
+  }
+  out = latest_;
+  return true;
+}
+
+uint64_t GeoclueProvider::generation() const {
+  return generation_.load();
+}
+
+void GeoclueProvider::OnLocationObject(const char* location_path) {
+  sd_bus_error err = SD_BUS_ERROR_NULL;
+  double lat = 0.0;
+  double lon = 0.0;
+  if (sd_bus_get_property_trivial(bus_, kGeoclue, location_path, kLocationIface,
+                                  "Latitude", &err, 'd', &lat) < 0 ||
+      sd_bus_get_property_trivial(bus_, kGeoclue, location_path, kLocationIface,
+                                  "Longitude", &err, 'd', &lon) < 0) {
+    sd_bus_error_free(&err);
+    return;
+  }
+  sd_bus_error_free(&err);
+
+  const double heading = ReadDouble(bus_, location_path, "Heading");
+  const double speed = ReadDouble(bus_, location_path, "Speed");
+
+  Position p;
+  p.latitude = lat;
+  p.longitude = lon;
+  p.mode = 3;  // geoclue reports a fix (no 2D/3D distinction); treat as valid
+  if (heading >= 0.0) {
+    p.bearing_deg = heading;
+    p.has_bearing = true;
+  }
+  if (speed >= 0.0) {
+    p.speed_mps = speed;
+  }
+  {
+    const std::lock_guard<std::mutex> lock(mu_);
+    latest_ = p;
+    have_fix_ = true;
+  }
+  generation_.fetch_add(1);
+}
+
+bool GeoclueProvider::Setup() {
+  int r = 0;
+  if (bus_address_.empty()) {
+    r = sd_bus_open_system(&bus_);
+  } else if (bus_address_ == "user") {
+    r = sd_bus_open_user(&bus_);
+  } else {
+    r = sd_bus_new(&bus_);
+    if (r >= 0) {
+      r = sd_bus_set_address(bus_, bus_address_.c_str());
+    }
+    if (r >= 0) {
+      sd_bus_set_bus_client(bus_, 1);
+      r = sd_bus_start(bus_);
+    }
+  }
+  if (r < 0 || bus_ == nullptr) {
+    return false;
+  }
+
+  sd_bus_error err = SD_BUS_ERROR_NULL;
+  sd_bus_message* reply = nullptr;
+
+  // Manager.GetClient -> our per-app client object path.
+  r = sd_bus_call_method(bus_, kGeoclue, kManagerPath, kManagerIface,
+                         "GetClient", &err, &reply, "");
+  if (r < 0) {
+    std::fprintf(stderr, "[ihs.location] geoclue: GetClient failed: %s\n",
+                 err.message ? err.message : "?");
+    sd_bus_error_free(&err);
+    return false;
+  }
+  const char* client_path = nullptr;
+  r = sd_bus_message_read(reply, "o", &client_path);
+  if (r >= 0 && client_path != nullptr) {
+    client_path_ = client_path;
+  }
+  reply = sd_bus_message_unref(reply);
+  if (client_path_.empty()) {
+    sd_bus_error_free(&err);
+    return false;
+  }
+
+  // Identify + request accuracy before starting (both required by geoclue).
+  sd_bus_set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                      "DesktopId", &err, "s", desktop_id_.c_str());
+  sd_bus_set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                      "RequestedAccuracyLevel", &err, "u", kAccuracyStreet);
+
+  // Fixes arrive via LocationUpdated(old, new).
+  r = sd_bus_match_signal(bus_, nullptr, kGeoclue, client_path_.c_str(),
+                          kClientIface, "LocationUpdated", &LocationUpdatedCb,
+                          this);
+  if (r < 0) {
+    sd_bus_error_free(&err);
+    return false;
+  }
+
+  r = sd_bus_call_method(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                         "Start", &err, &reply, "");
+  if (r < 0) {
+    std::fprintf(stderr, "[ihs.location] geoclue: Start failed: %s\n",
+                 err.message ? err.message : "?");
+    sd_bus_error_free(&err);
+    return false;
+  }
+  sd_bus_message_unref(reply);
+  sd_bus_error_free(&err);
+  std::fprintf(stderr, "[ihs.location] geoclue: watching %s\n",
+               client_path_.c_str());
+  return true;
+}
+
+void GeoclueProvider::Teardown() {
+  if (bus_ == nullptr) {
+    return;
+  }
+  if (!client_path_.empty()) {
+    sd_bus_error err = SD_BUS_ERROR_NULL;
+    sd_bus_message* reply = nullptr;
+    sd_bus_call_method(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                       "Stop", &err, &reply, "");
+    sd_bus_message_unref(reply);
+    sd_bus_error_free(&err);
+    client_path_.clear();
+  }
+  bus_ = sd_bus_flush_close_unref(bus_);
+}
+
+void GeoclueProvider::Run() {
+  while (running_.load()) {
+    if (!Setup()) {
+      Teardown();
+      if (running_.load()) {
+        std::this_thread::sleep_for(std::chrono::seconds(2));  // retry
+      }
+      continue;
+    }
+    while (running_.load()) {
+      const int r = sd_bus_process(bus_, nullptr);
+      if (r < 0) {
+        break;  // bus error -> reconnect
+      }
+      if (r > 0) {
+        continue;  // more queued, process again before waiting
+      }
+      sd_bus_wait(bus_, 200000);  // 200 ms, so running_ is re-checked
+    }
+    Teardown();
+    if (running_.load()) {
+      std::this_thread::sleep_for(std::chrono::seconds(2));
+    }
+  }
+}
+
+}  // namespace ihs::location

--- a/shared/src/location/geoclue_provider.cc
+++ b/shared/src/location/geoclue_provider.cc
@@ -267,8 +267,16 @@ void GeoclueProvider::Teardown() {
 }
 
 void GeoclueProvider::Run() {
+  // libsystemd is resolved once (std::call_once); if it is absent it will never
+  // appear later in this process, so there is nothing to retry — leave the
+  // worker idle rather than wake every 2s forever.
+  if (SdBusLoad() == nullptr) {
+    return;
+  }
   while (running_.load()) {
     if (!Setup()) {
+      // Setup only fails now for a transient reason (geoclue not up yet, a
+      // denied client), so retrying is worthwhile.
       Teardown();
       if (running_.load()) {
         std::this_thread::sleep_for(std::chrono::seconds(2));  // retry

--- a/shared/src/location/geoclue_provider.cc
+++ b/shared/src/location/geoclue_provider.cc
@@ -10,12 +10,12 @@
 
 #include "geoclue_provider.hpp"
 
-#include <systemd/sd-bus.h>
-
 #include <chrono>
 #include <cstdio>
 #include <thread>
 #include <utility>
+
+#include "sd_bus_dynamic.hpp"
 
 namespace ihs::location {
 
@@ -31,23 +31,30 @@ constexpr char kLocationIface[] = "org.freedesktop.GeoClue2.Location";
 // 8 exact. Request street-level; geoclue clamps to what it can provide.
 constexpr uint32_t kAccuracyStreet = 6;
 
-double ReadDouble(sd_bus* bus, const char* path, const char* member) {
-  sd_bus_error err = SD_BUS_ERROR_NULL;
+double ReadDouble(const SdBusApi* sd,
+                  sd_bus* bus,
+                  const char* path,
+                  const char* member) {
+  sd_bus_error err{};
   double v = -1.0;
-  if (sd_bus_get_property_trivial(bus, kGeoclue, path, kLocationIface, member,
-                                  &err, 'd', &v) < 0) {
+  if (sd->get_property_trivial(bus, kGeoclue, path, kLocationIface, member,
+                               &err, 'd', &v) < 0) {
     v = -1.0;
   }
-  sd_bus_error_free(&err);
+  sd->error_free(&err);
   return v;
 }
 
 // sd-bus signal handler for Client.LocationUpdated(old, new); reads the new
 // Location object path and hands it to the provider.
 int LocationUpdatedCb(sd_bus_message* m, void* userdata, sd_bus_error* /*e*/) {
+  const SdBusApi* sd = SdBusLoad();
+  if (sd == nullptr) {
+    return 0;
+  }
   const char* old_path = nullptr;
   const char* new_path = nullptr;
-  if (sd_bus_message_read(m, "oo", &old_path, &new_path) < 0 ||
+  if (sd->message_read(m, "oo", &old_path, &new_path) < 0 ||
       new_path == nullptr) {
     return 0;
   }
@@ -104,20 +111,23 @@ uint64_t GeoclueProvider::generation() const {
 }
 
 void GeoclueProvider::OnLocationObject(const char* location_path) {
-  sd_bus_error err = SD_BUS_ERROR_NULL;
-  double lat = 0.0;
-  double lon = 0.0;
-  if (sd_bus_get_property_trivial(bus_, kGeoclue, location_path, kLocationIface,
-                                  "Latitude", &err, 'd', &lat) < 0 ||
-      sd_bus_get_property_trivial(bus_, kGeoclue, location_path, kLocationIface,
-                                  "Longitude", &err, 'd', &lon) < 0) {
-    sd_bus_error_free(&err);
+  if (sd_ == nullptr) {
     return;
   }
-  sd_bus_error_free(&err);
+  sd_bus_error err{};
+  double lat = 0.0;
+  double lon = 0.0;
+  if (sd_->get_property_trivial(bus_, kGeoclue, location_path, kLocationIface,
+                                "Latitude", &err, 'd', &lat) < 0 ||
+      sd_->get_property_trivial(bus_, kGeoclue, location_path, kLocationIface,
+                                "Longitude", &err, 'd', &lon) < 0) {
+    sd_->error_free(&err);
+    return;
+  }
+  sd_->error_free(&err);
 
-  const double heading = ReadDouble(bus_, location_path, "Heading");
-  const double speed = ReadDouble(bus_, location_path, "Speed");
+  const double heading = ReadDouble(sd_, bus_, location_path, "Heading");
+  const double speed = ReadDouble(sd_, bus_, location_path, "Speed");
 
   Position p;
   p.latitude = lat;
@@ -139,92 +149,97 @@ void GeoclueProvider::OnLocationObject(const char* location_path) {
 }
 
 bool GeoclueProvider::Setup() {
+  sd_ = SdBusLoad();
+  if (sd_ == nullptr) {
+    return false;  // libsystemd not present -> geoclue unavailable
+  }
+
   int r = 0;
   if (bus_address_.empty()) {
-    r = sd_bus_open_system(&bus_);
+    r = sd_->open_system(&bus_);
   } else if (bus_address_ == "user") {
-    r = sd_bus_open_user(&bus_);
+    r = sd_->open_user(&bus_);
   } else {
-    r = sd_bus_new(&bus_);
+    r = sd_->bus_new(&bus_);
     if (r >= 0) {
-      r = sd_bus_set_address(bus_, bus_address_.c_str());
+      r = sd_->set_address(bus_, bus_address_.c_str());
     }
     if (r >= 0) {
-      sd_bus_set_bus_client(bus_, 1);
-      r = sd_bus_start(bus_);
+      sd_->set_bus_client(bus_, 1);
+      r = sd_->start(bus_);
     }
   }
   if (r < 0 || bus_ == nullptr) {
     return false;
   }
 
-  sd_bus_error err = SD_BUS_ERROR_NULL;
+  sd_bus_error err{};
   sd_bus_message* reply = nullptr;
 
   // Manager.GetClient -> our per-app client object path.
-  r = sd_bus_call_method(bus_, kGeoclue, kManagerPath, kManagerIface,
-                         "GetClient", &err, &reply, "");
+  r = sd_->call_method(bus_, kGeoclue, kManagerPath, kManagerIface, "GetClient",
+                       &err, &reply, "");
   if (r < 0) {
     std::fprintf(stderr, "[ihs.location] geoclue: GetClient failed: %s\n",
                  err.message ? err.message : "?");
-    sd_bus_error_free(&err);
+    sd_->error_free(&err);
     return false;
   }
   const char* client_path = nullptr;
-  r = sd_bus_message_read(reply, "o", &client_path);
+  r = sd_->message_read(reply, "o", &client_path);
   if (r >= 0 && client_path != nullptr) {
     client_path_ = client_path;
   }
-  reply = sd_bus_message_unref(reply);
+  reply = sd_->message_unref(reply);
   if (client_path_.empty()) {
-    sd_bus_error_free(&err);
+    sd_->error_free(&err);
     return false;
   }
 
   // Identify + request accuracy before starting (both required by geoclue).
-  sd_bus_set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
-                      "DesktopId", &err, "s", desktop_id_.c_str());
-  sd_bus_set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
-                      "RequestedAccuracyLevel", &err, "u", kAccuracyStreet);
+  sd_->set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                    "DesktopId", &err, "s", desktop_id_.c_str());
+  sd_->set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                    "RequestedAccuracyLevel", &err, "u", kAccuracyStreet);
 
   // Fixes arrive via LocationUpdated(old, new).
-  r = sd_bus_match_signal(bus_, nullptr, kGeoclue, client_path_.c_str(),
-                          kClientIface, "LocationUpdated", &LocationUpdatedCb,
-                          this);
+  r = sd_->match_signal(bus_, nullptr, kGeoclue, client_path_.c_str(),
+                        kClientIface, "LocationUpdated", &LocationUpdatedCb,
+                        this);
   if (r < 0) {
-    sd_bus_error_free(&err);
+    sd_->error_free(&err);
     return false;
   }
 
-  r = sd_bus_call_method(bus_, kGeoclue, client_path_.c_str(), kClientIface,
-                         "Start", &err, &reply, "");
+  r = sd_->call_method(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                       "Start", &err, &reply, "");
   if (r < 0) {
     std::fprintf(stderr, "[ihs.location] geoclue: Start failed: %s\n",
                  err.message ? err.message : "?");
-    sd_bus_error_free(&err);
+    sd_->error_free(&err);
     return false;
   }
-  sd_bus_message_unref(reply);
-  sd_bus_error_free(&err);
+  sd_->message_unref(reply);
+  sd_->error_free(&err);
   std::fprintf(stderr, "[ihs.location] geoclue: watching %s\n",
                client_path_.c_str());
   return true;
 }
 
 void GeoclueProvider::Teardown() {
-  if (bus_ == nullptr) {
+  if (sd_ == nullptr || bus_ == nullptr) {
     return;
   }
   if (!client_path_.empty()) {
-    sd_bus_error err = SD_BUS_ERROR_NULL;
+    sd_bus_error err{};
     sd_bus_message* reply = nullptr;
-    sd_bus_call_method(bus_, kGeoclue, client_path_.c_str(), kClientIface,
-                       "Stop", &err, &reply, "");
-    sd_bus_message_unref(reply);
-    sd_bus_error_free(&err);
+    sd_->call_method(bus_, kGeoclue, client_path_.c_str(), kClientIface, "Stop",
+                     &err, &reply, "");
+    sd_->message_unref(reply);
+    sd_->error_free(&err);
     client_path_.clear();
   }
-  bus_ = sd_bus_flush_close_unref(bus_);
+  bus_ = sd_->flush_close_unref(bus_);
 }
 
 void GeoclueProvider::Run() {
@@ -237,14 +252,14 @@ void GeoclueProvider::Run() {
       continue;
     }
     while (running_.load()) {
-      const int r = sd_bus_process(bus_, nullptr);
+      const int r = sd_->process(bus_, nullptr);
       if (r < 0) {
         break;  // bus error -> reconnect
       }
       if (r > 0) {
         continue;  // more queued, process again before waiting
       }
-      sd_bus_wait(bus_, 200000);  // 200 ms, so running_ is re-checked
+      sd_->wait(bus_, 200000);  // 200 ms, so running_ is re-checked
     }
     Teardown();
     if (running_.load()) {

--- a/shared/src/location/geoclue_provider.cc
+++ b/shared/src/location/geoclue_provider.cc
@@ -78,7 +78,12 @@ bool GeoclueProvider::Start() {
   if (!running_.compare_exchange_strong(expected, true)) {
     return true;  // already started
   }
-  thread_ = std::thread([this] { Run(); });
+  try {
+    thread_ = std::thread([this] { Run(); });
+  } catch (...) {
+    running_.store(false);  // roll back so the object is reusable / not stuck
+    return false;
+  }
   return true;
 }
 
@@ -197,10 +202,23 @@ bool GeoclueProvider::Setup() {
   }
 
   // Identify + request accuracy before starting (both required by geoclue).
-  sd_->set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
-                    "DesktopId", &err, "s", desktop_id_.c_str());
-  sd_->set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
-                    "RequestedAccuracyLevel", &err, "u", kAccuracyStreet);
+  // Check each return and reset the shared error on failure, so a first failure
+  // neither leaks nor leaves a stale error for the next call.
+  if (sd_->set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                        "DesktopId", &err, "s", desktop_id_.c_str()) < 0) {
+    std::fprintf(stderr, "[ihs.location] geoclue: set DesktopId failed: %s\n",
+                 err.message ? err.message : "?");
+    sd_->error_free(&err);
+  }
+  if (sd_->set_property(bus_, kGeoclue, client_path_.c_str(), kClientIface,
+                        "RequestedAccuracyLevel", &err, "u",
+                        kAccuracyStreet) < 0) {
+    std::fprintf(
+        stderr,
+        "[ihs.location] geoclue: set RequestedAccuracyLevel failed: %s\n",
+        err.message ? err.message : "?");
+    sd_->error_free(&err);
+  }
 
   // Fixes arrive via LocationUpdated(old, new).
   r = sd_->match_signal(bus_, nullptr, kGeoclue, client_path_.c_str(),

--- a/shared/src/location/geoclue_provider.hpp
+++ b/shared/src/location/geoclue_provider.hpp
@@ -18,20 +18,16 @@
 #include <thread>
 
 #include "location.hpp"
-
-// sd_bus is a named struct (portably forward-declarable); sd_bus_message /
-// sd_bus_error are not (sd_bus_error is an anonymous-struct typedef on some
-// libsystemd versions), so the D-Bus callback and its types stay in the .cc.
-extern "C" {
-typedef struct sd_bus sd_bus;
-}
+#include "sd_bus_dynamic.hpp"
 
 namespace ihs::location {
 
 // ILocationProvider backed by geoclue (freedesktop.org's location service) over
-// D-Bus (sd-bus, from libsystemd — present wherever systemd is, so no extra
-// dependency). This is the FALLBACK: geoclue aggregates network/Wi-Fi and, when
-// present, GPS. GpsdProvider is the primary; the engine selects one.
+// D-Bus. sd-bus (libsystemd) is loaded at runtime via SdBusLoad() so ihs_shared
+// carries no build- or link-time dependency on libsystemd; if the library is
+// absent the provider simply reports no fix. This is the FALLBACK: geoclue
+// aggregates network/Wi-Fi and, when present, GPS. GpsdProvider is the primary;
+// the engine selects one.
 //
 // A worker thread owns the bus: it creates a geoclue Client, sets DesktopId +
 // accuracy, subscribes to LocationUpdated, calls Start, and pumps the bus. Each
@@ -71,8 +67,9 @@ class GeoclueProvider final : public ILocationProvider {
   std::thread thread_;
   std::atomic<bool> running_{false};
 
-  sd_bus* bus_ = nullptr;    // worker-thread only
-  std::string client_path_;  // worker-thread only
+  const SdBusApi* sd_ = nullptr;  // resolved libsystemd entry points
+  sd_bus* bus_ = nullptr;         // worker-thread only
+  std::string client_path_;       // worker-thread only
 
   mutable std::mutex mu_;
   Position latest_;

--- a/shared/src/location/geoclue_provider.hpp
+++ b/shared/src/location/geoclue_provider.hpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_GEOCLUE_PROVIDER_H_
+#define IHS_LOC_GEOCLUE_PROVIDER_H_
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "location.hpp"
+
+// sd_bus is a named struct (portably forward-declarable); sd_bus_message /
+// sd_bus_error are not (sd_bus_error is an anonymous-struct typedef on some
+// libsystemd versions), so the D-Bus callback and its types stay in the .cc.
+extern "C" {
+typedef struct sd_bus sd_bus;
+}
+
+namespace ihs::location {
+
+// ILocationProvider backed by geoclue (freedesktop.org's location service) over
+// D-Bus (sd-bus, from libsystemd — present wherever systemd is, so no extra
+// dependency). This is the FALLBACK: geoclue aggregates network/Wi-Fi and, when
+// present, GPS. GpsdProvider is the primary; the engine selects one.
+//
+// A worker thread owns the bus: it creates a geoclue Client, sets DesktopId +
+// accuracy, subscribes to LocationUpdated, calls Start, and pumps the bus. Each
+// location update is published as a Position. The bus address is
+// system-by-default but overridable (IHS_LOC_GEOCLUE_BUS) so the D-Bus client
+// can be tested against a stand-in service on the session bus.
+class GeoclueProvider final : public ILocationProvider {
+ public:
+  // @desktop_id must match geoclue's allow-list expectation (a .desktop id);
+  // @bus_address empty means the system bus.
+  explicit GeoclueProvider(std::string desktop_id = "ihs-location",
+                           std::string bus_address = {});
+  ~GeoclueProvider() override;
+
+  GeoclueProvider(const GeoclueProvider&) = delete;
+  GeoclueProvider& operator=(const GeoclueProvider&) = delete;
+
+  bool Start() override;
+  void Stop() override;
+  bool Latest(Position& out) override;
+  [[nodiscard]] uint64_t generation() const override;
+
+  // Read a geoclue Location object's properties and publish a Position. Public
+  // only so the file-static D-Bus signal callback (in the .cc) can reach it;
+  // runs on the worker thread and is not part of the intended API.
+  void OnLocationObject(const char* location_path);
+
+ private:
+  void Run();         // worker: set up the client, then pump the bus
+  void StopWorker();  // non-virtual; Stop() and the destructor both call it
+  bool Setup();       // connect, GetClient, configure, subscribe, Start
+  void Teardown();
+
+  const std::string desktop_id_;
+  const std::string bus_address_;
+
+  std::thread thread_;
+  std::atomic<bool> running_{false};
+
+  sd_bus* bus_ = nullptr;    // worker-thread only
+  std::string client_path_;  // worker-thread only
+
+  mutable std::mutex mu_;
+  Position latest_;
+  bool have_fix_ = false;
+  std::atomic<uint64_t> generation_{0};
+};
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_GEOCLUE_PROVIDER_H_

--- a/shared/src/location/geoclue_provider.hpp
+++ b/shared/src/location/geoclue_provider.hpp
@@ -31,9 +31,10 @@ namespace ihs::location {
 //
 // A worker thread owns the bus: it creates a geoclue Client, sets DesktopId +
 // accuracy, subscribes to LocationUpdated, calls Start, and pumps the bus. Each
-// location update is published as a Position. The bus address is
-// system-by-default but overridable (IHS_LOC_GEOCLUE_BUS) so the D-Bus client
-// can be tested against a stand-in service on the session bus.
+// location update is published as a Position. The bus address is passed to the
+// constructor (empty = system bus; "user" = session bus; any other value is an
+// explicit D-Bus address), so a stand-in geoclue can be tested on the session
+// bus without a system-bus name.
 class GeoclueProvider final : public ILocationProvider {
  public:
   // @desktop_id must match geoclue's allow-list expectation (a .desktop id);

--- a/shared/src/location/gpsd_provider.cc
+++ b/shared/src/location/gpsd_provider.cc
@@ -49,7 +49,7 @@ constexpr char kWatchCommand[] = "?WATCH={\"enable\":true,\"json\":true}\r\n";
 }  // namespace
 
 bool ParseTpv(const std::string& line, Position& out) {
-  if (line.find("\"class\":\"TPV\"") == std::string::npos) {
+  if (line.find(R"("class":"TPV")") == std::string::npos) {
     return false;
   }
   double lat = 0.0;
@@ -92,7 +92,12 @@ bool GpsdProvider::Start() {
   if (!running_.compare_exchange_strong(expected, true)) {
     return true;  // already started
   }
-  thread_ = std::thread([this] { Run(); });
+  try {
+    thread_ = std::thread([this] { Run(); });
+  } catch (...) {
+    running_.store(false);  // roll back so the object is reusable / not stuck
+    return false;
+  }
   return true;
 }
 

--- a/shared/src/location/gpsd_provider.cc
+++ b/shared/src/location/gpsd_provider.cc
@@ -67,14 +67,17 @@ bool ParseTpv(const std::string& line, Position& out) {
   Position p;
   p.latitude = lat;
   p.longitude = lon;
+  // gpsd fix mode: only 2 (2D) and 3 (3D) are fixes. Reject anything else
+  // (0/1 = no fix, or a garbage value). A TPV with lat/lon but no mode field is
+  // treated as a 3D fix.
   double mode = 0.0;
-  // A TPV that carries lat/lon but omits mode (or reports a non-finite mode)
-  // still represents a fix; default to 3D so it counts as valid().
-  p.mode = (FindNumber(line, "mode", mode) && std::isfinite(mode))
-               ? static_cast<int>(mode)
-               : 3;
-  if (!p.valid()) {
-    return false;
+  if (FindNumber(line, "mode", mode)) {
+    if (mode != 2.0 && mode != 3.0) {
+      return false;
+    }
+    p.mode = static_cast<int>(mode);
+  } else {
+    p.mode = 3;
   }
   double track = 0.0;
   if (FindNumber(line, "track", track) && std::isfinite(track)) {

--- a/shared/src/location/gpsd_provider.cc
+++ b/shared/src/location/gpsd_provider.cc
@@ -58,10 +58,7 @@ bool ParseTpv(const std::string& line, Position& out) {
   if (!FindNumber(line, "lat", lat) || !FindNumber(line, "lon", lon)) {
     return false;  // TPV without a position (e.g. mode 1 acquiring)
   }
-  // A caller may point gpsd at an arbitrary host, so reject NaN/Inf and
-  // impossible coordinates rather than propagate them downstream.
-  if (!std::isfinite(lat) || !std::isfinite(lon) || lat < -90.0 || lat > 90.0 ||
-      lon < -180.0 || lon > 180.0) {
+  if (!ValidLatLon(lat, lon)) {
     return false;
   }
   Position p;

--- a/shared/src/location/gpsd_provider.cc
+++ b/shared/src/location/gpsd_provider.cc
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <thread>
@@ -57,23 +58,32 @@ bool ParseTpv(const std::string& line, Position& out) {
   if (!FindNumber(line, "lat", lat) || !FindNumber(line, "lon", lon)) {
     return false;  // TPV without a position (e.g. mode 1 acquiring)
   }
+  // A caller may point gpsd at an arbitrary host, so reject NaN/Inf and
+  // impossible coordinates rather than propagate them downstream.
+  if (!std::isfinite(lat) || !std::isfinite(lon) || lat < -90.0 || lat > 90.0 ||
+      lon < -180.0 || lon > 180.0) {
+    return false;
+  }
   Position p;
   p.latitude = lat;
   p.longitude = lon;
   double mode = 0.0;
-  // A TPV that carries lat/lon but omits mode still represents a fix; default
-  // to 3D so it counts as valid().
-  p.mode = FindNumber(line, "mode", mode) ? static_cast<int>(mode) : 3;
+  // A TPV that carries lat/lon but omits mode (or reports a non-finite mode)
+  // still represents a fix; default to 3D so it counts as valid().
+  p.mode = (FindNumber(line, "mode", mode) && std::isfinite(mode))
+               ? static_cast<int>(mode)
+               : 3;
   if (!p.valid()) {
     return false;
   }
   double track = 0.0;
-  if (FindNumber(line, "track", track)) {
+  if (FindNumber(line, "track", track) && std::isfinite(track)) {
     p.bearing_deg = track;
     p.has_bearing = true;
   }
   double speed = 0.0;
-  if (FindNumber(line, "speed", speed)) {
+  if (FindNumber(line, "speed", speed) && std::isfinite(speed) &&
+      speed >= 0.0) {
     p.speed_mps = speed;
   }
   out = p;

--- a/shared/src/location/gpsd_provider.cc
+++ b/shared/src/location/gpsd_provider.cc
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "gpsd_provider.hpp"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <utility>
+
+namespace ihs::location {
+
+namespace {
+
+// Extract the number following "key": in a compact gpsd JSON line. Returns
+// false if the key is absent or the value is not numeric. gpsd keys are
+// distinct tokens, so matching the quoted "key": literal avoids false hits.
+bool FindNumber(const std::string& s, const char* key, double& out) {
+  const std::string token = std::string("\"") + key + "\":";
+  const size_t at = s.find(token);
+  if (at == std::string::npos) {
+    return false;
+  }
+  const char* start = s.c_str() + at + token.size();
+  char* end = nullptr;
+  const double v = std::strtod(start, &end);
+  if (end == start) {
+    return false;
+  }
+  out = v;
+  return true;
+}
+
+constexpr char kWatchCommand[] = "?WATCH={\"enable\":true,\"json\":true}\r\n";
+
+}  // namespace
+
+bool ParseTpv(const std::string& line, Position& out) {
+  if (line.find("\"class\":\"TPV\"") == std::string::npos) {
+    return false;
+  }
+  double lat = 0.0;
+  double lon = 0.0;
+  if (!FindNumber(line, "lat", lat) || !FindNumber(line, "lon", lon)) {
+    return false;  // TPV without a position (e.g. mode 1 acquiring)
+  }
+  Position p;
+  p.latitude = lat;
+  p.longitude = lon;
+  double mode = 0.0;
+  // A TPV that carries lat/lon but omits mode still represents a fix; default
+  // to 3D so it counts as valid().
+  p.mode = FindNumber(line, "mode", mode) ? static_cast<int>(mode) : 3;
+  if (!p.valid()) {
+    return false;
+  }
+  double track = 0.0;
+  if (FindNumber(line, "track", track)) {
+    p.bearing_deg = track;
+    p.has_bearing = true;
+  }
+  double speed = 0.0;
+  if (FindNumber(line, "speed", speed)) {
+    p.speed_mps = speed;
+  }
+  out = p;
+  return true;
+}
+
+GpsdProvider::GpsdProvider(std::string host, uint16_t port)
+    : host_(std::move(host)), port_(port) {}
+
+GpsdProvider::~GpsdProvider() {
+  StopWorker();
+}
+
+bool GpsdProvider::Start() {
+  bool expected = false;
+  if (!running_.compare_exchange_strong(expected, true)) {
+    return true;  // already started
+  }
+  thread_ = std::thread([this] { Run(); });
+  return true;
+}
+
+void GpsdProvider::Stop() {
+  StopWorker();
+}
+
+void GpsdProvider::StopWorker() {
+  if (!running_.exchange(false)) {
+    return;  // already stopped
+  }
+  // Unblock a read() parked on the socket by shutting it down.
+  const int fd = sock_.load();
+  if (fd >= 0) {
+    ::shutdown(fd, SHUT_RDWR);
+  }
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+bool GpsdProvider::Latest(Position& out) {
+  const std::lock_guard<std::mutex> lock(mu_);
+  if (!have_fix_) {
+    return false;
+  }
+  out = latest_;
+  return true;
+}
+
+uint64_t GpsdProvider::generation() const {
+  return generation_.load();
+}
+
+void GpsdProvider::Run() {
+  while (running_.load()) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      continue;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port_);
+    if (::inet_pton(AF_INET, host_.c_str(), &addr.sin_addr) != 1 ||
+        ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+      ::close(fd);
+      // gpsd may not be up yet; retry until Stop().
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      continue;
+    }
+    sock_.store(fd);
+    ::send(fd, kWatchCommand, sizeof(kWatchCommand) - 1, MSG_NOSIGNAL);
+
+    // Read the byte stream and split into lines; gpsd delimits reports with \n.
+    std::string buf;
+    char chunk[2048];
+    while (running_.load()) {
+      const ssize_t n = ::recv(fd, chunk, sizeof(chunk), 0);
+      if (n <= 0) {
+        break;  // gpsd closed or shutdown() from Stop()
+      }
+      buf.append(chunk, static_cast<size_t>(n));
+      // Defensive: a gpsd report is a short single line. If a broken/hostile
+      // server streams without a newline, drop the backlog so buf can't grow
+      // without bound (resync on the next newline).
+      if (buf.size() > 65536 && buf.find('\n') == std::string::npos) {
+        buf.clear();
+      }
+      size_t nl = 0;
+      while ((nl = buf.find('\n')) != std::string::npos) {
+        const std::string line = buf.substr(0, nl);
+        buf.erase(0, nl + 1);
+        Position p;
+        if (ParseTpv(line, p)) {
+          {
+            const std::lock_guard<std::mutex> lock(mu_);
+            latest_ = p;
+            have_fix_ = true;
+          }
+          generation_.fetch_add(1);
+        }
+      }
+    }
+
+    sock_.store(-1);
+    ::close(fd);
+    if (running_.load()) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));  // reconnect
+    }
+  }
+}
+
+}  // namespace ihs::location

--- a/shared/src/location/gpsd_provider.hpp
+++ b/shared/src/location/gpsd_provider.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_GPSD_PROVIDER_H_
+#define IHS_LOC_GPSD_PROVIDER_H_
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "location.hpp"
+
+namespace ihs::location {
+
+// Parse one line of gpsd's JSON reporting protocol. Returns true and fills @out
+// only for a TPV (time-position-velocity) report that carries a usable fix
+// (mode >= 2 with lat/lon); every other class (VERSION, SKY, DEVICES, ...) and
+// any malformed line returns false. Split out from the socket so it can be
+// unit-tested against captured gpsd output. gpsd emits compact single-line
+// objects, so a targeted field scan is sufficient (no full JSON parser).
+bool ParseTpv(const std::string& line, Position& out);
+
+// ILocationProvider backed by gpsd (gpsd.io). Connects to the gpsd JSON socket
+// (default 127.0.0.1:2947), issues ?WATCH, and publishes each TPV fix. Runs a
+// worker thread that reconnects if gpsd drops, so it tolerates gpsd starting
+// after the map. This is the primary provider; GeoclueProvider is the fallback.
+class GpsdProvider : public ILocationProvider {
+ public:
+  explicit GpsdProvider(std::string host = "127.0.0.1", uint16_t port = 2947);
+  ~GpsdProvider() override;
+
+  GpsdProvider(const GpsdProvider&) = delete;
+  GpsdProvider& operator=(const GpsdProvider&) = delete;
+
+  bool Start() override;
+  void Stop() override;
+  bool Latest(Position& out) override;
+  [[nodiscard]] uint64_t generation() const override;
+
+ private:
+  void Run();         // worker: connect, WATCH, read TPV lines, publish
+  void StopWorker();  // non-virtual; Stop() and the destructor both call it
+
+  const std::string host_;
+  const uint16_t port_;
+
+  std::thread thread_;
+  std::atomic<bool> running_{false};
+  std::atomic<int> sock_{-1};  // current socket fd, -1 when not connected
+
+  mutable std::mutex mu_;
+  Position latest_;
+  bool have_fix_ = false;
+  std::atomic<uint64_t> generation_{0};
+};
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_GPSD_PROVIDER_H_

--- a/shared/src/location/location.hpp
+++ b/shared/src/location/location.hpp
@@ -11,9 +11,19 @@
 #ifndef IHS_LOC_LOCATION_H_
 #define IHS_LOC_LOCATION_H_
 
+#include <cmath>
 #include <cstdint>
 
 namespace ihs::location {
+
+// A coordinate is usable only if finite and within the geographic range. Both
+// providers validate before publishing so a malformed source (an arbitrary
+// gpsd host, a bad D-Bus reply) can't push NaN/Inf or impossible coordinates to
+// consumers doing projection/camera math.
+inline bool ValidLatLon(double lat, double lon) {
+  return std::isfinite(lat) && std::isfinite(lon) && lat >= -90.0 &&
+         lat <= 90.0 && lon >= -180.0 && lon <= 180.0;
+}
 
 // One location fix, provider-agnostic. Consumers (the map camera, a puck)
 // read this; whether it came from gpsd, geoclue, or a test source is hidden

--- a/shared/src/location/location.hpp
+++ b/shared/src/location/location.hpp
@@ -22,7 +22,7 @@ struct Position {
   double latitude = 0.0;
   double longitude = 0.0;
   double bearing_deg = 0.0;  // course over ground; valid only if has_bearing
-  double speed_mps = 0.0;    // ground speed, meters/second
+  double speed_mps = -1.0;   // ground speed m/s; < 0 means unknown
   int mode = 0;              // gpsd-style fix mode: <2 no fix, 2 = 2D, 3 = 3D
   bool has_bearing = false;
 

--- a/shared/src/location/location.hpp
+++ b/shared/src/location/location.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_LOCATION_H_
+#define IHS_LOC_LOCATION_H_
+
+#include <cstdint>
+
+namespace ihs::location {
+
+// One location fix, provider-agnostic. Consumers (the map camera, a puck)
+// read this; whether it came from gpsd, geoclue, or a test source is hidden
+// behind ILocationProvider.
+struct Position {
+  double latitude = 0.0;
+  double longitude = 0.0;
+  double bearing_deg = 0.0;  // course over ground; valid only if has_bearing
+  double speed_mps = 0.0;    // ground speed, meters/second
+  int mode = 0;              // gpsd-style fix mode: <2 no fix, 2 = 2D, 3 = 3D
+  bool has_bearing = false;
+
+  [[nodiscard]] bool valid() const { return mode >= 2; }
+};
+
+// A source of location fixes. Implementations (GpsdProvider, later
+// GeoclueProvider) acquire asynchronously on their own thread and publish the
+// latest fix; consumers poll. Kept deliberately small so it can move to a
+// shared location service later without dragging the map along.
+class ILocationProvider {
+ public:
+  virtual ~ILocationProvider() = default;
+
+  // Begin acquiring (starts the provider's worker). Returns false if the
+  // provider could not start at all; a transient source (no fix yet) still
+  // returns true and reports fixes as they arrive.
+  virtual bool Start() = 0;
+
+  // Stop acquiring and join the worker. Idempotent.
+  virtual void Stop() = 0;
+
+  // Copy the most recent fix into @out. Returns false until a valid fix exists.
+  virtual bool Latest(Position& out) = 0;
+
+  // Monotonic counter bumped on each new fix, so a consumer can cheaply tell
+  // whether the fix changed since it last looked (no timestamps needed).
+  [[nodiscard]] virtual uint64_t generation() const = 0;
+};
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_LOCATION_H_

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// C-ABI front (ihs_location_*) over the internal C++ providers. See
+// include/ihs/location.h for the contract.
+
+#include "ihs/location.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <new>
+#include <string>
+#include <utility>
+
+#include "fallback_location_provider.hpp"
+#include "geoclue_provider.hpp"
+#include "gpsd_provider.hpp"
+#include "location.hpp"
+
+// The opaque handle simply owns a running provider.
+struct IhsLocationService {
+  std::unique_ptr<ihs::location::ILocationProvider> provider;
+};
+
+namespace {
+
+// gpsd from an optional "host:port" (default 127.0.0.1:2947).
+std::unique_ptr<ihs::location::ILocationProvider> MakeGpsd(const char* config) {
+  std::string host = "127.0.0.1";
+  uint16_t port = 2947;
+  if (config != nullptr && config[0] != '\0') {
+    const std::string v(config);
+    if (const std::string::size_type c = v.find(':'); c != std::string::npos) {
+      host = v.substr(0, c);
+      const int p = std::atoi(v.c_str() + c + 1);
+      if (p > 0 && p < 65536) {
+        port = static_cast<uint16_t>(p);
+      }
+    } else {
+      host = v;
+    }
+  }
+  return std::make_unique<ihs::location::GpsdProvider>(host, port);
+}
+
+// geoclue with an optional bus address (empty => system bus).
+std::unique_ptr<ihs::location::ILocationProvider> MakeGeoclue(
+    const char* config) {
+  return std::make_unique<ihs::location::GeoclueProvider>(
+      "ihs-location", config != nullptr ? config : "");
+}
+
+}  // namespace
+
+extern "C" {
+
+IhsLocationService* ihs_location_start(IhsLocationSource source,
+                                       const char* config) {
+  std::unique_ptr<ihs::location::ILocationProvider> provider;
+  switch (source) {
+    case IHS_LOCATION_GEOCLUE:
+      provider = MakeGeoclue(config);
+      break;
+    case IHS_LOCATION_AUTO:
+      provider = std::make_unique<ihs::location::FallbackLocationProvider>(
+          MakeGpsd(nullptr), MakeGeoclue(nullptr));
+      break;
+    case IHS_LOCATION_GPSD:
+    default:
+      provider = MakeGpsd(config);
+      break;
+  }
+  if (!provider) {
+    return nullptr;
+  }
+  auto* service = new (std::nothrow) IhsLocationService{std::move(provider)};
+  if (service == nullptr) {
+    return nullptr;
+  }
+  service->provider->Start();
+  return service;
+}
+
+int ihs_location_latest(IhsLocationService* service, IhsPosition* out) {
+  if (service == nullptr || !service->provider || out == nullptr) {
+    return 0;
+  }
+  ihs::location::Position pos;
+  if (!service->provider->Latest(pos)) {
+    return 0;
+  }
+  out->latitude = pos.latitude;
+  out->longitude = pos.longitude;
+  out->bearing_deg = pos.bearing_deg;
+  out->speed_mps = pos.speed_mps;
+  out->mode = pos.mode;
+  out->has_bearing = pos.has_bearing ? 1 : 0;
+  return 1;
+}
+
+uint64_t ihs_location_generation(IhsLocationService* service) {
+  return (service != nullptr && service->provider)
+             ? service->provider->generation()
+             : 0;
+}
+
+void ihs_location_stop(IhsLocationService* service) {
+  if (service == nullptr) {
+    return;
+  }
+  if (service->provider) {
+    service->provider->Stop();
+  }
+  delete service;
+}
+
+}  // extern "C"

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -40,9 +40,12 @@ std::unique_ptr<ihs::location::ILocationProvider> MakeGpsd(const char* config) {
     const std::string v(config);
     if (const std::string::size_type c = v.find(':'); c != std::string::npos) {
       host = v.substr(0, c);
+      const char* pstr = v.c_str() + c + 1;
       char* end = nullptr;
-      const long p = std::strtol(v.c_str() + c + 1, &end, 10);
-      if (p > 0 && p < 65536) {
+      const long p = std::strtol(pstr, &end, 10);
+      // Require the whole substring to be the number (no trailing garbage) and
+      // a valid port; otherwise keep the default.
+      if (end != pstr && *end == '\0' && p > 0 && p < 65536) {
         port = static_cast<uint16_t>(p);
       }
     } else {

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -104,31 +104,45 @@ int ihs_location_latest(IhsLocationService* service, IhsPosition* out) {
   if (service == nullptr || !service->provider || out == nullptr) {
     return 0;
   }
-  ihs::location::Position pos;
-  if (!service->provider->Latest(pos)) {
+  try {
+    ihs::location::Position pos;
+    if (!service->provider->Latest(pos)) {
+      return 0;
+    }
+    out->latitude = pos.latitude;
+    out->longitude = pos.longitude;
+    out->bearing_deg = pos.bearing_deg;
+    out->speed_mps = pos.speed_mps;
+    out->mode = pos.mode;
+    out->has_bearing = pos.has_bearing ? 1 : 0;
+    return 1;
+  } catch (...) {
     return 0;
   }
-  out->latitude = pos.latitude;
-  out->longitude = pos.longitude;
-  out->bearing_deg = pos.bearing_deg;
-  out->speed_mps = pos.speed_mps;
-  out->mode = pos.mode;
-  out->has_bearing = pos.has_bearing ? 1 : 0;
-  return 1;
 }
 
 uint64_t ihs_location_generation(IhsLocationService* service) {
-  return (service != nullptr && service->provider)
-             ? service->provider->generation()
-             : 0;
+  if (service == nullptr || !service->provider) {
+    return 0;
+  }
+  try {
+    return service->provider->generation();
+  } catch (...) {
+    return 0;
+  }
 }
 
 void ihs_location_stop(IhsLocationService* service) {
   if (service == nullptr) {
     return;
   }
-  if (service->provider) {
-    service->provider->Stop();
+  // No exception may cross the C ABI; if a provider's Stop() throws, swallow it
+  // and still free the handle.
+  try {
+    if (service->provider) {
+      service->provider->Stop();
+    }
+  } catch (...) {
   }
   delete service;
 }

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -39,7 +39,9 @@ std::unique_ptr<ihs::location::ILocationProvider> MakeGpsd(const char* config) {
   if (config != nullptr && config[0] != '\0') {
     const std::string v(config);
     if (const std::string::size_type c = v.find(':'); c != std::string::npos) {
-      host = v.substr(0, c);
+      if (c > 0) {
+        host = v.substr(0, c);  // ":2947" (empty host) keeps the default host
+      }
       const char* pstr = v.c_str() + c + 1;
       char* end = nullptr;
       const long p = std::strtol(pstr, &end, 10);

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -40,7 +40,8 @@ std::unique_ptr<ihs::location::ILocationProvider> MakeGpsd(const char* config) {
     const std::string v(config);
     if (const std::string::size_type c = v.find(':'); c != std::string::npos) {
       host = v.substr(0, c);
-      const int p = std::atoi(v.c_str() + c + 1);
+      char* end = nullptr;
+      const long p = std::strtol(v.c_str() + c + 1, &end, 10);
       if (p > 0 && p < 65536) {
         port = static_cast<uint16_t>(p);
       }
@@ -64,29 +65,34 @@ extern "C" {
 
 IhsLocationService* ihs_location_start(IhsLocationSource source,
                                        const char* config) {
-  std::unique_ptr<ihs::location::ILocationProvider> provider;
-  switch (source) {
-    case IHS_LOCATION_GEOCLUE:
-      provider = MakeGeoclue(config);
-      break;
-    case IHS_LOCATION_AUTO:
-      provider = std::make_unique<ihs::location::FallbackLocationProvider>(
-          MakeGpsd(nullptr), MakeGeoclue(nullptr));
-      break;
-    case IHS_LOCATION_GPSD:
-    default:
-      provider = MakeGpsd(config);
-      break;
-  }
-  if (!provider) {
+  // No exception may cross this C ABI boundary: provider construction and
+  // Start() (allocations, std::thread) can throw, so translate any failure to
+  // a NULL return.
+  try {
+    std::unique_ptr<ihs::location::ILocationProvider> provider;
+    switch (source) {
+      case IHS_LOCATION_GEOCLUE:
+        provider = MakeGeoclue(config);
+        break;
+      case IHS_LOCATION_AUTO:
+        provider = std::make_unique<ihs::location::FallbackLocationProvider>(
+            MakeGpsd(nullptr), MakeGeoclue(nullptr));
+        break;
+      case IHS_LOCATION_GPSD:
+      default:
+        provider = MakeGpsd(config);
+        break;
+    }
+    if (!provider) {
+      return nullptr;
+    }
+    auto service = std::make_unique<IhsLocationService>();
+    service->provider = std::move(provider);
+    service->provider->Start();
+    return service.release();
+  } catch (...) {
     return nullptr;
   }
-  auto* service = new (std::nothrow) IhsLocationService{std::move(provider)};
-  if (service == nullptr) {
-    return nullptr;
-  }
-  service->provider->Start();
-  return service;
 }
 
 int ihs_location_latest(IhsLocationService* service, IhsPosition* out) {

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -88,7 +88,9 @@ IhsLocationService* ihs_location_start(IhsLocationSource source,
     }
     auto service = std::make_unique<IhsLocationService>();
     service->provider = std::move(provider);
-    service->provider->Start();
+    if (!service->provider->Start()) {
+      return nullptr;  // could not start at all — don't hand back a dead handle
+    }
     return service.release();
   } catch (...) {
     return nullptr;

--- a/shared/src/location/sd_bus_dynamic.cc
+++ b/shared/src/location/sd_bus_dynamic.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "sd_bus_dynamic.hpp"
+
+#include <dlfcn.h>
+
+#include <mutex>
+
+namespace ihs::location {
+
+namespace {
+
+// Resolve one symbol into @slot; records failure in @ok.
+template <typename Fn>
+void Resolve(void* handle, const char* name, Fn& slot, bool& ok) {
+  slot = reinterpret_cast<Fn>(dlsym(handle, name));
+  if (slot == nullptr) {
+    ok = false;
+  }
+}
+
+}  // namespace
+
+const SdBusApi* SdBusLoad() {
+  static SdBusApi api{};
+  static bool loaded = false;
+  static std::once_flag once;
+  std::call_once(once, [] {
+    void* h = dlopen("libsystemd.so.0", RTLD_NOW | RTLD_LOCAL);
+    if (h == nullptr) {
+      return;  // libsystemd absent -> geoclue unavailable
+    }
+    bool ok = true;
+    Resolve(h, "sd_bus_open_system", api.open_system, ok);
+    Resolve(h, "sd_bus_open_user", api.open_user, ok);
+    Resolve(h, "sd_bus_new", api.bus_new, ok);
+    Resolve(h, "sd_bus_set_address", api.set_address, ok);
+    Resolve(h, "sd_bus_set_bus_client", api.set_bus_client, ok);
+    Resolve(h, "sd_bus_start", api.start, ok);
+    Resolve(h, "sd_bus_call_method", api.call_method, ok);
+    Resolve(h, "sd_bus_message_read", api.message_read, ok);
+    Resolve(h, "sd_bus_message_unref", api.message_unref, ok);
+    Resolve(h, "sd_bus_set_property", api.set_property, ok);
+    Resolve(h, "sd_bus_match_signal", api.match_signal, ok);
+    Resolve(h, "sd_bus_get_property_trivial", api.get_property_trivial, ok);
+    Resolve(h, "sd_bus_process", api.process, ok);
+    Resolve(h, "sd_bus_wait", api.wait, ok);
+    Resolve(h, "sd_bus_flush_close_unref", api.flush_close_unref, ok);
+    Resolve(h, "sd_bus_error_free", api.error_free, ok);
+    loaded = ok;
+    // Intentionally leak @h: the library stays mapped for the process lifetime
+    // (like the DLT loader), so the resolved pointers remain valid.
+  });
+  return loaded ? &api : nullptr;
+}
+
+}  // namespace ihs::location

--- a/shared/src/location/sd_bus_dynamic.cc
+++ b/shared/src/location/sd_bus_dynamic.cc
@@ -56,8 +56,13 @@ const SdBusApi* SdBusLoad() {
     Resolve(h, "sd_bus_flush_close_unref", api.flush_close_unref, ok);
     Resolve(h, "sd_bus_error_free", api.error_free, ok);
     loaded = ok;
-    // Intentionally leak @h: the library stays mapped for the process lifetime
-    // (like the DLT loader), so the resolved pointers remain valid.
+    if (ok) {
+      // Intentionally leak @h on success: the library stays mapped for the
+      // process lifetime (like the DLT loader) so the resolved pointers stay
+      // valid.
+    } else {
+      dlclose(h);  // resolution failed; unmap rather than leave a dead mapping
+    }
   });
   return loaded ? &api : nullptr;
 }

--- a/shared/src/location/sd_bus_dynamic.hpp
+++ b/shared/src/location/sd_bus_dynamic.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_SD_BUS_DYNAMIC_HPP_
+#define IHS_LOC_SD_BUS_DYNAMIC_HPP_
+
+// Runtime loader for the slice of sd-bus (libsystemd) the geoclue provider
+// uses, so ihs_shared gains no build-time or link-time dependency on
+// libsystemd — matching how the DLT sink dlopens libdlt. The types below are
+// the stable public sd-bus ABI (so this compiles with no libsystemd headers
+// present); the functions are resolved from libsystemd.so.0 at first use, and
+// if that library is absent geoclue simply reports no fix.
+
+#include <cstdint>
+
+extern "C" {
+
+// Opaque sd-bus handles.
+struct sd_bus;
+struct sd_bus_message;
+struct sd_bus_slot;
+
+// Public sd_bus_error layout (sd-bus.h): { const char*; const char*; int; }.
+struct sd_bus_error {
+  const char* name;
+  const char* message;
+  int need_free;
+};
+
+using sd_bus_message_handler_t = int (*)(sd_bus_message*, void*, sd_bus_error*);
+
+}  // extern "C"
+
+namespace ihs::location {
+
+// The resolved sd-bus entry points. Signatures mirror sd-bus.h; the variadic
+// ones (call_method / message_read / set_property) keep the "..." so callers
+// pass the D-Bus argument list exactly as with the real API.
+struct SdBusApi {
+  int (*open_system)(sd_bus**);
+  int (*open_user)(sd_bus**);
+  int (*bus_new)(sd_bus**);
+  int (*set_address)(sd_bus*, const char*);
+  int (*set_bus_client)(sd_bus*, int);
+  int (*start)(sd_bus*);
+  int (*call_method)(sd_bus*,
+                     const char*,
+                     const char*,
+                     const char*,
+                     const char*,
+                     sd_bus_error*,
+                     sd_bus_message**,
+                     const char*,
+                     ...);
+  int (*message_read)(sd_bus_message*, const char*, ...);
+  sd_bus_message* (*message_unref)(sd_bus_message*);
+  int (*set_property)(sd_bus*,
+                      const char*,
+                      const char*,
+                      const char*,
+                      const char*,
+                      sd_bus_error*,
+                      const char*,
+                      ...);
+  int (*match_signal)(sd_bus*,
+                      sd_bus_slot**,
+                      const char*,
+                      const char*,
+                      const char*,
+                      const char*,
+                      sd_bus_message_handler_t,
+                      void*);
+  int (*get_property_trivial)(sd_bus*,
+                              const char*,
+                              const char*,
+                              const char*,
+                              const char*,
+                              sd_bus_error*,
+                              char,
+                              void*);
+  int (*process)(sd_bus*, sd_bus_message**);
+  int (*wait)(sd_bus*, uint64_t);
+  sd_bus* (*flush_close_unref)(sd_bus*);
+  void (*error_free)(sd_bus_error*);
+};
+
+// Resolve libsystemd.so.0 once (thread-safe) and return its sd-bus entry
+// points, or nullptr if the library is not present or a symbol is missing.
+const SdBusApi* SdBusLoad();
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_SD_BUS_DYNAMIC_HPP_

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -27,6 +27,7 @@
 
 #include "ihs/config.h"
 #include "ihs/ihs.h"
+#include "ihs/location.h"
 #include "ihs/logging.h"
 #include "ihs/trace.h"
 
@@ -88,6 +89,22 @@ int main(void) {
     api->logging->flush();
     api->logging->stop();
   }
+
+  /* Location: exercise the ihs_location_* ABI without needing gpsd or geoclue
+   * present. Point gpsd at a dead port so no fix is ever produced, and assert
+   * the contract: a handle is returned, no fix, generation 0, and stop frees
+   * cleanly. This guards the ABI/headers against regressions in CI. */
+  IhsLocationService* loc =
+      ihs_location_start(IHS_LOCATION_GPSD, "127.0.0.1:9");
+  CHECK(loc != NULL, "ihs_location_start returned NULL");
+  IhsPosition pos;
+  CHECK(ihs_location_latest(loc, &pos) == 0,
+        "no fix expected from a dead port");
+  CHECK(ihs_location_generation(loc) == 0, "generation 0 before any fix");
+  ihs_location_stop(loc);
+  CHECK(ihs_location_latest(NULL, &pos) == 0, "latest(NULL) is safe");
+  CHECK(ihs_location_generation(NULL) == 0, "generation(NULL) is 0");
+  ihs_location_stop(NULL); /* must be a safe nop */
 
   printf("OK ihs_shared consumer smoke: abi=0x%08x logging=%s\n",
          api->abi_version, api->logging != NULL ? "present" : "absent");

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -1,0 +1,37 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Unit test for the internal gpsd TPV parser. Standalone (like tests/consumer):
+# configured from an empty tree; compiles the provider source directly because
+# ParseTpv is internal, not part of the installed C ABI. Driven by
+# .github/workflows/ihs-shared.yml.
+
+cmake_minimum_required(VERSION 3.16)
+project(ihs_location_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+find_package(Threads REQUIRED)
+
+set(_loc_src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/location)
+
+add_executable(parse_tpv_test parse_tpv_test.cc ${_loc_src}/gpsd_provider.cc)
+target_include_directories(parse_tpv_test PRIVATE ${_loc_src})
+target_compile_options(parse_tpv_test PRIVATE -Wall -Wextra)
+target_link_libraries(parse_tpv_test PRIVATE Threads::Threads)
+
+add_test(NAME parse_tpv COMMAND parse_tpv_test)

--- a/shared/tests/location/parse_tpv_test.cc
+++ b/shared/tests/location/parse_tpv_test.cc
@@ -76,6 +76,16 @@ int main() {
   Expect(!ParseTpv("not json", p), "garbage rejected");
   Expect(!ParseTpv("", p), "empty rejected");
 
+  // Out-of-range / non-finite coordinates are rejected.
+  Expect(!ParseTpv(R"({"class":"TPV","mode":3,"lat":91.0,"lon":0.0})", p),
+         "latitude > 90 rejected");
+  Expect(!ParseTpv(R"({"class":"TPV","mode":3,"lat":0.0,"lon":-181.0})", p),
+         "longitude < -180 rejected");
+  Expect(!ParseTpv(R"({"class":"TPV","mode":3,"lat":nan,"lon":0.0})", p),
+         "NaN latitude rejected");
+  Expect(!ParseTpv(R"({"class":"TPV","mode":3,"lat":0.0,"lon":inf})", p),
+         "Inf longitude rejected");
+
   std::printf(g_fails ? "\n%d FAILED\n" : "\nALL PASS\n", g_fails);
   return g_fails == 0 ? 0 : 1;
 }

--- a/shared/tests/location/parse_tpv_test.cc
+++ b/shared/tests/location/parse_tpv_test.cc
@@ -86,6 +86,12 @@ int main() {
   Expect(!ParseTpv(R"({"class":"TPV","mode":3,"lat":0.0,"lon":inf})", p),
          "Inf longitude rejected");
 
+  // Only mode 2/3 are fixes: a valid position with mode 4 or 1 is rejected.
+  Expect(!ParseTpv(R"({"class":"TPV","mode":4,"lat":10.0,"lon":10.0})", p),
+         "mode 4 rejected even with a position");
+  Expect(!ParseTpv(R"({"class":"TPV","mode":1,"lat":10.0,"lon":10.0})", p),
+         "mode 1 rejected even with a position");
+
   std::printf(g_fails ? "\n%d FAILED\n" : "\nALL PASS\n", g_fails);
   return g_fails == 0 ? 0 : 1;
 }

--- a/shared/tests/location/parse_tpv_test.cc
+++ b/shared/tests/location/parse_tpv_test.cc
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Unit test for GpsdProvider::ParseTpv — the gpsd JSON parsing that was split
+// out from the socket precisely so it could be tested against captured output.
+// Compiles the provider source directly (ParseTpv is internal, not part of the
+// C ABI). No socket, gpsd, or D-Bus needed.
+
+#include <cstdio>
+#include <string>
+
+#include "gpsd_provider.hpp"
+
+using ihs::location::ParseTpv;
+using ihs::location::Position;
+
+namespace {
+int g_fails = 0;
+void Expect(bool cond, const char* what) {
+  std::printf("  [%s] %s\n", cond ? "ok" : "FAIL", what);
+  if (!cond) {
+    ++g_fails;
+  }
+}
+}  // namespace
+
+int main() {
+  Position p;
+
+  // A real gpsd 3D fix with track + speed.
+  const bool r =
+      ParseTpv(R"({"class":"TPV","device":"/dev/pts/3","mode":3,)"
+               R"("lat":37.774900,"lon":-122.419400,"alt":12.3,"track":95.4,)"
+               R"("speed":1.34})",
+               p);
+  Expect(r && p.valid() && p.mode == 3, "TPV 3D parses and is valid");
+  Expect(p.latitude > 37.7 && p.latitude < 37.8, "latitude ~37.77");
+  Expect(p.longitude < -122.4 && p.longitude > -122.5, "longitude ~-122.42");
+  Expect(p.has_bearing && p.bearing_deg > 95.0 && p.bearing_deg < 96.0,
+         "track 95.4 -> bearing");
+  Expect(p.speed_mps > 1.3 && p.speed_mps < 1.4, "speed 1.34");
+
+  // Non-TPV classes are rejected.
+  Expect(!ParseTpv(R"({"class":"VERSION","release":"3.22"})", p),
+         "VERSION rejected");
+  Expect(!ParseTpv(R"({"class":"SKY","satellites":[]})", p), "SKY rejected");
+
+  // TPV acquiring (mode 1, no position) is rejected.
+  Expect(!ParseTpv(R"({"class":"TPV","mode":1})", p),
+         "TPV mode 1 (no position) rejected");
+
+  // TPV 2D with a position is accepted.
+  Expect(ParseTpv(R"({"class":"TPV","mode":2,"lat":51.5,"lon":-0.12})", p) &&
+             p.mode == 2,
+         "TPV 2D accepted");
+
+  // TPV with lat/lon but no mode is treated as a fix.
+  Position q;
+  Expect(ParseTpv(R"({"class":"TPV","lat":48.85,"lon":2.35})", q) && q.valid(),
+         "TPV without mode assumes a fix");
+
+  // Malformed input.
+  Expect(!ParseTpv("not json", p), "garbage rejected");
+  Expect(!ParseTpv("", p), "empty rejected");
+
+  std::printf(g_fails ? "\n%d FAILED\n" : "\nALL PASS\n", g_fails);
+  return g_fails == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What
A single shared location service in `ihs_shared`, fronting gpsd and geoclue, so any consumer (a map's puck, a nav plugin, Dart via FFI) polls one place instead of re-implementing acquisition per plugin. First half of lifting the map's private `ILocationProvider` to a shared service; the maplibre_view side migrates to this C ABI in a follow-up.

## How
- **`ihs/location.h`** — the C ABI: `IhsPosition`, `IhsLocationSource` (gpsd / geoclue / auto), and `ihs_location_start/latest/generation/stop` over an opaque `IhsLocationService`. `speed_mps < 0` means unknown; geoclue's `@config` accepts a D-Bus address or the literal `"user"` (session bus).
- **`src/location/`** — the providers (threaded gpsd JSON-socket client, geoclue D-Bus client, gpsd-primary/geoclue-fallback combiner) + `location_api.cc` bridging them to the C ABI. `ihs_location_start` and each provider `Start()` are exception-safe across the C boundary. The version script already scopes exports to `ihs_*`.
- **No new dependency on the core lib.** geoclue's sd-bus is loaded from `libsystemd.so.0` at **runtime via `dlopen`** — exactly as the DLT sink loads libdlt — so `ihs_shared` keeps **no build- or link-time dependency on libsystemd** (only libdl); a small shim even defines the sd-bus types so it compiles without the headers. If libsystemd is absent at runtime, geoclue reports no fix and gpsd/auto are unaffected.

## Tests
- The out-of-tree `consumer` smoke now exercises the `ihs_location_*` ABI (dead-port gpsd → no fix, NULL-safety).
- A new standalone `parse_tpv` unit test covers the gpsd TPV parser (fixes, non-TPV classes, missing position, malformed input).
- Both wired into `.github/workflows/ihs-shared.yml`.

## Validation
On a host with a **real u-blox ZED-F9P GNSS + live geoclue**, via the C ABI: `AUTO` → the GPS fix with real speed/bearing; `GEOCLUE` → the network fix with `speed_mps == -1` (unknown); `GPSD` at a dead port → no fix. No `DT_NEEDED` on libsystemd; `ihs_location_*` exported, C++ internals local.