### PR TITLE
Export the Flutter desktop C API from ihs_shared for out-of-tree plugins

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -148,6 +148,30 @@ target_sources(ihs_shared PRIVATE
 )
 target_link_libraries(ihs_shared PRIVATE ${CMAKE_DL_LIBS})
 
+# Flutter desktop embedder C API forwarders (the FlutterDesktop* surface; see
+# include/ihs/flutter_desktop_bridge.h). They forward to a proc table the shell
+# installs at engine bring-up, so a plugin dlopen'd into the executable resolves
+# the whole host ABI -- ihs_* and FlutterDesktop* alike -- from this one .so.
+#
+# Only meaningful inside the homescreen tree: the standalone ABI-gate build has
+# no embedder to install the table, and the public embedder headers live under
+# third_party/flutter, outside this directory. So the source is gated on those
+# headers being present; the standalone build simply omits the forwarders (its
+# ihs_* surface is unchanged). FLUTTER_DESKTOP_LIBRARY (defined in the source)
+# makes the FLUTTER_EXPORT annotations resolve to default visibility despite the
+# hidden preset; the version script then keeps them in the dynamic table.
+set(_ihs_flutter_public
+        "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/flutter/shell/platform/common/public")
+if (EXISTS "${_ihs_flutter_public}/flutter_messenger.h" AND
+        EXISTS "${_ihs_flutter_public}/flutter_plugin_registrar.h" AND
+        EXISTS "${_ihs_flutter_public}/flutter_texture_registrar.h")
+    target_sources(ihs_shared PRIVATE src/flutter_desktop_bridge.cc)
+    # Only the forwarder source includes the embedder headers, but attach the
+    # path at target scope: it applies consistently across generators and IDEs,
+    # and no other source pulls those headers in.
+    target_include_directories(ihs_shared PRIVATE "${_ihs_flutter_public}")
+endif ()
+
 #
 # Install + CMake package export
 #
@@ -159,9 +183,18 @@ install(TARGETS ihs_shared EXPORT ihs_shared_targets
 )
 
 # Public headers (hand-written) + the generated export header.
+#
+# flutter_desktop_bridge.h is deliberately not installed. Its one exported
+# symbol, ihs_flutter_desktop_set_procs, is a real ihs_* entry point (the shell
+# calls it to install the proc table), but the header that declares it #includes
+# the Flutter embedder headers, which ihs_shared does not ship -- so an installed
+# copy could not compile standalone. It is a shell-internal integration point,
+# consumed in-tree from the source include directory; nothing out-of-tree needs
+# to declare the setter.
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ihs
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.h"
+        PATTERN "flutter_desktop_bridge.h" EXCLUDE
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/ihs/ihs_export.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ihs

--- a/shared/ihs_shared.map
+++ b/shared/ihs_shared.map
@@ -1,12 +1,23 @@
 # Linker version script for libihs_shared.so.
 #
-# Only the sanctioned C ABI (ihs_*) is exported; every other symbol — including
-# the C++ internals of the logging bridge and any vendored dependency compiled
-# in — stays local regardless of its visibility attributes. This is the hard
-# boundary: a plugin can reach nothing but the ihs_* surface.
+# Two sanctioned surfaces are exported; every other symbol — including the C++
+# internals of the logging bridge and any vendored dependency compiled in —
+# stays local regardless of its visibility attributes. This is the hard
+# boundary: a plugin can reach nothing but these.
+#
+#   ihs_*           the native C ABI (logging, tracing, platform-view surface
+#                   negotiation, config, location).
+#   FlutterDesktop* forwarders for the Flutter desktop embedder C API, over a
+#                   proc table the shell installs (see
+#                   include/ihs/flutter_desktop_bridge.h). The embedder itself
+#                   lives in the executable, which is not a shared object a
+#                   dlopen'd plugin can bind to, so a plugin resolves the whole
+#                   host ABI from this one library. Only the 18 forwarders
+#                   compiled into flutter_desktop_bridge.cc carry this prefix.
 {
   global:
     ihs_*;
+    FlutterDesktop*;
   local:
     *;
 };

--- a/shared/include/ihs/flutter_desktop_bridge.h
+++ b/shared/include/ihs/flutter_desktop_bridge.h
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Toyota Connected North America
+// SPDX-License-Identifier: Apache-2.0
+
+// The Flutter desktop C API, re-exported from libihs_shared.so.
+//
+// A plugin built to the standard embedder headers resolves FlutterDesktop*
+// from whatever it is loaded against. The implementation lives in the shell
+// (it operates on the engine state), which for an executable-hosted embedder
+// is not a shared object a dlopen'd plugin can bind to. So ihs_shared exports
+// the functions as forwarders over a proc table the shell installs, the same
+// way the trace surface forwards to the engine (see ihs_trace_set_engine_procs)
+// -- a plugin then resolves the whole host ABI, ihs_* and Flutter alike, from
+// this one library, regardless of what process loaded it.
+//
+// The forwarders return a safe default until the shell installs the table,
+// which it does at engine bring-up, before any plugin's registrar runs.
+
+#ifndef IHS_FLUTTER_DESKTOP_BRIDGE_H_
+#define IHS_FLUTTER_DESKTOP_BRIDGE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <flutter_messenger.h>
+#include <flutter_plugin_registrar.h>
+#include <flutter_texture_registrar.h>
+
+#include "ihs/ihs_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// The shell's real FlutterDesktop* implementations, as function pointers.
+// Filled by the shell (where the names bind unambiguously to those
+// implementations) and installed with ihs_flutter_desktop_set_procs. Field
+// order and struct_size gate forward-compatible growth.
+typedef struct IhsFlutterDesktopProcs {
+  size_t struct_size;
+
+  bool (*messenger_send)(FlutterDesktopMessengerRef,
+                         const char*,
+                         const uint8_t*,
+                         size_t);
+  bool (*messenger_send_with_reply)(FlutterDesktopMessengerRef,
+                                    const char*,
+                                    const uint8_t*,
+                                    size_t,
+                                    FlutterDesktopBinaryReply,
+                                    void*);
+  void (*messenger_send_response)(FlutterDesktopMessengerRef,
+                                  const FlutterDesktopMessageResponseHandle*,
+                                  const uint8_t*,
+                                  size_t);
+  void (*messenger_set_callback)(FlutterDesktopMessengerRef,
+                                 const char*,
+                                 FlutterDesktopMessageCallback,
+                                 void*);
+  FlutterDesktopMessengerRef (*messenger_add_ref)(FlutterDesktopMessengerRef);
+  void (*messenger_release)(FlutterDesktopMessengerRef);
+  bool (*messenger_is_available)(FlutterDesktopMessengerRef);
+  FlutterDesktopMessengerRef (*messenger_lock)(FlutterDesktopMessengerRef);
+  void (*messenger_unlock)(FlutterDesktopMessengerRef);
+
+  FlutterDesktopMessengerRef (*registrar_get_messenger)(
+      FlutterDesktopPluginRegistrarRef);
+  const char* (*registrar_get_asset_folder)(FlutterDesktopPluginRegistrarRef);
+  FlutterDesktopTextureRegistrarRef (*registrar_get_texture_registrar)(
+      FlutterDesktopPluginRegistrarRef);
+  void (*registrar_set_destruction_handler)(
+      FlutterDesktopPluginRegistrarRef,
+      FlutterDesktopOnPluginRegistrarDestroyed);
+
+  int64_t (*texture_register)(FlutterDesktopTextureRegistrarRef,
+                              const FlutterDesktopTextureInfo*);
+  void (*texture_unregister)(FlutterDesktopTextureRegistrarRef,
+                             int64_t,
+                             void (*)(void*),
+                             void*);
+  bool (*texture_mark_frame_available)(FlutterDesktopTextureRegistrarRef,
+                                       int64_t);
+  bool (*texture_make_current)(FlutterDesktopTextureRegistrarRef);
+  bool (*texture_clear_current)(FlutterDesktopTextureRegistrarRef);
+} IhsFlutterDesktopProcs;
+
+// Install (or clear, with NULL) the shell's implementations. Shell-only, called
+// once at engine bring-up. The pointer must remain valid for the process
+// lifetime.
+IHS_EXPORT void ihs_flutter_desktop_set_procs(
+    const IhsFlutterDesktopProcs* procs);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IHS_FLUTTER_DESKTOP_BRIDGE_H_

--- a/shared/src/flutter_desktop_bridge.cc
+++ b/shared/src/flutter_desktop_bridge.cc
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2026 Toyota Connected North America
+// SPDX-License-Identifier: Apache-2.0
+
+// Forwarders for the Flutter desktop C API (see flutter_desktop_bridge.h).
+//
+// FLUTTER_DESKTOP_LIBRARY makes the FLUTTER_EXPORT-annotated declarations
+// resolve to default visibility here, so the version script can keep them in
+// the dynamic symbol table; every other symbol stays local.
+
+#define FLUTTER_DESKTOP_LIBRARY
+
+#include "ihs/flutter_desktop_bridge.h"
+
+#include <atomic>
+
+namespace {
+
+// Installed once by the shell; read on every forwarded call. Acquire/release
+// pairs with the store so a plugin thread sees a fully-published table.
+std::atomic<const IhsFlutterDesktopProcs*> g_procs{nullptr};
+
+const IhsFlutterDesktopProcs* procs() {
+  return g_procs.load(std::memory_order_acquire);
+}
+
+}  // namespace
+
+extern "C" void ihs_flutter_desktop_set_procs(
+    const IhsFlutterDesktopProcs* procs) {
+  // Refuse a table too small to cover every field the forwarders call through.
+  // The struct only ever grows by appending, so a table shorter than the
+  // current definition means an older shell against a newer ihs_shared: the
+  // trailing fields would be absent and calling through them undefined. Leaving
+  // the forwarders on their safe defaults is a degraded but well-defined state.
+  if (procs != nullptr && procs->struct_size < sizeof(IhsFlutterDesktopProcs)) {
+    procs = nullptr;
+  }
+  g_procs.store(procs, std::memory_order_release);
+}
+
+// ---- messenger -------------------------------------------------------------
+
+extern "C" bool FlutterDesktopMessengerSend(
+    FlutterDesktopMessengerRef messenger,
+    const char* channel,
+    const uint8_t* message,
+    const size_t message_size) {
+  const auto* p = procs();
+  return p != nullptr
+             ? p->messenger_send(messenger, channel, message, message_size)
+             : false;
+}
+
+extern "C" bool FlutterDesktopMessengerSendWithReply(
+    FlutterDesktopMessengerRef messenger,
+    const char* channel,
+    const uint8_t* message,
+    const size_t message_size,
+    const FlutterDesktopBinaryReply reply,
+    void* user_data) {
+  const auto* p = procs();
+  return p != nullptr
+             ? p->messenger_send_with_reply(messenger, channel, message,
+                                            message_size, reply, user_data)
+             : false;
+}
+
+extern "C" void FlutterDesktopMessengerSendResponse(
+    FlutterDesktopMessengerRef messenger,
+    const FlutterDesktopMessageResponseHandle* handle,
+    const uint8_t* data,
+    size_t data_length) {
+  const auto* p = procs();
+  if (p != nullptr) {
+    p->messenger_send_response(messenger, handle, data, data_length);
+  }
+}
+
+extern "C" void FlutterDesktopMessengerSetCallback(
+    FlutterDesktopMessengerRef messenger,
+    const char* channel,
+    FlutterDesktopMessageCallback callback,
+    void* user_data) {
+  const auto* p = procs();
+  if (p != nullptr) {
+    p->messenger_set_callback(messenger, channel, callback, user_data);
+  }
+}
+
+extern "C" FlutterDesktopMessengerRef FlutterDesktopMessengerAddRef(
+    FlutterDesktopMessengerRef messenger) {
+  const auto* p = procs();
+  return p != nullptr ? p->messenger_add_ref(messenger) : nullptr;
+}
+
+extern "C" void FlutterDesktopMessengerRelease(
+    FlutterDesktopMessengerRef messenger) {
+  const auto* p = procs();
+  if (p != nullptr) {
+    p->messenger_release(messenger);
+  }
+}
+
+extern "C" bool FlutterDesktopMessengerIsAvailable(
+    FlutterDesktopMessengerRef messenger) {
+  const auto* p = procs();
+  return p != nullptr ? p->messenger_is_available(messenger) : false;
+}
+
+extern "C" FlutterDesktopMessengerRef FlutterDesktopMessengerLock(
+    FlutterDesktopMessengerRef messenger) {
+  const auto* p = procs();
+  return p != nullptr ? p->messenger_lock(messenger) : nullptr;
+}
+
+extern "C" void FlutterDesktopMessengerUnlock(
+    FlutterDesktopMessengerRef messenger) {
+  const auto* p = procs();
+  if (p != nullptr) {
+    p->messenger_unlock(messenger);
+  }
+}
+
+// ---- plugin registrar ------------------------------------------------------
+
+extern "C" FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  const auto* p = procs();
+  return p != nullptr ? p->registrar_get_messenger(registrar) : nullptr;
+}
+
+extern "C" const char* FlutterDesktopPluginRegistrarGetFlutterAssetFolder(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  const auto* p = procs();
+  return p != nullptr ? p->registrar_get_asset_folder(registrar) : nullptr;
+}
+
+extern "C" FlutterDesktopTextureRegistrarRef
+FlutterDesktopRegistrarGetTextureRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  const auto* p = procs();
+  return p != nullptr ? p->registrar_get_texture_registrar(registrar) : nullptr;
+}
+
+extern "C" void FlutterDesktopPluginRegistrarSetDestructionHandler(
+    FlutterDesktopPluginRegistrarRef registrar,
+    FlutterDesktopOnPluginRegistrarDestroyed callback) {
+  const auto* p = procs();
+  if (p != nullptr) {
+    p->registrar_set_destruction_handler(registrar, callback);
+  }
+}
+
+// ---- texture registrar -----------------------------------------------------
+
+extern "C" int64_t FlutterDesktopTextureRegistrarRegisterExternalTexture(
+    FlutterDesktopTextureRegistrarRef texture_registrar,
+    const FlutterDesktopTextureInfo* info) {
+  const auto* p = procs();
+  return p != nullptr ? p->texture_register(texture_registrar, info) : -1;
+}
+
+extern "C" void FlutterDesktopTextureRegistrarUnregisterExternalTexture(
+    FlutterDesktopTextureRegistrarRef texture_registrar,
+    int64_t texture_id,
+    void (*callback)(void* user_data),
+    void* user_data) {
+  const auto* p = procs();
+  if (p != nullptr) {
+    p->texture_unregister(texture_registrar, texture_id, callback, user_data);
+  }
+}
+
+extern "C" bool FlutterDesktopTextureRegistrarMarkExternalTextureFrameAvailable(
+    FlutterDesktopTextureRegistrarRef texture_registrar,
+    int64_t texture_id) {
+  const auto* p = procs();
+  return p != nullptr
+             ? p->texture_mark_frame_available(texture_registrar, texture_id)
+             : false;
+}
+
+extern "C" bool FlutterDesktopTextureMakeCurrent(
+    FlutterDesktopTextureRegistrarRef texture_registrar) {
+  const auto* p = procs();
+  return p != nullptr ? p->texture_make_current(texture_registrar) : false;
+}
+
+extern "C" bool FlutterDesktopTextureClearCurrent(
+    FlutterDesktopTextureRegistrarRef texture_registrar) {
+  const auto* p = procs();
+  return p != nullptr ? p->texture_clear_current(texture_registrar) : false;
+}

--- a/shell/libflutter_engine.cc
+++ b/shell/libflutter_engine.cc
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <string>
 
+#include "ihs/flutter_desktop_bridge.h"
 #include "ihs/trace.h"
 #include "logging.h"
 #include "shared_library.h"
@@ -169,6 +170,38 @@ bool LibFlutterEngine::Load(const char* library_path) {
         g_exports.TraceEventInstant,
     };
     ihs_trace_set_engine_procs(&kTraceProcs);
+
+    // Install the shell's Flutter desktop embedder implementations as the
+    // ihs_shared forwarder table, so an out-of-tree plugin resolves the whole
+    // host ABI -- ihs_* and FlutterDesktop* alike -- from libihs_shared.so. The
+    // embedder lives in this executable rather than a shared object, so it
+    // cannot export these itself (see ihs/flutter_desktop_bridge.h). The names
+    // bind to the real definitions here because platform_homescreen, which
+    // implements them, is linked into this binary; ihs_shared's exported
+    // symbols of the same name are its forwarders, which call back through this
+    // table. Installed before any plugin registrar runs.
+    static const IhsFlutterDesktopProcs kFlutterDesktopProcs = {
+        sizeof(IhsFlutterDesktopProcs),
+        FlutterDesktopMessengerSend,
+        FlutterDesktopMessengerSendWithReply,
+        FlutterDesktopMessengerSendResponse,
+        FlutterDesktopMessengerSetCallback,
+        FlutterDesktopMessengerAddRef,
+        FlutterDesktopMessengerRelease,
+        FlutterDesktopMessengerIsAvailable,
+        FlutterDesktopMessengerLock,
+        FlutterDesktopMessengerUnlock,
+        FlutterDesktopPluginRegistrarGetMessenger,
+        FlutterDesktopPluginRegistrarGetFlutterAssetFolder,
+        FlutterDesktopRegistrarGetTextureRegistrar,
+        FlutterDesktopPluginRegistrarSetDestructionHandler,
+        FlutterDesktopTextureRegistrarRegisterExternalTexture,
+        FlutterDesktopTextureRegistrarUnregisterExternalTexture,
+        FlutterDesktopTextureRegistrarMarkExternalTextureFrameAvailable,
+        FlutterDesktopTextureMakeCurrent,
+        FlutterDesktopTextureClearCurrent,
+    };
+    ihs_flutter_desktop_set_procs(&kFlutterDesktopProcs);
   });
 
   if (table_.load(std::memory_order_acquire) == nullptr) {

--- a/shell/platform/homescreen/CMakeLists.txt
+++ b/shell/platform/homescreen/CMakeLists.txt
@@ -12,6 +12,22 @@ add_library(platform_homescreen STATIC
         watchdog_plugin.cc
 )
 
+# Keep every symbol of this static library out of the executable's dynamic
+# symbol table. It implements the Flutter desktop C API (FlutterDesktop*), which
+# libihs_shared.so also defines -- as forwarders that re-export the surface for
+# out-of-tree plugins. Without hidden visibility the two colliding definitions
+# force the linker to export the executable's copies too; being first in symbol
+# search order the executable would then preempt the forwarders, so a plugin
+# would bind straight to these internal copies and libihs_shared.so's re-export
+# would be dead. Hidden here, these stay usable within the executable (the shell
+# installs their addresses into the forwarder proc table, see
+# shell/libflutter_engine.cc) while libihs_shared.so remains the sole exporter.
+set_target_properties(platform_homescreen PROPERTIES
+        CXX_VISIBILITY_PRESET hidden
+        C_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+)
+
 target_include_directories(platform_homescreen PUBLIC
         .
         ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
## What

An out-of-tree Dart FFI plugin built to the standard embedder headers must
resolve the `FlutterDesktop*` C API at load. That surface operates on engine
state and is implemented in the shell — which is an **executable**, not a
shared object a `dlopen`'d plugin can bind to. Publishing it from the
executable would make the binary its own plugin-ABI provider and split the
host contract across two artifacts.

This routes the surface through `libihs_shared.so` instead — the one library a
plugin already links for the `ihs_*` ABI — so a plugin resolves the whole host
contract from a single shared object, regardless of what process loaded it.

## How

- `ihs_shared` defines the 18 `FlutterDesktop*` functions as thin **forwarders**
  over a proc table (`include/ihs/flutter_desktop_bridge.h`,
  `src/flutter_desktop_bridge.cc`), the same shape as
  `ihs_trace_set_engine_procs`.
- The shell installs that table at engine bring-up
  (`shell/libflutter_engine.cc`), filling it with the real implementations'
  addresses — which bind unambiguously inside the executable, where
  `platform_homescreen` is linked.
- Before the table is installed the forwarders return safe defaults. The atomic
  proc-table pointer pairs a release store in the setter with an acquire load in
  each forwarder, so a plugin thread never sees a half-published table.
- `platform_homescreen` keeps its own copies for the shell's internal use, but
  they are given **hidden visibility**. Otherwise the colliding definitions in
  `ihs_shared` force the linker to export the executable's copies too, and —
  being first in symbol-search order — the executable would preempt the
  forwarders, leaving the re-export dead. Hidden, `ihs_shared` is the sole
  exporter and the executable's dynamic symbol table stays empty.
- The standalone ABI-gate build has no embedder to install the table and no
  access to the embedder headers (they live under `third_party/flutter`), so the
  forwarder source is gated on those headers being present; that build's `ihs_*`
  surface is unchanged.

## Changed from the first approach

The original revision exported `FlutterDesktop*` from the **executable** via a
version script + `ENABLE_EXPORTS`. That published the plugin ABI from the binary
rather than from the shared library plugins already link, and tripped lld on a
version-script entry that was a callback typedef, not a function. Reworked to
export from `ihs_shared` as described above; the executable now exports nothing.

## Verification (clang + lld)

| check | result |
|---|---|
| `ihs_shared` builds under lld with the forwarders | pass |
| exported symbols | 18 `FlutterDesktop*` + `ihs_*`, nothing else leaks |
| full shell builds; `libflutter_engine.cc` compiles and links `--no-undefined` | pass |
| executable `.dynsym` exports | 0 (`ihs_shared` is the sole exporter) |
| `libihs_shared.so.1` is `DT_NEEDED` of the executable (forwarders in global scope) | pass |
| runtime forwarder round-trip (default before install → forwards after install → default after clear) | pass |