### PR TITLE
Add opt-in per-frame timing capture to scroll_bench

### DIFF
--- a/test/integration/scroll_bench/README.md
+++ b/test/integration/scroll_bench/README.md
@@ -28,6 +28,7 @@ number that matters for that use case.
 | `ITEMS` | `2000` | number of rows |
 | `VELOCITY` | `600` | auto-scroll speed, logical px/s |
 | `AUTOSCROLL` | `true` | set `false` for a manual (touch-driven) run |
+| `TIMINGS_FILE` | *(empty)* | per-frame engine-timing CSV path, empty disables |
 
 Raise `VELOCITY` / `ITEMS` (and/or drive a higher-res mode) to push past the
 vsync cap and find the software-raster ceiling.
@@ -65,6 +66,17 @@ every 60 frames over the drm-cxx `DrmDumbSink` present path:
 
 Use `IVI_WL_PROFILE` (wayland-egl) or `IVI_VK_PROFILE` (wayland-vulkan /
 drm-kms-vulkan) for the same cadence report on the other backends.
+
+For per-frame data, build with `TIMINGS_FILE` set to write one CSV row per
+frame with [FrameTiming](https://api.flutter.dev/flutter/dart-ui/FrameTiming-class.html):
+
+```
+frame,vsync_start_us,build_start_us,build_finish_us,raster_start_us,raster_finish_us,raster_finish_wall_us
+```
+
+The first line records the tunables. Works on any backend in release mode.
+Stdout prints a summary every ~300 frames and
+`scroll_bench: first frame rasterized +N ms` once, for startup timing.
 
 ## Reference result
 

--- a/test/integration/scroll_bench/lib/main.dart
+++ b/test/integration/scroll_bench/lib/main.dart
@@ -9,17 +9,31 @@
 //   IVI_SW_PROFILE=1 homescreen -b <bundle> --window-type=NORMAL -f
 //
 // Tunables (compile-time --dart-define, all optional):
-//   ITEMS      number of rows                       (default 2000)
-//   VELOCITY   auto-scroll speed, logical px/s      (default 600)
-//   AUTOSCROLL "false" disables auto-scroll (manual)(default on)
+//   ITEMS        number of rows                       (default 2000)
+//   VELOCITY     auto-scroll speed, logical px/s      (default 600)
+//   AUTOSCROLL   "false" disables auto-scroll (manual)(default on)
+//   TIMINGS_FILE per-frame engine-timing CSV path     (default off)
+import 'dart:io';
+import 'dart:ui' show FramePhase;
+
 import 'package:flutter/material.dart';
 
 const int kItems = int.fromEnvironment('ITEMS', defaultValue: 2000);
 const int kVelocity = int.fromEnvironment('VELOCITY', defaultValue: 600);
 const bool kAutoScroll =
     bool.fromEnvironment('AUTOSCROLL', defaultValue: true);
+const String kTimingsFile =
+    String.fromEnvironment('TIMINGS_FILE', defaultValue: '');
 
-void main() => runApp(const ScrollBenchApp());
+void main() {
+  if (kTimingsFile.isNotEmpty) {
+    final sinceMain = Stopwatch()..start();
+    final binding = WidgetsFlutterBinding.ensureInitialized();
+    _logFrameTimings(binding, sinceMain);
+  }
+
+  runApp(const ScrollBenchApp());
+}
 
 class ScrollBenchApp extends StatelessWidget {
   const ScrollBenchApp({super.key});
@@ -216,4 +230,42 @@ class _InfoTile extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Writes a row of FrameTiming for each frame to a CSV, and prints a summary
+/// to stdout every ~300 frames.
+void _logFrameTimings(WidgetsBinding binding, Stopwatch sinceMain) {
+  final sink = File(kTimingsFile).openWrite();
+  sink
+    ..writeln('# scroll_bench items=$kItems velocity=$kVelocity')
+    ..writeln('frame,vsync_start_us,build_start_us,build_finish_us,'
+        'raster_start_us,raster_finish_us,raster_finish_wall_us');
+  var frames = 0;
+  var maxTotalUs = 0;
+  binding.addTimingsCallback((timings) {
+    for (final t in timings) {
+      sink.writeln('${t.frameNumber},'
+          '${t.timestampInMicroseconds(FramePhase.vsyncStart)},'
+          '${t.timestampInMicroseconds(FramePhase.buildStart)},'
+          '${t.timestampInMicroseconds(FramePhase.buildFinish)},'
+          '${t.timestampInMicroseconds(FramePhase.rasterStart)},'
+          '${t.timestampInMicroseconds(FramePhase.rasterFinish)},'
+          '${t.timestampInMicroseconds(FramePhase.rasterFinishWallTime)}');
+      frames += 1;
+      if (t.totalSpan.inMicroseconds > maxTotalUs) {
+        maxTotalUs = t.totalSpan.inMicroseconds;
+      }
+    }
+    if (frames >= 300) {
+      print('scroll_bench: $frames frames, max total '
+          '${(maxTotalUs / 1000).toStringAsFixed(1)} ms');
+      sink.flush();
+      frames = 0;
+      maxTotalUs = 0;
+    }
+  });
+  binding.waitUntilFirstFrameRasterized.then((_) {
+    print('scroll_bench: first frame rasterized '
+        '+${sinceMain.elapsedMilliseconds} ms');
+  });
 }


### PR DESCRIPTION
While benchmarking scroll_bench on an embedded board I wanted to see how long each frame took to build and draw, measured in release mode. The `IVI_*_PROFILE` reports show how steadily frames reach the display, but not how long the engine spent building and drawing each one. This adds that missing half, so it seemed worth upstreaming.

- Set the `TIMINGS_FILE` dart-define to write one CSV row of FrameTiming phase timestamps per frame (vsync, build start/finish, raster start/finish, wall clock).
- Stdout gets a periodic summary and a one-time first-frame marker for startup timing.

Opt-in: with `TIMINGS_FILE` unset (the default) there is no behavior change.

Verified in release mode on Linux desktop and on a TI SK-AM62 board:
| | |
| --- | --- |
| Board | TI SK-AM62 (am62xx-evm), GP silicon |
| SoC | AM62x, quad Cortex-A53 |
| GPU | PowerVR Rogue AXE-1-16M, driver 1.15 |
| Display | WaveShare panel, 60 Hz |
| OS | TISDK 10 (scarthgap), kernel 5.10 |
| Flutter | 3.38.3, release AOT bundle |