### PR TITLE
platform-views: sample planar YUV on the Vulkan importer (VkSamplerYcbcrConversion)

### DIFF
--- a/shell/backend/wayland_vulkan/wayland_vulkan.cc
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.cc
@@ -781,6 +781,32 @@ void WaylandVulkanBackend::createLogicalDevice() {
     }
   }
 
+  // Enable samplerYcbcrConversion so the platform-view compositor can build a
+  // VkSamplerYcbcrConversion to sample planar YUV (NV12) video dma-bufs. Core
+  // in Vulkan 1.1 (this device targets 1.1), but the feature bit must still be
+  // requested; query it and chain it only when the device reports support, so a
+  // device without it still creates rather than failing here. Without the
+  // feature the compositor's VkSamplerYcbcrConversion/pipeline creation fails
+  // (LayerCompositor logs it once and caches the failure); a planar-YUV layer
+  // is then skipped and its video does not display.
+  VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr_feature{};
+  ycbcr_feature.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES;
+  {
+    VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr_supported{};
+    ycbcr_supported.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES;
+    VkPhysicalDeviceFeatures2 features2{};
+    features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    features2.pNext = &ycbcr_supported;
+    d().vkGetPhysicalDeviceFeatures2(physical_device_, &features2);
+    if (ycbcr_supported.samplerYcbcrConversion == VK_TRUE) {
+      ycbcr_feature.samplerYcbcrConversion = VK_TRUE;
+      ycbcr_feature.pNext = const_cast<void*>(device_info.pNext);
+      device_info.pNext = &ycbcr_feature;
+    }
+  }
+
   CHECK_VK_RESULT(
       d().vkCreateDevice(physical_device_, &device_info, nullptr, &device_));
 
@@ -2617,6 +2643,10 @@ bool WaylandVulkanBackend::CompositeLayersBlend(VkCommandBuffer cmd,
     VkFormat format;
     int32_t dx, dy, dw, dh;
     VulkanBackingStore* store;  // non-null => restore to COLOR_ATTACHMENT after
+    // Color conversion for a planar-YUV source; ignored for RGB formats.
+    VkSamplerYcbcrModelConversion ycbcr_model{
+        VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY};
+    VkSamplerYcbcrRange ycbcr_range{VK_SAMPLER_YCBCR_RANGE_ITU_NARROW};
   };
   std::vector<Draw> draws;
   draws.reserve(count);
@@ -2689,6 +2719,16 @@ bool WaylandVulkanBackend::CompositeLayersBlend(VkCommandBuffer cmd,
         continue;  // GL / subsurface platform view — nothing to sample
       }
       auto src = reinterpret_cast<VkImage>(vk_img);
+      // The image's real format: 0 keeps the historical B8G8R8A8_UNORM contract
+      // (RGB producers); a planar YUV producer reports its format plus the
+      // color model/range for the compositor's VkSamplerYcbcrConversion.
+      const uint32_t pv_fmt = surface->GetVulkanImageFormat();
+      const VkFormat src_format = pv_fmt != 0 ? static_cast<VkFormat>(pv_fmt)
+                                              : VK_FORMAT_B8G8R8A8_UNORM;
+      const auto ycbcr_model = static_cast<VkSamplerYcbcrModelConversion>(
+          surface->GetVulkanYcbcrModel());
+      const auto ycbcr_range =
+          static_cast<VkSamplerYcbcrRange>(surface->GetVulkanYcbcrRange());
       // Wait the producer's acquire fence (if any) in this frame's submit.
       CollectAcquireWait(surface.get());
       const auto cur =
@@ -2703,7 +2743,8 @@ bool WaylandVulkanBackend::CompositeLayersBlend(VkCommandBuffer cmd,
                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
         surface->SetVulkanImageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
       }
-      draws.push_back({src, VK_FORMAT_B8G8R8A8_UNORM, dx, dy, dw, dh, nullptr});
+      draws.push_back(
+          {src, src_format, dx, dy, dw, dh, nullptr, ycbcr_model, ycbcr_range});
       if (const int64_t us = ivi::pv_latency::FirstCompositeLatencyUs(
               layer->platform_view->identifier);
           us >= 0) {
@@ -2715,12 +2756,19 @@ bool WaylandVulkanBackend::CompositeLayersBlend(VkCommandBuffer cmd,
   }
 
   // Phase 2: blend all layers into the target in one render pass (z-order).
-  layer_compositor_->BeginFrame(cmd, target_view, width, height, frame);
-  for (const Draw& dr : draws) {
-    layer_compositor_->DrawLayer(cmd, dr.src, dr.format, dr.dx, dr.dy, dr.dw,
-                                 dr.dh);
+  // Only record draws/EndFrame if BeginFrame actually opened the render pass;
+  // on failure (e.g. framebuffer creation) recording them would emit commands
+  // outside a render pass and produce an invalid command buffer. Phase 3 below
+  // still runs so the backing stores are restored regardless.
+  if (layer_compositor_->BeginFrame(cmd, target_view, width, height, frame)) {
+    for (const Draw& dr : draws) {
+      layer_compositor_->DrawLayer(cmd, dr.src, dr.format, dr.ycbcr_model,
+                                   dr.ycbcr_range, dr.dx, dr.dy, dr.dw, dr.dh);
+    }
+    wl_vulkan::LayerCompositor::EndFrame(cmd);
+  } else {
+    ok = false;
   }
-  wl_vulkan::LayerCompositor::EndFrame(cmd);
 
   // Phase 3: restore backing stores to COLOR_ATTACHMENT for the engine's next
   // render into them.

--- a/shell/backend/wayland_vulkan/wl_layer_compositor.cc
+++ b/shell/backend/wayland_vulkan/wl_layer_compositor.cc
@@ -18,6 +18,8 @@
 
 #include <array>
 
+#include "logging/logging.h"
+
 // Dynamic dispatch, shared with the backend (which owns the loader storage).
 #define VULKAN_HPP_NO_EXCEPTIONS 1
 #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
@@ -48,6 +50,94 @@ VkShaderModule MakeModule(VkDevice dev, const uint32_t* code, size_t bytes) {
   VkShaderModule m = VK_NULL_HANDLE;
   d().vkCreateShaderModule(dev, &ci, nullptr, &m);
   return m;
+}
+
+// Whether the compositor samples @p format through a VkSamplerYcbcrConversion.
+// Matches the planar formats DmabufVulkanImporter maps YUV fourccs to.
+bool IsYuvFormat(VkFormat format) {
+  return format == VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+}
+
+// Builds the compositing pipeline for @p layout. The RGB and YUV variants share
+// identical fixed-function state (a full quad, premultiplied src-over blend,
+// dynamic viewport/scissor, positions from gl_VertexIndex, no vertex input) and
+// the same shaders; they differ only in the layout — the YUV one references the
+// immutable-ycbcr-sampler set layout, which bakes the conversion into sampling.
+// Returns VK_NULL_HANDLE on failure.
+VkPipeline MakePipeline(VkDevice device,
+                        VkRenderPass render_pass,
+                        VkPipelineLayout layout) {
+  VkShaderModule vs = MakeModule(device, kVertSpv, sizeof(kVertSpv));
+  VkShaderModule fs = MakeModule(device, kFragSpv, sizeof(kFragSpv));
+  std::array<VkPipelineShaderStageCreateInfo, 2> stages{};
+  stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+  stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+  stages[0].module = vs;
+  stages[0].pName = "main";
+  stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+  stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+  stages[1].module = fs;
+  stages[1].pName = "main";
+
+  VkPipelineVertexInputStateCreateInfo vi{};
+  vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+  VkPipelineInputAssemblyStateCreateInfo ia{};
+  ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+  ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
+  VkPipelineViewportStateCreateInfo vp{};
+  vp.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+  vp.viewportCount = 1;
+  vp.scissorCount = 1;
+  VkPipelineRasterizationStateCreateInfo rs{};
+  rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+  rs.polygonMode = VK_POLYGON_MODE_FILL;
+  rs.cullMode = VK_CULL_MODE_NONE;
+  rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+  rs.lineWidth = 1.0f;
+  VkPipelineMultisampleStateCreateInfo ms{};
+  ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+  ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+  VkPipelineColorBlendAttachmentState blend{};
+  blend.blendEnable = VK_TRUE;
+  blend.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;  // premultiplied
+  blend.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+  blend.colorBlendOp = VK_BLEND_OP_ADD;
+  blend.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+  blend.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+  blend.alphaBlendOp = VK_BLEND_OP_ADD;
+  blend.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                         VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+  VkPipelineColorBlendStateCreateInfo cb{};
+  cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+  cb.attachmentCount = 1;
+  cb.pAttachments = &blend;
+  std::array<VkDynamicState, 2> dyn = {VK_DYNAMIC_STATE_VIEWPORT,
+                                       VK_DYNAMIC_STATE_SCISSOR};
+  VkPipelineDynamicStateCreateInfo ds{};
+  ds.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+  ds.dynamicStateCount = static_cast<uint32_t>(dyn.size());
+  ds.pDynamicStates = dyn.data();
+
+  VkGraphicsPipelineCreateInfo gp{};
+  gp.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+  gp.stageCount = static_cast<uint32_t>(stages.size());
+  gp.pStages = stages.data();
+  gp.pVertexInputState = &vi;
+  gp.pInputAssemblyState = &ia;
+  gp.pViewportState = &vp;
+  gp.pRasterizationState = &rs;
+  gp.pMultisampleState = &ms;
+  gp.pColorBlendState = &cb;
+  gp.pDynamicState = &ds;
+  gp.layout = layout;
+  gp.renderPass = render_pass;
+  gp.subpass = 0;
+  VkPipeline pipeline = VK_NULL_HANDLE;
+  const VkResult pr = d().vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1,
+                                                    &gp, nullptr, &pipeline);
+  d().vkDestroyShaderModule(device, vs, nullptr);
+  d().vkDestroyShaderModule(device, fs, nullptr);
+  return pr == VK_SUCCESS ? pipeline : VK_NULL_HANDLE;
 }
 
 }  // namespace
@@ -151,78 +241,11 @@ std::unique_ptr<LayerCompositor> LayerCompositor::Create(VkDevice device,
     return nullptr;
   }
 
-  // Graphics pipeline: full-screen-ish quad, premultiplied src-over blend,
-  // dynamic viewport/scissor, no vertex input (positions from gl_VertexIndex).
-  VkShaderModule vs = MakeModule(device, kVertSpv, sizeof(kVertSpv));
-  VkShaderModule fs = MakeModule(device, kFragSpv, sizeof(kFragSpv));
-  std::array<VkPipelineShaderStageCreateInfo, 2> stages{};
-  stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-  stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-  stages[0].module = vs;
-  stages[0].pName = "main";
-  stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-  stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-  stages[1].module = fs;
-  stages[1].pName = "main";
-
-  VkPipelineVertexInputStateCreateInfo vi{};
-  vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-  VkPipelineInputAssemblyStateCreateInfo ia{};
-  ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-  ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
-  VkPipelineViewportStateCreateInfo vp{};
-  vp.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-  vp.viewportCount = 1;
-  vp.scissorCount = 1;
-  VkPipelineRasterizationStateCreateInfo rs{};
-  rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-  rs.polygonMode = VK_POLYGON_MODE_FILL;
-  rs.cullMode = VK_CULL_MODE_NONE;
-  rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-  rs.lineWidth = 1.0f;
-  VkPipelineMultisampleStateCreateInfo ms{};
-  ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-  ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-  VkPipelineColorBlendAttachmentState blend{};
-  blend.blendEnable = VK_TRUE;
-  blend.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;  // premultiplied
-  blend.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-  blend.colorBlendOp = VK_BLEND_OP_ADD;
-  blend.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-  blend.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-  blend.alphaBlendOp = VK_BLEND_OP_ADD;
-  blend.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                         VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-  VkPipelineColorBlendStateCreateInfo cb{};
-  cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-  cb.attachmentCount = 1;
-  cb.pAttachments = &blend;
-  std::array<VkDynamicState, 2> dyn = {VK_DYNAMIC_STATE_VIEWPORT,
-                                       VK_DYNAMIC_STATE_SCISSOR};
-  VkPipelineDynamicStateCreateInfo ds{};
-  ds.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-  ds.dynamicStateCount = static_cast<uint32_t>(dyn.size());
-  ds.pDynamicStates = dyn.data();
-
-  VkGraphicsPipelineCreateInfo gp{};
-  gp.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-  gp.stageCount = static_cast<uint32_t>(stages.size());
-  gp.pStages = stages.data();
-  gp.pVertexInputState = &vi;
-  gp.pInputAssemblyState = &ia;
-  gp.pViewportState = &vp;
-  gp.pRasterizationState = &rs;
-  gp.pMultisampleState = &ms;
-  gp.pColorBlendState = &cb;
-  gp.pDynamicState = &ds;
-  gp.layout = c->pipeline_layout_;
-  gp.renderPass = c->render_pass_;
-  gp.subpass = 0;
-  const VkResult pr = d().vkCreateGraphicsPipelines(
-      device, VK_NULL_HANDLE, 1, &gp, nullptr, &c->pipeline_);
-  d().vkDestroyShaderModule(device, vs, nullptr);
-  d().vkDestroyShaderModule(device, fs, nullptr);
-  if (pr != VK_SUCCESS) {
+  // Graphics pipeline (see MakePipeline): full quad, premultiplied src-over
+  // blend, dynamic viewport/scissor, no vertex input. The YUV variants are
+  // built lazily against their own layouts in GetOrCreateYuvProgram.
+  c->pipeline_ = MakePipeline(device, c->render_pass_, c->pipeline_layout_);
+  if (c->pipeline_ == VK_NULL_HANDLE) {
     err = "vkCreateGraphicsPipelines failed";
     return nullptr;
   }
@@ -258,6 +281,26 @@ LayerCompositor::~LayerCompositor() {
       d().vkDestroyDescriptorPool(device_, fr.pool, nullptr);
     }
   }
+  for (const YuvProgram& p : yuv_programs_) {
+    // A cached negative result (ok == false) holds only null handles; guard
+    // each destroy like the rest of this destructor rather than relying on
+    // Vulkan accepting null.
+    if (p.pipeline != VK_NULL_HANDLE) {
+      d().vkDestroyPipeline(device_, p.pipeline, nullptr);
+    }
+    if (p.pipeline_layout != VK_NULL_HANDLE) {
+      d().vkDestroyPipelineLayout(device_, p.pipeline_layout, nullptr);
+    }
+    if (p.set_layout != VK_NULL_HANDLE) {
+      d().vkDestroyDescriptorSetLayout(device_, p.set_layout, nullptr);
+    }
+    if (p.sampler != VK_NULL_HANDLE) {
+      d().vkDestroySampler(device_, p.sampler, nullptr);
+    }
+    if (p.conversion != VK_NULL_HANDLE) {
+      d().vkDestroySamplerYcbcrConversion(device_, p.conversion, nullptr);
+    }
+  }
   if (pipeline_ != VK_NULL_HANDLE) {
     d().vkDestroyPipeline(device_, pipeline_, nullptr);
   }
@@ -275,18 +318,30 @@ LayerCompositor::~LayerCompositor() {
   }
 }
 
-VkImageView LayerCompositor::CreateSourceView(VkImage image, VkFormat format) {
+VkImageView LayerCompositor::CreateSourceView(
+    VkImage image,
+    VkFormat format,
+    VkSamplerYcbcrConversion conversion) {
   // The view format must match the image's own format (backing stores are
-  // R8G8B8A8, platform-view images B8G8R8A8); the sampler reads logical RGBA
-  // either way and the attachment format handles the byte order, so no swizzle.
+  // R8G8B8A8, platform-view images B8G8R8A8, YUV images their planar format);
+  // the sampler reads logical RGBA either way and the attachment format handles
+  // the byte order, so no swizzle. A YUV view carries the same conversion as
+  // the immutable sampler it will be paired with — required for a view of a
+  // multi-planar format used with ycbcr sampling.
+  VkSamplerYcbcrConversionInfo conv_info{};
+  conv_info.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
+  conv_info.conversion = conversion;
   VkImageViewCreateInfo ci{};
   ci.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+  ci.pNext = conversion != VK_NULL_HANDLE ? &conv_info : nullptr;
   ci.image = image;
   ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
   ci.format = format;
   ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
   VkImageView v = VK_NULL_HANDLE;
-  d().vkCreateImageView(device_, &ci, nullptr, &v);
+  if (d().vkCreateImageView(device_, &ci, nullptr, &v) != VK_SUCCESS) {
+    return VK_NULL_HANDLE;  // caller skips the layer; nothing to record/destroy
+  }
   ring_[cur_ring_].views.push_back(v);
   return v;
 }
@@ -346,7 +401,9 @@ bool LayerCompositor::BeginFrame(VkCommandBuffer cmd,
   rb.pClearValues = &clear;
   d().vkCmdBeginRenderPass(cmd, &rb, VK_SUBPASS_CONTENTS_INLINE);
 
-  d().vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_);
+  // Viewport/scissor are dynamic and persist across the pipeline binds each
+  // DrawLayer issues (RGB vs YUV layers use different pipelines); set them once
+  // here. The pipeline itself is bound per layer, not here.
   VkViewport viewport{
       0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height),
       0.0f, 1.0f};
@@ -359,6 +416,8 @@ bool LayerCompositor::BeginFrame(VkCommandBuffer cmd,
 void LayerCompositor::DrawLayer(VkCommandBuffer cmd,
                                 VkImage src_image,
                                 VkFormat src_format,
+                                VkSamplerYcbcrModelConversion ycbcr_model,
+                                VkSamplerYcbcrRange ycbcr_range,
                                 int32_t dst_x,
                                 int32_t dst_y,
                                 int32_t dst_w,
@@ -366,19 +425,45 @@ void LayerCompositor::DrawLayer(VkCommandBuffer cmd,
   if (fb_width_ == 0 || fb_height_ == 0) {
     return;
   }
-  VkImageView view = CreateSourceView(src_image, src_format);
+
+  // RGB layers use the shared pipeline/sampler; a YUV layer resolves (or
+  // builds) the program whose immutable ycbcr sampler bakes the conversion, and
+  // its view carries the same conversion. With an immutable sampler the
+  // descriptor write leaves the sampler null (the layout supplies it).
+  VkPipeline pipeline = pipeline_;
+  VkPipelineLayout pipeline_layout = pipeline_layout_;
+  VkDescriptorSetLayout set_layout = set_layout_;
+  VkSampler sampler = sampler_;
+  VkSamplerYcbcrConversion conversion = VK_NULL_HANDLE;
+  if (IsYuvFormat(src_format)) {
+    const YuvProgram* prog =
+        GetOrCreateYuvProgram(src_format, ycbcr_model, ycbcr_range);
+    if (prog == nullptr) {
+      return;  // conversion/pipeline unavailable — skip rather than draw wrong
+    }
+    pipeline = prog->pipeline;
+    pipeline_layout = prog->pipeline_layout;
+    set_layout = prog->set_layout;
+    sampler = VK_NULL_HANDLE;  // immutable in the layout
+    conversion = prog->conversion;
+  }
+
+  VkImageView view = CreateSourceView(src_image, src_format, conversion);
+  if (view == VK_NULL_HANDLE) {
+    return;  // view creation failed — skip this layer rather than bind null
+  }
 
   VkDescriptorSetAllocateInfo ai{};
   ai.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
   ai.descriptorPool = ring_[cur_ring_].pool;
   ai.descriptorSetCount = 1;
-  ai.pSetLayouts = &set_layout_;
+  ai.pSetLayouts = &set_layout;
   VkDescriptorSet set = VK_NULL_HANDLE;
   if (d().vkAllocateDescriptorSets(device_, &ai, &set) != VK_SUCCESS) {
     return;  // pool exhausted (> kMaxLayersPerFrame) — skip this layer
   }
   VkDescriptorImageInfo ii{};
-  ii.sampler = sampler_;
+  ii.sampler = sampler;  // ignored for the YUV binding's immutable sampler
   ii.imageView = view;
   ii.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
   VkWriteDescriptorSet w{};
@@ -389,8 +474,9 @@ void LayerCompositor::DrawLayer(VkCommandBuffer cmd,
   w.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
   w.pImageInfo = &ii;
   d().vkUpdateDescriptorSets(device_, 1, &w, 0, nullptr);
+  d().vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
   d().vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                              pipeline_layout_, 0, 1, &set, 0, nullptr);
+                              pipeline_layout, 0, 1, &set, 0, nullptr);
 
   // Destination rect -> NDC (top-left origin, y down; matches the blit path).
   const auto fw = static_cast<float>(fb_width_);
@@ -400,9 +486,169 @@ void LayerCompositor::DrawLayer(VkCommandBuffer cmd,
       2.0f * static_cast<float>(dst_y) / fh - 1.0f,
       2.0f * static_cast<float>(dst_x + dst_w) / fw - 1.0f,
       2.0f * static_cast<float>(dst_y + dst_h) / fh - 1.0f};
-  d().vkCmdPushConstants(cmd, pipeline_layout_, VK_SHADER_STAGE_VERTEX_BIT, 0,
+  d().vkCmdPushConstants(cmd, pipeline_layout, VK_SHADER_STAGE_VERTEX_BIT, 0,
                          sizeof(rect), rect.data());
   d().vkCmdDraw(cmd, 4, 1, 0, 0);
+}
+
+const LayerCompositor::YuvProgram* LayerCompositor::GetOrCreateYuvProgram(
+    VkFormat format,
+    VkSamplerYcbcrModelConversion model,
+    VkSamplerYcbcrRange range) {
+  for (const YuvProgram& p : yuv_programs_) {
+    if (p.format == format && p.model == model && p.range == range) {
+      return p.ok ? &p : nullptr;  // cached success or cached failure
+    }
+  }
+
+  YuvProgram prog{};
+  prog.format = format;
+  prog.model = model;
+  prog.range = range;
+
+  // Cache a negative result (ok stays false) and log once, so a device that
+  // cannot build the program does not reattempt this every frame. Any handles
+  // created before the failing step are destroyed by the caller sites below
+  // before this runs, so the cached record holds only null handles.
+  const auto fail = [&](const char* step) -> const YuvProgram* {
+    ihs::log::warn(
+        "[wl_vulkan] planar-YUV sampling unavailable ({} failed for format "
+        "{:#x}); the video layer will not display -- the device likely lacks "
+        "samplerYcbcrConversion or linear ycbcr filtering",
+        step, static_cast<uint32_t>(format));
+    yuv_programs_.push_back(prog);
+    return nullptr;
+  };
+
+  // Validate the producer's colorimetry before building anything, per the "skip
+  // rather than draw wrong" contract: a YUV format must carry an actual YCbCr
+  // model -- not the RGB-identity value the interface defaults to, which a
+  // producer that reported a YUV format but left the model unset would yield --
+  // and a defined range. Bad values would otherwise build a conversion that
+  // samples with unintended colorimetry. Cache the negative result and skip.
+  const bool valid_model =
+      model == VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601 ||
+      model == VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709 ||
+      model == VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
+  const bool valid_range = range == VK_SAMPLER_YCBCR_RANGE_ITU_NARROW ||
+                           range == VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
+  if (!valid_model || !valid_range) {
+    ihs::log::warn(
+        "[wl_vulkan] planar-YUV layer for format {:#x} has invalid color "
+        "model/range ({}/{}); skipping rather than sampling wrong",
+        static_cast<uint32_t>(format), static_cast<uint32_t>(model),
+        static_cast<uint32_t>(range));
+    yuv_programs_.push_back(prog);  // cache the negative result
+    return nullptr;
+  }
+
+  // The conversion that turns planar YUV texels into RGB at sample time. Chroma
+  // siting is not carried by IhsFrame, so default to the H.264/HEVC 4:2:0
+  // convention (horizontally cosited with luma, vertically midpoint). Linear
+  // chroma reconstruction matches the sampler's linear filter, so no separate-
+  // reconstruction format feature is required; a device lacking linear ycbcr
+  // filtering would fail creation here and the layer is skipped.
+  VkSamplerYcbcrConversionCreateInfo cci{};
+  cci.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO;
+  cci.format = format;
+  cci.ycbcrModel = model;
+  cci.ycbcrRange = range;
+  cci.components = {
+      VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+      VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY};
+  cci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
+  cci.yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
+  cci.chromaFilter = VK_FILTER_LINEAR;
+  cci.forceExplicitReconstruction = VK_FALSE;
+  if (d().vkCreateSamplerYcbcrConversion(device_, &cci, nullptr,
+                                         &prog.conversion) != VK_SUCCESS) {
+    prog.conversion = VK_NULL_HANDLE;
+    return fail("vkCreateSamplerYcbcrConversion");
+  }
+
+  // The sampler carries the conversion and is baked immutably into the set
+  // layout below; matching linear filters avoid the separate-reconstruction
+  // requirement, address modes are clamp (required for a ycbcr sampler).
+  VkSamplerYcbcrConversionInfo conv_info{};
+  conv_info.sType = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO;
+  conv_info.conversion = prog.conversion;
+  VkSamplerCreateInfo si{};
+  si.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+  si.pNext = &conv_info;
+  si.magFilter = VK_FILTER_LINEAR;
+  si.minFilter = VK_FILTER_LINEAR;
+  si.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+  si.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  si.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+  if (d().vkCreateSampler(device_, &si, nullptr, &prog.sampler) != VK_SUCCESS) {
+    d().vkDestroySamplerYcbcrConversion(device_, prog.conversion, nullptr);
+    prog.conversion = VK_NULL_HANDLE;
+    prog.sampler = VK_NULL_HANDLE;
+    return fail("vkCreateSampler");
+  }
+
+  // set 0, binding 0: combined image sampler with the ycbcr sampler immutable
+  // (a ycbcr conversion can only be used through an immutable sampler).
+  VkDescriptorSetLayoutBinding b{};
+  b.binding = 0;
+  b.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+  b.descriptorCount = 1;
+  b.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+  b.pImmutableSamplers = &prog.sampler;
+  VkDescriptorSetLayoutCreateInfo sl{};
+  sl.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+  sl.bindingCount = 1;
+  sl.pBindings = &b;
+  if (d().vkCreateDescriptorSetLayout(device_, &sl, nullptr,
+                                      &prog.set_layout) != VK_SUCCESS) {
+    d().vkDestroySampler(device_, prog.sampler, nullptr);
+    d().vkDestroySamplerYcbcrConversion(device_, prog.conversion, nullptr);
+    prog.conversion = VK_NULL_HANDLE;
+    prog.sampler = VK_NULL_HANDLE;
+    prog.set_layout = VK_NULL_HANDLE;
+    return fail("vkCreateDescriptorSetLayout");
+  }
+
+  // Same push constant (dest rect NDC) as the RGB pipeline layout.
+  VkPushConstantRange pc{};
+  pc.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+  pc.offset = 0;
+  pc.size = sizeof(float) * 4;
+  VkPipelineLayoutCreateInfo pl{};
+  pl.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+  pl.setLayoutCount = 1;
+  pl.pSetLayouts = &prog.set_layout;
+  pl.pushConstantRangeCount = 1;
+  pl.pPushConstantRanges = &pc;
+  if (d().vkCreatePipelineLayout(device_, &pl, nullptr,
+                                 &prog.pipeline_layout) != VK_SUCCESS) {
+    d().vkDestroyDescriptorSetLayout(device_, prog.set_layout, nullptr);
+    d().vkDestroySampler(device_, prog.sampler, nullptr);
+    d().vkDestroySamplerYcbcrConversion(device_, prog.conversion, nullptr);
+    prog.conversion = VK_NULL_HANDLE;
+    prog.sampler = VK_NULL_HANDLE;
+    prog.set_layout = VK_NULL_HANDLE;
+    prog.pipeline_layout = VK_NULL_HANDLE;
+    return fail("vkCreatePipelineLayout");
+  }
+
+  prog.pipeline = MakePipeline(device_, render_pass_, prog.pipeline_layout);
+  if (prog.pipeline == VK_NULL_HANDLE) {
+    d().vkDestroyPipelineLayout(device_, prog.pipeline_layout, nullptr);
+    d().vkDestroyDescriptorSetLayout(device_, prog.set_layout, nullptr);
+    d().vkDestroySampler(device_, prog.sampler, nullptr);
+    d().vkDestroySamplerYcbcrConversion(device_, prog.conversion, nullptr);
+    prog.conversion = VK_NULL_HANDLE;
+    prog.sampler = VK_NULL_HANDLE;
+    prog.set_layout = VK_NULL_HANDLE;
+    prog.pipeline_layout = VK_NULL_HANDLE;
+    return fail("vkCreateGraphicsPipelines");
+  }
+
+  prog.ok = true;
+  yuv_programs_.push_back(prog);
+  return &yuv_programs_.back();
 }
 
 void LayerCompositor::EndFrame(VkCommandBuffer cmd) {

--- a/shell/backend/wayland_vulkan/wl_layer_compositor.h
+++ b/shell/backend/wayland_vulkan/wl_layer_compositor.h
@@ -62,9 +62,16 @@ class LayerCompositor {
   // SHADER_READ_ONLY_OPTIMAL, of format @p src_format — the view must match the
   // image's own format) into the destination rect (pixels, top-left origin —
   // matches the blit path, no Y flip).
+  //
+  // A planar-YUV @p src_format is sampled through a VkSamplerYcbcrConversion of
+  // @p ycbcr_model / @p ycbcr_range (built and cached on first use); packed RGB
+  // formats ignore those and use the plain sampler. A layer whose YUV program
+  // cannot be built is skipped.
   void DrawLayer(VkCommandBuffer cmd,
                  VkImage src_image,
                  VkFormat src_format,
+                 VkSamplerYcbcrModelConversion ycbcr_model,
+                 VkSamplerYcbcrRange ycbcr_range,
                  int32_t dst_x,
                  int32_t dst_y,
                  int32_t dst_w,
@@ -80,10 +87,42 @@ class LayerCompositor {
 
  private:
   explicit LayerCompositor(VkDevice device) : device_(device) {}
-  VkImageView CreateSourceView(VkImage image, VkFormat format);
+  // Create a sampled view of @p image. For a YUV image pass the matching
+  // @p conversion so the view carries it (chained via
+  // VkSamplerYcbcrConversionInfo); pass VK_NULL_HANDLE for a plain RGB view.
+  // The view is owned by the current ring slot and freed when it recycles.
+  VkImageView CreateSourceView(VkImage image,
+                               VkFormat format,
+                               VkSamplerYcbcrConversion conversion);
   VkFramebuffer GetOrCreateFramebuffer(VkImageView slot_view,
                                        uint32_t width,
                                        uint32_t height);
+
+  // A YUV image needs its conversion baked into an immutable sampler, which in
+  // turn is baked into the descriptor set layout and thus a distinct pipeline.
+  // These are keyed by (format, model, range) — a video stream uses one for its
+  // lifetime — and built lazily on the first matching layer.
+  struct YuvProgram {
+    VkFormat format{VK_FORMAT_UNDEFINED};
+    VkSamplerYcbcrModelConversion model{
+        VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY};
+    VkSamplerYcbcrRange range{VK_SAMPLER_YCBCR_RANGE_ITU_NARROW};
+    VkSamplerYcbcrConversion conversion{VK_NULL_HANDLE};
+    VkSampler sampler{VK_NULL_HANDLE};
+    VkDescriptorSetLayout set_layout{VK_NULL_HANDLE};
+    VkPipelineLayout pipeline_layout{VK_NULL_HANDLE};
+    VkPipeline pipeline{VK_NULL_HANDLE};
+    // False for a cached negative result: the device could not build the
+    // program (no samplerYcbcrConversion / no linear ycbcr filtering), so the
+    // handles are null and the lookup returns nullptr without reattempting the
+    // expensive creation every frame.
+    bool ok{false};
+  };
+  // Returns the program for the given YUV parameters, building it on first use.
+  // nullptr if the conversion/sampler/pipeline could not be created.
+  const YuvProgram* GetOrCreateYuvProgram(VkFormat format,
+                                          VkSamplerYcbcrModelConversion model,
+                                          VkSamplerYcbcrRange range);
 
   VkDevice device_{VK_NULL_HANDLE};
   VkFormat color_format_{VK_FORMAT_UNDEFINED};
@@ -92,6 +131,7 @@ class LayerCompositor {
   VkPipelineLayout pipeline_layout_{VK_NULL_HANDLE};
   VkPipeline pipeline_{VK_NULL_HANDLE};
   VkSampler sampler_{VK_NULL_HANDLE};
+  std::vector<YuvProgram> yuv_programs_;
 
   // Current frame state.
   uint32_t fb_width_{0};

--- a/shell/platform/homescreen/platform_views/dmabuf_vulkan_import.cc
+++ b/shell/platform/homescreen/platform_views/dmabuf_vulkan_import.cc
@@ -16,6 +16,7 @@
 
 #include "dmabuf_vulkan_import.h"
 
+#include <array>
 #include <cstdint>
 
 #include "logging/logging.h"
@@ -29,10 +30,12 @@ constexpr uint32_t Fourcc(char a, char b, char c, char d) {
          (static_cast<uint32_t>(static_cast<uint8_t>(d)) << 24);
 }
 
-// The compositor samples platform-view images through a B8G8R8A8 view, so map
-// the RGB fourccs to the matching Vulkan format. Alpha vs. no-alpha share a
-// format (X* just ignores alpha). YUV maps land with the video path.
-VkFormat VkFormatFromFourcc(uint32_t fourcc) {
+// Maps a DRM fourcc to the Vulkan format an imported dma-buf is created with.
+// The packed RGB formats are sampled through a plain B8G8R8A8-style view; the
+// planar ones through a VkSamplerYcbcrConversion the compositor builds.
+// `is_yuv` distinguishes the two so the caller knows which path an image needs.
+VkFormat VkFormatFromFourcc(uint32_t fourcc, bool* is_yuv) {
+  *is_yuv = false;
   if (fourcc == Fourcc('A', 'R', '2', '4') ||  // DRM_FORMAT_ARGB8888
       fourcc == Fourcc('X', 'R', '2', '4')) {  // DRM_FORMAT_XRGB8888
     return VK_FORMAT_B8G8R8A8_UNORM;
@@ -41,7 +44,44 @@ VkFormat VkFormatFromFourcc(uint32_t fourcc) {
       fourcc == Fourcc('X', 'B', '2', '4')) {  // DRM_FORMAT_XBGR8888
     return VK_FORMAT_R8G8B8A8_UNORM;
   }
+  // NV12: Y plane then interleaved CbCr, 4:2:0. What the VAAPI and V4L2
+  // decoders both emit. Two planes on one dma-buf, so a non-disjoint 2-plane
+  // image; the plane offsets come from the frame.
+  if (fourcc == Fourcc('N', 'V', '1', '2')) {  // DRM_FORMAT_NV12
+    *is_yuv = true;
+    return VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+  }
   return VK_FORMAT_UNDEFINED;
+}
+
+// The YCbCr->RGB conversion the compositor's sampler must apply, resolved from
+// the frame's color metadata. IHS_COLOR_SPACE_DEFAULT follows the contract in
+// platform_view.h -- BT.601 for SD, BT.709 for HD, split at the standard 720p
+// boundary -- and IHS_COLOR_RANGE_DEFAULT is studio (narrow) range, what the
+// hardware decoders emit. This is the first shell implementation of that
+// default; the EGL path leaves the same choice to the GL driver.
+void ResolveYcbcr(const IhsFrame& frame,
+                  VkSamplerYcbcrModelConversion* model,
+                  VkSamplerYcbcrRange* range) {
+  switch (frame.color_space) {
+    case IHS_COLOR_SPACE_BT601:
+      *model = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601;
+      break;
+    case IHS_COLOR_SPACE_BT709:
+      *model = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709;
+      break;
+    case IHS_COLOR_SPACE_BT2020:
+      *model = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020;
+      break;
+    default:  // IHS_COLOR_SPACE_DEFAULT
+      *model = frame.height >= 720
+                   ? VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709
+                   : VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601;
+      break;
+  }
+  *range = frame.color_range == IHS_COLOR_RANGE_FULL
+               ? VK_SAMPLER_YCBCR_RANGE_ITU_FULL
+               : VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
 }
 
 // The first memory type common to the image's requirements and the imported
@@ -116,28 +156,62 @@ bool DmabufVulkanImporter::Init(VkInstance instance,
 
 bool DmabufVulkanImporter::Import(const IhsFrame& frame,
                                   ImportedImage* out) const {
-  if (!ready() || out == nullptr || frame.plane_count != 1 ||
-      frame.plane_fd[0] < 0) {
+  if (!ready() || out == nullptr) {
     return false;
   }
-  const VkFormat format = VkFormatFromFourcc(frame.format.fourcc);
+  bool is_yuv = false;
+  const VkFormat format = VkFormatFromFourcc(frame.format.fourcc, &is_yuv);
   if (format == VK_FORMAT_UNDEFINED) {
     ihs::log::warn("[ihs_pv] dma-buf import: unsupported fourcc {:#x}",
                    frame.format.fourcc);
     return false;
   }
 
-  // Explicit modifier + plane layout the producer exported with, so the driver
-  // reads the tiled memory correctly.
-  VkSubresourceLayout plane_layout{};
-  plane_layout.offset = frame.plane_offset[0];
-  plane_layout.rowPitch = frame.plane_stride[0];
+  // The plane count is fixed by the format: 1 for the packed RGB formats, 2 for
+  // NV12. Reject a frame whose plane_count disagrees so an RGB fourcc cannot
+  // arrive claiming two planes (which would mis-drive the plane-layout array
+  // and vkCreateImage) and NV12 cannot arrive under-specified.
+  const uint32_t expected_planes = is_yuv ? 2u : 1u;
+  if (frame.plane_count != expected_planes) {
+    ihs::log::warn(
+        "[ihs_pv] dma-buf import: fourcc {:#x} expects {} plane(s), got {}",
+        frame.format.fourcc, expected_planes, frame.plane_count);
+    return false;
+  }
+  if (frame.plane_fd[0] < 0) {
+    ihs::log::warn("[ihs_pv] dma-buf import: fourcc {:#x} has no dma-buf fd",
+                   frame.format.fourcc);
+    return false;
+  }
+  // All planes must live in the one dma-buf -- the non-disjoint layout the
+  // VAAPI and V4L2 decoders emit, imported through plane_fd[0] with the offsets
+  // indexing into it. The IhsFrame contract lets "one fd back several planes",
+  // so a secondary plane_fd is either unset (-1) or a duplicate handle to
+  // plane_fd[0]; both are accepted. A distinct fd is the disjoint layout this
+  // path does not import (it would read the wrong memory).
+  for (uint32_t p = 1; p < frame.plane_count; ++p) {
+    if (frame.plane_fd[p] >= 0 && frame.plane_fd[p] != frame.plane_fd[0]) {
+      ihs::log::warn(
+          "[ihs_pv] dma-buf import: multi-planar frame with separate per-plane "
+          "fds not supported (planes must share one dma-buf)");
+      return false;
+    }
+  }
+
+  // One explicit layout per plane, all within the single dma-buf's allocation:
+  // the driver reads Y and interleaved CbCr from their offsets in the same
+  // memory (a non-disjoint multi-planar image).
+  std::array<VkSubresourceLayout, 2> plane_layouts{};
+  for (uint32_t p = 0; p < frame.plane_count && p < 2; ++p) {
+    plane_layouts[p].offset = frame.plane_offset[p];
+    plane_layouts[p].rowPitch = frame.plane_stride[p];
+  }
   VkImageDrmFormatModifierExplicitCreateInfoEXT mod{};
   mod.sType =
       VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT;
   mod.drmFormatModifier = frame.format.modifier;
-  mod.drmFormatModifierPlaneCount = 1;
-  mod.pPlaneLayouts = &plane_layout;
+  mod.drmFormatModifierPlaneCount = frame.plane_count;
+  mod.pPlaneLayouts = plane_layouts.data();
 
   VkExternalMemoryImageCreateInfo ext{};
   ext.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
@@ -223,6 +297,11 @@ bool DmabufVulkanImporter::Import(const IhsFrame& frame,
   out->memory = memory;
   out->width = frame.width;
   out->height = frame.height;
+  out->format = format;
+  out->yuv = is_yuv;
+  if (is_yuv) {
+    ResolveYcbcr(frame, &out->ycbcr_model, &out->ycbcr_range);
+  }
   return true;
 }
 

--- a/shell/platform/homescreen/platform_views/dmabuf_vulkan_import.h
+++ b/shell/platform/homescreen/platform_views/dmabuf_vulkan_import.h
@@ -40,6 +40,19 @@ class DmabufVulkanImporter {
     VkDeviceMemory memory{VK_NULL_HANDLE};
     uint32_t width{0};
     uint32_t height{0};
+    // The format the image was created with, and whether it is a planar YUV
+    // one. The compositor needs both to build the view and sampler: a YUV
+    // image samples through a VkSamplerYcbcrConversion of this format, an RGB
+    // image through a plain sampler. VK_FORMAT_UNDEFINED on an unset image.
+    VkFormat format{VK_FORMAT_UNDEFINED};
+    bool yuv{false};
+    // For a YUV image, the color model and range the compositor's
+    // VkSamplerYcbcrConversion must use, resolved from the frame's color_space/
+    // color_range (IHS_COLOR_*_DEFAULT -> BT.601/709 by height, limited range).
+    // Unused for RGB.
+    VkSamplerYcbcrModelConversion ycbcr_model{
+        VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY};
+    VkSamplerYcbcrRange ycbcr_range{VK_SAMPLER_YCBCR_RANGE_ITU_NARROW};
   };
 
   DmabufVulkanImporter() = default;
@@ -54,10 +67,15 @@ class DmabufVulkanImporter {
 
   [[nodiscard]] bool ready() const { return device_ != VK_NULL_HANDLE; }
 
-  // Import @frame's first-plane dma-buf into @out. On success the imported
-  // image has taken ownership of frame.plane_fd[0] (freed with the memory in
-  // Destroy); on failure the fd is left untouched for the caller to close.
-  // Single-plane RGB only for now (the YUV multi-plane path lands with video).
+  // Import @frame's dma-buf into @out. On success the imported image has taken
+  // ownership of frame.plane_fd[0] (freed with the memory in Destroy); on
+  // failure the fd is left untouched for the caller to close.
+  //
+  // Packed RGB (one plane) and planar YUV whose planes share a single dma-buf
+  // (NV12: two planes, one fd, offsets within the one allocation). A YUV image
+  // must be sampled through a VkSamplerYcbcrConversion of ImportedImage::format
+  // -- created in the compositor, since the conversion is baked into the
+  // sampler and descriptor layout there, not here.
   bool Import(const IhsFrame& frame, ImportedImage* out) const;
 
   void Destroy(ImportedImage* image) const;

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -287,6 +287,27 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     }
     return reinterpret_cast<void*>(current->image);
   }
+  [[nodiscard]] uint32_t GetVulkanImageFormat() const override {
+    const std::lock_guard<std::mutex> lock(mutex);
+    return current != nullptr ? static_cast<uint32_t>(current->format) : 0;
+  }
+  // Model/range are meaningful only for a YUV image; for an RGB one return the
+  // interface default (0) rather than the ImportedImage field, so the reported
+  // values match the ICompositorSurface contract and nothing keys off a stray
+  // narrow-range/601 default on a frame that is never sampled through a
+  // conversion.
+  [[nodiscard]] uint32_t GetVulkanYcbcrModel() const override {
+    const std::lock_guard<std::mutex> lock(mutex);
+    return current != nullptr && current->yuv
+               ? static_cast<uint32_t>(current->ycbcr_model)
+               : 0;
+  }
+  [[nodiscard]] uint32_t GetVulkanYcbcrRange() const override {
+    const std::lock_guard<std::mutex> lock(mutex);
+    return current != nullptr && current->yuv
+               ? static_cast<uint32_t>(current->ycbcr_range)
+               : 0;
+  }
   [[nodiscard]] uint32_t GetVulkanImageLayout() const override {
     const std::lock_guard<std::mutex> lock(mutex);
     return current_layout;
@@ -524,8 +545,21 @@ IhsPluginView::~IhsPluginView() {
 
 // Close every plane fd a frame still owns (its import did not consume them).
 void CloseFrameFds(const IhsFrame* frame) {
+  // One fd may back several planes (IhsFrame contract), so a plane_fd can
+  // repeat across entries. Close each distinct numeric fd once -- closing a
+  // duplicate a second time could close an unrelated fd that reused the number.
   for (uint32_t i = 0; i < frame->plane_count && i < 4; ++i) {
-    if (frame->plane_fd[i] >= 0) {
+    if (frame->plane_fd[i] < 0) {
+      continue;
+    }
+    bool already_closed = false;
+    for (uint32_t j = 0; j < i; ++j) {
+      if (frame->plane_fd[j] == frame->plane_fd[i]) {
+        already_closed = true;
+        break;
+      }
+    }
+    if (!already_closed) {
       close(frame->plane_fd[i]);
     }
   }

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -126,25 +126,55 @@ class ICompositorSurface {
   [[nodiscard]] virtual bool TextureIsExternalOes() const { return false; }
 
   /**
-   * @brief Expose a Vulkan platform-view image the compositor can blit.
+   * @brief Expose a Vulkan platform-view image the compositor can composite.
    *
    * The Vulkan counterpart to @c GetGlTextureName: a plugin that rendered into
    * a @c VkImage on the backend's own device (obtained via
    * @c Backend::GetVulkanContext) returns that handle here so a Vulkan
    * compositor can composite it directly — same device, no cross-API/-device
-   * import. Returned as @c void* so this header stays free of a Vulkan include;
-   * the caller casts back to @c VkImage. Fills @p width / @p height with the
-   * image extent. Returns nullptr (default) when the plugin has no Vulkan image
-   * (GL path, or nothing rendered yet).
+   * import. The layer compositor samples it in a shader
+   * (SHADER_READ_ONLY_OPTIMAL), so it composes with alpha rather than a plain
+   * overwriting blit. Returned as @c void* so this header stays free of a
+   * Vulkan include; the caller casts back to @c VkImage. Fills @p width / @p
+   * height with the image extent. Returns nullptr (default) when the plugin has
+   * no Vulkan image (GL path, or nothing rendered yet).
    *
-   * Contract: the image is B8G8R8A8_UNORM, its memory holds a complete frame
-   * (the plugin has made its writes visible), and it is safe to transition to
-   * a transfer-source layout and read this frame.
+   * Contract: the image's memory holds a complete frame (the plugin has made
+   * its writes visible) and it is safe to transition to a shader-read layout
+   * and read this frame. Its VkFormat is reported by @c GetVulkanImageFormat
+   * (a packed RGB format sampled directly, or a planar YUV format sampled
+   * through a VkSamplerYcbcrConversion the compositor builds).
    */
   [[nodiscard]] virtual void* GetVulkanImage(int32_t* /*width*/,
                                              int32_t* /*height*/) const {
     return nullptr;
   }
+
+  /**
+   * @brief VkFormat (as uint32_t, keeping this header Vulkan-free) of the image
+   * returned by @c GetVulkanImage. 0 (VK_FORMAT_UNDEFINED, the default) means
+   * the historical B8G8R8A8_UNORM contract, so an RGB producer need not
+   * override this. A planar YUV producer returns its multi-planar format (e.g.
+   * VK_FORMAT_G8_B8R8_2PLANE_420_UNORM), which the compositor samples through a
+   * VkSamplerYcbcrConversion built from @c GetVulkanYcbcrModel /
+   * @c GetVulkanYcbcrRange.
+   */
+  [[nodiscard]] virtual uint32_t GetVulkanImageFormat() const { return 0; }
+
+  /**
+   * @brief For a YUV @c GetVulkanImage, the VkSamplerYcbcrModelConversion and
+   * VkSamplerYcbcrRange (as uint32_t) the compositor's conversion must apply,
+   * resolved by the producer from the frame's color metadata. Consulted only
+   * when @c GetVulkanImageFormat reports a YUV format; a producer that reports
+   * one MUST override both (there is no color metadata to default from here).
+   *
+   * The defaults are the values a non-overriding (RGB) producer yields and are
+   * never sampled through a conversion: 0 is
+   * VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY for the model and
+   * VK_SAMPLER_YCBCR_RANGE_ITU_FULL for the range.
+   */
+  [[nodiscard]] virtual uint32_t GetVulkanYcbcrModel() const { return 0; }
+  [[nodiscard]] virtual uint32_t GetVulkanYcbcrRange() const { return 0; }
 
   /**
    * @brief Current VkImageLayout of the Vulkan image (as uint32_t, so this


### PR DESCRIPTION
## What

A hardware-decoded NV12 dma-buf on a Vulkan backend was refused at import
(`VkFormatFromFourcc` mapped only packed RGB), so a WebRTC video platform view
showed nothing on `drm-kms-vulkan` / `wayland-vulkan`. The Vulkan counterpart to
the EGL gap #335 closed; implements #339.

## How

- **Importer** (`dmabuf_vulkan_import.*`): import NV12 as a non-disjoint
  two-plane `VK_FORMAT_G8_B8R8_2PLANE_420_UNORM` (planes share one dma-buf,
  offsets within the single allocation). Resolve the frame's
  `color_space`/`color_range` into a `VkSamplerYcbcrModelConversion` /
  `VkSamplerYcbcrRange`: `IHS_COLOR_SPACE_DEFAULT` → BT.601/709 by height,
  `IHS_COLOR_RANGE_DEFAULT` → studio range. First shell implementation of the
  `platform_view.h` contract the EGL path leaves to the GL driver.
- **Compositor** (`wl_layer_compositor.*`): a ycbcr conversion can only be used
  through an immutable sampler, baked into the descriptor set layout and hence a
  distinct pipeline. Build a YUV program (conversion + immutable sampler + set
  layout + pipeline) lazily, cached per `(format, model, range)` — one per video
  stream. RGB path unchanged; the two pipelines share all state and shaders and
  differ only in the layout, so the pipeline is bound per layer (viewport/scissor
  stay dynamic). The YUV image view carries the same conversion.
- **Plumbing**: the producer exposes format + colorimetry through new
  `GetVulkanImageFormat` / `GetVulkanYcbcrModel` / `GetVulkanYcbcrRange` seams on
  `ICompositorSurface`; an RGB producer returns 0 and keeps the historical
  `B8G8R8A8_UNORM` contract. The device enables `samplerYcbcrConversion`, queried
  and chained only where supported.

## Failure modes

A device without the feature (or without linear ycbcr filtering) fails
conversion creation and the layer is skipped rather than drawn wrong. Chroma
siting is not carried by `IhsFrame` and defaults to the H.264/HEVC 4:2:0
convention (cosited-x, midpoint-y).

## Verification

Builds clean on `wayland-vulkan` (clang + libc++, lld): all changed TUs compile,
the executable links, clang-tidy and clang-format clean. **On-screen
verification is pending** — needs a Vulkan backend on real hardware (AMD over
`drm-kms-vulkan`, or the Pi's Mali/panvk stack) to confirm colour and chroma
siting. EGL backends remain the verified path.

Closes #339
