### PR TITLE
platform-views: schedule a frame when a producer submits

### DIFF
--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -74,10 +74,22 @@ namespace {
 // platform view out on their own vblank loop don't need this, but the nudge is
 // harmless there. ScheduleFrame is thread-safe, so it is safe from the
 // producer's thread (same reason the software cursor uses it).
+//
+// Submitting on its own thread also means a submit can land while the view is
+// being torn down, and flutter_engine is never cleared on shutdown — a null
+// check alone only covers "before the engine started" and would still hand a
+// shut-down engine to ScheduleFrame. ~FlutterView latches shutting_down on the
+// texture registrar before the engine state is destroyed for exactly this class
+// of caller (the same gate the external-texture entry points use), so honor it
+// here too.
 void ScheduleEngineFrame(void* user_data) {
   auto* state = static_cast<FlutterDesktopEngineState*>(user_data);
   if (state == nullptr || state->flutter_engine == nullptr) {
     return;  // submit before the engine is running: nothing to nudge
+  }
+  if (state->texture_registrar == nullptr ||
+      state->texture_registrar->shutting_down.load(std::memory_order_acquire)) {
+    return;  // tearing down: the engine handle is no longer safe to call
   }
   LibFlutterEngine->ScheduleFrame(state->flutter_engine);
 }

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -39,6 +39,7 @@
 #include <cstring>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #if IVI_HAVE_VULKAN
@@ -60,6 +61,26 @@
 #include "view/flutter_view.h"
 
 namespace {
+
+// Ask the engine for a frame after a producer submits.
+//
+// A producer renders and submits on its own thread, out of band with Flutter's
+// frame pipeline, but a platform-view surface is only composited from inside
+// the embedder's PresentLayers callback — which runs when the engine presents a
+// frame, and the engine only presents dirty ones. Flutter itself has nothing to
+// repaint when just the platform-view content changed, so without this nudge
+// the new frame sits unshown until something unrelated (input, a Dart repaint)
+// drives a frame, which reads as a frozen view. The backends that scan a
+// platform view out on their own vblank loop don't need this, but the nudge is
+// harmless there. ScheduleFrame is thread-safe, so it is safe from the
+// producer's thread (same reason the software cursor uses it).
+void ScheduleEngineFrame(void* user_data) {
+  auto* state = static_cast<FlutterDesktopEngineState*>(user_data);
+  if (state == nullptr || state->flutter_engine == nullptr) {
+    return;  // submit before the engine is running: nothing to nudge
+  }
+  LibFlutterEngine->ScheduleFrame(state->flutter_engine);
+}
 
 // Reaches the active Backend for the engine the host was installed for.
 Backend* BackendOf(void* user_data) {
@@ -818,7 +839,6 @@ int HostSubmit(void* user_data,
     *out_release_fence_fd = -1;
   }
 
-  (void)user_data;
   auto* v = reinterpret_cast<IhsPluginView*>(view);
 
   // The plugin may be built against an older, smaller IhsFrame. Copying *frame
@@ -868,7 +888,7 @@ int HostSubmit(void* user_data,
     // plane's IN_FENCE_FD for explicit sync; the GL-texture fallback has no
     // plane fence, so GetGlTextureName CPU-waits on it before sampling. Stash
     // the fence with the frame for both.
-    const std::lock_guard<std::mutex> lock(v->mutex);
+    std::unique_lock<std::mutex> lock(v->mutex);
     ++v->submit_seq;
     if (v->pending_egl.valid) {
       CloseFrameFds(&v->pending_egl.frame);  // superseded before import
@@ -880,6 +900,8 @@ int HostSubmit(void* user_data,
     v->pending_egl.frame.hdr = nullptr;  // do not retain the plugin's hdr ptr
     v->pending_egl.acquire_fence_fd = acquire_fence_fd;  // ownership moves here
     v->pending_egl.valid = true;
+    lock.unlock();  // don't call into the engine holding the view lock
+    ScheduleEngineFrame(user_data);
     return IHS_PV_OK;
   }
 #endif
@@ -908,7 +930,7 @@ int HostSubmit(void* user_data,
   // buffer still binds it by the time it is freed.
   constexpr uint64_t kImportRetireMargin = 8;
 
-  const std::lock_guard<std::mutex> lock(v->mutex);
+  std::unique_lock<std::mutex> lock(v->mutex);
   ++v->submit_seq;
   // Stash this frame's acquire fence (a sync_file) for the compositor to wait
   // on before sampling; it supersedes any previous unconsumed one, since the
@@ -984,6 +1006,8 @@ int HostSubmit(void* user_data,
   // transitions from GENERAL to read it. A spec-correct foreign-queue-family
   // acquire from the producer is the explicit-sync increment.
   v->current_layout = VK_IMAGE_LAYOUT_GENERAL;
+  lock.unlock();  // don't call into the engine holding the view lock
+  ScheduleEngineFrame(user_data);
   return IHS_PV_OK;
 }
 #endif  // IVI_HAVE_VULKAN


### PR DESCRIPTION
A platform-view surface is only composited from inside the embedder's \`PresentLayers\` callback, which the engine runs while presenting a frame — and the engine only presents *dirty* frames. A producer renders and submits on its own thread, out of band with that pipeline, and Flutter has nothing to repaint when only the platform-view content changed. So `HostSubmit` accepted the frame and returned with nothing scheduled to show it.

There was no edge from "producer submitted" to "engine schedules a frame":

- `HostSubmit` (platform_view_host.cc) stashes/imports the frame and returns — no wake, no frame request.
- PV surfaces are composited only in `WaylandEglBackend::PresentLayers()`, the embedder compositor callback.
- The reactor (`app.cc`) idles until an fd event or an explicit wake.
- `FlutterView::NeedsPeriodicPump()` is `!m_comp_surf.empty()` under `ENABLE_PLUGIN_COMP_SURF` — the *legacy* CompositorSurface plugins. `ihs_pv` views do not participate.

**Symptom:** on the Wayland backends the view looked frozen. The producer kept rendering and submitting, but new content only reached the screen when something unrelated (input, a Dart repaint) happened to drive a frame — dragging over the surface showed nothing, then all the accumulated movement appeared at once when focus left the window.

The drm-kms backends were unaffected: they present a platform view on their own vblank loop rather than riding Flutter frames, which is why this never showed in the Pi HW validation.

## Fix

Nudge the engine with `ScheduleFrame` once a submit is accepted, on both the EGL and Vulkan paths. `ScheduleFrame` is thread-safe so it is callable from the producer's thread — `software_seat.cc` already relies on exactly this to keep the software cursor from freezing on an idle UI.

The view lock is released first (`lock_guard` → `unique_lock` + explicit `unlock()`) so the engine is never called while holding it, and a submit arriving before the engine is running is ignored.

## Validation

HW-validated on wayland-egl with the maplibre quad playground: gestures over a platform view now track the pointer continuously instead of only updating on focus change. Built clean; clang-tidy-19 and clang-format-19 clean.

This affects any `ihs_pv` producer on Wayland — maplibre, video_player, future CEF/Filament views — not just the demo.