### PR TITLE
location: gnss.file replay source (captured gpsd JSON → event source)

### DIFF
--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -80,7 +80,7 @@ jobs:
           export LD_LIBRARY_PATH="$PWD/prefix/lib:$PWD/prefix/lib64:$PWD/prefix/lib/x86_64-linux-gnu"
           ctest --test-dir sbuild --output-on-failure
 
-      - name: Location unit tests (parser / registry / manager / fallback / filter)
+      - name: Location unit tests (parser / registry / manager / fallback / filter / file)
         # Standalone: compiles the internal location sources directly (ParseTpv,
         # registry, manager, etc. are not part of the installed C ABI), so no
         # prefix / gpsd is needed. ctest runs every add_test in the project.

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -146,6 +146,7 @@ target_sources(ihs_shared PRIVATE
         src/location/gpsd_provider.cc
         src/location/geoclue_provider.cc
         src/location/fallback_source.cc
+        src/location/file_source.cc
         src/location/sd_bus_dynamic.cc
 )
 target_link_libraries(ihs_shared PRIVATE ${CMAKE_DL_LIBS})

--- a/shared/src/location/file_source.cc
+++ b/shared/src/location/file_source.cc
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "file_source.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
+#include <fstream>
+#include <string>
+#include <utility>
+
+#include "gpsd_provider.hpp"  // ParseTpv
+
+namespace ihs::location {
+
+namespace {
+// Cadence assumed for a fix whose line carries no usable time (gpsd's default).
+constexpr uint64_t kNominalStepNs = 1000000000ULL;  // 1 s
+// Largest wall-clock wait honored in kRealtime, so a long gap in the capture (a
+// paused recording) cannot stall a demo or teardown; the stamped timeline still
+// reflects the true gap so a filter coasts correctly.
+constexpr uint64_t kMaxRealtimeSleepNs = 5000000000ULL;  // 5 s
+}  // namespace
+
+bool ParseTpvTimeNs(const std::string& line, uint64_t& epoch_ns) {
+  static constexpr char kToken[] = R"("time":")";
+  const size_t at = line.find(kToken);
+  if (at == std::string::npos) {
+    return false;
+  }
+  const char* p = line.c_str() + at + (sizeof(kToken) - 1);
+  int year = 0;
+  int mon = 0;
+  int day = 0;
+  int hour = 0;
+  int min = 0;
+  double sec = 0.0;
+  // gpsd emits ISO8601 UTC ("...Z"); read the calendar fields and the (possibly
+  // fractional) seconds. The field-width caps keep a malformed capture from
+  // overflowing the int conversions, and the matched-field count (== 6) is the
+  // conversion-error check the bare return value would otherwise hide.
+  // NOLINTNEXTLINE(cert-err34-c)
+  if (std::sscanf(p, "%4d-%2d-%2dT%2d:%2d:%lf", &year, &mon, &day, &hour, &min,
+                  &sec) != 6) {
+    return false;
+  }
+  if (mon < 1 || mon > 12 || day < 1 || day > 31 || hour < 0 || hour > 23 ||
+      min < 0 || min > 59 || !std::isfinite(sec) || sec < 0.0 || sec >= 61.0) {
+    return false;  // out-of-range fields — not a usable timestamp
+  }
+  std::tm tm{};
+  tm.tm_year = year - 1900;
+  tm.tm_mon = mon - 1;
+  tm.tm_mday = day;
+  tm.tm_hour = hour;
+  tm.tm_min = min;
+  tm.tm_sec = 0;  // whole seconds folded in below to keep the fraction exact
+  const time_t base = timegm(&tm);
+  if (base == static_cast<time_t>(-1)) {
+    return false;
+  }
+  // Assemble in integer nanoseconds: the whole seconds go through the integer
+  // epoch and only the sub-second fraction (< 1 s, so exactly representable)
+  // touches floating point. Differencing two of these stays exact.
+  const auto whole_sec = static_cast<uint64_t>(sec);
+  const double frac = sec - static_cast<double>(whole_sec);
+  const auto frac_ns = static_cast<uint64_t>(std::llround(frac * 1e9));
+  epoch_ns =
+      (static_cast<uint64_t>(base) + whole_sec) * 1000000000ULL + frac_ns;
+  return true;
+}
+
+FileSource::FileSource(std::string path, Pace pace, bool loop)
+    : path_(std::move(path)), pace_(pace), loop_(loop) {}
+
+FileSource::~FileSource() {
+  StopWorker();
+}
+
+void FileSource::SetOnFix(FixSink on_fix) {
+  on_fix_ = std::move(on_fix);
+}
+
+bool FileSource::Start() {
+  {
+    // Fail fast on a missing/unreadable file so a caller learns at Start(),
+    // matching "returns NULL on failure" at the C ABI; the worker reopens.
+    std::ifstream probe(path_);
+    if (!probe) {
+      return false;
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (running_) {
+      return true;  // already started
+    }
+    running_ = true;
+  }
+  try {
+    thread_ = std::thread([this] { Run(); });
+  } catch (...) {
+    std::lock_guard<std::mutex> lk(mu_);
+    running_ = false;  // roll back so the object is reusable
+    return false;
+  }
+  return true;
+}
+
+void FileSource::Stop() {
+  StopWorker();
+}
+
+void FileSource::StopWorker() {
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    running_ = false;
+  }
+  cv_.notify_all();  // wake an interruptible realtime wait
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+void FileSource::Run() {
+  const uint64_t base_mono = MonotonicNs();
+  bool have_prev = false;   // any fix emitted yet (persists across loop passes)
+  uint64_t prev_stamp = 0;  // last stamped time, kept non-decreasing
+
+  do {
+    std::ifstream in(path_);
+    if (!in) {
+      break;  // file vanished between Start() and here
+    }
+    bool pass_have_epoch =
+        false;                   // reset each pass: no epoch continuity across
+    uint64_t prev_epoch_ns = 0;  // a loop boundary or a reopen
+    size_t pass_fixes = 0;       // fixes emitted this pass
+    std::string line;
+    while (std::getline(in, line)) {
+      {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (!running_) {
+          return;
+        }
+      }
+      Position p;
+      if (!ParseTpv(line, p)) {
+        continue;  // non-TPV or malformed
+      }
+      uint64_t epoch_ns = 0;
+      const bool have_time = ParseTpvTimeNs(line, epoch_ns);
+
+      // Advance the synthesized monotonic timeline. First fix ever anchors at
+      // base_mono; within a pass a timed fix advances by its recorded delta
+      // (clamped non-negative); otherwise (first fix of a looped pass, or a
+      // line with no time) it advances by the nominal cadence.
+      uint64_t dt_ns = 0;
+      uint64_t stamp = base_mono;
+      if (!have_prev) {
+        stamp = base_mono;
+      } else if (have_time && pass_have_epoch) {
+        dt_ns = epoch_ns > prev_epoch_ns ? epoch_ns - prev_epoch_ns : 0;
+        stamp = prev_stamp + dt_ns;
+      } else {
+        dt_ns = kNominalStepNs;
+        stamp = prev_stamp + dt_ns;
+      }
+      if (have_time) {
+        prev_epoch_ns = epoch_ns;
+        pass_have_epoch = true;
+      }
+      have_prev = true;
+      prev_stamp = stamp;
+      p.t_monotonic_ns = stamp;
+
+      // Realtime pacing: wait the recorded gap before emitting, interruptibly.
+      if (pace_ == Pace::kRealtime && dt_ns > 0) {
+        const uint64_t sleep_ns =
+            dt_ns > kMaxRealtimeSleepNs ? kMaxRealtimeSleepNs : dt_ns;
+        std::unique_lock<std::mutex> lk(mu_);
+        if (cv_.wait_for(lk, std::chrono::nanoseconds(sleep_ns),
+                         [this] { return !running_; })) {
+          return;  // Stop() requested during the wait
+        }
+      }
+
+      ++pass_fixes;
+      if (on_fix_) {
+        on_fix_(p);  // event push on the worker thread — the wake point
+      }
+    }
+
+    // Stop looping if this pass yielded nothing: a capture with no usable fix
+    // will not gain one on a re-read, and re-reading it in a tight loop would
+    // just spin the CPU.
+    if (pass_fixes == 0) {
+      break;
+    }
+    std::lock_guard<std::mutex> lk(mu_);
+    if (!running_) {
+      return;
+    }
+  } while (loop_);
+}
+
+}  // namespace ihs::location

--- a/shared/src/location/file_source.hpp
+++ b/shared/src/location/file_source.hpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_FILE_SOURCE_H_
+#define IHS_LOC_FILE_SOURCE_H_
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "location.hpp"
+
+namespace ihs::location {
+
+// Parse the gpsd TPV "time" field (ISO8601 UTC, e.g. "2026-07-20T18:03:11.5Z")
+// into Unix epoch nanoseconds, fractional seconds included. Returns false if
+// the field is absent or malformed. Nanoseconds (not seconds-as-double) so that
+// a sub-second inter-sample delta stays exact: the absolute epoch is ~1.7e9 s,
+// where a double's precision is only ~0.5 us, and differencing two of them
+// would corrupt a 10 ms gap. Split out (like ParseTpv) so it can be unit-tested
+// and reused by the file replay source; gpsd always emits UTC with a trailing
+// Z, so the zone is fixed.
+bool ParseTpvTimeNs(const std::string& line, uint64_t& epoch_ns);
+
+// Replays a captured gpsd JSON stream as an event source. The capture is
+// newline-delimited, one report per line — exactly what `gpspipe -w` writes, or
+// a raw dump of the gpsd socket. Each TPV line is parsed with ParseTpv and
+// pushed to the sink on a worker thread, so it drives the Manager identically
+// to a live gpsd, but deterministically, off a file, with no hardware. Non-TPV
+// and malformed lines are skipped.
+//
+// Timeline: each fix is stamped (t_monotonic_ns) from a monotonic timeline
+// synthesized from the recorded "time" deltas, NOT wall-clock arrival. A filter
+// downstream then sees the true inter-sample dt regardless of how fast the file
+// is replayed — the identical input in either pace. A line with no usable time
+// advances the timeline by a nominal 1 Hz step, and a capture whose clock steps
+// backward is clamped to a non-decreasing timeline.
+//
+// Pace: kAsFast emits back-to-back with no delay (deterministic tests / CI);
+// kRealtime additionally waits the recorded inter-sample gap before each fix,
+// reproducing the original cadence for a demo (the wait is interruptible by
+// Stop() and capped so a gap in the capture cannot hang teardown). With @loop
+// the worker restarts from the top at EOF (continuous demo); otherwise it ends
+// after the last fix, leaving Latest() reporting it. SetOnFix must precede
+// Start(), the same contract the gpsd/geoclue sources honor.
+class FileSource : public IEventSource {
+ public:
+  enum class Pace { kAsFast, kRealtime };
+
+  explicit FileSource(std::string path,
+                      Pace pace = Pace::kAsFast,
+                      bool loop = false);
+  ~FileSource() override;
+
+  FileSource(const FileSource&) = delete;
+  FileSource& operator=(const FileSource&) = delete;
+
+  void SetOnFix(FixSink on_fix) override;
+  bool Start() override;  // false if the file cannot be opened
+  void Stop() override;
+
+ private:
+  void Run();         // worker: read the file, stamp, pace, push
+  void StopWorker();  // non-virtual; Stop() and the destructor both call it
+
+  const std::string path_;
+  const Pace pace_;
+  const bool loop_;
+
+  FixSink on_fix_;  // set before Start(); read on the worker thread
+
+  std::thread thread_;
+  std::mutex mu_;
+  std::condition_variable cv_;
+  bool running_ =
+      false;  // guarded by mu_; also the interruptible-wait predicate
+};
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_FILE_SOURCE_H_

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -89,3 +89,14 @@ target_compile_options(filter_test PRIVATE -Wall -Wextra)
 target_link_libraries(filter_test PRIVATE Threads::Threads)
 
 add_test(NAME filter COMMAND filter_test)
+
+# gnss.file replay source: parses captured gpsd JSON and re-emits fixes as an
+# event source. Compiles file_source.cc + gpsd_provider.cc (ParseTpv) directly.
+add_executable(file_source_test file_source_test.cc
+        ${_loc_src}/file_source.cc ${_loc_src}/gpsd_provider.cc)
+target_include_directories(file_source_test PRIVATE
+        ${_loc_src} ${_loc_inc} ${CMAKE_CURRENT_BINARY_DIR}/gen)
+target_compile_options(file_source_test PRIVATE -Wall -Wextra)
+target_link_libraries(file_source_test PRIVATE Threads::Threads)
+
+add_test(NAME file_source COMMAND file_source_test)

--- a/shared/tests/location/file_source_test.cc
+++ b/shared/tests/location/file_source_test.cc
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Unit tests for the gnss.file replay source: the ISO8601 time extraction and
+// the event-driven replay (a synthesized monotonic timeline from the recorded
+// cadence, non-TPV/malformed lines skipped, missing file rejected). The replay
+// waits on a condition variable fed by the sink — no polling.
+
+#include "file_source.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "location.hpp"
+
+namespace {
+
+using ihs::location::FileSource;
+using ihs::location::ParseTpvTimeNs;
+using ihs::location::Position;
+
+int g_tests = 0;
+int g_failures = 0;
+void Check(bool cond, const char* what) {
+  ++g_tests;
+  if (!cond) {
+    ++g_failures;
+    std::fprintf(stderr, "FAIL: %s\n", what);
+  }
+}
+
+std::filesystem::path WriteFixture(const std::string& name,
+                                   const std::string& content) {
+  const std::filesystem::path path =
+      std::filesystem::temp_directory_path() / name;
+  std::ofstream out(path, std::ios::trunc);
+  out << content;
+  out.close();
+  return path;
+}
+
+// Collects fixes and lets a test block until a target count arrives — the
+// event-driven counterpart of polling for completion.
+struct Collector {
+  std::mutex mu;
+  std::condition_variable cv;
+  std::vector<Position> fixes;
+
+  void OnFix(const Position& p) {
+    std::lock_guard<std::mutex> lk(mu);
+    fixes.push_back(p);
+    cv.notify_all();
+  }
+  bool WaitFor(size_t n, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lk(mu);
+    return cv.wait_for(lk, timeout, [&] { return fixes.size() >= n; });
+  }
+};
+
+void TestTimeParse() {
+  uint64_t a = 0;
+  uint64_t b = 0;
+  Check(
+      ParseTpvTimeNs(R"({"class":"TPV","time":"2026-07-20T18:03:11.000Z"})", a),
+      "parses a TPV time");
+  Check(ParseTpvTimeNs(R"({"time":"2026-07-20T18:03:12.500Z"})", b),
+        "parses a fractional TPV time");
+  // Assert the delta (1.5 s), not an absolute epoch, so the test does not
+  // depend on a hardcoded timegm result — and it stays exact in integer
+  // nanoseconds.
+  Check(b - a == 1500000000ULL, "time delta is 1.5 s");
+
+  uint64_t dummy = 0;
+  Check(!ParseTpvTimeNs(R"({"class":"TPV","lat":1.0})", dummy),
+        "absent time returns false");
+  Check(!ParseTpvTimeNs(R"({"time":"not-a-timestamp"})", dummy),
+        "malformed time returns false");
+}
+
+void TestReplayTimeline() {
+  // Three usable fixes at t=11, 12, 14 s; interleaved with non-TPV, garbage,
+  // and a mode-1 (no-fix) TPV that must all be skipped.
+  const std::string fixture =
+      R"({"class":"VERSION","release":"3.22"})"
+      "\n"
+      R"({"class":"TPV","time":"2026-07-20T18:03:11.000Z","mode":3,"lat":48.10000,"lon":-122.2,"track":90.0,"speed":5.0,"eph":8.0})"
+      "\n"
+      "this is not json at all\n"
+      R"({"class":"SKY","satellites":[]})"
+      "\n"
+      R"({"class":"TPV","time":"2026-07-20T18:03:12.000Z","mode":3,"lat":48.10009,"lon":-122.2,"speed":5.0})"
+      "\n"
+      R"({"class":"TPV","time":"2026-07-20T18:03:14.000Z","mode":3,"lat":48.10027,"lon":-122.2,"speed":5.0})"
+      "\n"
+      R"({"class":"TPV","time":"2026-07-20T18:03:15.000Z","mode":1})"
+      "\n";
+  const auto path = WriteFixture("ihs_file_source_timeline.jsonl", fixture);
+
+  Collector c;
+  FileSource src(path.string(), FileSource::Pace::kAsFast, /*loop=*/false);
+  src.SetOnFix([&c](const Position& p) { c.OnFix(p); });
+  Check(src.Start(), "Start() succeeds on an existing file");
+  Check(c.WaitFor(3, std::chrono::seconds(2)), "three fixes replayed");
+  src.Stop();
+
+  std::filesystem::remove(path);
+
+  if (c.fixes.size() < 3) {
+    return;  // WaitFor already failed; avoid indexing past the end
+  }
+  Check(c.fixes[0].mode == 3 && std::abs(c.fixes[0].latitude - 48.10000) < 1e-6,
+        "first fix carries the parsed position");
+  Check(
+      c.fixes[0].has_bearing && std::abs(c.fixes[0].bearing_deg - 90.0) < 1e-6,
+      "first fix carries the parsed track");
+  // Timeline reflects the recorded cadence (1 s then 2 s), not wall-clock
+  // arrival (as-fast emits back-to-back).
+  const uint64_t d1 = c.fixes[1].t_monotonic_ns - c.fixes[0].t_monotonic_ns;
+  const uint64_t d2 = c.fixes[2].t_monotonic_ns - c.fixes[1].t_monotonic_ns;
+  Check(d1 == 1000000000ULL, "1 s gap stamped between fix 0 and 1");
+  Check(d2 == 2000000000ULL, "2 s gap stamped between fix 1 and 2");
+}
+
+void TestRealtimeDelivery() {
+  // Millisecond deltas so the realtime pacing runs in ~20 ms, not seconds. This
+  // exercises the interruptible-wait path and confirms the stamped timeline
+  // still reflects the recorded (10 ms) cadence.
+  const std::string fixture =
+      R"({"class":"TPV","time":"2026-07-20T18:03:11.000Z","mode":3,"lat":48.0,"lon":-122.0})"
+      "\n"
+      R"({"class":"TPV","time":"2026-07-20T18:03:11.010Z","mode":3,"lat":48.0,"lon":-122.0})"
+      "\n"
+      R"({"class":"TPV","time":"2026-07-20T18:03:11.020Z","mode":3,"lat":48.0,"lon":-122.0})"
+      "\n";
+  const auto path = WriteFixture("ihs_file_source_realtime.jsonl", fixture);
+
+  Collector c;
+  FileSource src(path.string(), FileSource::Pace::kRealtime, /*loop=*/false);
+  src.SetOnFix([&c](const Position& p) { c.OnFix(p); });
+  Check(src.Start(), "realtime Start() succeeds");
+  Check(c.WaitFor(3, std::chrono::seconds(2)),
+        "three fixes replayed in realtime");
+  src.Stop();
+  std::filesystem::remove(path);
+
+  if (c.fixes.size() >= 2) {
+    const uint64_t d1 = c.fixes[1].t_monotonic_ns - c.fixes[0].t_monotonic_ns;
+    Check(d1 == 10000000ULL, "10 ms gap stamped in realtime");
+  }
+}
+
+void TestStopInterruptsRealtimeWait() {
+  // A 14 s gap parks the worker in the (5 s-capped) realtime wait. Stop() must
+  // interrupt it promptly rather than block for the cap.
+  const std::string fixture =
+      R"({"class":"TPV","time":"2026-07-20T18:03:11.000Z","mode":3,"lat":48.0,"lon":-122.0})"
+      "\n"
+      R"({"class":"TPV","time":"2026-07-20T18:03:25.000Z","mode":3,"lat":48.0,"lon":-122.0})"
+      "\n";
+  const auto path = WriteFixture("ihs_file_source_interrupt.jsonl", fixture);
+
+  Collector c;
+  FileSource src(path.string(), FileSource::Pace::kRealtime, /*loop=*/false);
+  src.SetOnFix([&c](const Position& p) { c.OnFix(p); });
+  src.Start();
+  Check(c.WaitFor(1, std::chrono::seconds(2)), "first fix arrives immediately");
+
+  const auto t0 = std::chrono::steady_clock::now();
+  src.Stop();
+  const auto elapsed = std::chrono::steady_clock::now() - t0;
+  std::filesystem::remove(path);
+
+  // Correct: Stop() returns in ~ms; a broken interrupt would wait the 5 s cap.
+  Check(elapsed < std::chrono::seconds(2),
+        "Stop() interrupts the realtime wait");
+}
+
+void TestMissingFile() {
+  Collector c;
+  FileSource src("/nonexistent/ihs/does-not-exist.jsonl");
+  src.SetOnFix([&c](const Position& p) { c.OnFix(p); });
+  Check(!src.Start(), "Start() fails on a missing file");
+  Check(c.fixes.empty(), "no fixes from a missing file");
+}
+
+}  // namespace
+
+int main() {
+  TestTimeParse();
+  TestReplayTimeline();
+  TestRealtimeDelivery();
+  TestStopInterruptsRealtimeWait();
+  TestMissingFile();
+
+  if (g_failures == 0) {
+    std::printf("file_source_test: all %d checks passed\n", g_tests);
+  } else {
+    std::fprintf(stderr, "file_source_test: %d/%d checks FAILED\n", g_failures,
+                 g_tests);
+  }
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
> Stacked on #351 (increment 3a). Base is `jw/location-filter-harness` so this diff stays scoped to the replay source; I'll retarget to `v2.0` once #351 merges.

Adds `FileSource`, an `IEventSource` that replays a captured gpsd JSON stream (newline-delimited, one report per line — what `gpspipe -w` writes, or a raw socket dump) so the location `Manager`, and the filter behind it, can be driven off a recorded drive with **no hardware**. Each TPV line is parsed with the existing `ParseTpv` and pushed to the sink on a worker thread, exactly as a live gpsd would; non-TPV and malformed lines are skipped.

## Timeline (the interesting part)

Fixes are stamped (`t_monotonic_ns`) from a monotonic timeline **synthesized from the recorded `time` deltas**, not wall-clock arrival — so a filter downstream sees the true inter-sample `dt` regardless of replay speed (identical input in either pace).

The times are assembled and differenced in **integer nanoseconds** (`ParseTpvTimeNs`): the absolute epoch is ~1.7e9 s, where a `double` resolves only ~0.5 µs, so seconds-as-double would corrupt a 10 ms gap (found and fixed while writing the realtime test). A line with no usable time advances by a nominal 1 Hz step; a capture whose clock steps backward is clamped to a non-decreasing timeline.

## Paces

- **`kAsFast`** — emits back-to-back, deterministic (tests / CI).
- **`kRealtime`** — waits the recorded gap before each fix (interruptibly, capped at 5 s so a gap in the capture can't stall teardown) to reproduce the original cadence.
- **`loop`** — restarts at EOF, unless a pass yielded no fix (re-reading a fixless capture would just spin the CPU — guarded).

## Tests (`file_source_test`, +18 checks)

Time parse (delta exact to the nanosecond), as-fast timeline stamping, realtime delivery, **prompt `Stop()` during a realtime wait**, and missing-file rejection — all driven by a condition variable fed from the sink, **no polling**. Runs in <30 ms.

## Notes

- Compiled into `libihs_shared` but **internal** (not exported by the `ihs_*` version script) and inert until `ihs_location_start` binds it — same pattern the Manager landed under. No ABI change in this PR.
- Wiring it into `ihs_location_start` (a new `IHS_LOCATION_FILE` enumerator, additive) is the next step, kept separate so the ABI-touching change is isolated.
- Pre-push review: no ABI-crossing structs; bounded-width `sscanf` + range checks; integer-ns timeline; `Stop()` prompt+idempotent (tested); no-spin guard; `on_fix_` set-before-`Start()` contract matches gpsd/geoclue.
- clang-tidy-19 + clang-format-19 clean.