### PR TITLE
location: synthetic-track filter harness with raw-vs-filtered RMSE

### DIFF
--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -80,9 +80,10 @@ jobs:
           export LD_LIBRARY_PATH="$PWD/prefix/lib:$PWD/prefix/lib64:$PWD/prefix/lib/x86_64-linux-gnu"
           ctest --test-dir sbuild --output-on-failure
 
-      - name: Location gpsd TPV parser unit test
-        # Standalone: compiles the internal provider source directly (ParseTpv
-        # is not part of the installed C ABI), so no prefix / gpsd is needed.
+      - name: Location unit tests (parser / registry / manager / fallback / filter)
+        # Standalone: compiles the internal location sources directly (ParseTpv,
+        # registry, manager, etc. are not part of the installed C ABI), so no
+        # prefix / gpsd is needed. ctest runs every add_test in the project.
         run: |
           cmake -S shared/tests/location -B lbuild -G Ninja
           cmake --build lbuild

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -77,3 +77,15 @@ target_compile_options(manager_test PRIVATE -Wall -Wextra)
 target_link_libraries(manager_test PRIVATE Threads::Threads)
 
 add_test(NAME manager COMMAND manager_test)
+
+# Filter harness: synthetic ground-truth tracks + Gaussian noise driven through
+# the Manager, comparing filtered RMSE to raw RMSE. Today it exercises the
+# passthrough (filtered == raw baseline); the estimator increments must beat it.
+add_executable(filter_test filter_test.cc track_gen.cc
+        ${_loc_src}/manager.cc ${_loc_src}/registry.cc)
+target_include_directories(filter_test PRIVATE
+        ${_loc_src} ${_loc_inc} ${CMAKE_CURRENT_BINARY_DIR}/gen)
+target_compile_options(filter_test PRIVATE -Wall -Wextra)
+target_link_libraries(filter_test PRIVATE Threads::Threads)
+
+add_test(NAME filter COMMAND filter_test)

--- a/shared/tests/location/filter_test.cc
+++ b/shared/tests/location/filter_test.cc
@@ -29,6 +29,7 @@
 
 #include "manager.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -135,17 +136,23 @@ std::vector<Position> RunFilter(const std::vector<NoisyFix>& fixes,
   return est;
 }
 
-// RMSE (meters) of the noisy fixes vs truth.
+// RMSE (meters) of the noisy fixes vs truth, over [from, to). Total: clamps to
+// the shorter vector and returns 0 over an empty window.
 double RmseRaw(const std::vector<NoisyFix>& fixes,
                const std::vector<TruthSample>& truth,
-               double ref_lat) {
+               double ref_lat,
+               size_t from,
+               size_t to) {
+  const size_t end = std::min({to, fixes.size(), truth.size()});
   double sum = 0.0;
-  for (size_t i = 0; i < truth.size(); ++i) {
+  size_t n = 0;
+  for (size_t i = from; i < end; ++i) {
     const double d = MetersBetween(fixes[i].lat, fixes[i].lon, truth[i].lat,
                                    truth[i].lon, ref_lat);
     sum += d * d;
+    ++n;
   }
-  return std::sqrt(sum / static_cast<double>(truth.size()));
+  return n == 0 ? 0.0 : std::sqrt(sum / static_cast<double>(n));
 }
 
 // RMSE (meters) of the estimates vs truth, over [from, to).
@@ -180,7 +187,7 @@ int main() {
     const auto fixes = AddNoise(truth, kSigma, rng);
     const auto est = RunFilter(fixes, "" /* passthrough */);
 
-    const double raw = RmseRaw(fixes, truth, kLat0);
+    const double raw = RmseRaw(fixes, truth, kLat0, 0, truth.size());
     const double filt = RmseEst(est, truth, kLat0, 0, truth.size());
     std::printf("straight : raw=%.3f m  filtered=%.3f m  (sigma=%.1f)\n", raw,
                 filt, kSigma);
@@ -203,13 +210,20 @@ int main() {
     const auto fixes = AddNoise(truth, kSigma, rng);
     const auto est = RunFilter(fixes, "" /* passthrough */);
 
-    const double raw = RmseRaw(fixes, truth, kLat0);
-    // Late-window estimate RMSE: for a real filter this collapses well below
-    // raw; for the passthrough it stays at the measurement noise.
-    const double filt_late = RmseEst(est, truth, kLat0, 60, truth.size());
-    std::printf("stationary: raw=%.3f m  filtered(late)=%.3f m\n", raw,
-                filt_late);
-    Check(std::abs(filt_late - raw) < kSigma,
+    const double raw_full = RmseRaw(fixes, truth, kLat0, 0, truth.size());
+    // Compare like windows: late-window filtered vs late-window raw. For a real
+    // filter the filtered value collapses well below raw; for the passthrough
+    // it equals raw exactly (the estimate is the last measurement), so a tight
+    // tolerance holds and a regression that perturbed the passthrough here
+    // would trip it — where the earlier full-window-vs-late-window compare
+    // would not.
+    const size_t late = 60;
+    const double raw_late = RmseRaw(fixes, truth, kLat0, late, truth.size());
+    const double filt_late = RmseEst(est, truth, kLat0, late, truth.size());
+    std::printf(
+        "stationary: raw=%.3f m  raw(late)=%.3f m  filtered(late)=%.3f m\n",
+        raw_full, raw_late, filt_late);
+    Check(std::abs(filt_late - raw_late) < 0.05,
           "passthrough does not collapse the stationary variance (baseline)");
   }
 

--- a/shared/tests/location/filter_test.cc
+++ b/shared/tests/location/filter_test.cc
@@ -15,8 +15,17 @@
 // Today the only "filter" is the Manager's passthrough (no filter registered),
 // so this reports filtered == raw: the baseline increment 4's kalman.cv must
 // improve on. The scenarios (straight, stationary, outage) and their reports
-// are built now so that adding a filter is a one-line change here plus the
-// filter itself, and the improvement is provable in CI rather than eyeballed.
+// are built now so the improvement is provable in CI rather than eyeballed.
+//
+// One seam is deliberately deferred to the filter increment. This harness reads
+// the estimate with Manager::Latest(), which for a real filter evaluates
+// estimate() at the wall clock (MonotonicNs()), not at the synthetic
+// measurement time stamped into each pushed measurement. The passthrough is
+// time-independent, so the baseline here is exact; but a constant-velocity
+// filter would extrapolate across the gap between the synthetic timeline (based
+// at 0) and the wall clock and produce nonsense. Wiring a real filter therefore
+// also needs the estimate sampled on the synthetic timeline (a
+// time-parameterized read) — that lands with the filter, where it is testable.
 
 #include "manager.hpp"
 
@@ -89,10 +98,14 @@ std::vector<Position> RunFilter(const std::vector<NoisyFix>& fixes,
   ops.struct_size = sizeof(ops);
   ops.start = &FakeStart;
   ops.stop = &FakeStop;
-  ihs_location_register_source("gnss.harness", &ops, &src);
+  Check(ihs_location_register_source("gnss.harness", &ops, &src) == 1,
+        "fake source registered");
 
   Manager m({"gnss.harness"}, filter_key, "");
-  m.Start();
+  Check(m.Start(), "Manager started");
+  // Prove the Manager bound the source: FakeStart ran and handed us the sink.
+  // Without this the loop below would silently exercise the no-fix path.
+  Check(src.sink != nullptr, "Manager bound the fake source");
 
   std::vector<Position> est;
   est.reserve(fixes.size());

--- a/shared/tests/location/filter_test.cc
+++ b/shared/tests/location/filter_test.cc
@@ -155,15 +155,17 @@ double RmseRaw(const std::vector<NoisyFix>& fixes,
   return n == 0 ? 0.0 : std::sqrt(sum / static_cast<double>(n));
 }
 
-// RMSE (meters) of the estimates vs truth, over [from, to).
+// RMSE (meters) of the estimates vs truth, over [from, to). Total: clamps to
+// the shorter vector and returns 0 over an empty window.
 double RmseEst(const std::vector<Position>& est,
                const std::vector<TruthSample>& truth,
                double ref_lat,
                size_t from,
                size_t to) {
+  const size_t end = std::min({to, est.size(), truth.size()});
   double sum = 0.0;
   size_t n = 0;
-  for (size_t i = from; i < to && i < truth.size(); ++i) {
+  for (size_t i = from; i < end; ++i) {
     const double d = MetersBetween(est[i].latitude, est[i].longitude,
                                    truth[i].lat, truth[i].lon, ref_lat);
     sum += d * d;

--- a/shared/tests/location/filter_test.cc
+++ b/shared/tests/location/filter_test.cc
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Location filter harness. Generates a synthetic ground-truth track, adds
+// Gaussian measurement noise, feeds the noisy fixes through a Manager, and
+// compares filtered RMSE to raw RMSE — the metric a real estimator must beat.
+//
+// Today the only "filter" is the Manager's passthrough (no filter registered),
+// so this reports filtered == raw: the baseline increment 4's kalman.cv must
+// improve on. The scenarios (straight, stationary, outage) and their reports
+// are built now so that adding a filter is a one-line change here plus the
+// filter itself, and the improvement is provable in CI rather than eyeballed.
+
+#include "manager.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ihs/location.h"
+#include "location.hpp"
+#include "track_gen.hpp"
+
+namespace {
+
+using ihs::location::Manager;
+using ihs::location::Position;
+using ihs::location::test::AddNoise;
+using ihs::location::test::MetersBetween;
+using ihs::location::test::NoisyFix;
+using ihs::location::test::Rng;
+using ihs::location::test::TruthSample;
+
+int g_tests = 0;
+int g_failures = 0;
+void Check(bool cond, const char* what) {
+  ++g_tests;
+  if (!cond) {
+    ++g_failures;
+    std::fprintf(stderr, "FAIL: %s\n", what);
+  }
+}
+
+// A fake measurement source: start() records the sink so the harness can push
+// the synthetic measurements as if a real source produced them.
+struct FakeSource {
+  IhsMeasSink sink = nullptr;
+  void* sink_ud = nullptr;
+};
+int FakeStart(void* ud, IhsMeasSink sink, void* sink_ud) {
+  auto* s = static_cast<FakeSource*>(ud);
+  s->sink = sink;
+  s->sink_ud = sink_ud;
+  return 1;
+}
+void FakeStop(void* /*ud*/) {}
+
+// The registry keeps a raw pointer to a source's user-data for the process
+// lifetime (there is no unregister), so the source must outlive every Manager
+// that could bind it. Own the fakes here rather than in a stack local, whose
+// address would dangle in the registry once RunFilter returns.
+std::vector<std::unique_ptr<FakeSource>>& SourceStore() {
+  static std::vector<std::unique_ptr<FakeSource>> store;
+  return store;
+}
+
+// Feed the noisy fixes through a Manager bound to @filter_key (empty = the
+// built-in passthrough), sampling the Manager's estimate after each. @withhold
+// pairs (first, count): skip pushing `count` fixes starting at index `first`,
+// to model a measurement outage — the estimate is still sampled, so a coasting
+// filter shows up as a moving estimate during the gap.
+std::vector<Position> RunFilter(const std::vector<NoisyFix>& fixes,
+                                const std::string& filter_key,
+                                size_t withhold_first = 0,
+                                size_t withhold_count = 0) {
+  FakeSource& src = *SourceStore().emplace_back(std::make_unique<FakeSource>());
+  IhsLocationSourceOps ops{};
+  ops.struct_size = sizeof(ops);
+  ops.start = &FakeStart;
+  ops.stop = &FakeStop;
+  ihs_location_register_source("gnss.harness", &ops, &src);
+
+  Manager m({"gnss.harness"}, filter_key, "");
+  m.Start();
+
+  std::vector<Position> est;
+  est.reserve(fixes.size());
+  for (size_t i = 0; i < fixes.size(); ++i) {
+    const bool withheld = withhold_count > 0 && i >= withhold_first &&
+                          i < withhold_first + withhold_count;
+    if (!withheld && src.sink != nullptr) {
+      const NoisyFix& f = fixes[i];
+      IhsMeasurement mm{};
+      mm.struct_size = sizeof(mm);
+      mm.kind = IHS_MEAS_POSITION_LLA;
+      mm.t_monotonic_ns = f.t_ns;
+      mm.value_count = 2;
+      mm.value[0] = f.lat;
+      mm.value[1] = f.lon;
+      mm.variance[0] = f.sigma_m * f.sigma_m;
+      mm.variance[1] = f.sigma_m * f.sigma_m;
+      src.sink(src.sink_ud, &mm);
+    }
+    Position p;
+    if (!m.Latest(p)) {
+      p = Position{};  // no fix yet
+    }
+    est.push_back(p);
+  }
+  m.Stop();
+  return est;
+}
+
+// RMSE (meters) of the noisy fixes vs truth.
+double RmseRaw(const std::vector<NoisyFix>& fixes,
+               const std::vector<TruthSample>& truth,
+               double ref_lat) {
+  double sum = 0.0;
+  for (size_t i = 0; i < truth.size(); ++i) {
+    const double d = MetersBetween(fixes[i].lat, fixes[i].lon, truth[i].lat,
+                                   truth[i].lon, ref_lat);
+    sum += d * d;
+  }
+  return std::sqrt(sum / static_cast<double>(truth.size()));
+}
+
+// RMSE (meters) of the estimates vs truth, over [from, to).
+double RmseEst(const std::vector<Position>& est,
+               const std::vector<TruthSample>& truth,
+               double ref_lat,
+               size_t from,
+               size_t to) {
+  double sum = 0.0;
+  size_t n = 0;
+  for (size_t i = from; i < to && i < truth.size(); ++i) {
+    const double d = MetersBetween(est[i].latitude, est[i].longitude,
+                                   truth[i].lat, truth[i].lon, ref_lat);
+    sum += d * d;
+    ++n;
+  }
+  return n == 0 ? 0.0 : std::sqrt(sum / static_cast<double>(n));
+}
+
+}  // namespace
+
+int main() {
+  const double kLat0 = 48.0;
+  const double kLon0 = -122.0;
+  const double kSigma = 8.0;  // per-axis measurement noise, meters
+
+  // --- straight track: raw vs filtered RMSE --------------------------------
+  {
+    const auto truth =
+        ihs::location::test::StraightTrack(kLat0, kLon0, 5.0, 3.0, 120, 1.0);
+    Rng rng(0x1234ABCD);
+    const auto fixes = AddNoise(truth, kSigma, rng);
+    const auto est = RunFilter(fixes, "" /* passthrough */);
+
+    const double raw = RmseRaw(fixes, truth, kLat0);
+    const double filt = RmseEst(est, truth, kLat0, 0, truth.size());
+    std::printf("straight : raw=%.3f m  filtered=%.3f m  (sigma=%.1f)\n", raw,
+                filt, kSigma);
+
+    // Harness sanity: per-axis sigma 8 m gives a 2D RMSE ~ sigma*sqrt(2).
+    Check(raw > kSigma && raw < kSigma * 2.0,
+          "raw RMSE is in the expected band for the noise sigma");
+    // Baseline: the passthrough republishes the last measurement, so filtered
+    // equals raw. increment 4's kalman.cv must drive filtered materially below.
+    Check(
+        std::abs(filt - raw) < 0.05,
+        "passthrough filtered RMSE equals raw (no improvement) — the baseline");
+  }
+
+  // --- stationary: does the estimate settle? -------------------------------
+  {
+    const auto truth =
+        ihs::location::test::StationaryTrack(kLat0, kLon0, 120, 1.0);
+    Rng rng(0x55AA55AA);
+    const auto fixes = AddNoise(truth, kSigma, rng);
+    const auto est = RunFilter(fixes, "" /* passthrough */);
+
+    const double raw = RmseRaw(fixes, truth, kLat0);
+    // Late-window estimate RMSE: for a real filter this collapses well below
+    // raw; for the passthrough it stays at the measurement noise.
+    const double filt_late = RmseEst(est, truth, kLat0, 60, truth.size());
+    std::printf("stationary: raw=%.3f m  filtered(late)=%.3f m\n", raw,
+                filt_late);
+    Check(std::abs(filt_late - raw) < kSigma,
+          "passthrough does not collapse the stationary variance (baseline)");
+  }
+
+  // --- outage: withhold measurements mid-track -----------------------------
+  {
+    const auto truth =
+        ihs::location::test::StraightTrack(kLat0, kLon0, 6.0, 0.0, 120, 1.0);
+    Rng rng(0x0F0F0F0F);
+    const auto fixes = AddNoise(truth, kSigma, rng);
+    // Withhold 10 s (samples 50..59).
+    const auto est = RunFilter(fixes, "" /* passthrough */, 50, 10);
+
+    // During the gap the passthrough holds the last fix (no coasting): its
+    // error grows only because the vehicle keeps moving away from that stale
+    // point.
+    const double gap = RmseEst(est, truth, kLat0, 50, 60);
+    std::printf(
+        "outage   : passthrough error across the 10 s gap=%.3f m "
+        "(coasting filter must beat this)\n",
+        gap);
+    Check(gap > 0.0, "harness produced an estimate across the outage");
+  }
+
+  if (g_failures == 0) {
+    std::printf("filter_test: all %d checks passed\n", g_tests);
+  } else {
+    std::fprintf(stderr, "filter_test: %d/%d checks FAILED\n", g_failures,
+                 g_tests);
+  }
+  return g_failures == 0 ? 0 : 1;
+}

--- a/shared/tests/location/track_gen.cc
+++ b/shared/tests/location/track_gen.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "track_gen.hpp"
+
+#include <cmath>
+
+namespace ihs::location::test {
+
+namespace {
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kMetersPerDegLat = 111320.0;
+uint64_t SecToNs(double s) {
+  // Guard the cast: a negative double to uint64_t is undefined behavior.
+  // Callers pass t >= 0, but keep the conversion total.
+  return s <= 0.0 ? 0 : static_cast<uint64_t>(s * 1e9);
+}
+}  // namespace
+
+double MetersPerDegLat() {
+  return kMetersPerDegLat;
+}
+double MetersPerDegLon(double lat_deg) {
+  return kMetersPerDegLat * std::cos(lat_deg * kPi / 180.0);
+}
+
+double MetersBetween(double lat_a,
+                     double lon_a,
+                     double lat_b,
+                     double lon_b,
+                     double ref_lat) {
+  const double de = (lon_a - lon_b) * MetersPerDegLon(ref_lat);
+  const double dn = (lat_a - lat_b) * MetersPerDegLat();
+  return std::sqrt(de * de + dn * dn);
+}
+
+uint64_t Rng::Next() {
+  // splitmix64.
+  state_ += 0x9E3779B97F4A7C15ULL;
+  uint64_t z = state_;
+  z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+  z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+  return z ^ (z >> 31);
+}
+
+double Rng::Uniform() {
+  // Top 53 bits → [0, 1).
+  return static_cast<double>(Next() >> 11) * (1.0 / 9007199254740992.0);
+}
+
+double Rng::Gaussian() {
+  // Box-Muller. u1 in (0, 1] to avoid log(0).
+  double u1 = Uniform();
+  if (u1 <= 0.0) {
+    u1 = 1.0 / 9007199254740992.0;
+  }
+  const double u2 = Uniform();
+  return std::sqrt(-2.0 * std::log(u1)) * std::cos(2.0 * kPi * u2);
+}
+
+// Convert an east/north offset in meters (from the origin) to lat/lon.
+static void OffsetToLatLon(double lat0,
+                           double lon0,
+                           double east_m,
+                           double north_m,
+                           double& lat,
+                           double& lon) {
+  lat = lat0 + north_m / MetersPerDegLat();
+  lon = lon0 + east_m / MetersPerDegLon(lat0);
+}
+
+std::vector<TruthSample> StraightTrack(double lat0,
+                                       double lon0,
+                                       double v_e,
+                                       double v_n,
+                                       int n,
+                                       double dt_s) {
+  std::vector<TruthSample> out;
+  out.reserve(static_cast<size_t>(n < 0 ? 0 : n));
+  for (int i = 0; i < n; ++i) {
+    const double t = static_cast<double>(i) * dt_s;
+    TruthSample s;
+    s.t_ns = SecToNs(t);
+    OffsetToLatLon(lat0, lon0, v_e * t, v_n * t, s.lat, s.lon);
+    s.v_e = v_e;
+    s.v_n = v_n;
+    out.push_back(s);
+  }
+  return out;
+}
+
+std::vector<TruthSample> ConstantTurnTrack(double lat0,
+                                           double lon0,
+                                           double speed_mps,
+                                           double yaw_rate_dps,
+                                           double heading0_deg,
+                                           int n,
+                                           double dt_s) {
+  std::vector<TruthSample> out;
+  out.reserve(static_cast<size_t>(n < 0 ? 0 : n));
+  double east = 0.0;
+  double north = 0.0;
+  for (int i = 0; i < n; ++i) {
+    const double t = static_cast<double>(i) * dt_s;
+    // Heading (clockwise from north) advancing at the yaw rate.
+    const double hdg = (heading0_deg + yaw_rate_dps * t) * kPi / 180.0;
+    const double v_e = speed_mps * std::sin(hdg);  // east = sin(heading)
+    const double v_n = speed_mps * std::cos(hdg);  // north = cos(heading)
+    TruthSample s;
+    s.t_ns = SecToNs(t);
+    OffsetToLatLon(lat0, lon0, east, north, s.lat, s.lon);
+    s.v_e = v_e;
+    s.v_n = v_n;
+    out.push_back(s);
+    // Integrate position for the next sample (forward Euler; dt is small).
+    east += v_e * dt_s;
+    north += v_n * dt_s;
+  }
+  return out;
+}
+
+std::vector<TruthSample> StationaryTrack(double lat0,
+                                         double lon0,
+                                         int n,
+                                         double dt_s) {
+  return StraightTrack(lat0, lon0, 0.0, 0.0, n, dt_s);
+}
+
+std::vector<NoisyFix> AddNoise(const std::vector<TruthSample>& truth,
+                               double sigma_m,
+                               Rng& rng) {
+  std::vector<NoisyFix> out;
+  out.reserve(truth.size());
+  for (const TruthSample& s : truth) {
+    const double de = rng.Gaussian() * sigma_m;  // east error, m
+    const double dn = rng.Gaussian() * sigma_m;  // north error, m
+    NoisyFix f;
+    f.t_ns = s.t_ns;
+    f.lat = s.lat + dn / MetersPerDegLat();
+    f.lon = s.lon + de / MetersPerDegLon(s.lat);
+    f.sigma_m = sigma_m;
+    out.push_back(f);
+  }
+  return out;
+}
+
+}  // namespace ihs::location::test

--- a/shared/tests/location/track_gen.cc
+++ b/shared/tests/location/track_gen.cc
@@ -147,13 +147,24 @@ std::vector<NoisyFix> AddNoise(const std::vector<TruthSample>& truth,
                                Rng& rng) {
   std::vector<NoisyFix> out;
   out.reserve(truth.size());
+  // Scale the east error to longitude at a single reference latitude — the
+  // origin, truth.front().lat — not each sample's latitude. The rest of the
+  // harness pins the tangent plane to the origin the same way (OffsetToLatLon
+  // and the RMSE both use lat0), so using per-sample latitude here would read
+  // the injected east noise back at a slightly different scale as the track
+  // drifts north, skewing RMSE. An empty track has no reference; skip it.
+  if (truth.empty()) {
+    return out;
+  }
+  const double ref_lat = truth.front().lat;
+  const double m_per_deg_lon = MetersPerDegLon(ref_lat);
   for (const TruthSample& s : truth) {
     const double de = rng.Gaussian() * sigma_m;  // east error, m
     const double dn = rng.Gaussian() * sigma_m;  // north error, m
     NoisyFix f;
     f.t_ns = s.t_ns;
     f.lat = s.lat + dn / MetersPerDegLat();
-    f.lon = s.lon + de / MetersPerDegLon(s.lat);
+    f.lon = s.lon + de / m_per_deg_lon;
     f.sigma_m = sigma_m;
     out.push_back(f);
   }

--- a/shared/tests/location/track_gen.cc
+++ b/shared/tests/location/track_gen.cc
@@ -11,6 +11,7 @@
 #include "track_gen.hpp"
 
 #include <cmath>
+#include <limits>
 
 namespace ihs::location::test {
 
@@ -18,9 +19,17 @@ namespace {
 constexpr double kPi = 3.14159265358979323846;
 constexpr double kMetersPerDegLat = 111320.0;
 uint64_t SecToNs(double s) {
-  // Guard the cast: a negative double to uint64_t is undefined behavior.
-  // Callers pass t >= 0, but keep the conversion total.
-  return s <= 0.0 ? 0 : static_cast<uint64_t>(s * 1e9);
+  // Keep the conversion total: a negative, NaN, or out-of-range double cast to
+  // uint64_t is undefined behavior. Callers pass a finite t >= 0, but guard it
+  // all — !(s > 0) also rejects NaN, since every NaN comparison is false.
+  if (!(s > 0.0)) {
+    return 0;
+  }
+  const double ns = s * 1e9;
+  if (ns >= static_cast<double>(std::numeric_limits<uint64_t>::max())) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return static_cast<uint64_t>(ns);
 }
 }  // namespace
 

--- a/shared/tests/location/track_gen.hpp
+++ b/shared/tests/location/track_gen.hpp
@@ -41,7 +41,9 @@ struct NoisyFix {
   double sigma_m = 0.0;  // the 1-sigma the noise was drawn at (per axis), m
 };
 
-// Meters-per-degree at a latitude (flat-earth local scale).
+// Local flat-earth scale, meters per degree. A degree of latitude is very
+// nearly constant, so MetersPerDegLat() takes no argument; a degree of
+// longitude shrinks with latitude (by cos), so MetersPerDegLon() takes it.
 double MetersPerDegLat();
 double MetersPerDegLon(double lat_deg);
 

--- a/shared/tests/location/track_gen.hpp
+++ b/shared/tests/location/track_gen.hpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_TEST_TRACK_GEN_H_
+#define IHS_LOC_TEST_TRACK_GEN_H_
+
+#include <cstdint>
+#include <vector>
+
+// Synthetic ground truth and measurement noise for the location filter harness.
+// Deterministic (a splitmix64 RNG + Box-Muller, so the sequence is identical on
+// libstdc++ and libc++ — unlike std::normal_distribution), so CI is stable.
+//
+// Everything is planar: tracks are generated in a local east/north tangent
+// plane (meters) around a fixed origin and converted to lat/lon, and errors are
+// measured back in meters. Over the short tracks the tests use, the flat-earth
+// approximation is well below the noise being studied.
+namespace ihs::location::test {
+
+// One ground-truth sample: true position and true velocity at arrival time t.
+struct TruthSample {
+  uint64_t t_ns = 0;
+  double lat = 0.0;  // degrees
+  double lon = 0.0;  // degrees
+  double v_e = 0.0;  // true east velocity, m/s
+  double v_n = 0.0;  // true north velocity, m/s
+};
+
+// A noisy position measurement derived from a truth sample.
+struct NoisyFix {
+  uint64_t t_ns = 0;
+  double lat = 0.0;      // degrees, truth + Gaussian error
+  double lon = 0.0;      // degrees
+  double sigma_m = 0.0;  // the 1-sigma the noise was drawn at (per axis), m
+};
+
+// Meters-per-degree at a latitude (flat-earth local scale).
+double MetersPerDegLat();
+double MetersPerDegLon(double lat_deg);
+
+// Great-circle-free planar distance between two lat/lon points, in meters,
+// using the local scale at @ref_lat. Adequate for the short synthetic tracks.
+double MetersBetween(double lat_a,
+                     double lon_a,
+                     double lat_b,
+                     double lon_b,
+                     double ref_lat);
+
+// Deterministic RNG: splitmix64 for uniforms, Box-Muller for a standard normal.
+class Rng {
+ public:
+  explicit Rng(uint64_t seed) : state_(seed) {}
+  double Uniform();   // [0, 1)
+  double Gaussian();  // mean 0, sigma 1
+
+ private:
+  uint64_t Next();
+  uint64_t state_;
+};
+
+// --- tracks (each starts at the origin at t=0, samples every @dt_s) ---------
+
+// Constant-velocity straight line at (@v_e, @v_n) m/s.
+std::vector<TruthSample> StraightTrack(double lat0,
+                                       double lon0,
+                                       double v_e,
+                                       double v_n,
+                                       int n,
+                                       double dt_s);
+
+// Constant-speed circular arc: speed @speed_mps, turn rate @yaw_rate_dps
+// (deg/s), initial heading @heading0_deg (clockwise from north).
+std::vector<TruthSample> ConstantTurnTrack(double lat0,
+                                           double lon0,
+                                           double speed_mps,
+                                           double yaw_rate_dps,
+                                           double heading0_deg,
+                                           int n,
+                                           double dt_s);
+
+// Stationary: no motion (velocity 0). The baseline for the variance-collapse
+// check.
+std::vector<TruthSample> StationaryTrack(double lat0,
+                                         double lon0,
+                                         int n,
+                                         double dt_s);
+
+// Add per-axis Gaussian noise at @sigma_m meters to each truth sample.
+std::vector<NoisyFix> AddNoise(const std::vector<TruthSample>& truth,
+                               double sigma_m,
+                               Rng& rng);
+
+}  // namespace ihs::location::test
+
+#endif  // IHS_LOC_TEST_TRACK_GEN_H_


### PR DESCRIPTION
Adds a deterministic test harness for the location filter path: it generates a synthetic ground-truth track, adds Gaussian measurement noise, drives the fixes through the location `Manager`, and compares **filtered RMSE to raw RMSE** — the metric a real estimator has to beat.

Today the only "filter" is the `Manager`'s passthrough, so the harness reports `filtered == raw` and asserts that as the documented baseline. The upcoming `kalman.cv` increment becomes a one-line change here (pass a filter key), and its improvement is provable in CI rather than eyeballed.

## What's here

- **`track_gen.{hpp,cc}`** — deterministic synthetic ground truth. splitmix64 + Box-Muller so the noise sequence is identical on libstdc++ and libc++ (`std::normal_distribution` is not), keeping CI stable. Tracks are generated in a local east/north tangent plane in meters and converted to lat/lon; errors are measured back in meters. Straight, constant-turn, and stationary tracks + `AddNoise`.
- **`filter_test.cc`** — three scenarios through the `Manager`:
  - **straight**: raw ≈ σ√2, filtered == raw (passthrough identity)
  - **stationary**: no variance collapse (the baseline a filter must beat)
  - **outage**: last fix held across a 10 s gap, no coasting (the baseline a filter must beat)

  `RunFilter` is parameterized by filter key, so adding an estimator is a one-line change.
- Wired into `shared/tests/location` (a new `filter` ctest) and the `ihs-shared` CI job — `ctest` already runs every `add_test`; the step name is generalized to match.

## Measured baseline (runs in <10 ms, well under the 1 s budget)

```
straight : raw=11.493 m  filtered=11.493 m  (sigma=8.0)
stationary: raw=11.068 m  filtered(late)=11.190 m
outage   : passthrough error across the 10 s gap=34.514 m (coasting filter must beat this)
filter_test: all 4 checks passed
```

## Notes

- Test-only; no ABI-crossing structs beyond the fully-initialized `IhsMeasurement` fed through the Manager's bounded-copy sink.
- The fake sources are owned in a process-lifetime store rather than a stack local: the registry keeps a raw pointer for the process lifetime (no unregister), so the source must outlive every `Manager` that binds it.
- `SecToNs` guards the `double`→`uint64_t` cast (a negative input would be UB).
- clang-tidy-19 + clang-format-19 clean.