### PR TITLE
ihs_location: scaffold the measurement Manager

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -142,6 +142,7 @@ endif ()
 target_sources(ihs_shared PRIVATE
         src/location/location_api.cc
         src/location/registry.cc
+        src/location/manager.cc
         src/location/gpsd_provider.cc
         src/location/geoclue_provider.cc
         src/location/fallback_location_provider.cc

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -123,8 +123,12 @@ void Manager::Shutdown() {
   sources_.clear();
 
   // Detach the filter under the lock (a concurrent Latest() reads it there) and
-  // reset have_fix_ so a restarted Manager cannot report a pre-stop fix; then
-  // destroy the instance outside the lock (destroy() is a user callback).
+  // reset the whole fix state to pristine, so a restarted Manager behaves like
+  // a fresh one: no fix and generation 0 until a new fix arrives (the
+  // documented "0 before any fix" contract). Resetting have_fix_ without
+  // generation_ would leave generation() non-zero while Latest() reports
+  // nothing. Destroy the instance outside the lock (destroy() is a user
+  // callback).
   void* inst = nullptr;
   IhsLocationFilterOps ops{};
   {
@@ -133,6 +137,8 @@ void Manager::Shutdown() {
     ops = filter_ops_;
     filter_instance_ = nullptr;
     have_fix_ = false;
+    generation_ = 0;
+    latest_ = Position{};
   }
   if (inst != nullptr && ops.destroy != nullptr) {
     ops.destroy(inst);

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -98,8 +98,10 @@ bool Manager::Start() {
     }
   }
 
-  // Return true even if nothing started: a transient source may appear later,
-  // matching the enum providers' "handle returned, no fix yet" contract.
+  // Return true even if no bound source has produced a fix yet: a live source
+  // may only start reporting later, matching the enum providers' "handle
+  // returned, no fix yet" contract. Sources bind once here and are not
+  // re-queried, so registering one after Start() has no effect.
   started_ = true;
   return true;
 }
@@ -160,6 +162,17 @@ void Manager::SinkThunk(void* sink_user_data, const IhsMeasurement* m) {
 }
 
 void Manager::OnMeasurement(const IhsMeasurement& m) {
+  // Drop an unusable position up front so neither the filter nor the
+  // passthrough ever sees NaN/out-of-range coordinates, and so
+  // have_fix_/generation_ below never mark a fix that was not actually accepted
+  // (which would let Latest() report the zero-initialized default, or bump
+  // generation over a stale fix). Other measurement kinds carry their own
+  // guards in ApplyToPassthrough.
+  if (m.kind == IHS_MEAS_POSITION_LLA &&
+      (m.value_count < 2 || !ValidLatLon(m.value[0], m.value[1]))) {
+    return;
+  }
+
   const std::lock_guard<std::mutex> lock(mutex_);
   if (filter_instance_ != nullptr && filter_ops_.update != nullptr) {
     filter_ops_.update(filter_instance_, &m);
@@ -167,7 +180,7 @@ void Manager::OnMeasurement(const IhsMeasurement& m) {
     ApplyToPassthrough(m);
   }
   // A position measurement is the anchor of a fix; count one generation per
-  // such measurement (velocity/heading augment the same fix silently), so a
+  // accepted position (velocity/heading augment the same fix silently), so a
   // consumer sees one bump per fix regardless of how many components a source
   // splits it into.
   if (m.kind == IHS_MEAS_POSITION_LLA) {
@@ -179,16 +192,16 @@ void Manager::OnMeasurement(const IhsMeasurement& m) {
 void Manager::ApplyToPassthrough(const IhsMeasurement& m) {
   switch (m.kind) {
     case IHS_MEAS_POSITION_LLA:
-      if (m.value_count >= 2 && ValidLatLon(m.value[0], m.value[1])) {
-        latest_.latitude = m.value[0];
-        latest_.longitude = m.value[1];
-        // A third component (altitude) marks a 3D fix, mirroring gpsd's
-        // mode 2 (lat/lon) vs mode 3 (lat/lon/alt).
-        latest_.mode = m.value_count >= 3 ? 3 : 2;
-        latest_.t_monotonic_ns = m.t_monotonic_ns;
-        latest_.sigma_e_m = SigmaFromVariance(m.variance[0]);
-        latest_.sigma_n_m = SigmaFromVariance(m.variance[1]);
-      }
+      // OnMeasurement has already validated value_count >= 2 and the
+      // coordinates, so store them directly.
+      latest_.latitude = m.value[0];
+      latest_.longitude = m.value[1];
+      // A third component (altitude) marks a 3D fix, mirroring gpsd's
+      // mode 2 (lat/lon) vs mode 3 (lat/lon/alt).
+      latest_.mode = m.value_count >= 3 ? 3 : 2;
+      latest_.t_monotonic_ns = m.t_monotonic_ns;
+      latest_.sigma_e_m = SigmaFromVariance(m.variance[0]);
+      latest_.sigma_n_m = SigmaFromVariance(m.variance[1]);
       break;
     case IHS_MEAS_SPEED:
       if (m.value_count >= 1) {

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -249,15 +249,21 @@ void Manager::ApplyToPassthrough(const IhsMeasurement& m) {
 
 bool Manager::Latest(Position& out) {
   const std::lock_guard<std::mutex> lock(mutex_);
+  // No fix until at least one position correction has arrived — in both the
+  // filter and passthrough paths. For the filter this keeps Latest() consistent
+  // with generation() (which bumps on an accepted position): a filter that can
+  // produce an estimate from velocity alone, with no position anchor, must not
+  // surface a fix while generation() is still 0, and cannot know absolute
+  // position anyway.
+  if (!have_fix_) {
+    return false;
+  }
   if (filter_instance_ != nullptr && filter_ops_.estimate != nullptr) {
     IhsPosition est{};
     if (filter_ops_.estimate(filter_instance_, MonotonicNs(), &est) == 1) {
       FromIhsPosition(out, est);
       return true;
     }
-    return false;
-  }
-  if (!have_fix_) {
     return false;
   }
   out = latest_;

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -149,7 +149,9 @@ void Manager::Shutdown() {
 }
 
 void Manager::SinkThunk(void* sink_user_data, const IhsMeasurement* m) {
-  if (m == nullptr) {
+  // Guard the trampoline: a misbehaving source could call the sink with an
+  // unexpected user_data or a null measurement.
+  if (sink_user_data == nullptr || m == nullptr) {
     return;
   }
   // Bounded copy across the ABI boundary (the #337 discipline the header
@@ -166,6 +168,14 @@ void Manager::SinkThunk(void* sink_user_data, const IhsMeasurement* m) {
   }
   std::memcpy(&full, m, n);
   full.struct_size = n;
+  // Clamp value_count to the array bound: value[]/variance[] are fixed at 6, so
+  // a source that over-declares it must not lead a downstream filter iterating
+  // [0, value_count) to read past the arrays.
+  const auto kMaxComponents =
+      static_cast<uint32_t>(sizeof(full.value) / sizeof(full.value[0]));
+  if (full.value_count > kMaxComponents) {
+    full.value_count = kMaxComponents;
+  }
   static_cast<Manager*>(sink_user_data)->OnMeasurement(full);
 }
 
@@ -200,8 +210,15 @@ void Manager::OnMeasurement(const IhsMeasurement& m) {
 void Manager::ApplyToPassthrough(const IhsMeasurement& m) {
   switch (m.kind) {
     case IHS_MEAS_POSITION_LLA:
-      // OnMeasurement has already validated value_count >= 2 and the
-      // coordinates, so store them directly.
+      // A position anchors a new fix. Reset to a fresh Position so
+      // speed/heading are reported only if (re)supplied for THIS fix, matching
+      // the gpsd/geoclue providers that build each fix fresh (a TPV without
+      // speed/track leaves those unknown) rather than carrying stale scalars
+      // forward. A source emits the POSITION anchor first, then any SPEED/
+      // HEADING for the same fix; independent multi-rate sensors are the
+      // filter's domain, not the passthrough's. OnMeasurement has already
+      // validated value_count >= 2 and the coordinates.
+      latest_ = Position{};
       latest_.latitude = m.value[0];
       latest_.longitude = m.value[1];
       // A third component (altitude) marks a 3D fix, mirroring gpsd's

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -136,6 +136,8 @@ void Manager::Shutdown() {
     inst = filter_instance_;
     ops = filter_ops_;
     filter_instance_ = nullptr;
+    filter_ops_ = IhsLocationFilterOps{};
+    filter_user_data_ = nullptr;
     have_fix_ = false;
     generation_ = 0;
     latest_ = Position{};

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// The location Manager (see manager.hpp): binds registered sources, fuses the
+// measurements they push into a Position, and serves it through
+// ILocationProvider. Not yet on the ihs_location_start() path — exercised only
+// by manager_test until the gpsd/geoclue sources are registered.
+
+#include "manager.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <utility>
+
+#include "registry.hpp"
+
+namespace ihs::location {
+
+namespace {
+
+// 1-sigma from a per-component variance (1-sigma^2); < 0 stays "unknown".
+double SigmaFromVariance(double variance) {
+  return variance >= 0.0 ? std::sqrt(variance) : -1.0;
+}
+
+// Copy the C-ABI IhsPosition a filter fills into the internal Position.
+void FromIhsPosition(Position& out, const IhsPosition& in) {
+  out.latitude = in.latitude;
+  out.longitude = in.longitude;
+  out.bearing_deg = in.bearing_deg;
+  out.speed_mps = in.speed_mps;
+  out.mode = in.mode;
+  out.has_bearing = in.has_bearing != 0;
+  out.t_monotonic_ns = in.t_monotonic_ns;
+  out.sigma_e_m = in.sigma_e_m;
+  out.sigma_n_m = in.sigma_n_m;
+  out.sigma_v_mps = in.sigma_v_mps;
+}
+
+}  // namespace
+
+Manager::Manager(std::vector<std::string> source_keys,
+                 std::string filter_key,
+                 std::string filter_config)
+    : source_keys_(std::move(source_keys)),
+      filter_key_(std::move(filter_key)),
+      filter_config_(std::move(filter_config)) {}
+
+Manager::~Manager() {
+  Shutdown();
+}
+
+bool Manager::Start() {
+  if (started_) {
+    return true;
+  }
+
+  // Resolve the optional filter first, so its instance exists before any
+  // measurement can arrive from a source.
+  if (!filter_key_.empty()) {
+    FilterEntry fe;
+    if (LookupFilter(filter_key_, fe) && fe.ops.create != nullptr) {
+      // create() is a user callback, so run it outside the lock; publish the
+      // resolved filter under the lock so a concurrent Latest() never reads a
+      // torn pointer. Sources are not started yet, so no measurement races it.
+      void* const inst = fe.ops.create(
+          fe.user_data,
+          filter_config_.empty() ? nullptr : filter_config_.c_str());
+      const std::lock_guard<std::mutex> lock(mutex_);
+      filter_ops_ = fe.ops;
+      filter_user_data_ = fe.user_data;
+      filter_instance_ = inst;
+    }
+    // A configured-but-missing (or create-failed) filter leaves
+    // filter_instance_ null, so the built-in passthrough is used instead of
+    // failing the whole service.
+  }
+
+  // Bind each registered source key (skipping the rest), then start them.
+  for (const std::string& key : source_keys_) {
+    SourceEntry se;
+    if (LookupSource(key, se)) {
+      sources_.push_back(BoundSource{se.ops, se.user_data, false});
+    }
+  }
+  for (BoundSource& s : sources_) {
+    if (s.ops.start != nullptr &&
+        s.ops.start(s.user_data, &SinkThunk, this) == 1) {
+      s.started = true;
+    }
+  }
+
+  // Return true even if nothing started: a transient source may appear later,
+  // matching the enum providers' "handle returned, no fix yet" contract.
+  started_ = true;
+  return true;
+}
+
+void Manager::Stop() {
+  Shutdown();
+}
+
+void Manager::Shutdown() {
+  // Stop sources before tearing down the filter so no measurement can arrive
+  // after the filter instance is destroyed. A source's stop() joins its worker,
+  // so no sink call is in flight once it returns.
+  for (BoundSource& s : sources_) {
+    if (s.started && s.ops.stop != nullptr) {
+      s.ops.stop(s.user_data);
+    }
+    s.started = false;
+  }
+  sources_.clear();
+
+  // Detach the filter under the lock (a concurrent Latest() reads it there) and
+  // reset have_fix_ so a restarted Manager cannot report a pre-stop fix; then
+  // destroy the instance outside the lock (destroy() is a user callback).
+  void* inst = nullptr;
+  IhsLocationFilterOps ops{};
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    inst = filter_instance_;
+    ops = filter_ops_;
+    filter_instance_ = nullptr;
+    have_fix_ = false;
+  }
+  if (inst != nullptr && ops.destroy != nullptr) {
+    ops.destroy(inst);
+  }
+  started_ = false;
+}
+
+void Manager::SinkThunk(void* sink_user_data, const IhsMeasurement* m) {
+  if (m == nullptr) {
+    return;
+  }
+  // Bounded copy across the ABI boundary (the #337 discipline the header
+  // promises and the registry ops already apply): a source may be built against
+  // a different IhsMeasurement layout, so copy only min(its struct_size, ours)
+  // into a zeroed full-size struct and never read past the source's object. A
+  // struct too small to carry the value/variance block cannot describe a fix,
+  // so it is dropped rather than read speculatively.
+  IhsMeasurement full{};
+  const size_t n =
+      m->struct_size < sizeof(full) ? m->struct_size : sizeof(full);
+  if (n < offsetof(IhsMeasurement, flags)) {
+    return;
+  }
+  std::memcpy(&full, m, n);
+  full.struct_size = n;
+  static_cast<Manager*>(sink_user_data)->OnMeasurement(full);
+}
+
+void Manager::OnMeasurement(const IhsMeasurement& m) {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (filter_instance_ != nullptr && filter_ops_.update != nullptr) {
+    filter_ops_.update(filter_instance_, &m);
+  } else {
+    ApplyToPassthrough(m);
+  }
+  // A position measurement is the anchor of a fix; count one generation per
+  // such measurement (velocity/heading augment the same fix silently), so a
+  // consumer sees one bump per fix regardless of how many components a source
+  // splits it into.
+  if (m.kind == IHS_MEAS_POSITION_LLA) {
+    have_fix_ = true;
+    ++generation_;
+  }
+}
+
+void Manager::ApplyToPassthrough(const IhsMeasurement& m) {
+  switch (m.kind) {
+    case IHS_MEAS_POSITION_LLA:
+      if (m.value_count >= 2 && ValidLatLon(m.value[0], m.value[1])) {
+        latest_.latitude = m.value[0];
+        latest_.longitude = m.value[1];
+        // A third component (altitude) marks a 3D fix, mirroring gpsd's
+        // mode 2 (lat/lon) vs mode 3 (lat/lon/alt).
+        latest_.mode = m.value_count >= 3 ? 3 : 2;
+        latest_.t_monotonic_ns = m.t_monotonic_ns;
+        latest_.sigma_e_m = SigmaFromVariance(m.variance[0]);
+        latest_.sigma_n_m = SigmaFromVariance(m.variance[1]);
+      }
+      break;
+    case IHS_MEAS_SPEED:
+      if (m.value_count >= 1) {
+        latest_.speed_mps = m.value[0];
+        latest_.sigma_v_mps = SigmaFromVariance(m.variance[0]);
+      }
+      break;
+    case IHS_MEAS_HEADING:
+      if (m.value_count >= 1) {
+        latest_.bearing_deg = m.value[0];
+        latest_.has_bearing = true;
+      }
+      break;
+    default:
+      // VELOCITY_NED / YAW_RATE / ACCEL_BODY are filter inputs; the passthrough
+      // reports only what maps directly onto a fix.
+      break;
+  }
+}
+
+bool Manager::Latest(Position& out) {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (filter_instance_ != nullptr && filter_ops_.estimate != nullptr) {
+    IhsPosition est{};
+    if (filter_ops_.estimate(filter_instance_, MonotonicNs(), &est) == 1) {
+      FromIhsPosition(out, est);
+      return true;
+    }
+    return false;
+  }
+  if (!have_fix_) {
+    return false;
+  }
+  out = latest_;
+  return true;
+}
+
+uint64_t Manager::generation() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return generation_;
+}
+
+}  // namespace ihs::location

--- a/shared/src/location/manager.hpp
+++ b/shared/src/location/manager.hpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_MANAGER_H_
+#define IHS_LOC_MANAGER_H_
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "ihs/location.h"
+#include "location.hpp"
+
+namespace ihs::location {
+
+// Composes a location service from registered measurement sources and an
+// optional filter — the runtime counterpart of the registry. It binds each
+// source key (skipping any not registered), hands them a sink, and fuses the
+// measurements they push into one Position that consumers poll through the
+// ILocationProvider interface. That is deliberate: IhsLocationService can hold
+// a Manager exactly as it holds a gpsd/geoclue provider today, so swapping the
+// enum path onto the registry is a one-line change with no consumer impact.
+//
+// With no filter key a built-in passthrough assembles the latest measurements
+// into a Position directly (today's behavior — the fix is reported as
+// received). With a filter key, measurements are routed to the registered
+// filter's update(), and Latest() asks it to estimate() the state at the
+// current time.
+//
+// Threading: sources push from their own acquisition threads; a single mutex
+// serializes measurement intake, the (non-thread-safe) filter instance, and the
+// stored Position/generation that Latest()/generation() read. A source must not
+// call the sink after its stop() returns — the same contract the gpsd/geoclue
+// workers already honor (stop() joins the thread).
+//
+// Start()/Stop() are lifecycle calls on the owning thread and must not run
+// concurrently with each other or with Latest()/generation() — the same
+// contract as the C ABI handle they back, where ihs_location_stop() frees the
+// service. Between Start() and Stop(), Latest()/generation() may be polled from
+// any thread while sources push concurrently.
+class Manager : public ILocationProvider {
+ public:
+  // @source_keys are bound in order, skipping any not registered. @filter_key
+  // empty selects the built-in passthrough; otherwise the registered filter is
+  // created with @filter_config (NULL when empty). A configured-but-missing (or
+  // create-failed) filter falls back to the passthrough rather than failing.
+  Manager(std::vector<std::string> source_keys,
+          std::string filter_key,
+          std::string filter_config);
+  ~Manager() override;
+
+  Manager(const Manager&) = delete;
+  Manager& operator=(const Manager&) = delete;
+
+  bool Start() override;
+  void Stop() override;
+  bool Latest(Position& out) override;
+  [[nodiscard]] uint64_t generation() const override;
+
+ private:
+  // C sink trampoline: sink_user_data is the Manager*.
+  static void SinkThunk(void* sink_user_data, const IhsMeasurement* m);
+  void OnMeasurement(const IhsMeasurement& m);
+  // Fold one measurement into latest_ (built-in passthrough). Caller holds
+  // mutex_.
+  void ApplyToPassthrough(const IhsMeasurement& m);
+  // Stop sources + destroy the filter. Idempotent; used by Stop() and the
+  // destructor (non-virtual so the destructor does not call an override).
+  void Shutdown();
+
+  struct BoundSource {
+    IhsLocationSourceOps ops{};
+    void* user_data = nullptr;
+    bool started = false;
+  };
+
+  const std::vector<std::string> source_keys_;
+  const std::string filter_key_;
+  const std::string filter_config_;
+
+  std::vector<BoundSource> sources_;
+
+  // Optional registered filter; filter_instance_ null => built-in passthrough.
+  IhsLocationFilterOps filter_ops_{};
+  void* filter_user_data_ = nullptr;
+  void* filter_instance_ = nullptr;
+
+  mutable std::mutex mutex_;
+  Position latest_;          // guarded by mutex_
+  bool have_fix_ = false;    // guarded by mutex_
+  uint64_t generation_ = 0;  // guarded by mutex_
+  bool started_ = false;
+};
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_MANAGER_H_

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -55,3 +55,15 @@ target_compile_options(registry_test PRIVATE -Wall -Wextra)
 target_link_libraries(registry_test PRIVATE Threads::Threads)
 
 add_test(NAME registry COMMAND registry_test)
+
+# Location Manager: fuses registered sources' measurements into a Position.
+# Compiles manager.cc + registry.cc directly (both use internal APIs) and shares
+# the same ihs_export.h stub include path.
+add_executable(manager_test manager_test.cc
+        ${_loc_src}/manager.cc ${_loc_src}/registry.cc)
+target_include_directories(manager_test PRIVATE
+        ${_loc_src} ${_loc_inc} ${CMAKE_CURRENT_BINARY_DIR}/gen)
+target_compile_options(manager_test PRIVATE -Wall -Wextra)
+target_link_libraries(manager_test PRIVATE Threads::Threads)
+
+add_test(NAME manager COMMAND manager_test)

--- a/shared/tests/location/manager_test.cc
+++ b/shared/tests/location/manager_test.cc
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Unit test for the location Manager. Standalone (like registry_test): compiles
+// manager.cc + registry.cc directly, registers fake measurement sources/filters
+// through the public ABI, then drives measurements into the sink the manager
+// hands each source and asserts the fused Position, the generation counter, the
+// filter route, and source lifecycle.
+
+#include "manager.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "ihs/location.h"
+#include "location.hpp"
+
+namespace {
+
+int g_tests = 0;
+int g_failures = 0;
+
+void Check(bool cond, const char* what) {
+  ++g_tests;
+  if (!cond) {
+    ++g_failures;
+    std::fprintf(stderr, "FAIL: %s\n", what);
+  }
+}
+
+// A fake source: start() records the sink so the test can push measurements as
+// if the source's own thread produced them.
+struct FakeSource {
+  IhsMeasSink sink = nullptr;
+  void* sink_ud = nullptr;
+  int start_calls = 0;
+  int stop_calls = 0;
+
+  void Push(const IhsMeasurement& m) {
+    if (sink != nullptr) {
+      sink(sink_ud, &m);
+    }
+  }
+};
+
+int FakeSourceStart(void* ud, IhsMeasSink sink, void* sink_ud) {
+  auto* s = static_cast<FakeSource*>(ud);
+  s->sink = sink;
+  s->sink_ud = sink_ud;
+  ++s->start_calls;
+  return 1;
+}
+void FakeSourceStop(void* ud) {
+  ++static_cast<FakeSource*>(ud)->stop_calls;
+}
+
+IhsLocationSourceOps FakeSourceOps() {
+  IhsLocationSourceOps ops{};
+  ops.struct_size = sizeof(ops);
+  ops.start = &FakeSourceStart;
+  ops.stop = &FakeSourceStop;
+  return ops;
+}
+
+// A position measurement with per-axis 1-sigma^2 variance.
+IhsMeasurement PosMeas(double lat,
+                       double lon,
+                       uint64_t t,
+                       double var_e = -1.0,
+                       double var_n = -1.0) {
+  IhsMeasurement m{};
+  m.struct_size = sizeof(m);
+  m.kind = IHS_MEAS_POSITION_LLA;
+  m.t_monotonic_ns = t;
+  m.value_count = 2;
+  m.value[0] = lat;
+  m.value[1] = lon;
+  m.variance[0] = var_e;
+  m.variance[1] = var_n;
+  return m;
+}
+
+IhsMeasurement ScalarMeas(uint32_t kind, double v) {
+  IhsMeasurement m{};
+  m.struct_size = sizeof(m);
+  m.kind = kind;
+  m.value_count = 1;
+  m.value[0] = v;
+  m.variance[0] = -1.0;
+  return m;
+}
+
+// A fake filter that stores the last position measurement and reports it.
+struct FakeFilter {
+  double lat = 0.0;
+  double lon = 0.0;
+  int updates = 0;
+};
+void* FakeFilterCreate(void* /*ud*/, const char* /*config*/) {
+  return new FakeFilter();
+}
+void FakeFilterDestroy(void* inst) {
+  delete static_cast<FakeFilter*>(inst);
+}
+void FakeFilterUpdate(void* inst, const IhsMeasurement* m) {
+  auto* f = static_cast<FakeFilter*>(inst);
+  if (m->kind == IHS_MEAS_POSITION_LLA && m->value_count >= 2) {
+    f->lat = m->value[0];
+    f->lon = m->value[1];
+  }
+  ++f->updates;
+}
+int FakeFilterEstimate(void* inst, uint64_t t_ns, IhsPosition* out) {
+  auto* f = static_cast<FakeFilter*>(inst);
+  if (f->updates == 0) {
+    return 0;
+  }
+  out->latitude = f->lat;
+  out->longitude = f->lon;
+  out->t_monotonic_ns = t_ns;
+  out->mode = 3;
+  return 1;
+}
+
+}  // namespace
+
+int main() {
+  using namespace ihs::location;
+
+  // --- passthrough: fuse position + speed + heading into one fix ------------
+  {
+    FakeSource src;
+    IhsLocationSourceOps ops = FakeSourceOps();
+    Check(ihs_location_register_source("gnss.mgr", &ops, &src) == 1,
+          "register source");
+
+    Manager m({"gnss.mgr"}, "", "");
+    Position pos;
+    Check(!m.Latest(pos), "no fix before Start");
+    Check(m.Start(), "Start succeeds");
+    Check(src.start_calls == 1, "source started once");
+    Check(!m.Latest(pos), "no fix before any measurement");
+    Check(m.generation() == 0, "generation 0 before any fix");
+
+    src.Push(PosMeas(48.75, -122.48, 1000, 9.0, 16.0));  // sigma 3 / 4 m
+    Check(m.Latest(pos), "fix after a position measurement");
+    Check(pos.latitude == 48.75 && pos.longitude == -122.48, "lat/lon fused");
+    Check(pos.mode == 2, "2-component position => 2D mode");
+    Check(pos.t_monotonic_ns == 1000, "timestamp carried");
+    Check(std::abs(pos.sigma_e_m - 3.0) < 1e-9 &&
+              std::abs(pos.sigma_n_m - 4.0) < 1e-9,
+          "variance -> 1-sigma");
+    Check(m.generation() == 1, "generation bumped once by the position");
+    Check(!pos.has_bearing, "no bearing until a heading arrives");
+
+    src.Push(ScalarMeas(IHS_MEAS_SPEED, 5.5));
+    src.Push(ScalarMeas(IHS_MEAS_HEADING, 90.0));
+    Check(m.Latest(pos), "still a fix");
+    Check(pos.speed_mps == 5.5, "speed fused");
+    Check(pos.has_bearing && pos.bearing_deg == 90.0, "heading fused");
+    Check(m.generation() == 1,
+          "speed/heading augment the same fix (no extra generation)");
+
+    src.Push(PosMeas(48.76, -122.49, 2000));
+    Check(m.generation() == 2, "next position bumps generation");
+    Check(m.Latest(pos) && pos.latitude == 48.76, "latest position wins");
+
+    m.Stop();
+    Check(src.stop_calls == 1, "source stopped");
+  }
+
+  // --- bounded copy at the sink: a shorter (no-flags) measurement is still
+  //     understood; a runt too small for the value block is dropped ----------
+  {
+    FakeSource src;
+    IhsLocationSourceOps ops = FakeSourceOps();
+    ihs_location_register_source("gnss.short", &ops, &src);
+    Manager m({"gnss.short"}, "", "");
+    m.Start();
+
+    // A source built against a layout without the trailing flags field (a
+    // shorter struct_size) is copied bounded and fully understood.
+    IhsMeasurement shortm = PosMeas(33.0, 44.0, 7);
+    shortm.struct_size = offsetof(IhsMeasurement, flags);
+    src.Push(shortm);
+    Position pos;
+    Check(m.Latest(pos) && pos.latitude == 33.0,
+          "a measurement without the trailing flags field is accepted");
+
+    // A runt whose struct_size cannot even cover the value/variance block is
+    // dropped, not read past.
+    IhsMeasurement runt = PosMeas(55.0, 66.0, 8);
+    runt.struct_size = offsetof(IhsMeasurement, value_count);
+    const uint64_t before = m.generation();
+    src.Push(runt);
+    Check(m.generation() == before && m.Latest(pos) && pos.latitude == 33.0,
+          "a runt measurement is dropped, leaving the prior fix intact");
+    m.Stop();
+  }
+
+  // --- an unregistered source key is skipped, a registered one still binds --
+  {
+    FakeSource src;
+    IhsLocationSourceOps ops = FakeSourceOps();
+    ihs_location_register_source("gnss.present", &ops, &src);
+
+    Manager m({"gnss.absent", "gnss.present"}, "", "");
+    Check(m.Start(), "Start with a missing key");
+    Check(src.start_calls == 1, "the registered source still started");
+    src.Push(PosMeas(1.0, 2.0, 10));
+    Position pos;
+    Check(m.Latest(pos) && pos.latitude == 1.0, "fix from the present source");
+    m.Stop();
+  }
+
+  // --- filter route: measurements go to update(), Latest() -> estimate() ----
+  {
+    FakeSource src;
+    IhsLocationSourceOps sops = FakeSourceOps();
+    ihs_location_register_source("gnss.filt", &sops, &src);
+
+    IhsLocationFilterOps fops{};
+    fops.struct_size = sizeof(fops);
+    fops.create = &FakeFilterCreate;
+    fops.destroy = &FakeFilterDestroy;
+    fops.update = &FakeFilterUpdate;
+    fops.estimate = &FakeFilterEstimate;
+    Check(ihs_location_register_filter("kalman.mgr", &fops, nullptr) == 1,
+          "register filter");
+
+    Manager m({"gnss.filt"}, "kalman.mgr", "");
+    Check(m.Start(), "Start with a filter");
+    Position pos;
+    Check(!m.Latest(pos), "filter reports no fix before any update");
+
+    src.Push(PosMeas(51.5, -0.12, 42));
+    Check(m.Latest(pos), "filter reports a fix after an update");
+    Check(pos.latitude == 51.5 && pos.longitude == -0.12,
+          "estimate carries the measurement");
+    Check(pos.mode == 3, "estimate mode from the filter");
+    m.Stop();  // destroys the filter instance (no leak)
+  }
+
+  // --- a configured-but-missing filter falls back to passthrough ------------
+  {
+    FakeSource src;
+    IhsLocationSourceOps ops = FakeSourceOps();
+    ihs_location_register_source("gnss.fb", &ops, &src);
+
+    Manager m({"gnss.fb"}, "kalman.nope", "");
+    Check(m.Start(), "Start with an unregistered filter key");
+    src.Push(PosMeas(10.0, 20.0, 5));
+    Position pos;
+    Check(m.Latest(pos) && pos.latitude == 10.0,
+          "missing filter falls back to passthrough, not a dead service");
+    m.Stop();
+  }
+
+  if (g_failures == 0) {
+    std::printf("manager_test: all %d checks passed\n", g_tests);
+  } else {
+    std::fprintf(stderr, "manager_test: %d/%d checks FAILED\n", g_failures,
+                 g_tests);
+  }
+  return g_failures == 0 ? 0 : 1;
+}

--- a/shared/tests/location/manager_test.cc
+++ b/shared/tests/location/manager_test.cc
@@ -101,6 +101,10 @@ IhsMeasurement ScalarMeas(uint32_t kind, double v) {
   return m;
 }
 
+// value_count of the last measurement any filter saw — lets a test assert the
+// manager clamped it before the filter was called.
+uint32_t g_last_meas_value_count = 0;
+
 // A fake filter that stores the last position measurement and reports it.
 struct FakeFilter {
   double lat = 0.0;
@@ -115,6 +119,7 @@ void FakeFilterDestroy(void* inst) {
 }
 void FakeFilterUpdate(void* inst, const IhsMeasurement* m) {
   auto* f = static_cast<FakeFilter*>(inst);
+  g_last_meas_value_count = m->value_count;
   if (m->kind == IHS_MEAS_POSITION_LLA && m->value_count >= 2) {
     f->lat = m->value[0];
     f->lon = m->value[1];
@@ -239,6 +244,53 @@ int main() {
     src.Push(runt);
     Check(m.generation() == before && m.Latest(pos) && pos.latitude == 33.0,
           "a runt measurement is dropped, leaving the prior fix intact");
+    m.Stop();
+  }
+
+  // --- a new position anchor clears stale per-fix speed/heading -------------
+  {
+    FakeSource src;
+    IhsLocationSourceOps ops = FakeSourceOps();
+    ihs_location_register_source("gnss.fresh", &ops, &src);
+    Manager m({"gnss.fresh"}, "", "");
+    m.Start();
+    src.Push(PosMeas(1.0, 2.0, 1));
+    src.Push(ScalarMeas(IHS_MEAS_SPEED, 7.0));
+    src.Push(ScalarMeas(IHS_MEAS_HEADING, 45.0));
+    Position pos;
+    Check(m.Latest(pos) && pos.speed_mps == 7.0 && pos.has_bearing,
+          "speed/heading present for the fix they follow");
+
+    // A new position with no following speed/heading must not carry the old
+    // ones forward (each fix is fresh, like the gpsd/geoclue providers).
+    src.Push(PosMeas(1.1, 2.1, 2));
+    Check(m.Latest(pos) && pos.latitude == 1.1 && pos.speed_mps < 0 &&
+              !pos.has_bearing,
+          "a new position anchor clears stale speed/heading");
+    m.Stop();
+  }
+
+  // --- an over-declared value_count is clamped before a filter sees it ------
+  {
+    FakeSource src;
+    IhsLocationSourceOps sops = FakeSourceOps();
+    ihs_location_register_source("gnss.clamp", &sops, &src);
+    IhsLocationFilterOps fops{};
+    fops.struct_size = sizeof(fops);
+    fops.create = &FakeFilterCreate;
+    fops.destroy = &FakeFilterDestroy;
+    fops.update = &FakeFilterUpdate;
+    fops.estimate = &FakeFilterEstimate;
+    ihs_location_register_filter("kalman.clamp", &fops, nullptr);
+
+    Manager m({"gnss.clamp"}, "kalman.clamp", "");
+    m.Start();
+    IhsMeasurement over = PosMeas(1.0, 2.0, 1);
+    over.value_count = 100;  // absurd; must be clamped to the array bound (6)
+    g_last_meas_value_count = 0;
+    src.Push(over);
+    Check(g_last_meas_value_count == 6,
+          "value_count is clamped to 6 before a filter is called");
     m.Stop();
   }
 

--- a/shared/tests/location/manager_test.cc
+++ b/shared/tests/location/manager_test.cc
@@ -242,6 +242,28 @@ int main() {
     m.Stop();
   }
 
+  // --- restart is pristine: after Stop, a fresh Start reports no fix and
+  //     generation 0 until a new fix arrives (not a stale generation) ---------
+  {
+    FakeSource src;
+    IhsLocationSourceOps ops = FakeSourceOps();
+    ihs_location_register_source("gnss.restart", &ops, &src);
+    Manager m({"gnss.restart"}, "", "");
+    m.Start();
+    src.Push(PosMeas(1.0, 2.0, 1));
+    Position pos;
+    Check(m.Latest(pos) && m.generation() == 1, "fix before restart");
+    m.Stop();
+
+    m.Start();
+    Check(!m.Latest(pos) && m.generation() == 0,
+          "after restart: no fix and generation 0, not a stale generation");
+    src.Push(PosMeas(3.0, 4.0, 2));
+    Check(m.Latest(pos) && pos.latitude == 3.0 && m.generation() == 1,
+          "restarted Manager tracks fixes from generation 1");
+    m.Stop();
+  }
+
   // --- an unregistered source key is skipped, a registered one still binds --
   {
     FakeSource src;

--- a/shared/tests/location/manager_test.cc
+++ b/shared/tests/location/manager_test.cc
@@ -359,6 +359,35 @@ int main() {
     m.Stop();  // destroys the filter instance (no leak)
   }
 
+  // --- filter route: Latest() and generation() stay consistent — no fix is
+  //     surfaced until a position correction, so a velocity-only-primed filter
+  //     cannot report a fix while generation() is still 0 --------------------
+  {
+    FakeSource src;
+    IhsLocationSourceOps sops = FakeSourceOps();
+    ihs_location_register_source("gnss.prime", &sops, &src);
+    IhsLocationFilterOps fops{};
+    fops.struct_size = sizeof(fops);
+    fops.create = &FakeFilterCreate;
+    fops.destroy = &FakeFilterDestroy;
+    fops.update = &FakeFilterUpdate;  // estimate() succeeds after ANY update
+    fops.estimate = &FakeFilterEstimate;
+    ihs_location_register_filter("kalman.prime", &fops, nullptr);
+
+    Manager m({"gnss.prime"}, "kalman.prime", "");
+    m.Start();
+    Position pos;
+    src.Push(ScalarMeas(IHS_MEAS_SPEED, 3.0));  // primes the filter, not a fix
+    Check(!m.Latest(pos) && m.generation() == 0,
+          "no fix and generation 0 before any position, even if the filter "
+          "could estimate");
+    src.Push(PosMeas(51.5, -0.12, 42));
+    Check(m.Latest(pos) && m.generation() == 1,
+          "the first position correction is the first fix; Latest and "
+          "generation agree");
+    m.Stop();
+  }
+
   // --- a configured-but-missing filter falls back to passthrough ------------
   {
     FakeSource src;

--- a/shared/tests/location/manager_test.cc
+++ b/shared/tests/location/manager_test.cc
@@ -180,6 +180,39 @@ int main() {
     Check(src.stop_calls == 1, "source stopped");
   }
 
+  // --- an invalid position is dropped: no fix, no generation bump, and it
+  //     never clobbers a prior good fix
+  //     ----------------------------------------
+  {
+    FakeSource src;
+    IhsLocationSourceOps ops = FakeSourceOps();
+    ihs_location_register_source("gnss.invalid", &ops, &src);
+    Manager m({"gnss.invalid"}, "", "");
+    m.Start();
+    Position pos;
+
+    src.Push(PosMeas(200.0, 10.0, 1));  // latitude out of range
+    Check(!m.Latest(pos) && m.generation() == 0,
+          "out-of-range position is dropped (no fix, no generation)");
+    src.Push(PosMeas(std::nan(""), 10.0, 2));  // non-finite latitude
+    Check(!m.Latest(pos) && m.generation() == 0, "NaN position is dropped");
+    IhsMeasurement one_comp = PosMeas(10.0, 20.0, 3);
+    one_comp.value_count = 1;
+    src.Push(one_comp);
+    Check(!m.Latest(pos) && m.generation() == 0,
+          "a position with < 2 components is dropped");
+
+    src.Push(PosMeas(10.0, 20.0, 4));  // finally a valid one
+    Check(m.Latest(pos) && pos.latitude == 10.0 && m.generation() == 1,
+          "a valid position after invalid ones is the first accepted fix");
+
+    src.Push(PosMeas(-999.0, 0.0, 5));  // invalid again
+    Check(m.Latest(pos) && pos.latitude == 10.0 && m.generation() == 1,
+          "an invalid position after a fix neither bumps generation nor "
+          "clobbers the prior fix");
+    m.Stop();
+  }
+
   // --- bounded copy at the sink: a shorter (no-flags) measurement is still
   //     understood; a runt too small for the value block is dropped ----------
   {


### PR DESCRIPTION
First half of the location "measurement + registry" work, building on the registry ABI from #346. Adds the runtime that composes a service from registered measurement sources and an optional filter — the counterpart of the registry.

`Manager` implements `ILocationProvider`, so `IhsLocationService` can hold it exactly as it holds a gpsd/geoclue provider today — the seam for moving the enum path onto the registry with no consumer impact.

### What's here
- **`manager.{hpp,cc}`** — binds source keys from the registry (skipping unregistered), hands each a sink, and fuses pushed `IhsMeasurement`s into one `Position`.
  - The sink **bounded-copies** each measurement (`min(struct_size, sizeof)` into a zeroed struct, dropping a runt) — the #337 discipline, so a source built against a different `IhsMeasurement` layout is never read past its object.
  - **Built-in passthrough** (no filter key) assembles `POSITION`/`SPEED`/`HEADING` into a fix, reported as received — today's behavior. One generation per `POSITION`.
  - **Filter route** (with a key) sends measurements to `update()` and answers `Latest()` via `estimate(now)`; a missing/failed filter falls back to passthrough.
  - One mutex serializes intake, the filter, and the polled `Position`. `Start()`/`Stop()` are owning-thread lifecycle calls (documented C-ABI handle contract); `Shutdown` resets `have_fix_` so a restart can't report a stale fix.
- **`manager_test`** (33 checks): passthrough fusion, generation counting, filter route, missing-key skip, missing-filter fallback, bounded-copy of a short/runt measurement, lifecycle.

### Behavior
**Inert** — not on the `ihs_location_start()` path yet, so no runtime behavior change.

### Follow-up
Register gpsd/geoclue as sources (emitting at their existing `recv`/`LocationUpdated` notification points — no polling) and flip `ihs_location_start` to a thin enum→key shim. That's the behavior-change step; acceptance is the live-GNSS matrix unchanged.

### Verification
`manager_test` 33/33; all 3 standalone location tests pass; `cmake -S shared` links against merged v2.0; clang-tidy-19 + clang-format-19 clean.
