### PR TITLE
ihs_location: measurement source/filter registry

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -141,6 +141,7 @@ endif ()
 # dependency on libsystemd; only libdl (for dlopen) is needed.
 target_sources(ihs_shared PRIVATE
         src/location/location_api.cc
+        src/location/registry.cc
         src/location/gpsd_provider.cc
         src/location/geoclue_provider.cc
         src/location/fallback_location_provider.cc

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -115,6 +115,107 @@ IHS_EXPORT uint64_t ihs_location_generation(IhsLocationService* service);
 /* Stop acquiring and free @service; the handle is invalid afterwards. */
 IHS_EXPORT void ihs_location_stop(IhsLocationService* service);
 
+/*
+ * --- Measurement source / filter registry ----------------------------------
+ *
+ * A second, composable way to build the service, mirroring ihs_pv's factory
+ * registry: sources push tagged IhsMeasurement records, a filter fuses them
+ * into an IhsPosition. It exists so a non-GNSS sensor (CAN speed, an IMU) or a
+ * real estimator (a Kalman filter) can be added without touching this ABI or
+ * the enum providers above — a new sensor differs only by measurement `kind`.
+ *
+ * This surface is purely additive. The ihs_location_start() enum API is
+ * unchanged, and with nothing registered the registry is simply empty; the two
+ * ways to build the service do not interfere.
+ */
+
+/*
+ * What an IhsMeasurement's value[] carries. POSITION/VELOCITY are the GNSS
+ * staples; the rest let non-GNSS sensors feed the same filter unchanged — they
+ * differ only by `kind`, never by interface.
+ */
+typedef enum IhsMeasKind {
+  IHS_MEAS_POSITION_LLA = 0, /* lat, lon [, alt] (deg, deg, m)   — GNSS */
+  IHS_MEAS_VELOCITY_NED = 1, /* v_n, v_e [, v_d] (m/s)           — GNSS/CAN */
+  IHS_MEAS_SPEED = 2,        /* scalar ground speed (m/s)        — CAN wheel */
+  IHS_MEAS_HEADING = 3,      /* course over ground (deg)         — GNSS track */
+  IHS_MEAS_YAW_RATE = 4,     /* yaw rate (rad/s)                 — gyro/CAN */
+  IHS_MEAS_ACCEL_BODY = 5,   /* a_x, a_y, a_z (m/s^2)            — IMU */
+} IhsMeasKind;
+
+/* IhsMeasurement.flags bits. */
+enum {
+  IHS_MEAS_FLAG_DEAD_RECKONED = 1u << 0, /* propagated, not directly observed */
+};
+
+/*
+ * One tagged sensor measurement pushed by a source into the filter.
+ *
+ * ABI: struct_size versions it exactly as IhsFrame does — a producer built
+ * against a newer header may append fields, and a consumer copies only
+ * min(its sizeof, the producer's struct_size), never reading past either
+ * object (the bounded-copy discipline). value_count says how many of value[]
+ * /variance[] carry data for this `kind`.
+ */
+typedef struct IhsMeasurement {
+  uint32_t struct_size;
+  uint32_t kind;           /* IhsMeasKind */
+  uint64_t t_monotonic_ns; /* arrival on CLOCK_MONOTONIC — see IhsPosition */
+  uint32_t value_count;    /* components used in value[]/variance[] */
+  double value[6];
+  double variance[6]; /* per-component 1-sigma^2; < 0 = unknown, filter fills */
+  uint32_t flags;     /* IHS_MEAS_FLAG_* */
+} IhsMeasurement;
+
+/*
+ * A source pushes each measurement into this sink, which the manager supplies
+ * to IhsLocationSourceOps.start. Called on the source's own acquisition thread;
+ * @m is owned by the caller and valid only for the duration of the call.
+ */
+typedef void (*IhsMeasSink)(void* sink_user_data, const IhsMeasurement* m);
+
+/*
+ * Lifecycle of a measurement source. start() begins acquisition and pushes
+ * measurements to @sink (with @sink_user_data) until stop(); both receive the
+ * user_data passed to ihs_location_register_source. start() returns 1 on
+ * success, 0 if it could not begin at all.
+ */
+typedef struct IhsLocationSourceOps {
+  uint32_t struct_size;
+  int (*start)(void* user_data, IhsMeasSink sink, void* sink_user_data);
+  void (*stop)(void* user_data);
+} IhsLocationSourceOps;
+
+/*
+ * A filter fuses measurements into a position estimate. estimate(t) predicts
+ * the state forward to @t_monotonic_ns rather than returning the last fix, so a
+ * consumer polling at UI rate gets a fresh position from a 1 Hz source — the
+ * actual value of running a filter. create() returns an opaque instance (or
+ * NULL on failure) that the other ops receive; estimate() returns 1 when @out
+ * holds a valid estimate, else 0.
+ */
+typedef struct IhsLocationFilterOps {
+  uint32_t struct_size;
+  void* (*create)(void* user_data, const char* config);
+  void (*destroy)(void* instance);
+  void (*update)(void* instance, const IhsMeasurement* m);
+  int (*estimate)(void* instance, uint64_t t_monotonic_ns, IhsPosition* out);
+} IhsLocationFilterOps;
+
+/*
+ * Register a measurement source / filter under @key (e.g. "gnss.gpsd",
+ * "kalman.cv"). @ops is copied (bounded by its struct_size) and @user_data is
+ * passed back to each callback. Re-registering a key replaces the prior entry.
+ * Returns 1 on success, 0 on invalid arguments (NULL key/ops, or an ops with a
+ * struct_size too small to hold its required callbacks). Thread-safe.
+ */
+IHS_EXPORT int ihs_location_register_source(const char* key,
+                                            const IhsLocationSourceOps* ops,
+                                            void* user_data);
+IHS_EXPORT int ihs_location_register_filter(const char* key,
+                                            const IhsLocationFilterOps* ops,
+                                            void* user_data);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -151,14 +151,14 @@ enum {
 /*
  * One tagged sensor measurement pushed by a source into the filter.
  *
- * ABI: struct_size versions it exactly as IhsFrame does — a producer built
- * against a newer header may append fields, and a consumer copies only
- * min(its sizeof, the producer's struct_size), never reading past either
- * object (the bounded-copy discipline). value_count says how many of value[]
- * /variance[] carry data for this `kind`.
+ * ABI: struct_size versions it as IhsFrame does (a size_t leading field) — a
+ * producer built against a newer header may append fields, and a consumer
+ * copies only min(its sizeof, the producer's struct_size), never reading past
+ * either object (the bounded-copy discipline). value_count says how many of
+ * value[]/variance[] carry data for this `kind`.
  */
 typedef struct IhsMeasurement {
-  uint32_t struct_size;
+  size_t struct_size;
   uint32_t kind;           /* IhsMeasKind */
   uint64_t t_monotonic_ns; /* arrival on CLOCK_MONOTONIC — see IhsPosition */
   uint32_t value_count;    /* components used in value[]/variance[] */
@@ -181,7 +181,7 @@ typedef void (*IhsMeasSink)(void* sink_user_data, const IhsMeasurement* m);
  * success, 0 if it could not begin at all.
  */
 typedef struct IhsLocationSourceOps {
-  uint32_t struct_size;
+  size_t struct_size;
   int (*start)(void* user_data, IhsMeasSink sink, void* sink_user_data);
   void (*stop)(void* user_data);
 } IhsLocationSourceOps;
@@ -195,7 +195,7 @@ typedef struct IhsLocationSourceOps {
  * holds a valid estimate, else 0.
  */
 typedef struct IhsLocationFilterOps {
-  uint32_t struct_size;
+  size_t struct_size;
   void* (*create)(void* user_data, const char* config);
   void (*destroy)(void* instance);
   void (*update)(void* instance, const IhsMeasurement* m);

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -206,8 +206,11 @@ typedef struct IhsLocationFilterOps {
  * Register a measurement source / filter under @key (e.g. "gnss.gpsd",
  * "kalman.cv"). @ops is copied (bounded by its struct_size) and @user_data is
  * passed back to each callback. Re-registering a key replaces the prior entry.
- * Returns 1 on success, 0 on invalid arguments (NULL key/ops, or an ops with a
- * struct_size too small to hold its required callbacks). Thread-safe.
+ * Returns 1 on success, 0 on invalid arguments: a NULL key/ops, a struct_size
+ * too small to hold the mandatory callbacks, or a NULL mandatory callback — for
+ * a source that is start(); for a filter, create()/update()/estimate(). The
+ * optional teardown callbacks (source stop(), filter destroy()) may be NULL.
+ * Thread-safe.
  */
 IHS_EXPORT int ihs_location_register_source(const char* key,
                                             const IhsLocationSourceOps* ops,

--- a/shared/src/location/registry.cc
+++ b/shared/src/location/registry.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// The measurement source / filter registry (see registry.hpp) plus the two
+// public ihs_location_register_* entry points that populate it.
+
+#include "registry.hpp"
+
+#include <cstddef>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <string>
+
+namespace ihs::location {
+
+namespace {
+
+std::mutex g_mutex;
+std::map<std::string, SourceEntry>& sources() {
+  static std::map<std::string, SourceEntry> m;
+  return m;
+}
+std::map<std::string, FilterEntry>& filters() {
+  static std::map<std::string, FilterEntry> m;
+  return m;
+}
+
+// Copy the caller's ops into a zeroed full-size struct, taking only the bytes
+// the caller declared (min(struct_size, sizeof)). This is the ivi-homescreen
+// #337 bounded-copy discipline applied to an inbound struct: a caller built
+// against an older header passes a smaller struct_size, and any callback slot
+// it does not carry stays NULL (so the manager null-checks before calling)
+// rather than being read from past the caller's object.
+template <typename T>
+T CopyOps(const T* ops) {
+  T full{};
+  const size_t n = ops->struct_size < sizeof(T) ? ops->struct_size : sizeof(T);
+  std::memcpy(&full, ops, n);
+  full.struct_size = sizeof(T);  // normalize to what this build understands
+  return full;
+}
+
+}  // namespace
+
+bool RegisterSource(const std::string& key,
+                    const IhsLocationSourceOps* ops,
+                    void* user_data) {
+  // A source is useless without start(); struct_size must at least reach it.
+  if (key.empty() || ops == nullptr ||
+      ops->struct_size <
+          offsetof(IhsLocationSourceOps, start) + sizeof(ops->start)) {
+    return false;
+  }
+  const std::lock_guard<std::mutex> lock(g_mutex);
+  sources()[key] = SourceEntry{CopyOps(ops), user_data};
+  return true;
+}
+
+bool RegisterFilter(const std::string& key,
+                    const IhsLocationFilterOps* ops,
+                    void* user_data) {
+  // A filter must at least carry estimate() (the last of its callbacks) to be
+  // usable; require struct_size to reach it.
+  if (key.empty() || ops == nullptr ||
+      ops->struct_size <
+          offsetof(IhsLocationFilterOps, estimate) + sizeof(ops->estimate)) {
+    return false;
+  }
+  const std::lock_guard<std::mutex> lock(g_mutex);
+  filters()[key] = FilterEntry{CopyOps(ops), user_data};
+  return true;
+}
+
+bool LookupSource(const std::string& key, SourceEntry& out) {
+  const std::lock_guard<std::mutex> lock(g_mutex);
+  const auto it = sources().find(key);
+  if (it == sources().end()) {
+    return false;
+  }
+  out = it->second;
+  return true;
+}
+
+bool LookupFilter(const std::string& key, FilterEntry& out) {
+  const std::lock_guard<std::mutex> lock(g_mutex);
+  const auto it = filters().find(key);
+  if (it == filters().end()) {
+    return false;
+  }
+  out = it->second;
+  return true;
+}
+
+}  // namespace ihs::location
+
+// --- public C ABI: registration ---------------------------------------------
+
+extern "C" int ihs_location_register_source(const char* key,
+                                            const IhsLocationSourceOps* ops,
+                                            void* user_data) {
+  if (key == nullptr) {
+    return 0;
+  }
+  try {
+    return ihs::location::RegisterSource(key, ops, user_data) ? 1 : 0;
+  } catch (...) {
+    return 0;  // no exception may cross the C ABI (std::map alloc can throw)
+  }
+}
+
+extern "C" int ihs_location_register_filter(const char* key,
+                                            const IhsLocationFilterOps* ops,
+                                            void* user_data) {
+  if (key == nullptr) {
+    return 0;
+  }
+  try {
+    return ihs::location::RegisterFilter(key, ops, user_data) ? 1 : 0;
+  } catch (...) {
+    return 0;
+  }
+}

--- a/shared/src/location/registry.cc
+++ b/shared/src/location/registry.cc
@@ -70,7 +70,7 @@ constexpr bool Covers(size_t copied, size_t offset, size_t size) {
 IhsLocationSourceOps CopySourceOps(const IhsLocationSourceOps* ops) {
   const size_t n = CopiedSize(ops);
   IhsLocationSourceOps full{};
-  full.struct_size = static_cast<uint32_t>(n);
+  full.struct_size = n;
   COPY_FIELD(full, ops, n, start);
   COPY_FIELD(full, ops, n, stop);
   return full;
@@ -79,7 +79,7 @@ IhsLocationSourceOps CopySourceOps(const IhsLocationSourceOps* ops) {
 IhsLocationFilterOps CopyFilterOps(const IhsLocationFilterOps* ops) {
   const size_t n = CopiedSize(ops);
   IhsLocationFilterOps full{};
-  full.struct_size = static_cast<uint32_t>(n);
+  full.struct_size = n;
   COPY_FIELD(full, ops, n, create);
   COPY_FIELD(full, ops, n, destroy);
   COPY_FIELD(full, ops, n, update);

--- a/shared/src/location/registry.cc
+++ b/shared/src/location/registry.cc
@@ -44,7 +44,11 @@ T CopyOps(const T* ops) {
   T full{};
   const size_t n = ops->struct_size < sizeof(T) ? ops->struct_size : sizeof(T);
   std::memcpy(&full, ops, n);
-  full.struct_size = sizeof(T);  // normalize to what this build understands
+  // Preserve the copied (clamped) size, not sizeof(T): the stored struct_size
+  // is the ABI signal for which fields the caller actually provided, so a
+  // consumer can tell a field that was omitted from one supplied with a
+  // zero/NULL value. Matches platform_view.cc's zero_out discipline.
+  full.struct_size = static_cast<uint32_t>(n);
   return full;
 }
 

--- a/shared/src/location/registry.cc
+++ b/shared/src/location/registry.cc
@@ -53,10 +53,15 @@ T CopyOps(const T* ops) {
 bool RegisterSource(const std::string& key,
                     const IhsLocationSourceOps* ops,
                     void* user_data) {
-  // A source is useless without start(); struct_size must at least reach it.
+  // start() is the mandatory callback — a source with none can never be
+  // started, so reject it here rather than let a manager NULL-call it later.
+  // struct_size must reach start() before it can be read (short-circuits so the
+  // NULL check never touches an out-of-bounds slot). stop() stays optional (a
+  // source with nothing to tear down is fine; the manager NULL-checks it).
   if (key.empty() || ops == nullptr ||
       ops->struct_size <
-          offsetof(IhsLocationSourceOps, start) + sizeof(ops->start)) {
+          offsetof(IhsLocationSourceOps, start) + sizeof(ops->start) ||
+      ops->start == nullptr) {
     return false;
   }
   const std::lock_guard<std::mutex> lock(g_mutex);
@@ -67,11 +72,16 @@ bool RegisterSource(const std::string& key,
 bool RegisterFilter(const std::string& key,
                     const IhsLocationFilterOps* ops,
                     void* user_data) {
-  // A filter must at least carry estimate() (the last of its callbacks) to be
-  // usable; require struct_size to reach it.
+  // create()/update()/estimate() are the mandatory filter contract; reject an
+  // ops missing any of them rather than register an unusable filter that fails
+  // at bind/call time. struct_size must reach estimate() (the last callback,
+  // so this also covers create()/update()) before those slots can be read.
+  // destroy() stays optional (a filter with nothing to free is fine).
   if (key.empty() || ops == nullptr ||
       ops->struct_size <
-          offsetof(IhsLocationFilterOps, estimate) + sizeof(ops->estimate)) {
+          offsetof(IhsLocationFilterOps, estimate) + sizeof(ops->estimate) ||
+      ops->create == nullptr || ops->update == nullptr ||
+      ops->estimate == nullptr) {
     return false;
   }
   const std::lock_guard<std::mutex> lock(g_mutex);

--- a/shared/src/location/registry.cc
+++ b/shared/src/location/registry.cc
@@ -14,7 +14,6 @@
 #include "registry.hpp"
 
 #include <cstddef>
-#include <cstring>
 #include <map>
 #include <mutex>
 #include <string>
@@ -33,24 +32,62 @@ std::map<std::string, FilterEntry>& filters() {
   return m;
 }
 
-// Copy the caller's ops into a zeroed full-size struct, taking only the bytes
-// the caller declared (min(struct_size, sizeof)). This is the ivi-homescreen
-// #337 bounded-copy discipline applied to an inbound struct: a caller built
-// against an older header passes a smaller struct_size, and any callback slot
-// it does not carry stays NULL (so the manager null-checks before calling)
-// rather than being read from past the caller's object.
+// Inbound ops are copied with the ivi-homescreen #337 bounded-copy discipline:
+// a caller built against an older header passes a smaller struct_size, and any
+// callback it does not carry stays NULL (the manager null-checks before
+// calling) rather than being read from past the caller's object.
+
+// The clamped number of bytes the caller actually declared.
 template <typename T>
-T CopyOps(const T* ops) {
-  T full{};
-  const size_t n = ops->struct_size < sizeof(T) ? ops->struct_size : sizeof(T);
-  std::memcpy(&full, ops, n);
-  // Preserve the copied (clamped) size, not sizeof(T): the stored struct_size
-  // is the ABI signal for which fields the caller actually provided, so a
-  // consumer can tell a field that was omitted from one supplied with a
-  // zero/NULL value. Matches platform_view.cc's zero_out discipline.
+size_t CopiedSize(const T* ops) {
+  return ops->struct_size < sizeof(T) ? ops->struct_size : sizeof(T);
+}
+
+// True iff the field at [offset, offset+size) is FULLY within the caller's
+// declared bytes. A per-field copy is guarded by this so that (a) a field the
+// caller did not carry is never read past their object, and (b) a struct_size
+// that ends mid-field never yields a truncated, non-NULL garbage pointer that a
+// manager would later call — the omitted/partial field stays NULL/zero.
+constexpr bool Covers(size_t copied, size_t offset, size_t size) {
+  return offset + size <= copied;
+}
+
+// COPY_FIELD(full, ops, copied, name): copy one field only when fully covered.
+#define COPY_FIELD(full, ops, copied, name)              \
+  do {                                                   \
+    if (Covers((copied), offsetof(decltype(full), name), \
+               sizeof((full).name))) {                   \
+      (full).name = (ops)->name;                         \
+    }                                                    \
+  } while (0)
+
+// Copy the caller's ops field-by-field into a zeroed full-size struct. Unlike a
+// byte-wise memcpy of struct_size bytes (which can split a pointer field), this
+// copies each callback only when the caller's struct_size fully covers it, so
+// an omitted or straddled callback reads back NULL — the bounded-copy contract.
+// The stored struct_size keeps the caller's clamped size (the ABI signal for
+// which fields were provided), matching platform_view.cc's zero_out discipline.
+IhsLocationSourceOps CopySourceOps(const IhsLocationSourceOps* ops) {
+  const size_t n = CopiedSize(ops);
+  IhsLocationSourceOps full{};
   full.struct_size = static_cast<uint32_t>(n);
+  COPY_FIELD(full, ops, n, start);
+  COPY_FIELD(full, ops, n, stop);
   return full;
 }
+
+IhsLocationFilterOps CopyFilterOps(const IhsLocationFilterOps* ops) {
+  const size_t n = CopiedSize(ops);
+  IhsLocationFilterOps full{};
+  full.struct_size = static_cast<uint32_t>(n);
+  COPY_FIELD(full, ops, n, create);
+  COPY_FIELD(full, ops, n, destroy);
+  COPY_FIELD(full, ops, n, update);
+  COPY_FIELD(full, ops, n, estimate);
+  return full;
+}
+
+#undef COPY_FIELD
 
 }  // namespace
 
@@ -69,7 +106,7 @@ bool RegisterSource(const std::string& key,
     return false;
   }
   const std::lock_guard<std::mutex> lock(g_mutex);
-  sources()[key] = SourceEntry{CopyOps(ops), user_data};
+  sources()[key] = SourceEntry{CopySourceOps(ops), user_data};
   return true;
 }
 
@@ -89,7 +126,7 @@ bool RegisterFilter(const std::string& key,
     return false;
   }
   const std::lock_guard<std::mutex> lock(g_mutex);
-  filters()[key] = FilterEntry{CopyOps(ops), user_data};
+  filters()[key] = FilterEntry{CopyFilterOps(ops), user_data};
   return true;
 }
 

--- a/shared/src/location/registry.hpp
+++ b/shared/src/location/registry.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_REGISTRY_H_
+#define IHS_LOC_REGISTRY_H_
+
+#include <string>
+
+#include "ihs/location.h"
+
+// Process-wide table of measurement sources and filters, keyed by string, the
+// same shape as ihs_pv's factory registry. Unlike ihs_pv (whose views live in
+// the shell, so its registry is a host indirection), the location providers
+// live in libihs_shared itself, so this is a plain in-process table.
+//
+// The manager (built next) looks entries up by key to compose a service; the
+// public ihs_location_register_source/_filter functions populate it. Thread-
+// safe: registration and lookup take an internal mutex, so a source thread can
+// register while the manager binds.
+namespace ihs::location {
+
+// A registered source/filter: the caller's ops (copied bounded by struct_size
+// into a zeroed full-size struct, so a shorter caller ops is never over-read
+// and any callback it did not provide reads back NULL) plus its user_data.
+struct SourceEntry {
+  IhsLocationSourceOps ops{};
+  void* user_data = nullptr;
+};
+struct FilterEntry {
+  IhsLocationFilterOps ops{};
+  void* user_data = nullptr;
+};
+
+// Register under @key, replacing any prior entry. Returns false on a NULL/empty
+// key, NULL @ops, or an @ops whose struct_size is too small to carry the
+// callbacks the entry requires. Thread-safe.
+bool RegisterSource(const std::string& key,
+                    const IhsLocationSourceOps* ops,
+                    void* user_data);
+bool RegisterFilter(const std::string& key,
+                    const IhsLocationFilterOps* ops,
+                    void* user_data);
+
+// Copy the entry for @key into @out. Returns false if @key is not registered.
+// Thread-safe; @out is a value copy, so it stays valid across later
+// (re-)registrations.
+bool LookupSource(const std::string& key, SourceEntry& out);
+bool LookupFilter(const std::string& key, FilterEntry& out);
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_REGISTRY_H_

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -40,6 +40,37 @@
     }                              \
   } while (0)
 
+/* A trivial C measurement source + filter, only so the registration ABI is
+ * exercised as strict C11 (the point of this consumer). They are never bound
+ * here — that is the manager's job in a later step. */
+static int smoke_src_start(void* ud, IhsMeasSink sink, void* sink_ud) {
+  (void)ud;
+  (void)sink;
+  (void)sink_ud;
+  return 1;
+}
+static void smoke_src_stop(void* ud) {
+  (void)ud;
+}
+static void* smoke_flt_create(void* ud, const char* config) {
+  (void)ud;
+  (void)config;
+  return (void*)&smoke_flt_create; /* any non-NULL instance */
+}
+static void smoke_flt_destroy(void* inst) {
+  (void)inst;
+}
+static void smoke_flt_update(void* inst, const IhsMeasurement* m) {
+  (void)inst;
+  (void)m;
+}
+static int smoke_flt_estimate(void* inst, uint64_t t_ns, IhsPosition* out) {
+  (void)inst;
+  (void)t_ns;
+  (void)out;
+  return 0;
+}
+
 int main(void) {
   /* Version handshake. */
   const IhsApi* api = ihs_get_api(IHS_SHARED_ABI_VERSION);
@@ -121,6 +152,36 @@ int main(void) {
   }
   CHECK(ihs_location_generation(NULL) == 0, "generation(NULL) is 0");
   ihs_location_stop(NULL); /* must be a safe nop */
+
+  /* Measurement source / filter registry: additive ABI. Register one of each,
+   * assert the return codes and the argument-rejection contract. Nothing binds
+   * them here; this is the header/ABI C-cleanliness gate for the new surface.
+   */
+  {
+    IhsLocationSourceOps src_ops;
+    IhsLocationFilterOps flt_ops;
+    memset(&src_ops, 0, sizeof(src_ops));
+    src_ops.struct_size = sizeof(src_ops);
+    src_ops.start = smoke_src_start;
+    src_ops.stop = smoke_src_stop;
+    CHECK(ihs_location_register_source("gnss.smoke", &src_ops, NULL) == 1,
+          "register a measurement source");
+    CHECK(ihs_location_register_source(NULL, &src_ops, NULL) == 0,
+          "reject a NULL source key");
+    CHECK(ihs_location_register_source("gnss.smoke", NULL, NULL) == 0,
+          "reject NULL source ops");
+
+    memset(&flt_ops, 0, sizeof(flt_ops));
+    flt_ops.struct_size = sizeof(flt_ops);
+    flt_ops.create = smoke_flt_create;
+    flt_ops.destroy = smoke_flt_destroy;
+    flt_ops.update = smoke_flt_update;
+    flt_ops.estimate = smoke_flt_estimate;
+    CHECK(ihs_location_register_filter("kalman.smoke", &flt_ops, NULL) == 1,
+          "register a filter");
+    CHECK(ihs_location_register_filter(NULL, &flt_ops, NULL) == 0,
+          "reject a NULL filter key");
+  }
 
   printf("OK ihs_shared consumer smoke: abi=0x%08x logging=%s\n",
          api->abi_version, api->logging != NULL ? "present" : "absent");

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -52,10 +52,11 @@ static int smoke_src_start(void* ud, IhsMeasSink sink, void* sink_ud) {
 static void smoke_src_stop(void* ud) {
   (void)ud;
 }
+static int smoke_flt_state; /* a static object handed back as the instance */
 static void* smoke_flt_create(void* ud, const char* config) {
   (void)ud;
   (void)config;
-  return (void*)&smoke_flt_create; /* any non-NULL instance */
+  return &smoke_flt_state; /* any non-NULL instance (object, not a function) */
 }
 static void smoke_flt_destroy(void* inst) {
   (void)inst;

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -43,6 +43,7 @@ add_test(NAME parse_tpv COMMAND parse_tpv_test)
 # only the full library build produces. This test links everything statically,
 # so a trivial empty IHS_EXPORT stands in — no installed library needed.
 set(_export_stub ${CMAKE_CURRENT_BINARY_DIR}/gen/ihs/ihs_export.h)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gen/ihs)
 file(WRITE ${_export_stub}
         "#ifndef IHS_EXPORT_H\n#define IHS_EXPORT_H\n"
         "#define IHS_EXPORT\n#define IHS_NO_EXPORT\n#endif\n")

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -28,6 +28,7 @@ enable_testing()
 find_package(Threads REQUIRED)
 
 set(_loc_src ${CMAKE_CURRENT_SOURCE_DIR}/../../src/location)
+set(_loc_inc ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
 add_executable(parse_tpv_test parse_tpv_test.cc ${_loc_src}/gpsd_provider.cc)
 target_include_directories(parse_tpv_test PRIVATE ${_loc_src})
@@ -35,3 +36,21 @@ target_compile_options(parse_tpv_test PRIVATE -Wall -Wextra)
 target_link_libraries(parse_tpv_test PRIVATE Threads::Threads)
 
 add_test(NAME parse_tpv COMMAND parse_tpv_test)
+
+# Measurement source / filter registry. Compiles registry.cc directly (the
+# Lookup* API is internal) and reaches the public header for IhsMeasurement etc.
+# That header includes the CMake-generated ihs/ihs_export.h (IHS_EXPORT), which
+# only the full library build produces. This test links everything statically,
+# so a trivial empty IHS_EXPORT stands in — no installed library needed.
+set(_export_stub ${CMAKE_CURRENT_BINARY_DIR}/gen/ihs/ihs_export.h)
+file(WRITE ${_export_stub}
+        "#ifndef IHS_EXPORT_H\n#define IHS_EXPORT_H\n"
+        "#define IHS_EXPORT\n#define IHS_NO_EXPORT\n#endif\n")
+
+add_executable(registry_test registry_test.cc ${_loc_src}/registry.cc)
+target_include_directories(registry_test PRIVATE
+        ${_loc_src} ${_loc_inc} ${CMAKE_CURRENT_BINARY_DIR}/gen)
+target_compile_options(registry_test PRIVATE -Wall -Wextra)
+target_link_libraries(registry_test PRIVATE Threads::Threads)
+
+add_test(NAME registry COMMAND registry_test)

--- a/shared/tests/location/registry_test.cc
+++ b/shared/tests/location/registry_test.cc
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Unit test for the measurement source / filter registry. Standalone (like
+// parse_tpv_test): compiles registry.cc directly, exercising both the internal
+// Lookup* API and the public ihs_location_register_* entry points. Proves the
+// table stores/replaces/rejects entries, that a shorter-struct_size caller is
+// accepted with its missing callbacks read back NULL (the bounded-copy
+// discipline), and that a measurement pushed to a source's sink and a filter's
+// create/update/estimate round-trip through the stored ops.
+
+#include "registry.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include "ihs/location.h"
+
+namespace {
+
+int g_tests = 0;
+int g_failures = 0;
+
+void Check(bool cond, const char* what) {
+  ++g_tests;
+  if (!cond) {
+    ++g_failures;
+    std::fprintf(stderr, "FAIL: %s\n", what);
+  }
+}
+
+// --- a fake source: start() records the sink and pushes one measurement ------
+
+struct FakeSource {
+  IhsMeasSink sink = nullptr;
+  void* sink_ud = nullptr;
+  int start_calls = 0;
+  int stop_calls = 0;
+};
+
+int FakeSourceStart(void* ud, IhsMeasSink sink, void* sink_ud) {
+  auto* s = static_cast<FakeSource*>(ud);
+  s->sink = sink;
+  s->sink_ud = sink_ud;
+  ++s->start_calls;
+  return 1;
+}
+void FakeSourceStop(void* ud) {
+  ++static_cast<FakeSource*>(ud)->stop_calls;
+}
+
+// --- a captured sink ---------------------------------------------------------
+
+struct SinkCapture {
+  IhsMeasurement last{};
+  int count = 0;
+};
+void CaptureSink(void* ud, const IhsMeasurement* m) {
+  auto* c = static_cast<SinkCapture*>(ud);
+  // Bounded copy, exactly what a real manager does: never read past the
+  // producer's declared struct_size.
+  std::memset(&c->last, 0, sizeof(c->last));
+  const size_t n = m->struct_size < sizeof(IhsMeasurement)
+                       ? m->struct_size
+                       : sizeof(IhsMeasurement);
+  std::memcpy(&c->last, m, n);
+  ++c->count;
+}
+
+// --- a fake filter: sums position measurements -------------------------------
+
+struct FakeFilter {
+  double last_lat = 0.0;
+  int updates = 0;
+};
+
+void* FakeFilterCreate(void* /*ud*/, const char* /*config*/) {
+  return new FakeFilter();
+}
+void FakeFilterDestroy(void* inst) {
+  delete static_cast<FakeFilter*>(inst);
+}
+void FakeFilterUpdate(void* inst, const IhsMeasurement* m) {
+  auto* f = static_cast<FakeFilter*>(inst);
+  if (m->kind == IHS_MEAS_POSITION_LLA && m->value_count >= 2) {
+    f->last_lat = m->value[0];
+  }
+  ++f->updates;
+}
+int FakeFilterEstimate(void* inst, uint64_t t_ns, IhsPosition* out) {
+  auto* f = static_cast<FakeFilter*>(inst);
+  if (f->updates == 0) {
+    return 0;
+  }
+  out->latitude = f->last_lat;
+  out->t_monotonic_ns = t_ns;
+  out->mode = 3;
+  return 1;
+}
+
+}  // namespace
+
+int main() {
+  using namespace ihs::location;
+
+  // --- source registration + lookup + a measurement through the sink ---------
+  {
+    FakeSource src;
+    IhsLocationSourceOps ops{};
+    ops.struct_size = sizeof(ops);
+    ops.start = &FakeSourceStart;
+    ops.stop = &FakeSourceStop;
+
+    Check(ihs_location_register_source("gnss.fake", &ops, &src) == 1,
+          "register source succeeds");
+
+    SourceEntry entry;
+    Check(LookupSource("gnss.fake", entry), "lookup registered source");
+    Check(entry.user_data == &src, "source user_data round-trips");
+    Check(entry.ops.start != nullptr && entry.ops.stop != nullptr,
+          "source ops round-trip");
+
+    SinkCapture cap;
+    Check(entry.ops.start(entry.user_data, &CaptureSink, &cap) == 1,
+          "start returns success");
+    Check(src.start_calls == 1 && src.sink == &CaptureSink,
+          "start recorded sink");
+
+    IhsMeasurement m{};
+    m.struct_size = sizeof(m);
+    m.kind = IHS_MEAS_POSITION_LLA;
+    m.t_monotonic_ns = 42;
+    m.value_count = 2;
+    m.value[0] = 48.75;
+    m.value[1] = -122.48;
+    src.sink(src.sink_ud, &m);  // source pushes into the captured sink
+    Check(cap.count == 1, "sink received one measurement");
+    Check(cap.last.value[0] == 48.75 && cap.last.value[1] == -122.48,
+          "measurement values round-trip through sink");
+    Check(cap.last.t_monotonic_ns == 42, "measurement timestamp round-trips");
+
+    entry.ops.stop(entry.user_data);
+    Check(src.stop_calls == 1, "stop reached the source");
+  }
+
+  // --- re-registering a key replaces the entry -------------------------------
+  {
+    FakeSource a;
+    FakeSource b;
+    IhsLocationSourceOps ops{};
+    ops.struct_size = sizeof(ops);
+    ops.start = &FakeSourceStart;
+    ops.stop = &FakeSourceStop;
+
+    ihs_location_register_source("gnss.dup", &ops, &a);
+    ihs_location_register_source("gnss.dup", &ops, &b);
+    SourceEntry entry;
+    Check(LookupSource("gnss.dup", entry) && entry.user_data == &b,
+          "re-register replaces the prior entry");
+  }
+
+  // --- filter registration + create/update/estimate round-trip ---------------
+  {
+    IhsLocationFilterOps ops{};
+    ops.struct_size = sizeof(ops);
+    ops.create = &FakeFilterCreate;
+    ops.destroy = &FakeFilterDestroy;
+    ops.update = &FakeFilterUpdate;
+    ops.estimate = &FakeFilterEstimate;
+
+    Check(ihs_location_register_filter("kalman.fake", &ops, nullptr) == 1,
+          "register filter succeeds");
+
+    FilterEntry entry;
+    Check(LookupFilter("kalman.fake", entry), "lookup registered filter");
+
+    void* inst = entry.ops.create(entry.user_data, nullptr);
+    Check(inst != nullptr, "filter create returns an instance");
+
+    IhsPosition out{};
+    Check(entry.ops.estimate(inst, 0, &out) == 0,
+          "estimate before any update reports no fix");
+
+    IhsMeasurement m{};
+    m.struct_size = sizeof(m);
+    m.kind = IHS_MEAS_POSITION_LLA;
+    m.value_count = 2;
+    m.value[0] = 12.5;
+    entry.ops.update(inst, &m);
+    Check(entry.ops.estimate(inst, 99, &out) == 1,
+          "estimate after update reports a fix");
+    Check(out.latitude == 12.5 && out.t_monotonic_ns == 99,
+          "filter estimate carries the measurement + query time");
+    entry.ops.destroy(inst);
+  }
+
+  // --- rejections: NULL args and an under-sized ops --------------------------
+  {
+    IhsLocationSourceOps good{};
+    good.struct_size = sizeof(good);
+    good.start = &FakeSourceStart;
+    good.stop = &FakeSourceStop;
+
+    Check(ihs_location_register_source(nullptr, &good, nullptr) == 0,
+          "reject NULL key");
+    Check(ihs_location_register_source("k", nullptr, nullptr) == 0,
+          "reject NULL ops");
+
+    // struct_size that does not even reach start() — rejected, not accepted
+    // with a garbage callback.
+    IhsLocationSourceOps tiny{};
+    tiny.struct_size = offsetof(IhsLocationSourceOps, start);
+    tiny.start = &FakeSourceStart;
+    Check(ihs_location_register_source("gnss.tiny", &tiny, nullptr) == 0,
+          "reject ops too small to hold start()");
+
+    SourceEntry absent;
+    Check(!LookupSource("gnss.absent", absent),
+          "lookup of an unregistered key fails");
+  }
+
+  // --- bounded copy: a shorter-struct_size ops that omits stop() reads back
+  //     NULL rather than being over-read past the caller's object -------------
+  {
+    IhsLocationSourceOps partial{};
+    // Declare a size that covers start() but stops before stop(). stop is set
+    // to a real callback, but it lies past the declared struct_size, so the
+    // registry must NOT copy it.
+    partial.struct_size = offsetof(IhsLocationSourceOps, stop);
+    partial.start = &FakeSourceStart;
+    partial.stop = &FakeSourceStop;
+
+    Check(ihs_location_register_source("gnss.partial", &partial, nullptr) == 1,
+          "accept ops that reaches start() but not stop()");
+    SourceEntry entry;
+    Check(LookupSource("gnss.partial", entry), "lookup partial source");
+    Check(entry.ops.start == &FakeSourceStart, "partial: start copied");
+    Check(entry.ops.stop == nullptr,
+          "partial: stop past struct_size read back NULL, not the bogus value");
+  }
+
+  if (g_failures == 0) {
+    std::printf("registry_test: all %d checks passed\n", g_tests);
+  } else {
+    std::fprintf(stderr, "registry_test: %d/%d checks FAILED\n", g_failures,
+                 g_tests);
+  }
+  return g_failures == 0 ? 0 : 1;
+}

--- a/shared/tests/location/registry_test.cc
+++ b/shared/tests/location/registry_test.cc
@@ -278,6 +278,8 @@ int main() {
     Check(entry.ops.start == &FakeSourceStart, "partial: start copied");
     Check(entry.ops.stop == nullptr,
           "partial: stop past struct_size read back NULL, not the bogus value");
+    Check(entry.ops.struct_size == offsetof(IhsLocationSourceOps, stop),
+          "partial: stored struct_size preserves the caller's declared size");
   }
 
   if (g_failures == 0) {

--- a/shared/tests/location/registry_test.cc
+++ b/shared/tests/location/registry_test.cc
@@ -18,7 +18,7 @@
 
 #include "registry.hpp"
 
-#include <cassert>
+#include <cstddef>  // offsetof
 #include <cstdint>
 #include <cstdio>
 #include <cstring>

--- a/shared/tests/location/registry_test.cc
+++ b/shared/tests/location/registry_test.cc
@@ -223,9 +223,41 @@ int main() {
     Check(ihs_location_register_source("gnss.tiny", &tiny, nullptr) == 0,
           "reject ops too small to hold start()");
 
+    // A source with room for start() but a NULL start() is unusable — rejected.
+    IhsLocationSourceOps no_start{};
+    no_start.struct_size = sizeof(no_start);
+    no_start.start = nullptr;
+    no_start.stop = &FakeSourceStop;
+    Check(ihs_location_register_source("gnss.nostart", &no_start, nullptr) == 0,
+          "reject a source with a NULL start()");
+
     SourceEntry absent;
     Check(!LookupSource("gnss.absent", absent),
           "lookup of an unregistered key fails");
+  }
+
+  // --- a filter missing a mandatory callback is rejected ---------------------
+  {
+    IhsLocationFilterOps ops{};
+    ops.struct_size = sizeof(ops);
+    ops.create = &FakeFilterCreate;
+    ops.destroy = &FakeFilterDestroy;
+    ops.update = &FakeFilterUpdate;
+    ops.estimate = nullptr;  // the mandatory estimator is missing
+    Check(ihs_location_register_filter("kalman.noest", &ops, nullptr) == 0,
+          "reject a filter with a NULL estimate()");
+
+    // destroy() is optional: a filter that provides create/update/estimate but
+    // no destroy() is still usable and must be accepted.
+    IhsLocationFilterOps no_destroy{};
+    no_destroy.struct_size = sizeof(no_destroy);
+    no_destroy.create = &FakeFilterCreate;
+    no_destroy.destroy = nullptr;
+    no_destroy.update = &FakeFilterUpdate;
+    no_destroy.estimate = &FakeFilterEstimate;
+    Check(ihs_location_register_filter("kalman.nodestroy", &no_destroy,
+                                       nullptr) == 1,
+          "accept a filter with no destroy()");
   }
 
   // --- bounded copy: a shorter-struct_size ops that omits stop() reads back

--- a/shared/tests/location/registry_test.cc
+++ b/shared/tests/location/registry_test.cc
@@ -282,6 +282,26 @@ int main() {
           "partial: stored struct_size preserves the caller's declared size");
   }
 
+  // --- a struct_size that ends MID-pointer must not yield a truncated,
+  //     non-NULL stop(): the field is only partly covered, so it stays NULL ---
+  {
+    IhsLocationSourceOps straddle{};
+    // One byte into stop's pointer — a byte-wise copy would splice a truncated,
+    // non-NULL garbage pointer; the field-at-a-time copy leaves it NULL.
+    straddle.struct_size = offsetof(IhsLocationSourceOps, stop) + 1;
+    straddle.start = &FakeSourceStart;
+    straddle.stop = &FakeSourceStop;
+
+    Check(
+        ihs_location_register_source("gnss.straddle", &straddle, nullptr) == 1,
+        "accept ops whose size ends mid-stop()");
+    SourceEntry entry;
+    Check(LookupSource("gnss.straddle", entry), "lookup straddle source");
+    Check(entry.ops.start == &FakeSourceStart, "straddle: start copied");
+    Check(entry.ops.stop == nullptr,
+          "straddle: a partially-covered stop() reads back NULL, not garbage");
+  }
+
   if (g_failures == 0) {
     std::printf("registry_test: all %d checks passed\n", g_tests);
   } else {


### PR DESCRIPTION
Adds a composable way to build the location service alongside the existing enum providers, mirroring `ihs_pv`'s string-keyed factory registry: **sources** push tagged `IhsMeasurement` records and a **filter** fuses them into an `IhsPosition`. This is the surface a non-GNSS sensor (CAN speed, an IMU) or a real estimator plugs into without touching the shipped `ihs_location_*` ABI.

### What's here
- **`location.h`** — `IhsMeasurement`/`IhsMeasKind`, `IhsLocationSourceOps`/`IhsLocationFilterOps` + `IhsMeasSink`, and `ihs_location_register_source`/`_filter`. `struct_size`-versioned like `IhsFrame`; the bounded-copy discipline applies to inbound ops — a caller built against a shorter header has its missing callback slots read back NULL rather than over-read past its object.
- **`registry.{hpp,cc}`** — mutex-guarded key→ops table (thread-safe register/lookup) with the two public register entry points over it. Every C entry point wraps the throwing `std::map` ops so no exception crosses the ABI.
- **Tests** — `registry_test` (25 checks: register/replace/reject, sink round-trip, filter create/update/estimate, bounded-copy of a short ops) and `consumer.c` strict-C11 coverage of the new registration surface.

### Behavior
Purely additive. `ihs_location_start()`'s enum API is unchanged and the registry is empty until something registers, so the two paths do not interfere — no runtime behavior changes. Nothing binds the registry yet.

### Follow-up
The manager that binds registered sources through a filter, plus re-expressing the gpsd/geoclue providers as sources and making `ihs_location_start` a thin shim over the registry, is the next PR — where the no-behavior-change bar is exercised against the live-GNSS matrix.

### Verification
- `registry_test`: 25/25 checks pass.
- consumer smoke (install + out-of-tree strict-C11 `find_package` build): pass.
- Standalone `cmake -S shared` library build links; `ihs_location_register_source`/`_filter` export in the `ihs_*` dynamic symbol table.
- clang-tidy-19 clean on the new sources; clang-format-19 clean.