### PR TITLE
platform-views: bound the frame copy by the caller's struct_size

### DIFF
--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -144,6 +144,13 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // each of its frames is imported afresh instead of aliasing cache slot 0.
   uint32_t rolling_buffer_id{0};
 
+  // Set once an id has been synthesised (the plugin's IhsFrame predates
+  // buffer_id). Synthesised ids never repeat, so the import cache can never
+  // reuse them; for such a view the import paths keep only the current import
+  // and retire the rest, so the cache stays bounded instead of accumulating a
+  // VkImage/GL texture (and its dma-buf) per frame for the producer's lifetime.
+  bool synth_buffer_id{false};
+
   // Deliver-once guard for the direct-scanout path: the submit_seq last handed
   // to GetDmabuf. The compositor commits faster than a 30fps producer submits,
   // so a reused overlay layer polls GetDmabuf every present; without this it
@@ -555,6 +562,21 @@ uint32_t IhsPluginView::GetGlTextureName() const {
       if (g_egl_importer.Import(f, &imported)) {
         auto [pos, ins] = buffers_egl.emplace(f.buffer_id, imported);
         current_egl = &pos->second;
+        // Synthesised ids never repeat, so every earlier entry is dead. Retire
+        // them (the reap margin covers a compositor present still binding one)
+        // so the cache holds just the current import rather than growing per
+        // frame.
+        if (synth_buffer_id) {
+          for (auto bit = buffers_egl.begin(); bit != buffers_egl.end();) {
+            if (bit->first != f.buffer_id) {
+              retired_egl.push_back(
+                  {bit->second, submit_seq + kImportRetireMargin});
+              bit = buffers_egl.erase(bit);
+            } else {
+              ++bit;
+            }
+          }
+        }
       } else {
         CloseFrameFds(&f);  // import left the fds untouched on failure
       }
@@ -821,6 +843,7 @@ int HostSubmit(void* user_data,
   if (frame->struct_size <
       offsetof(IhsFrame, buffer_id) + sizeof(normalized.buffer_id)) {
     normalized.buffer_id = v->rolling_buffer_id++;
+    v->synth_buffer_id = true;
   }
   frame = &normalized;
 
@@ -934,6 +957,20 @@ int HostSubmit(void* user_data,
     // Import consumed plane_fd[0]; a single-plane RGB frame owns no other fds.
     auto [pos, inserted] = v->buffers.emplace(frame->buffer_id, imported);
     v->current = &pos->second;
+    // Synthesised ids never repeat, so every earlier entry is dead. Retire them
+    // (the reap margin covers a compositor present still binding one) so the
+    // cache holds just the current import rather than growing per frame.
+    if (v->synth_buffer_id) {
+      for (auto bit = v->buffers.begin(); bit != v->buffers.end();) {
+        if (bit->first != frame->buffer_id) {
+          v->retired.push_back(
+              {bit->second, v->submit_seq + kImportRetireMargin});
+          bit = v->buffers.erase(bit);
+        } else {
+          ++bit;
+        }
+      }
+    }
   }
 
   // The plugin re-rendered the buffer before submitting, so the compositor

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <map>
@@ -138,6 +139,10 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
 
   // Common retire clock for both import paths (incremented on every submit).
   uint64_t submit_seq{0};
+
+  // Synthesised buffer_id for a plugin whose IhsFrame predates that field, so
+  // each of its frames is imported afresh instead of aliasing cache slot 0.
+  uint32_t rolling_buffer_id{0};
 
   // Deliver-once guard for the direct-scanout path: the submit_seq last handed
   // to GetDmabuf. The compositor commits faster than a 30fps producer submits,
@@ -787,6 +792,37 @@ int HostSubmit(void* user_data,
 
   (void)user_data;
   auto* v = reinterpret_cast<IhsPluginView*>(view);
+
+  // The plugin may be built against an older, smaller IhsFrame. Copying *frame
+  // whole would read past the end of its object, and the trailing buffer_id
+  // (the import-cache key) would be garbage. Copy only the bytes it provided
+  // into a full-size zeroed frame; fields its struct did not reach read as
+  // zero. A struct too small to even carry the plane data is rejected -- and
+  // not closed, since plane_count/plane_fd cannot be trusted either.
+  IhsFrame normalized{};
+  if (frame == nullptr ||
+      frame->struct_size <
+          offsetof(IhsFrame, plane_stride) + sizeof(normalized.plane_stride)) {
+    if (acquire_fence_fd >= 0) {
+      close(acquire_fence_fd);
+    }
+    ihs::log::warn(
+        "[ihs_pv] submit rejected: IhsFrame struct_size {} too small",
+        frame != nullptr ? frame->struct_size : 0);
+    return IHS_PV_ERR_INVALID;
+  }
+  const size_t copy = frame->struct_size < sizeof(IhsFrame) ? frame->struct_size
+                                                            : sizeof(IhsFrame);
+  std::memcpy(&normalized, frame, copy);
+  normalized.struct_size = sizeof(IhsFrame);
+  // buffer_id absent from the plugin's struct read as 0, which would key every
+  // frame on one cache slot and freeze on the first. Give each such frame a
+  // fresh id so it is imported rather than aliased.
+  if (frame->struct_size <
+      offsetof(IhsFrame, buffer_id) + sizeof(normalized.buffer_id)) {
+    normalized.buffer_id = v->rolling_buffer_id++;
+  }
+  frame = &normalized;
 
 #if IVI_HAVE_VULKAN
   const bool vulkan_ready = g_importer.ready();


### PR DESCRIPTION
## The bug

`HostSubmit` copies the incoming frame whole and reads its newest field directly:

```cpp
v->pending_egl.frame = *frame;      // sizeof(IhsFrame) bytes
...
const auto it = v->buffers.find(frame->buffer_id);   // the import-cache key
```

Both assume the caller's object is the size this shell was compiled against. The ABI is `struct_size`-first and additive by contract, so a plugin built against an **older** header passes a **smaller** `IhsFrame` — and `*frame` then reads past the end of it. What lands in the trailing `buffer_id` is whatever followed the caller's object, and that value is used as the import-cache key.

Nothing validated the incoming `struct_size`; the field existed for exactly this and was unused on the submit path.

## The fix

Normalise once at the top of `HostSubmit`, before either the EGL or Vulkan branch:

- Copy only `min(sizeof(IhsFrame), frame->struct_size)` bytes into a full-size zeroed local. Fields the caller's struct did not reach read as zero, not garbage.
- Reject a struct too small to carry the plane data (`< offsetof(IhsFrame, plane_stride) + sizeof plane_stride`), and do **not** close its fds — `plane_count`/`plane_fd` can't be trusted either at that size.
- If the caller's struct predates `buffer_id`, that field read as 0, which would key every frame on cache slot 0 and freeze on the first frame. Synthesise a fresh rolling id instead — the documented behaviour for a producer with no ring identity ("a plugin that hands a fresh dma-buf every frame ... uses a rolling id").

## Compatibility

A caller built against the current or a newer header is unaffected: `copy == sizeof(IhsFrame)`, the memcpy equals the old `*frame`, and `buffer_id` is preserved. Verified on `wayland-egl` with a hardware-decoded NV12 stream — zero import errors, no rejects, picture unchanged.