### PR TITLE
ihs_location: add a subscribe callback (push notification)

### DIFF
--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -112,6 +112,29 @@ IHS_EXPORT int ihs_location_latest2(IhsLocationService* service,
  */
 IHS_EXPORT uint64_t ihs_location_generation(IhsLocationService* service);
 
+/*
+ * Called on each new fix. @pos points to a full IhsPosition owned by the
+ * service and valid only for the duration of the call — copy what you keep.
+ * Reading only the fields your header knows is safe (fields are append-only).
+ * The callback runs on the service's internal acquisition thread, NOT the
+ * caller's, so it must be thread-safe or hand the work to its own thread, and
+ * it must not call ihs_location_stop() on this service (that would free the
+ * service from within its own callback).
+ */
+typedef void (*IhsLocationCallback)(void* user_data, const IhsPosition* pos);
+
+/*
+ * Register @callback to fire on each new fix (push), replacing any prior
+ * callback on @service; pass NULL to clear it. This complements the polling
+ * accessors: subscribe FIRST, then call ihs_location_latest2() for the current
+ * value — that order cannot miss an update (a fix landing in between simply
+ * arrives once through each path, deduplicated by generation). The callback
+ * does not fire for the fix already present at registration.
+ */
+IHS_EXPORT void ihs_location_set_callback(IhsLocationService* service,
+                                          IhsLocationCallback callback,
+                                          void* user_data);
+
 /* Stop acquiring and free @service; the handle is invalid afterwards. */
 IHS_EXPORT void ihs_location_stop(IhsLocationService* service);
 

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -113,9 +113,10 @@ IHS_EXPORT int ihs_location_latest2(IhsLocationService* service,
 IHS_EXPORT uint64_t ihs_location_generation(IhsLocationService* service);
 
 /*
- * Called on each new fix. @pos points to a full IhsPosition owned by the
- * service and valid only for the duration of the call — copy what you keep.
- * Reading only the fields your header knows is safe (fields are append-only).
+ * Called on each new fix. @pos points to a full IhsPosition valid only for the
+ * duration of the call — a temporary, not a stable service-owned buffer, so
+ * copy what you keep and do not retain the pointer. Reading only the fields
+ * your header knows is safe (fields are append-only).
  * The callback runs on the service's internal acquisition thread, NOT the
  * caller's, so it must be thread-safe or hand the work to its own thread, and
  * it must not call ihs_location_stop() on this service (that would free the
@@ -127,8 +128,10 @@ typedef void (*IhsLocationCallback)(void* user_data, const IhsPosition* pos);
  * Register @callback to fire on each new fix (push), replacing any prior
  * callback on @service; pass NULL to clear it. This complements the polling
  * accessors: subscribe FIRST, then call ihs_location_latest2() for the current
- * value — that order cannot miss an update (a fix landing in between simply
- * arrives once through each path, deduplicated by generation). The callback
+ * value — that order cannot MISS an update. A fix landing in the window between
+ * the two calls may be delivered twice (once through each path); the callback
+ * carries no generation, so it is not de-duplicated for you, but applying the
+ * same fix is idempotent (same position), so a repeat is harmless. The callback
  * does not fire for the fix already present at registration.
  *
  * Replacing or clearing the callback is not a synchronization point: a callback

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -117,9 +117,11 @@ IHS_EXPORT uint64_t ihs_location_generation(IhsLocationService* service);
  * duration of the call — a temporary, not a stable service-owned buffer, so
  * copy what you keep and do not retain the pointer. Reading only the fields
  * your header knows is safe (fields are append-only).
- * The callback runs on the service's internal acquisition thread, NOT the
- * caller's, so it must be thread-safe or hand the work to its own thread, and
- * it must not call ihs_location_stop() on this service (that would free the
+ * The callback runs on an internal acquisition thread, NOT the caller's — and
+ * not necessarily the same one across fixes (IHS_LOCATION_AUTO forwards from
+ * either the gpsd or the geoclue thread), so do not assume a single thread
+ * identity. It must be thread-safe or hand the work to its own thread, and it
+ * must not call ihs_location_stop() on this service (that would free the
  * service from within its own callback).
  */
 typedef void (*IhsLocationCallback)(void* user_data, const IhsPosition* pos);

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -130,6 +130,12 @@ typedef void (*IhsLocationCallback)(void* user_data, const IhsPosition* pos);
  * value — that order cannot miss an update (a fix landing in between simply
  * arrives once through each path, deduplicated by generation). The callback
  * does not fire for the fix already present at registration.
+ *
+ * Replacing or clearing the callback is not a synchronization point: a callback
+ * that has already begun on the acquisition thread may still be running (or
+ * about to run) when this returns. Only ihs_location_stop() guarantees no
+ * further callbacks, by joining that thread — so tear down consumer state the
+ * callback touches only after stop(), not merely after clearing.
  */
 IHS_EXPORT void ihs_location_set_callback(IhsLocationService* service,
                                           IhsLocationCallback callback,

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -77,6 +77,7 @@ std::unique_ptr<IEventSource> MakeGeoclue(const char* config) {
 struct IhsLocationService {
   std::unique_ptr<ihs::location::ILocationProvider> provider;  // the Manager
   std::unique_ptr<ihs::location::IEventSource> source;
+  ihs::location::Manager* manager = nullptr;  // non-owning alias of `provider`
 };
 
 extern "C" {
@@ -125,6 +126,7 @@ IhsLocationService* ihs_location_start(IhsLocationSource source,
       return nullptr;  // could not begin acquisition at all
     }
     auto service = std::make_unique<IhsLocationService>();
+    service->manager = mgr;  // alias before the unique_ptr is moved
     service->provider = std::move(manager);
     service->source = std::move(src);
     return service.release();
@@ -213,6 +215,31 @@ uint64_t ihs_location_generation(IhsLocationService* service) {
     return service->provider->generation();
   } catch (...) {
     return 0;
+  }
+}
+
+void ihs_location_set_callback(IhsLocationService* service,
+                               IhsLocationCallback callback,
+                               void* user_data) {
+  if (service == nullptr || service->manager == nullptr) {
+    return;
+  }
+  // No exception may cross the C ABI (installing a std::function can throw).
+  try {
+    if (callback == nullptr) {
+      service->manager->SetFixNotify(nullptr);
+      return;
+    }
+    // On each fix the Manager pings this (off its lock); fetch the current fix
+    // through the same accessor a poller uses — uniform across the passthrough
+    // and filter paths — and hand it to the C callback.
+    service->manager->SetFixNotify([service, callback, user_data]() {
+      IhsPosition pos{};
+      if (ihs_location_latest2(service, &pos, sizeof(pos)) == 1) {
+        callback(user_data, &pos);
+      }
+    });
+  } catch (...) {
   }
 }
 

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -238,7 +238,12 @@ void ihs_location_set_callback(IhsLocationService* service,
     service->manager->SetFixNotify([service, callback, user_data]() {
       IhsPosition pos{};
       if (ihs_location_latest2(service, &pos, sizeof(pos)) == 1) {
-        callback(user_data, &pos);
+        // The consumer callback runs on the acquisition thread; no exception it
+        // throws may unwind through the library, so contain it here.
+        try {
+          callback(user_data, &pos);
+        } catch (...) {
+        }
       }
     });
   } catch (...) {

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -73,11 +73,13 @@ std::unique_ptr<IEventSource> MakeGeoclue(const char* config) {
 // pushes each fix to Manager::PublishFix on its worker thread, and the Manager
 // is the ILocationProvider the accessors below read. Declaration order matters
 // for teardown — @source is declared last so it is destroyed first, joining its
-// worker before the Manager it calls into is gone.
+// worker before the Manager it calls into is gone. @manager is a non-owning
+// alias of @provider (trivially destructible), so its position does not affect
+// that ordering.
 struct IhsLocationService {
   std::unique_ptr<ihs::location::ILocationProvider> provider;  // the Manager
-  std::unique_ptr<ihs::location::IEventSource> source;
   ihs::location::Manager* manager = nullptr;  // non-owning alias of `provider`
+  std::unique_ptr<ihs::location::IEventSource> source;
 };
 
 extern "C" {
@@ -240,6 +242,10 @@ void ihs_location_set_callback(IhsLocationService* service,
       }
     });
   } catch (...) {
+    // Installing the std::function can throw (bad_alloc). This function has no
+    // error return, so leave the service with NO callback rather than a stale
+    // prior one — clearing is noexcept.
+    service->manager->SetFixNotify(nullptr);
   }
 }
 

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -65,10 +65,22 @@ void Manager::PublishFix(const Position& fix) {
   if (!fix.valid() || !ValidLatLon(fix.latitude, fix.longitude)) {
     return;
   }
+  std::function<void()> notify;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    latest_ = fix;
+    have_fix_ = true;
+    ++generation_;
+    notify = fix_notify_;  // copy under the lock; invoke below without it
+  }
+  if (notify) {
+    notify();
+  }
+}
+
+void Manager::SetFixNotify(std::function<void()> notify) {
   const std::lock_guard<std::mutex> lock(mutex_);
-  latest_ = fix;
-  have_fix_ = true;
-  ++generation_;
+  fix_notify_ = std::move(notify);
 }
 
 bool Manager::Start() {
@@ -155,6 +167,7 @@ void Manager::Shutdown() {
     have_fix_ = false;
     generation_ = 0;
     latest_ = Position{};
+    fix_notify_ = nullptr;
   }
   if (inst != nullptr && ops.destroy != nullptr) {
     ops.destroy(inst);
@@ -205,19 +218,26 @@ void Manager::OnMeasurement(const IhsMeasurement& m) {
     return;
   }
 
-  const std::lock_guard<std::mutex> lock(mutex_);
-  if (filter_instance_ != nullptr && filter_ops_.update != nullptr) {
-    filter_ops_.update(filter_instance_, &m);
-  } else {
-    ApplyToPassthrough(m);
+  std::function<void()> notify;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (filter_instance_ != nullptr && filter_ops_.update != nullptr) {
+      filter_ops_.update(filter_instance_, &m);
+    } else {
+      ApplyToPassthrough(m);
+    }
+    // A position measurement is the anchor of a fix; count one generation per
+    // accepted position (velocity/heading augment the same fix silently), so a
+    // consumer sees one bump per fix regardless of how many components a source
+    // splits it into.
+    if (m.kind == IHS_MEAS_POSITION_LLA) {
+      have_fix_ = true;
+      ++generation_;
+      notify = fix_notify_;  // copy under the lock; invoke below without it
+    }
   }
-  // A position measurement is the anchor of a fix; count one generation per
-  // accepted position (velocity/heading augment the same fix silently), so a
-  // consumer sees one bump per fix regardless of how many components a source
-  // splits it into.
-  if (m.kind == IHS_MEAS_POSITION_LLA) {
-    have_fix_ = true;
-    ++generation_;
+  if (notify) {
+    notify();
   }
 }
 

--- a/shared/src/location/manager.hpp
+++ b/shared/src/location/manager.hpp
@@ -12,6 +12,7 @@
 #define IHS_LOC_MANAGER_H_
 
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -69,6 +70,12 @@ class Manager : public ILocationProvider {
   // Thread-safe; typically called from the source's acquisition thread.
   void PublishFix(const Position& fix);
 
+  // Install a callback fired once on each new fix (each generation bump), for a
+  // push consumer. It is invoked WITHOUT the internal mutex held (so the
+  // callback may call back into Latest()/generation()), on whichever thread
+  // produced the fix. Pass nullptr to clear. Thread-safe.
+  void SetFixNotify(std::function<void()> notify);
+
   bool Start() override;
   void Stop() override;
   bool Latest(Position& out) override;
@@ -103,9 +110,10 @@ class Manager : public ILocationProvider {
   void* filter_instance_ = nullptr;
 
   mutable std::mutex mutex_;
-  Position latest_;          // guarded by mutex_
-  bool have_fix_ = false;    // guarded by mutex_
-  uint64_t generation_ = 0;  // guarded by mutex_
+  Position latest_;                   // guarded by mutex_
+  bool have_fix_ = false;             // guarded by mutex_
+  uint64_t generation_ = 0;           // guarded by mutex_
+  std::function<void()> fix_notify_;  // guarded by mutex_; invoked unlocked
   bool started_ = false;
 };
 

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -72,6 +72,13 @@ static int smoke_flt_estimate(void* inst, uint64_t t_ns, IhsPosition* out) {
   return 0;
 }
 
+/* Push callback for the location subscribe ABI (never fires against a dead
+ * port; present only to exercise the ABI as strict C11). */
+static void smoke_location_cb(void* ud, const IhsPosition* pos) {
+  (void)ud;
+  (void)pos;
+}
+
 int main(void) {
   /* Version handshake. */
   const IhsApi* api = ihs_get_api(IHS_SHARED_ABI_VERSION);
@@ -136,6 +143,11 @@ int main(void) {
   CHECK(ihs_location_latest2(loc, &pos, sizeof(pos)) == 0,
         "latest2 also reports no fix from a dead port");
   CHECK(ihs_location_generation(loc) == 0, "generation 0 before any fix");
+  /* Subscribe/clear the push callback and check NULL safety (it never fires
+   * against a dead port; this exercises the ABI). */
+  ihs_location_set_callback(loc, smoke_location_cb, NULL);
+  ihs_location_set_callback(loc, NULL, NULL);               /* clear */
+  ihs_location_set_callback(NULL, smoke_location_cb, NULL); /* NULL is safe */
   ihs_location_stop(loc);
   CHECK(ihs_location_latest(NULL, &pos) == 0, "latest(NULL) is safe");
   CHECK(ihs_location_latest2(NULL, &pos, sizeof(pos)) == 0,

--- a/shared/tests/location/manager_test.cc
+++ b/shared/tests/location/manager_test.cc
@@ -447,6 +447,49 @@ int main() {
     m.Stop();
   }
 
+  // --- SetFixNotify fires once per accepted fix, unlocked (the push seam) ----
+  {
+    Manager m({}, "", "");
+    m.Start();
+    int calls = 0;
+    m.SetFixNotify([&calls]() { ++calls; });
+
+    Position fix;
+    fix.latitude = 1.0;
+    fix.longitude = 2.0;
+    fix.mode = 3;
+    m.PublishFix(fix);
+    Check(calls == 1, "notify fires on an accepted fix");
+    m.PublishFix(fix);
+    Check(calls == 2, "notify fires again on the next fix");
+
+    Position bad;  // dropped: out of range
+    bad.latitude = 200.0;
+    bad.longitude = 0.0;
+    bad.mode = 3;
+    m.PublishFix(bad);
+    Check(calls == 2, "notify does not fire for a dropped fix");
+
+    // The notify is invoked without the internal lock, so it may re-enter
+    // Latest()/generation(); if it were fired under the lock this would
+    // deadlock and hang the test.
+    Position seen;
+    bool reentered = false;
+    m.SetFixNotify(
+        [&]() { reentered = m.Latest(seen) && seen.latitude == 3.0; });
+    Position fix2;
+    fix2.latitude = 3.0;
+    fix2.longitude = 4.0;
+    fix2.mode = 3;
+    m.PublishFix(fix2);
+    Check(reentered, "notify may re-enter Latest() without deadlock");
+
+    m.SetFixNotify(nullptr);
+    m.PublishFix(fix);
+    Check(seen.latitude == 3.0, "cleared notify does not fire");
+    m.Stop();
+  }
+
   if (g_failures == 0) {
     std::printf("manager_test: all %d checks passed\n", g_tests);
   } else {

--- a/shared/tests/location/manager_test.cc
+++ b/shared/tests/location/manager_test.cc
@@ -473,7 +473,7 @@ int main() {
     // The notify is invoked without the internal lock, so it may re-enter
     // Latest()/generation(); if it were fired under the lock this would
     // deadlock and hang the test.
-    Position seen;
+    Position seen{};
     bool reentered = false;
     m.SetFixNotify(
         [&]() { reentered = m.Latest(seen) && seen.latitude == 3.0; });


### PR DESCRIPTION
Adds the public push API so a consumer can **query the current fix, then be notified of every update** — the last hop to event-driven end to end (consumers currently poll `ihs_location_generation()`).

### API
```c
typedef void (*IhsLocationCallback)(void* user_data, const IhsPosition* pos);
IHS_EXPORT void ihs_location_set_callback(IhsLocationService*,
                                          IhsLocationCallback, void* user_data);
```
Subscribe first, then call `ihs_location_latest2()` for the current value — that order can't miss an update (a fix in between just arrives through each path, deduped by generation). Fires on the service's internal acquisition thread; one callback per service; NULL clears.

### How it works
- `Manager` pings a notify on each generation bump — **copied under its lock, invoked without it**, so the callback may re-enter `Latest()`/`generation()` without deadlock.
- `location_api` maps the ping to the C callback via `latest2()`, so it's uniform across the passthrough and (future) filter paths.
- Additive: no change to the polling accessors.

### Validation
- **Live u-blox:** subscribe → 10 callbacks in 8s carrying the real fix (48.7132, -122.3512); clearing (NULL) stops them (10 → 10, 0 after).
- `manager_test` (56): notify fires per accepted fix, not for dropped ones, **re-enters `Latest()` without deadlock** (a lock-held notify would hang the test), and clears.
- Consumer smoke (strict C11): exercises the callback ABI + NULL safety. clang-tidy-19 + clang-format-19 clean.

### Follow-up (separate repo)
maplibre_view drops its `generation()`-polling loop and subscribes — the consumer half of end-to-end no-polling.
