### PR TITLE
platform-views: make the synthesised-id fields atomic

### DIFF
--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -32,6 +32,7 @@
 #include <poll.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
@@ -142,14 +143,19 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
 
   // Synthesised buffer_id for a plugin whose IhsFrame predates that field, so
   // each of its frames is imported afresh instead of aliasing cache slot 0.
-  uint32_t rolling_buffer_id{0};
+  // Atomic: written on the plugin thread in HostSubmit (outside v->mutex) and,
+  // if a view ever sees concurrent submits, the increment must not tear.
+  std::atomic<uint32_t> rolling_buffer_id{0};
 
   // Set once an id has been synthesised (the plugin's IhsFrame predates
   // buffer_id). Synthesised ids never repeat, so the import cache can never
   // reuse them; for such a view the import paths keep only the current import
   // and retire the rest, so the cache stays bounded instead of accumulating a
   // VkImage/GL texture (and its dma-buf) per frame for the producer's lifetime.
-  bool synth_buffer_id{false};
+  // Atomic: written on the plugin thread (HostSubmit, outside v->mutex) and
+  // read on the raster thread (GetGlTextureName / GetVulkanImage, under
+  // v->mutex).
+  std::atomic<bool> synth_buffer_id{false};
 
   // Deliver-once guard for the direct-scanout path: the submit_seq last handed
   // to GetDmabuf. The compositor commits faster than a 30fps producer submits,
@@ -566,7 +572,7 @@ uint32_t IhsPluginView::GetGlTextureName() const {
         // them (the reap margin covers a compositor present still binding one)
         // so the cache holds just the current import rather than growing per
         // frame.
-        if (synth_buffer_id) {
+        if (synth_buffer_id.load()) {
           for (auto bit = buffers_egl.begin(); bit != buffers_egl.end();) {
             if (bit->first != f.buffer_id) {
               retired_egl.push_back(
@@ -842,8 +848,8 @@ int HostSubmit(void* user_data,
   // fresh id so it is imported rather than aliased.
   if (frame->struct_size <
       offsetof(IhsFrame, buffer_id) + sizeof(normalized.buffer_id)) {
-    normalized.buffer_id = v->rolling_buffer_id++;
-    v->synth_buffer_id = true;
+    normalized.buffer_id = v->rolling_buffer_id.fetch_add(1);
+    v->synth_buffer_id.store(true);
   }
   frame = &normalized;
 
@@ -960,7 +966,7 @@ int HostSubmit(void* user_data,
     // Synthesised ids never repeat, so every earlier entry is dead. Retire them
     // (the reap margin covers a compositor present still binding one) so the
     // cache holds just the current import rather than growing per frame.
-    if (v->synth_buffer_id) {
+    if (v->synth_buffer_id.load()) {
       for (auto bit = v->buffers.begin(); bit != v->buffers.end();) {
         if (bit->first != frame->buffer_id) {
           v->retired.push_back(

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -572,7 +572,7 @@ uint32_t IhsPluginView::GetGlTextureName() const {
         // them (the reap margin covers a compositor present still binding one)
         // so the cache holds just the current import rather than growing per
         // frame.
-        if (synth_buffer_id.load()) {
+        if (synth_buffer_id.load(std::memory_order_relaxed)) {
           for (auto bit = buffers_egl.begin(); bit != buffers_egl.end();) {
             if (bit->first != f.buffer_id) {
               retired_egl.push_back(
@@ -848,8 +848,9 @@ int HostSubmit(void* user_data,
   // fresh id so it is imported rather than aliased.
   if (frame->struct_size <
       offsetof(IhsFrame, buffer_id) + sizeof(normalized.buffer_id)) {
-    normalized.buffer_id = v->rolling_buffer_id.fetch_add(1);
-    v->synth_buffer_id.store(true);
+    normalized.buffer_id =
+        v->rolling_buffer_id.fetch_add(1, std::memory_order_relaxed);
+    v->synth_buffer_id.store(true, std::memory_order_relaxed);
   }
   frame = &normalized;
 
@@ -966,7 +967,7 @@ int HostSubmit(void* user_data,
     // Synthesised ids never repeat, so every earlier entry is dead. Retire them
     // (the reap margin covers a compositor present still binding one) so the
     // cache holds just the current import rather than growing per frame.
-    if (v->synth_buffer_id.load()) {
+    if (v->synth_buffer_id.load(std::memory_order_relaxed)) {
       for (auto bit = v->buffers.begin(); bit != v->buffers.end();) {
         if (bit->first != frame->buffer_id) {
           v->retired.push_back(


### PR DESCRIPTION
Follow-up to #337. Copilot flagged a data race in the synthesised-`buffer_id` eviction added there.

`rolling_buffer_id` and `synth_buffer_id` are written in `HostSubmit` on the plugin thread, **outside** `v->mutex`. `synth_buffer_id` is then read on the **raster** thread **under** `v->mutex` at both import sites (`GetGlTextureName`, `GetVulkanImage`) to decide whether to retire superseded synthesised cache entries.

An unsynchronised write racing a mutex-held read is still a data race — the read side's lock doesn't order against an unlocked write — so it's UB and TSAN-visible, even though the flag only ever transitions `false -> true`. `rolling_buffer_id`'s read-modify-write increment would also tear if a view ever saw concurrent submits.

Fix: make both fields `std::atomic` (the reviewer's suggested option). The plain `store`/`fetch_add` need no ordering beyond atomicity; the import caches themselves stay guarded by `v->mutex`. The struct already holds a `std::mutex` so it was already non-copyable — atomics add no new constraint.

Built + clang-tidy-19 + clang-format-19 clean; host build links.