### PR TITLE
ihs_location: carry fix time and accuracy

### DIFF
--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -27,6 +27,7 @@
 #ifndef IHS_LOCATION_H_
 #define IHS_LOCATION_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "ihs/ihs_export.h"
@@ -35,7 +36,18 @@
 extern "C" {
 #endif
 
-/* One location fix. */
+/*
+ * One location fix.
+ *
+ * ABI: fields are only ever APPENDED, never reordered or removed. Older callers
+ * pass a shorter struct, so the two accessors differ by what they may write:
+ *   - ihs_location_latest() fills only the original six fields, so it is safe
+ *     for a caller built against any past version of this header.
+ *   - ihs_location_latest2(out, out_size) fills up to out_size bytes, so a
+ *     caller passing sizeof(IhsPosition) gets the newer fields too.
+ * A caller that wants the timestamp or accuracy MUST use ihs_location_latest2;
+ * ihs_location_latest leaves those fields untouched.
+ */
 typedef struct IhsPosition {
   double latitude;
   double longitude;
@@ -43,6 +55,12 @@ typedef struct IhsPosition {
   double speed_mps;    /* ground speed, meters/second; < 0 means unknown */
   int32_t mode;        /* gpsd-style fix mode: <2 no fix, 2 = 2D, 3 = 3D */
   int32_t has_bearing; /* 0/1 */
+
+  /* --- appended; only ihs_location_latest2 writes these --- */
+  uint64_t t_monotonic_ns; /* fix arrival on CLOCK_MONOTONIC; 0 if unstamped */
+  double sigma_e_m;        /* 1-sigma east position error, m; < 0 unknown */
+  double sigma_n_m;        /* 1-sigma north position error, m; < 0 unknown */
+  double sigma_v_mps;      /* 1-sigma speed error, m/s; < 0 unknown */
 } IhsPosition;
 
 /* Which backend(s) the service acquires from. */
@@ -68,11 +86,24 @@ IHS_EXPORT IhsLocationService* ihs_location_start(IhsLocationSource source,
                                                   const char* config);
 
 /*
- * Copy the most recent fix into @out. Returns 1 if a valid fix exists, else 0
- * (in which case @out is left unchanged).
+ * Copy the most recent fix into @out, filling only the original six fields
+ * (through has_bearing). Returns 1 if a valid fix exists, else 0 (in which case
+ * @out is left unchanged). Use ihs_location_latest2 for the timestamp/accuracy.
  */
 IHS_EXPORT int ihs_location_latest(IhsLocationService* service,
                                    IhsPosition* out);
+
+/*
+ * Copy the most recent fix into @out, writing at most @out_size bytes — pass
+ * sizeof(IhsPosition) as compiled against the header you built with, and only
+ * fields that fit are written. This is the forward-compatible accessor: a
+ * caller built against a newer header gets the appended fields (timestamp,
+ * accuracy); one built against an older header passes its smaller size and is
+ * never overrun. Returns 1 if a valid fix exists, else 0.
+ */
+IHS_EXPORT int ihs_location_latest2(IhsLocationService* service,
+                                    IhsPosition* out,
+                                    size_t out_size);
 
 /*
  * A monotonic counter bumped on each new fix, so a consumer can tell whether

--- a/shared/src/location/geoclue_provider.cc
+++ b/shared/src/location/geoclue_provider.cc
@@ -137,17 +137,25 @@ void GeoclueProvider::OnLocationObject(const char* location_path) {
 
   const double heading = ReadDouble(sd_, bus_, location_path, "Heading");
   const double speed = ReadDouble(sd_, bus_, location_path, "Speed");
+  // geoclue reports a single horizontal accuracy in meters (ReadDouble returns
+  // < 0 when absent), which stands in for both position axes.
+  const double accuracy = ReadDouble(sd_, bus_, location_path, "Accuracy");
 
   Position p;
   p.latitude = lat;
   p.longitude = lon;
   p.mode = 3;  // geoclue reports a fix (no 2D/3D distinction); treat as valid
+  p.t_monotonic_ns = MonotonicNs();
   if (heading >= 0.0) {
     p.bearing_deg = heading;
     p.has_bearing = true;
   }
   if (speed >= 0.0) {
     p.speed_mps = speed;
+  }
+  if (accuracy >= 0.0) {
+    p.sigma_e_m = accuracy;
+    p.sigma_n_m = accuracy;
   }
   {
     const std::lock_guard<std::mutex> lock(mu_);

--- a/shared/src/location/gpsd_provider.cc
+++ b/shared/src/location/gpsd_provider.cc
@@ -86,6 +86,28 @@ bool ParseTpv(const std::string& line, Position& out) {
       speed >= 0.0) {
     p.speed_mps = speed;
   }
+
+  // Error estimates, all in the same units as the fix. gpsd gives per-axis
+  // (epx = longitude/east error, epy = latitude/north error) and a combined
+  // horizontal (eph); prefer the per-axis pair, falling back to eph for both.
+  // eps is the speed error. A filter reads these as measurement noise, so only
+  // finite, non-negative values are accepted.
+  auto positive = [](double v) { return std::isfinite(v) && v >= 0.0; };
+  double epx = 0.0;
+  double epy = 0.0;
+  double eph = 0.0;
+  const bool have_eph = FindNumber(line, "eph", eph) && positive(eph);
+  p.sigma_e_m = (FindNumber(line, "epx", epx) && positive(epx)) ? epx
+                : have_eph                                      ? eph
+                                                                : -1.0;
+  p.sigma_n_m = (FindNumber(line, "epy", epy) && positive(epy)) ? epy
+                : have_eph                                      ? eph
+                                                                : -1.0;
+  double eps = 0.0;
+  if (FindNumber(line, "eps", eps) && positive(eps)) {
+    p.sigma_v_mps = eps;
+  }
+
   out = p;
   return true;
 }
@@ -183,6 +205,7 @@ void GpsdProvider::Run() {
         buf.erase(0, nl + 1);
         Position p;
         if (ParseTpv(line, p)) {
+          p.t_monotonic_ns = MonotonicNs();  // arrival, not gpsd's GPS time
           {
             const std::lock_guard<std::mutex> lock(mu_);
             latest_ = p;

--- a/shared/src/location/location.hpp
+++ b/shared/src/location/location.hpp
@@ -11,10 +11,22 @@
 #ifndef IHS_LOC_LOCATION_H_
 #define IHS_LOC_LOCATION_H_
 
+#include <ctime>
+
 #include <cmath>
 #include <cstdint>
 
 namespace ihs::location {
+
+// Now on CLOCK_MONOTONIC in nanoseconds — the fix arrival clock. Monotonic
+// because a filter's dt must not be corrupted by wall-clock jumps (NTP steps,
+// and gpsd hands out GPS time that can step at startup).
+inline uint64_t MonotonicNs() {
+  struct timespec ts{};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
 
 // A coordinate is usable only if finite and within the geographic range. Both
 // providers validate before publishing so a malformed source (an arbitrary
@@ -35,6 +47,19 @@ struct Position {
   double speed_mps = -1.0;   // ground speed m/s; < 0 means unknown
   int mode = 0;              // gpsd-style fix mode: <2 no fix, 2 = 2D, 3 = 3D
   bool has_bearing = false;
+
+  // Arrival time on CLOCK_MONOTONIC, stamped when the fix is received. A filter
+  // needs a clock immune to wall-clock jumps (NTP steps, and gpsd hands out GPS
+  // time that can jump at startup) for its dt; 0 means unstamped.
+  uint64_t t_monotonic_ns = 0;
+
+  // 1-sigma position error, meters, split east/north; the measurement noise a
+  // filter weights the fix by. < 0 means the source did not report it. A source
+  // that gives only a combined horizontal error fills both with that value.
+  double sigma_e_m = -1.0;
+  double sigma_n_m = -1.0;
+  // 1-sigma speed error, m/s; < 0 unknown.
+  double sigma_v_mps = -1.0;
 
   [[nodiscard]] bool valid() const { return mode >= 2; }
 };

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -13,8 +13,10 @@
 
 #include "ihs/location.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <new>
 #include <string>
@@ -102,6 +104,30 @@ IhsLocationService* ihs_location_start(IhsLocationSource source,
   }
 }
 
+namespace {
+
+// Fill a full IhsPosition from the internal fix.
+void Fill(IhsPosition& out, const ihs::location::Position& pos) {
+  out.latitude = pos.latitude;
+  out.longitude = pos.longitude;
+  out.bearing_deg = pos.bearing_deg;
+  out.speed_mps = pos.speed_mps;
+  out.mode = pos.mode;
+  out.has_bearing = pos.has_bearing ? 1 : 0;
+  out.t_monotonic_ns = pos.t_monotonic_ns;
+  out.sigma_e_m = pos.sigma_e_m;
+  out.sigma_n_m = pos.sigma_n_m;
+  out.sigma_v_mps = pos.sigma_v_mps;
+}
+
+// Offset one past has_bearing — the original struct's size, and the boundary
+// this accessor must not write beyond so a pre-accuracy caller is never
+// overrun.
+constexpr size_t kLegacySize =
+    offsetof(IhsPosition, has_bearing) + sizeof(int32_t);
+
+}  // namespace
+
 int ihs_location_latest(IhsLocationService* service, IhsPosition* out) {
   if (service == nullptr || !service->provider || out == nullptr) {
     return 0;
@@ -111,12 +137,39 @@ int ihs_location_latest(IhsLocationService* service, IhsPosition* out) {
     if (!service->provider->Latest(pos)) {
       return 0;
     }
+    // Legacy accessor: fill only the original fields, leaving the appended ones
+    // untouched, since @out may be a caller's smaller pre-accuracy struct.
     out->latitude = pos.latitude;
     out->longitude = pos.longitude;
     out->bearing_deg = pos.bearing_deg;
     out->speed_mps = pos.speed_mps;
     out->mode = pos.mode;
     out->has_bearing = pos.has_bearing ? 1 : 0;
+    return 1;
+  } catch (...) {
+    return 0;
+  }
+}
+
+int ihs_location_latest2(IhsLocationService* service,
+                         IhsPosition* out,
+                         size_t out_size) {
+  if (service == nullptr || !service->provider || out == nullptr ||
+      out_size < kLegacySize) {
+    return 0;  // too small to even hold a fix
+  }
+  try {
+    ihs::location::Position pos;
+    if (!service->provider->Latest(pos)) {
+      return 0;
+    }
+    // Build the full struct, then copy only what the caller's buffer holds, so
+    // a caller compiled against an older (shorter) header is never overrun.
+    IhsPosition full{};
+    Fill(full, pos);
+    const size_t n =
+        out_size < sizeof(IhsPosition) ? out_size : sizeof(IhsPosition);
+    std::memcpy(out, &full, n);
     return 1;
   } catch (...) {
     return 0;

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -22,6 +22,7 @@
  * version handshake and each capability sub-table end to end.
  */
 
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -100,9 +101,24 @@ int main(void) {
   IhsPosition pos;
   CHECK(ihs_location_latest(loc, &pos) == 0,
         "no fix expected from a dead port");
+  CHECK(ihs_location_latest2(loc, &pos, sizeof(pos)) == 0,
+        "latest2 also reports no fix from a dead port");
   CHECK(ihs_location_generation(loc) == 0, "generation 0 before any fix");
   ihs_location_stop(loc);
   CHECK(ihs_location_latest(NULL, &pos) == 0, "latest(NULL) is safe");
+  CHECK(ihs_location_latest2(NULL, &pos, sizeof(pos)) == 0,
+        "latest2(NULL) is safe");
+  /* latest2 with the old (pre-accuracy) struct size: a smaller out_size must be
+   * honored without overrunning, which is the whole point of the accessor.
+   * offsetof(has_bearing)+4 is the legacy size; a byte less must be rejected.
+   */
+  {
+    const size_t legacy = offsetof(IhsPosition, has_bearing) + sizeof(int32_t);
+    CHECK(ihs_location_latest2(NULL, &pos, legacy) == 0,
+          "latest2 accepts the legacy struct size");
+    CHECK(ihs_location_latest2(loc, &pos, legacy - 1) == 0,
+          "latest2 rejects a below-legacy size");
+  }
   CHECK(ihs_location_generation(NULL) == 0, "generation(NULL) is 0");
   ihs_location_stop(NULL); /* must be a safe nop */
 

--- a/shared/tests/location/parse_tpv_test.cc
+++ b/shared/tests/location/parse_tpv_test.cc
@@ -53,6 +53,44 @@ int main() {
          "track 95.4 -> bearing");
   Expect(p.speed_mps > 1.3 && p.speed_mps < 1.4, "speed 1.34");
 
+  // Error estimates: per-axis epx/epy/eps map to the sigma fields.
+  Position e;
+  Expect(ParseTpv(R"({"class":"TPV","mode":3,"lat":37.77,"lon":-122.42,)"
+                  R"("epx":4.5,"epy":6.0,"eph":7.1,"eps":0.8})",
+                  e),
+         "TPV with error estimates parses");
+  Expect(e.sigma_e_m > 4.4 && e.sigma_e_m < 4.6, "epx 4.5 -> sigma_e");
+  Expect(e.sigma_n_m > 5.9 && e.sigma_n_m < 6.1, "epy 6.0 -> sigma_n");
+  Expect(e.sigma_v_mps > 0.7 && e.sigma_v_mps < 0.9, "eps 0.8 -> sigma_v");
+
+  // Only eph present: it fills both position axes.
+  Position h;
+  Expect(
+      ParseTpv(
+          R"({"class":"TPV","mode":3,"lat":37.77,"lon":-122.42,"eph":9.0})", h),
+      "TPV with only eph parses");
+  Expect(h.sigma_e_m > 8.9 && h.sigma_e_m < 9.1 && h.sigma_n_m > 8.9 &&
+             h.sigma_n_m < 9.1,
+         "eph fills both sigma_e and sigma_n");
+
+  // No error fields: sigmas stay unknown (< 0), and speed defaults unknown too.
+  Position n;
+  Expect(ParseTpv(R"({"class":"TPV","mode":3,"lat":37.77,"lon":-122.42})", n),
+         "TPV with no error fields parses");
+  Expect(n.sigma_e_m < 0.0 && n.sigma_n_m < 0.0 && n.sigma_v_mps < 0.0,
+         "absent error fields -> sigmas < 0 (unknown)");
+
+  // A garbage/negative error is rejected, not stored.
+  Position g;
+  Expect(ParseTpv(R"({"class":"TPV","mode":3,"lat":37.77,"lon":-122.42,)"
+                  R"("epx":-1.0})",
+                  g) &&
+             g.sigma_e_m < 0.0,
+         "negative epx -> sigma_e unknown");
+
+  // ParseTpv is pure: it must not stamp a timestamp (that is done at receipt).
+  Expect(e.t_monotonic_ns == 0, "ParseTpv leaves t_monotonic_ns unstamped");
+
   // Non-TPV classes are rejected.
   Expect(!ParseTpv(R"({"class":"VERSION","release":"3.22"})", p),
          "VERSION rejected");


### PR DESCRIPTION
A location filter needs two things this service dropped on the floor: a **timestamp** to form `dt`, and a **measurement-noise estimate** to weight a fix. gpsd sends both — `eph`/`epx`/`epy` (position error) and `eps` (speed error), plus a time — and `ParseTpv` already saw and discarded them. First increment of the Kalman location manager (plan at `~/Documents/ivi-homescreen/kalman_location_manager_plan.md`), and independently useful — it is also what lets the map puck draw a real accuracy circle.

## What changed

`Position` gains `t_monotonic_ns`, `sigma_e_m`, `sigma_n_m`, `sigma_v_mps` (negative = unknown). `ParseTpv` fills the sigmas: per-axis `epx`/`epy` when present, `eph` as a fallback for both, `eps` for speed; non-finite or negative values stay unknown. The timestamp is stamped **at receipt on `CLOCK_MONOTONIC`** — never gpsd’s GPS time, which can step at startup and corrupt a `dt` — so `ParseTpv` stays pure and the stamp happens in the socket loop. geoclue fills accuracy from its `Accuracy` property and stamps the same way.

## The ABI move

`IhsPosition` grows by four appended fields. It has **no `struct_size`**, so it cannot be grown in place without overrunning a caller built against the old header. So:

- `ihs_location_latest()` now fills **only the original six fields**, leaving a pre-accuracy caller’s shorter struct untouched.
- `ihs_location_latest2(out, out_size)` is the forward-compatible accessor: it builds the full struct and copies `min(out_size, sizeof)` bytes, so a caller compiled against any header version is never overrun. Callers wanting the timestamp/accuracy use it.

## Tests

- `parse_tpv_test`: per-axis, `eph`-only, absent, and negative-error cases, plus an assertion that `ParseTpv` leaves the timestamp unstamped (purity).
- consumer smoke: exercises `latest2`, including that a **below-legacy `out_size` is rejected** and the legacy size accepted — the bounded-copy contract that keeps the ABI safe.

## Validation

Parse test 28/28. Consumer smoke green against the installed package (including the size checks). HW-validated against a u-blox ZED-F9P via gpsd: `latest2` returns a nonzero monotonic timestamp and real per-axis sigma — **7.5 m E, 9.6 m N, 18.9 m/s**. clang-format-19 clean.