### PR TITLE
location: constant-velocity Kalman filter (kalman.cv)

### DIFF
--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -80,7 +80,7 @@ jobs:
           export LD_LIBRARY_PATH="$PWD/prefix/lib:$PWD/prefix/lib64:$PWD/prefix/lib/x86_64-linux-gnu"
           ctest --test-dir sbuild --output-on-failure
 
-      - name: Location unit tests (parser / registry / manager / fallback / filter / file)
+      - name: Location unit tests (parser / registry / manager / fallback / filter / file / kalman)
         # Standalone: compiles the internal location sources directly (ParseTpv,
         # registry, manager, etc. are not part of the installed C ABI), so no
         # prefix / gpsd is needed. ctest runs every add_test in the project.

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -147,6 +147,7 @@ target_sources(ihs_shared PRIVATE
         src/location/geoclue_provider.cc
         src/location/fallback_source.cc
         src/location/file_source.cc
+        src/location/kalman_cv.cc
         src/location/sd_bus_dynamic.cc
 )
 target_link_libraries(ihs_shared PRIVATE ${CMAKE_DL_LIBS})

--- a/shared/src/location/kalman_cv.cc
+++ b/shared/src/location/kalman_cv.cc
@@ -139,8 +139,11 @@ class KalmanCv {
     const double s10 = p_[1][0];
     const double s11 = p_[1][1] + var_n;
     const double det = s00 * s11 - s01 * s10;
+    // The state's time advances even when the correction is skipped below (the
+    // Predict above coasted it to m.t), but last_mode_ describes the last
+    // ACCEPTED fix, so it is only updated on the accept path (and on a seed /
+    // reset), never for a rejected measurement.
     last_t_ns_ = m.t_monotonic_ns;
-    last_mode_ = mode;
     if (!(std::fabs(det) > 0.0)) {
       return;  // singular S (degenerate covariance): skip the correction
     }
@@ -161,6 +164,7 @@ class KalmanCv {
       return;  // keep the predicted (coasted) state; skip this correction
     }
     consecutive_rejects_ = 0;
+    last_mode_ = mode;  // this measurement is accepted; it defines the fix mode
 
     // Kalman gain K = P H^T S^-1 (P H^T is the first two columns of P).
     std::array<std::array<double, 2>, 4> k{};

--- a/shared/src/location/kalman_cv.cc
+++ b/shared/src/location/kalman_cv.cc
@@ -42,7 +42,13 @@ constexpr double kReanchorMeters = 10000.0;
 constexpr double kMinSpeedForBearing = 0.5;
 
 double MetersPerDegLon(double lat_deg) {
-  return kMetersPerDegLat * std::cos(lat_deg * kPi / 180.0);
+  // cos -> 0 at the poles, and this scale is a divisor in the meters->degrees
+  // conversions (Estimate / ReanchorIfFar), so clamp to a small positive floor:
+  // an unclamped value would produce inf/NaN or wild longitude jumps for an
+  // otherwise-valid high latitude.
+  constexpr double kMinMetersPerDegLon = 1.0;
+  const double scale = kMetersPerDegLat * std::cos(lat_deg * kPi / 180.0);
+  return scale > kMinMetersPerDegLon ? scale : kMinMetersPerDegLon;
 }
 
 // A measurement variance is usable only if finite and non-negative; a negative

--- a/shared/src/location/kalman_cv.cc
+++ b/shared/src/location/kalman_cv.cc
@@ -45,6 +45,13 @@ double MetersPerDegLon(double lat_deg) {
   return kMetersPerDegLat * std::cos(lat_deg * kPi / 180.0);
 }
 
+// A measurement variance is usable only if finite and non-negative; a negative
+// value is the "unknown" sentinel and a non-finite one (NaN/+Inf) is garbage
+// that would poison S / NIS / K. Either falls back to @fallback.
+double FiniteVarianceOr(double variance, double fallback) {
+  return (std::isfinite(variance) && variance >= 0.0) ? variance : fallback;
+}
+
 using Mat4 = std::array<std::array<double, 4>, 4>;
 
 Mat4 Zero4() {
@@ -101,9 +108,11 @@ class KalmanCv {
     // value[] is [lat, lon] (lat = north, lon = east), but variance[] follows
     // the service convention variance[0] = east, variance[1] = north — the same
     // order as IhsPosition's sigma_e_m/sigma_n_m and the Manager passthrough —
-    // decoupled from the value order.
-    const double var_e = m.variance[0] >= 0.0 ? m.variance[0] : kDefaultPosVar;
-    const double var_n = m.variance[1] >= 0.0 ? m.variance[1] : kDefaultPosVar;
+    // decoupled from the value order. A non-finite or negative variance is
+    // "unknown": +Inf would otherwise make S infinite and produce NaNs through
+    // S^-1 / NIS / K that corrupt the state.
+    const double var_e = FiniteVarianceOr(m.variance[0], kDefaultPosVar);
+    const double var_n = FiniteVarianceOr(m.variance[1], kDefaultPosVar);
     const int mode = m.value_count >= 3 ? 3 : 2;
 
     if (!have_state_) {
@@ -220,10 +229,14 @@ class KalmanCv {
 
  private:
   [[nodiscard]] double SecondsSince(uint64_t t_monotonic_ns) const {
-    // Signed difference in seconds; both are CLOCK_MONOTONIC nanoseconds.
-    const auto now = static_cast<double>(t_monotonic_ns);
-    const auto last = static_cast<double>(last_t_ns_);
-    return (now - last) * 1e-9;
+    // Difference in integer nanoseconds first, then to seconds: both are
+    // CLOCK_MONOTONIC ns (well under 2^63), so the int64 subtraction is exact
+    // and signed. Converting each to double before subtracting would lose
+    // sub-microsecond precision once the clock passes ~2^52 ns (~52 days up),
+    // jittering dt and breaking out-of-order detection.
+    const int64_t d =
+        static_cast<int64_t>(t_monotonic_ns) - static_cast<int64_t>(last_t_ns_);
+    return static_cast<double>(d) * 1e-9;
   }
 
   void Seed(double lat,

--- a/shared/src/location/kalman_cv.cc
+++ b/shared/src/location/kalman_cv.cc
@@ -98,10 +98,12 @@ class KalmanCv {
     }
     const double lat = m.value[0];
     const double lon = m.value[1];
-    // value[] is [lat, lon]: lat maps to north, lon to east, so variance[0]
-    // (lat) is the north measurement variance and variance[1] (lon) the east.
-    const double var_n = m.variance[0] >= 0.0 ? m.variance[0] : kDefaultPosVar;
-    const double var_e = m.variance[1] >= 0.0 ? m.variance[1] : kDefaultPosVar;
+    // value[] is [lat, lon] (lat = north, lon = east), but variance[] follows
+    // the service convention variance[0] = east, variance[1] = north — the same
+    // order as IhsPosition's sigma_e_m/sigma_n_m and the Manager passthrough —
+    // decoupled from the value order.
+    const double var_e = m.variance[0] >= 0.0 ? m.variance[0] : kDefaultPosVar;
+    const double var_n = m.variance[1] >= 0.0 ? m.variance[1] : kDefaultPosVar;
     const int mode = m.value_count >= 3 ? 3 : 2;
 
     if (!have_state_) {

--- a/shared/src/location/kalman_cv.cc
+++ b/shared/src/location/kalman_cv.cc
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "kalman_cv.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+namespace ihs::location {
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kMetersPerDegLat = 111320.0;
+
+// Default process-noise spectral density (m^2/s^3): the manoeuvring a road
+// vehicle does between fixes. Overridable via the "q=<value>" config.
+constexpr double kDefaultQ = 1.0;
+// Seed variance for the (unknown) initial velocity, (m/s)^2.
+constexpr double kInitVelVar = 50.0 * 50.0;
+// Position variance used when a measurement does not report one, m^2.
+constexpr double kDefaultPosVar = 10.0 * 10.0;
+// 2-DOF chi-square gate at p=0.001: a single innovation past this is treated as
+// an outlier. A persistent run of them means the filter has diverged.
+constexpr double kChi2Gate2Dof = 13.816;
+constexpr int kMaxConsecutiveRejects = 3;
+// Re-anchor the tangent plane once the state drifts this far, keeping the
+// flat-earth conversion honest.
+constexpr double kReanchorMeters = 10000.0;
+// Report a course only above this speed; below it, bearing is noise.
+constexpr double kMinSpeedForBearing = 0.5;
+
+double MetersPerDegLon(double lat_deg) {
+  return kMetersPerDegLat * std::cos(lat_deg * kPi / 180.0);
+}
+
+using Mat4 = std::array<std::array<double, 4>, 4>;
+
+Mat4 Zero4() {
+  return Mat4{};
+}
+
+Mat4 Mul(const Mat4& a, const Mat4& b) {
+  Mat4 c = Zero4();
+  for (std::size_t i = 0; i < 4; ++i) {
+    for (std::size_t k = 0; k < 4; ++k) {
+      const double aik = a[i][k];
+      for (std::size_t j = 0; j < 4; ++j) {
+        c[i][j] += aik * b[k][j];
+      }
+    }
+  }
+  return c;
+}
+
+Mat4 Transpose(const Mat4& a) {
+  Mat4 t = Zero4();
+  for (std::size_t i = 0; i < 4; ++i) {
+    for (std::size_t j = 0; j < 4; ++j) {
+      t[i][j] = a[j][i];
+    }
+  }
+  return t;
+}
+
+double ParseQ(const char* config) {
+  if (config == nullptr) {
+    return kDefaultQ;
+  }
+  const char* at = std::strstr(config, "q=");
+  if (at == nullptr) {
+    return kDefaultQ;
+  }
+  char* end = nullptr;
+  const double v = std::strtod(at + 2, &end);
+  return (end != at + 2 && std::isfinite(v) && v > 0.0) ? v : kDefaultQ;
+}
+
+// Constant-velocity Kalman filter in a local east/north tangent plane.
+class KalmanCv {
+ public:
+  explicit KalmanCv(double q) : q_(q) {}
+
+  void Update(const IhsMeasurement& m) {
+    if (m.kind != IHS_MEAS_POSITION_LLA || m.value_count < 2) {
+      return;  // position-only filter; other kinds are future inputs
+    }
+    const double lat = m.value[0];
+    const double lon = m.value[1];
+    // value[] is [lat, lon]: lat maps to north, lon to east, so variance[0]
+    // (lat) is the north measurement variance and variance[1] (lon) the east.
+    const double var_n = m.variance[0] >= 0.0 ? m.variance[0] : kDefaultPosVar;
+    const double var_e = m.variance[1] >= 0.0 ? m.variance[1] : kDefaultPosVar;
+    const int mode = m.value_count >= 3 ? 3 : 2;
+
+    if (!have_state_) {
+      Seed(lat, lon, var_e, var_n, m.t_monotonic_ns, mode);
+      return;
+    }
+
+    const double e_meas = (lon - anchor_lon_) * MetersPerDegLon(anchor_lat_);
+    const double n_meas = (lat - anchor_lat_) * kMetersPerDegLat;
+    const double dt = SecondsSince(m.t_monotonic_ns);
+    if (dt < 0.0) {
+      return;  // older than the last correction: drop (replay buffer is the
+               // upgrade if this proves common)
+    }
+
+    Predict(dt);
+
+    // Innovation and its covariance S = H P H^T + R (the top-left 2x2 of P,
+    // since H selects the position states).
+    const double y_e = e_meas - x_[0];
+    const double y_n = n_meas - x_[1];
+    const double s00 = p_[0][0] + var_e;
+    const double s01 = p_[0][1];
+    const double s10 = p_[1][0];
+    const double s11 = p_[1][1] + var_n;
+    const double det = s00 * s11 - s01 * s10;
+    last_t_ns_ = m.t_monotonic_ns;
+    last_mode_ = mode;
+    if (!(std::fabs(det) > 0.0)) {
+      return;  // singular S (degenerate covariance): skip the correction
+    }
+    const double inv = 1.0 / det;
+    const double si00 = s11 * inv;
+    const double si01 = -s01 * inv;
+    const double si10 = -s10 * inv;
+    const double si11 = s00 * inv;
+
+    // Normalized innovation squared; gate outliers, reset on persistent
+    // divergence.
+    const double nis =
+        y_e * (si00 * y_e + si01 * y_n) + y_n * (si10 * y_e + si11 * y_n);
+    if (nis > kChi2Gate2Dof) {
+      if (++consecutive_rejects_ >= kMaxConsecutiveRejects) {
+        Seed(lat, lon, var_e, var_n, m.t_monotonic_ns, mode);
+      }
+      return;  // keep the predicted (coasted) state; skip this correction
+    }
+    consecutive_rejects_ = 0;
+
+    // Kalman gain K = P H^T S^-1 (P H^T is the first two columns of P).
+    std::array<std::array<double, 2>, 4> k{};
+    for (std::size_t i = 0; i < 4; ++i) {
+      const double a = p_[i][0];
+      const double b = p_[i][1];
+      k[i][0] = a * si00 + b * si10;
+      k[i][1] = a * si01 + b * si11;
+    }
+    for (std::size_t i = 0; i < 4; ++i) {
+      x_[i] += k[i][0] * y_e + k[i][1] * y_n;
+    }
+    // P = (I - K H) P, then symmetrize to keep it numerically well-formed.
+    Mat4 m_ikh = Zero4();
+    for (std::size_t i = 0; i < 4; ++i) {
+      for (std::size_t j = 0; j < 4; ++j) {
+        m_ikh[i][j] = (i == j ? 1.0 : 0.0);
+      }
+      m_ikh[i][0] -= k[i][0];
+      m_ikh[i][1] -= k[i][1];
+    }
+    p_ = Mul(m_ikh, p_);
+    Symmetrize();
+
+    ReanchorIfFar();
+  }
+
+  int Estimate(uint64_t t_monotonic_ns, IhsPosition& out) const {
+    if (!have_state_) {
+      return 0;
+    }
+    double dt = SecondsSince(t_monotonic_ns);
+    if (dt < 0.0) {
+      dt = 0.0;  // never predict backward
+    }
+    // Predict a copy forward to t; do not mutate the stored state.
+    const double e = x_[0] + x_[2] * dt;
+    const double n = x_[1] + x_[3] * dt;
+    const double ve = x_[2];
+    const double vn = x_[3];
+    const Mat4 pp = PredictedP(dt);
+
+    out.latitude = anchor_lat_ + n / kMetersPerDegLat;
+    out.longitude = anchor_lon_ + e / MetersPerDegLon(anchor_lat_);
+    out.mode = last_mode_;
+    const double speed = std::sqrt(ve * ve + vn * vn);
+    out.speed_mps = speed;
+    if (speed > kMinSpeedForBearing) {
+      double course = std::atan2(ve, vn) * 180.0 / kPi;  // clockwise from north
+      if (course < 0.0) {
+        course += 360.0;
+      }
+      out.bearing_deg = course;
+      out.has_bearing = 1;
+    } else {
+      out.bearing_deg = 0.0;
+      out.has_bearing = 0;
+    }
+    out.t_monotonic_ns = t_monotonic_ns;
+    out.sigma_e_m = std::sqrt(pp[0][0] > 0.0 ? pp[0][0] : 0.0);
+    out.sigma_n_m = std::sqrt(pp[1][1] > 0.0 ? pp[1][1] : 0.0);
+    const double var_v = 0.5 * (pp[2][2] + pp[3][3]);
+    out.sigma_v_mps = std::sqrt(var_v > 0.0 ? var_v : 0.0);
+    return 1;
+  }
+
+ private:
+  [[nodiscard]] double SecondsSince(uint64_t t_monotonic_ns) const {
+    // Signed difference in seconds; both are CLOCK_MONOTONIC nanoseconds.
+    const auto now = static_cast<double>(t_monotonic_ns);
+    const auto last = static_cast<double>(last_t_ns_);
+    return (now - last) * 1e-9;
+  }
+
+  void Seed(double lat,
+            double lon,
+            double var_e,
+            double var_n,
+            uint64_t t_ns,
+            int mode) {
+    anchor_lat_ = lat;
+    anchor_lon_ = lon;
+    x_ = {0.0, 0.0, 0.0, 0.0};
+    p_ = Zero4();
+    p_[0][0] = var_e;
+    p_[1][1] = var_n;
+    p_[2][2] = kInitVelVar;
+    p_[3][3] = kInitVelVar;
+    last_t_ns_ = t_ns;
+    last_mode_ = mode;
+    have_state_ = true;
+    consecutive_rejects_ = 0;
+  }
+
+  void Predict(double dt) {
+    x_[0] += x_[2] * dt;
+    x_[1] += x_[3] * dt;
+    p_ = PredictedP(dt);
+  }
+
+  // F P F^T + Q(dt), the covariance predicted forward by dt.
+  [[nodiscard]] Mat4 PredictedP(double dt) const {
+    Mat4 f = Zero4();
+    for (std::size_t i = 0; i < 4; ++i) {
+      f[i][i] = 1.0;
+    }
+    f[0][2] = dt;
+    f[1][3] = dt;
+    Mat4 out = Mul(Mul(f, p_), Transpose(f));
+    // Continuous white-noise-acceleration Q, coupling each position with its
+    // own velocity.
+    const double dt2 = dt * dt;
+    const double dt3 = dt2 * dt;
+    const double q = q_;
+    out[0][0] += q * dt3 / 3.0;
+    out[0][2] += q * dt2 / 2.0;
+    out[2][0] += q * dt2 / 2.0;
+    out[2][2] += q * dt;
+    out[1][1] += q * dt3 / 3.0;
+    out[1][3] += q * dt2 / 2.0;
+    out[3][1] += q * dt2 / 2.0;
+    out[3][3] += q * dt;
+    return out;
+  }
+
+  void Symmetrize() {
+    for (std::size_t i = 0; i < 4; ++i) {
+      for (std::size_t j = i + 1; j < 4; ++j) {
+        const double avg = 0.5 * (p_[i][j] + p_[j][i]);
+        p_[i][j] = avg;
+        p_[j][i] = avg;
+      }
+    }
+  }
+
+  void ReanchorIfFar() {
+    if (std::sqrt(x_[0] * x_[0] + x_[1] * x_[1]) <= kReanchorMeters) {
+      return;
+    }
+    // Fold the accumulated offset into the anchor; the covariance is in meters
+    // and invariant under the translation, so only the position states reset.
+    // The east offset was measured in the old frame, so convert it back with
+    // the old anchor latitude's longitude scale.
+    const double old_anchor_lat = anchor_lat_;
+    anchor_lat_ += x_[1] / kMetersPerDegLat;
+    anchor_lon_ += x_[0] / MetersPerDegLon(old_anchor_lat);
+    x_[0] = 0.0;
+    x_[1] = 0.0;
+  }
+
+  double q_;
+  std::array<double, 4> x_{{0.0, 0.0, 0.0, 0.0}};
+  Mat4 p_ = Zero4();
+  double anchor_lat_ = 0.0;
+  double anchor_lon_ = 0.0;
+  uint64_t last_t_ns_ = 0;
+  int last_mode_ = 2;
+  bool have_state_ = false;
+  int consecutive_rejects_ = 0;
+};
+
+void* Create(void* /*user_data*/, const char* config) {
+  try {
+    return new KalmanCv(ParseQ(config));
+  } catch (...) {
+    return nullptr;  // never let an exception cross the C ABI
+  }
+}
+
+void Destroy(void* instance) {
+  delete static_cast<KalmanCv*>(instance);
+}
+
+void Update(void* instance, const IhsMeasurement* m) {
+  if (instance != nullptr && m != nullptr) {
+    static_cast<KalmanCv*>(instance)->Update(*m);
+  }
+}
+
+int Estimate(void* instance, uint64_t t_monotonic_ns, IhsPosition* out) {
+  if (instance == nullptr || out == nullptr) {
+    return 0;
+  }
+  return static_cast<const KalmanCv*>(instance)->Estimate(t_monotonic_ns, *out);
+}
+
+}  // namespace
+
+const IhsLocationFilterOps& KalmanCvFilterOps() {
+  static const IhsLocationFilterOps ops = [] {
+    IhsLocationFilterOps o{};
+    o.struct_size = sizeof(o);
+    o.create = &Create;
+    o.destroy = &Destroy;
+    o.update = &Update;
+    o.estimate = &Estimate;
+    return o;
+  }();
+  return ops;
+}
+
+bool RegisterKalmanCvFilter() {
+  return ihs_location_register_filter("kalman.cv", &KalmanCvFilterOps(),
+                                      nullptr) == 1;
+}
+
+}  // namespace ihs::location

--- a/shared/src/location/kalman_cv.hpp
+++ b/shared/src/location/kalman_cv.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_KALMAN_CV_H_
+#define IHS_LOC_KALMAN_CV_H_
+
+#include "ihs/location.h"
+
+namespace ihs::location {
+
+// The constant-velocity Kalman filter, registered under "kalman.cv".
+//
+// State x = [e, n, v_e, v_n] in a local east/north tangent plane (meters),
+// anchored at the first fix, so the filter is fully linear (no Jacobians) and
+// tuned in meters rather than degrees, which are not a Euclidean space. It
+// updates from GNSS position measurements (IHS_MEAS_POSITION_LLA) with a
+// continuous white-noise-acceleration process model, and estimate(t) predicts
+// the state forward to @t, so a consumer polling at UI rate gets a fresh,
+// smooth position between 1 Hz fixes and a stationary vehicle stops wandering.
+//
+// A single measurement whose normalized innovation squared exceeds the 2-DOF
+// chi-square gate is rejected as an outlier; a persistent run of them resets
+// the filter to the raw measurement (a diverged filter is worse than none). The
+// anchor is moved once the state drifts past ~10 km, keeping the flat-earth
+// approximation honest.
+//
+// config (optional, may be NULL/empty): "q=<value>" sets the process-noise
+// spectral density (m^2/s^3), the one manoeuvring tuning knob; the default
+// suits a road vehicle.
+
+// Register the filter under "kalman.cv" in the process-wide location registry.
+// Idempotent (re-registration replaces the entry). Returns true on success.
+bool RegisterKalmanCvFilter();
+
+// The filter's ops table, exposed so it can be unit-tested directly (create /
+// update / estimate / destroy) without going through the registry or a Manager.
+const IhsLocationFilterOps& KalmanCvFilterOps();
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_KALMAN_CV_H_

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -282,6 +282,10 @@ void Manager::ApplyToPassthrough(const IhsMeasurement& m) {
 }
 
 bool Manager::Latest(Position& out) {
+  return Estimate(out, MonotonicNs());
+}
+
+bool Manager::Estimate(Position& out, uint64_t at_monotonic_ns) {
   const std::lock_guard<std::mutex> lock(mutex_);
   // No fix until at least one position correction has arrived — in both the
   // filter and passthrough paths. For the filter this keeps Latest() consistent
@@ -294,7 +298,7 @@ bool Manager::Latest(Position& out) {
   }
   if (filter_instance_ != nullptr && filter_ops_.estimate != nullptr) {
     IhsPosition est{};
-    if (filter_ops_.estimate(filter_instance_, MonotonicNs(), &est) == 1) {
+    if (filter_ops_.estimate(filter_instance_, at_monotonic_ns, &est) == 1) {
       FromIhsPosition(out, est);
       return true;
     }

--- a/shared/src/location/manager.hpp
+++ b/shared/src/location/manager.hpp
@@ -81,6 +81,15 @@ class Manager : public ILocationProvider {
   bool Latest(Position& out) override;
   [[nodiscard]] uint64_t generation() const override;
 
+  // Read the estimate at a specific CLOCK_MONOTONIC time. For the built-in
+  // passthrough this returns the last fix unchanged (it is time-independent);
+  // for a filter it runs estimate(@at_monotonic_ns), which predicts the state
+  // forward to that instant. Latest() is exactly Estimate(out, MonotonicNs());
+  // a caller passes an explicit time to sample the state on its own timeline
+  // (e.g. a deterministic test clock, or to compensate pipeline latency).
+  // Returns false until a fix exists. Thread-safe.
+  bool Estimate(Position& out, uint64_t at_monotonic_ns);
+
  private:
   // C sink trampoline: sink_user_data is the Manager*.
   static void SinkThunk(void* sink_user_data, const IhsMeasurement* m);

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -82,13 +82,24 @@ add_test(NAME manager COMMAND manager_test)
 # the Manager, comparing filtered RMSE to raw RMSE. Today it exercises the
 # passthrough (filtered == raw baseline); the estimator increments must beat it.
 add_executable(filter_test filter_test.cc track_gen.cc
-        ${_loc_src}/manager.cc ${_loc_src}/registry.cc)
+        ${_loc_src}/manager.cc ${_loc_src}/registry.cc ${_loc_src}/kalman_cv.cc)
 target_include_directories(filter_test PRIVATE
         ${_loc_src} ${_loc_inc} ${CMAKE_CURRENT_BINARY_DIR}/gen)
 target_compile_options(filter_test PRIVATE -Wall -Wextra)
 target_link_libraries(filter_test PRIVATE Threads::Threads)
 
 add_test(NAME filter COMMAND filter_test)
+
+# Constant-velocity Kalman filter, unit-tested directly through its ops table
+# (create/update/estimate/destroy) without a Manager.
+add_executable(kalman_cv_test kalman_cv_test.cc track_gen.cc
+        ${_loc_src}/kalman_cv.cc ${_loc_src}/registry.cc)
+target_include_directories(kalman_cv_test PRIVATE
+        ${_loc_src} ${_loc_inc} ${CMAKE_CURRENT_BINARY_DIR}/gen)
+target_compile_options(kalman_cv_test PRIVATE -Wall -Wextra)
+target_link_libraries(kalman_cv_test PRIVATE Threads::Threads)
+
+add_test(NAME kalman_cv COMMAND kalman_cv_test)
 
 # gnss.file replay source: parses captured gpsd JSON and re-emits fixes as an
 # event source. Compiles file_source.cc + gpsd_provider.cc (ParseTpv) directly.

--- a/shared/tests/location/filter_test.cc
+++ b/shared/tests/location/filter_test.cc
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "ihs/location.h"
+#include "kalman_cv.hpp"
 #include "location.hpp"
 #include "track_gen.hpp"
 
@@ -126,8 +127,12 @@ std::vector<Position> RunFilter(const std::vector<NoisyFix>& fixes,
       mm.variance[1] = f.sigma_m * f.sigma_m;
       src.sink(src.sink_ud, &mm);
     }
+    // Sample on the SYNTHETIC timeline, not the wall clock: for a filter this
+    // predicts the estimate to this measurement's timestamp, so the RMSE is
+    // deterministic and the outage window coasts to the right times. The
+    // passthrough ignores the time and returns the last fix.
     Position p;
-    if (!m.Latest(p)) {
+    if (!m.Estimate(p, fixes[i].t_ns)) {
       p = Position{};  // no fix yet
     }
     est.push_back(p);
@@ -181,27 +186,34 @@ int main() {
   const double kLon0 = -122.0;
   const double kSigma = 8.0;  // per-axis measurement noise, meters
 
+  Check(ihs::location::RegisterKalmanCvFilter(), "kalman.cv registered");
+
   // --- straight track: raw vs filtered RMSE --------------------------------
   {
     const auto truth =
         ihs::location::test::StraightTrack(kLat0, kLon0, 5.0, 3.0, 120, 1.0);
     Rng rng(0x1234ABCD);
     const auto fixes = AddNoise(truth, kSigma, rng);
-    const auto est = RunFilter(fixes, "" /* passthrough */);
+    const auto est_pt = RunFilter(fixes, "" /* passthrough */);
+    const auto est_kf = RunFilter(fixes, "kalman.cv");
 
     const double raw = RmseRaw(fixes, truth, kLat0, 0, truth.size());
-    const double filt = RmseEst(est, truth, kLat0, 0, truth.size());
-    std::printf("straight : raw=%.3f m  filtered=%.3f m  (sigma=%.1f)\n", raw,
-                filt, kSigma);
+    const double filt_pt = RmseEst(est_pt, truth, kLat0, 0, truth.size());
+    const double filt_kf = RmseEst(est_kf, truth, kLat0, 0, truth.size());
+    std::printf(
+        "straight : raw=%.3f m  passthrough=%.3f m  kalman.cv=%.3f m  "
+        "(sigma=%.1f)\n",
+        raw, filt_pt, filt_kf, kSigma);
 
     // Harness sanity: per-axis sigma 8 m gives a 2D RMSE ~ sigma*sqrt(2).
     Check(raw > kSigma && raw < kSigma * 2.0,
           "raw RMSE is in the expected band for the noise sigma");
-    // Baseline: the passthrough republishes the last measurement, so filtered
-    // equals raw. increment 4's kalman.cv must drive filtered materially below.
-    Check(
-        std::abs(filt - raw) < 0.05,
-        "passthrough filtered RMSE equals raw (no improvement) — the baseline");
+    // The passthrough republishes the last measurement, so filtered equals raw
+    // exactly — the baseline the estimator must beat.
+    Check(std::abs(filt_pt - raw) < 0.05,
+          "passthrough filtered RMSE equals raw (the baseline)");
+    // kalman.cv fuses the history, so it must come in materially below raw.
+    Check(filt_kf < raw * 0.8, "kalman.cv beats raw on a straight track");
   }
 
   // --- stationary: does the estimate settle? -------------------------------
@@ -210,23 +222,25 @@ int main() {
         ihs::location::test::StationaryTrack(kLat0, kLon0, 120, 1.0);
     Rng rng(0x55AA55AA);
     const auto fixes = AddNoise(truth, kSigma, rng);
-    const auto est = RunFilter(fixes, "" /* passthrough */);
+    const auto est_pt = RunFilter(fixes, "" /* passthrough */);
+    const auto est_kf = RunFilter(fixes, "kalman.cv");
 
-    const double raw_full = RmseRaw(fixes, truth, kLat0, 0, truth.size());
-    // Compare like windows: late-window filtered vs late-window raw. For a real
-    // filter the filtered value collapses well below raw; for the passthrough
-    // it equals raw exactly (the estimate is the last measurement), so a tight
-    // tolerance holds and a regression that perturbed the passthrough here
-    // would trip it — where the earlier full-window-vs-late-window compare
-    // would not.
+    // Compare like windows: late-window filtered vs late-window raw. The
+    // passthrough equals raw exactly (the estimate is the last measurement);
+    // kalman.cv's variance should have collapsed well below it by the late
+    // window on a stationary vehicle (no more wandering puck).
     const size_t late = 60;
     const double raw_late = RmseRaw(fixes, truth, kLat0, late, truth.size());
-    const double filt_late = RmseEst(est, truth, kLat0, late, truth.size());
+    const double pt_late = RmseEst(est_pt, truth, kLat0, late, truth.size());
+    const double kf_late = RmseEst(est_kf, truth, kLat0, late, truth.size());
     std::printf(
-        "stationary: raw=%.3f m  raw(late)=%.3f m  filtered(late)=%.3f m\n",
-        raw_full, raw_late, filt_late);
-    Check(std::abs(filt_late - raw_late) < 0.05,
+        "stationary: raw(late)=%.3f m  passthrough(late)=%.3f m  "
+        "kalman.cv(late)=%.3f m\n",
+        raw_late, pt_late, kf_late);
+    Check(std::abs(pt_late - raw_late) < 0.05,
           "passthrough does not collapse the stationary variance (baseline)");
+    Check(kf_late < raw_late * 0.6,
+          "kalman.cv collapses the stationary variance");
   }
 
   // --- outage: withhold measurements mid-track -----------------------------
@@ -236,17 +250,26 @@ int main() {
     Rng rng(0x0F0F0F0F);
     const auto fixes = AddNoise(truth, kSigma, rng);
     // Withhold 10 s (samples 50..59).
-    const auto est = RunFilter(fixes, "" /* passthrough */, 50, 10);
+    const size_t gap_from = 50;
+    const size_t gap_to = 60;
+    const auto est_pt = RunFilter(fixes, "" /* passthrough */, gap_from, 10);
+    const auto est_kf = RunFilter(fixes, "kalman.cv", gap_from, 10);
 
-    // During the gap the passthrough holds the last fix (no coasting): its
-    // error grows only because the vehicle keeps moving away from that stale
-    // point.
-    const double gap = RmseEst(est, truth, kLat0, 50, 60);
+    // The passthrough holds the last fix (no coasting): its error grows as the
+    // vehicle moves away from that stale point. kalman.cv coasts on its
+    // velocity estimate, so it tracks the (still moving) truth far better
+    // across the gap.
+    const double gap_pt = RmseEst(est_pt, truth, kLat0, gap_from, gap_to);
+    const double gap_kf = RmseEst(est_kf, truth, kLat0, gap_from, gap_to);
     std::printf(
-        "outage   : passthrough error across the 10 s gap=%.3f m "
-        "(coasting filter must beat this)\n",
-        gap);
-    Check(gap > 0.0, "harness produced an estimate across the outage");
+        "outage   : passthrough gap error=%.3f m  kalman.cv gap error=%.3f m\n",
+        gap_pt, gap_kf);
+    Check(gap_kf < gap_pt, "kalman.cv coasts through the outage better");
+    // Reported accuracy must GROW while coasting (no confident wrong position):
+    // the covariance widens with each prediction step through the gap.
+    Check(est_kf[gap_to - 1].sigma_e_m > est_kf[gap_from].sigma_e_m &&
+              est_kf[gap_to - 1].sigma_n_m > est_kf[gap_from].sigma_n_m,
+          "kalman.cv accuracy degrades monotonically across the outage");
   }
 
   if (g_failures == 0) {

--- a/shared/tests/location/kalman_cv_test.cc
+++ b/shared/tests/location/kalman_cv_test.cc
@@ -213,7 +213,7 @@ void TestOutlierRejection() {
   IhsPosition before{};
   ops.estimate(inst, SecToNs(20), &before);
   // One gross outlier ~500 m north (well past the gate).
-  const double bad_lat = kLat0 + 500.0 / 111320.0;
+  const double bad_lat = kLat0 + 500.0 / MetersPerDegLat();
   const IhsMeasurement spike = PosMeas(bad_lat, kLon0, 5.0, SecToNs(21));
   ops.update(inst, &spike);
   IhsPosition after{};
@@ -328,10 +328,30 @@ void TestModePreservedOnReject() {
   ops.destroy(inst);
 }
 
+// Near the poles cos(lat) -> 0, so the meters<->degrees longitude scale (a
+// divisor) must stay bounded or the estimate goes inf/NaN. Feed a high-latitude
+// fix and assert the output stays finite.
+void TestNearPoleFinite() {
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  const double lat = 89.9999;
+  for (int i = 0; i < 3; ++i) {
+    const IhsMeasurement m = PosMeas(lat, 10.0, 5.0, SecToNs(i));
+    ops.update(inst, &m);
+  }
+  IhsPosition out{};
+  Check(ops.estimate(inst, SecToNs(3), &out) == 1, "estimate near the pole");
+  Check(std::isfinite(out.latitude) && std::isfinite(out.longitude) &&
+            std::isfinite(out.sigma_e_m),
+        "near-pole estimate stays finite (bounded longitude scale)");
+  ops.destroy(inst);
+}
+
 }  // namespace
 
 int main() {
   TestSeeding();
+  TestNearPoleFinite();
   TestBeatsRawStraight();
   TestVelocityRecovery();
   TestPredictionForward();

--- a/shared/tests/location/kalman_cv_test.cc
+++ b/shared/tests/location/kalman_cv_test.cc
@@ -28,6 +28,8 @@ namespace {
 using ihs::location::KalmanCvFilterOps;
 using ihs::location::test::AddNoise;
 using ihs::location::test::MetersBetween;
+using ihs::location::test::MetersPerDegLat;
+using ihs::location::test::MetersPerDegLon;
 using ihs::location::test::Rng;
 using ihs::location::test::TruthSample;
 
@@ -54,6 +56,26 @@ IhsMeasurement PosMeas(double lat, double lon, double sigma_m, uint64_t t_ns) {
   m.value[1] = lon;
   m.variance[0] = sigma_m * sigma_m;
   m.variance[1] = sigma_m * sigma_m;
+  return m;
+}
+
+// Position measurement with per-axis variance in the service order:
+// variance[0] = east, variance[1] = north (see IhsPosition
+// sigma_e_m/sigma_n_m).
+IhsMeasurement PosMeasAniso(double lat,
+                            double lon,
+                            double var_e,
+                            double var_n,
+                            uint64_t t_ns) {
+  IhsMeasurement m{};
+  m.struct_size = sizeof(m);
+  m.kind = IHS_MEAS_POSITION_LLA;
+  m.t_monotonic_ns = t_ns;
+  m.value_count = 2;
+  m.value[0] = lat;
+  m.value[1] = lon;
+  m.variance[0] = var_e;
+  m.variance[1] = var_n;
   return m;
 }
 
@@ -216,6 +238,40 @@ void TestCoastingGrowsSigma() {
   ops.destroy(inst);
 }
 
+// Axis mapping of the measurement variance: variance[0] is the EAST error and
+// variance[1] the NORTH error (the service convention). A fix offset equally in
+// both axes but declared very uncertain in east and precise in north must pull
+// the estimate north (trusted) far more than east (distrusted); a swapped
+// mapping would do the opposite.
+void TestAnisotropicVariance() {
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  // Seed once so the state covariance is still wide (a tightly settled filter
+  // would NIS-reject the offset below as an outlier, defeating the test).
+  const IhsMeasurement seed = PosMeas(kLat0, kLon0, 2.0, SecToNs(0));
+  ops.update(inst, &seed);
+  // A modest +5 m offset in both axes — within the gate — but east variance
+  // dominant and north variance tiny. (East must dominate the still-wide state
+  // covariance, which the first predict inflates via the unknown initial
+  // velocity, for the axes to separate cleanly.)
+  const double off = 5.0;
+  const double lat = kLat0 + off / MetersPerDegLat();
+  const double lon = kLon0 + off / MetersPerDegLon(kLat0);
+  const IhsMeasurement m =
+      PosMeasAniso(lat, lon, /*var_e=*/1.0e6, /*var_n=*/0.01, SecToNs(1));
+  ops.update(inst, &m);
+  IhsPosition out{};
+  ops.estimate(inst, SecToNs(1), &out);
+  const double moved_n = (out.latitude - kLat0) * MetersPerDegLat();
+  const double moved_e = (out.longitude - kLon0) * MetersPerDegLon(kLat0);
+  std::printf("aniso    : moved north=%.2f m  east=%.2f m (offset 5 m each)\n",
+              moved_n, moved_e);
+  Check(moved_n > 3.0 && moved_e < 1.0,
+        "the low-variance (north) axis is tracked, the high-variance (east) is "
+        "not");
+  ops.destroy(inst);
+}
+
 }  // namespace
 
 int main() {
@@ -225,6 +281,7 @@ int main() {
   TestPredictionForward();
   TestOutlierRejection();
   TestCoastingGrowsSigma();
+  TestAnisotropicVariance();
 
   if (g_failures == 0) {
     std::printf("kalman_cv_test: all %d checks passed\n", g_tests);

--- a/shared/tests/location/kalman_cv_test.cc
+++ b/shared/tests/location/kalman_cv_test.cc
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <limits>
 
 #include "ihs/location.h"
 #include "track_gen.hpp"
@@ -272,6 +273,26 @@ void TestAnisotropicVariance() {
   ops.destroy(inst);
 }
 
+// A garbage (non-finite) measurement variance must be treated as unknown, not
+// fed into S — otherwise S^-1 / NIS / K produce NaNs that corrupt the state.
+void TestNonFiniteVariance() {
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  const IhsMeasurement seed = PosMeas(kLat0, kLon0, 4.0, SecToNs(0));
+  ops.update(inst, &seed);
+  const double inf = std::numeric_limits<double>::infinity();
+  const double lat = kLat0 + 3.0 / MetersPerDegLat();
+  const IhsMeasurement bad = PosMeasAniso(lat, kLon0, inf, inf, SecToNs(1));
+  ops.update(inst, &bad);
+  IhsPosition out{};
+  Check(ops.estimate(inst, SecToNs(1), &out) == 1,
+        "estimate valid after an inf-variance measurement");
+  Check(std::isfinite(out.latitude) && std::isfinite(out.longitude) &&
+            std::isfinite(out.sigma_e_m) && std::isfinite(out.sigma_n_m),
+        "non-finite variance does not corrupt the state with NaN");
+  ops.destroy(inst);
+}
+
 }  // namespace
 
 int main() {
@@ -282,6 +303,7 @@ int main() {
   TestOutlierRejection();
   TestCoastingGrowsSigma();
   TestAnisotropicVariance();
+  TestNonFiniteVariance();
 
   if (g_failures == 0) {
     std::printf("kalman_cv_test: all %d checks passed\n", g_tests);

--- a/shared/tests/location/kalman_cv_test.cc
+++ b/shared/tests/location/kalman_cv_test.cc
@@ -302,6 +302,32 @@ void TestNonFiniteVariance() {
   ops.destroy(inst);
 }
 
+// The reported fix mode reflects the last ACCEPTED measurement: a rejected
+// outlier must not change it (mode is not updated on the gate-reject path).
+void TestModePreservedOnReject() {
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  // Settle a 3D fix (a third component = altitude marks mode 3).
+  for (int i = 0; i < 20; ++i) {
+    IhsMeasurement m = PosMeas(kLat0, kLon0, 5.0, SecToNs(i));
+    m.value_count = 3;
+    m.value[2] = 100.0;
+    m.variance[2] = 25.0;
+    ops.update(inst, &m);
+  }
+  IhsPosition before{};
+  ops.estimate(inst, SecToNs(20), &before);
+  Check(before.mode == 3, "seeded as a 3D fix");
+  // A single gross 2D outlier is gated out; it must not downgrade the mode.
+  const double bad_lat = kLat0 + 500.0 / MetersPerDegLat();
+  const IhsMeasurement spike = PosMeas(bad_lat, kLon0, 5.0, SecToNs(21));
+  ops.update(inst, &spike);
+  IhsPosition after{};
+  ops.estimate(inst, SecToNs(21), &after);
+  Check(after.mode == 3, "a rejected 2D outlier does not change the fix mode");
+  ops.destroy(inst);
+}
+
 }  // namespace
 
 int main() {
@@ -313,6 +339,7 @@ int main() {
   TestCoastingGrowsSigma();
   TestAnisotropicVariance();
   TestNonFiniteVariance();
+  TestModePreservedOnReject();
 
   if (g_failures == 0) {
     std::printf("kalman_cv_test: all %d checks passed\n", g_tests);

--- a/shared/tests/location/kalman_cv_test.cc
+++ b/shared/tests/location/kalman_cv_test.cc
@@ -81,7 +81,16 @@ IhsMeasurement PosMeasAniso(double lat,
 }
 
 uint64_t SecToNs(double s) {
-  return static_cast<uint64_t>(s * 1e9);
+  // Total conversion: a negative, NaN, or out-of-range double cast to uint64_t
+  // is undefined behavior. !(s > 0) also rejects NaN.
+  if (!(s > 0.0)) {
+    return 0;
+  }
+  const double ns = s * 1e9;
+  if (ns >= static_cast<double>(std::numeric_limits<uint64_t>::max())) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return static_cast<uint64_t>(ns);
 }
 
 // Lifecycle + seeding: no estimate before a measurement; the first measurement

--- a/shared/tests/location/kalman_cv_test.cc
+++ b/shared/tests/location/kalman_cv_test.cc
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Direct unit tests for the constant-velocity Kalman filter, driven through its
+// ops table (create/update/estimate/destroy) without a Manager: the estimator
+// math in isolation — seeding, noise reduction below raw, velocity recovery,
+// prediction between fixes, outlier rejection (NIS gate), and coasting with a
+// growing covariance through an outage.
+
+#include "kalman_cv.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "ihs/location.h"
+#include "track_gen.hpp"
+
+namespace {
+
+using ihs::location::KalmanCvFilterOps;
+using ihs::location::test::AddNoise;
+using ihs::location::test::MetersBetween;
+using ihs::location::test::Rng;
+using ihs::location::test::TruthSample;
+
+int g_tests = 0;
+int g_failures = 0;
+void Check(bool cond, const char* what) {
+  ++g_tests;
+  if (!cond) {
+    ++g_failures;
+    std::fprintf(stderr, "FAIL: %s\n", what);
+  }
+}
+
+constexpr double kLat0 = 48.0;
+constexpr double kLon0 = -122.0;
+
+IhsMeasurement PosMeas(double lat, double lon, double sigma_m, uint64_t t_ns) {
+  IhsMeasurement m{};
+  m.struct_size = sizeof(m);
+  m.kind = IHS_MEAS_POSITION_LLA;
+  m.t_monotonic_ns = t_ns;
+  m.value_count = 2;
+  m.value[0] = lat;
+  m.value[1] = lon;
+  m.variance[0] = sigma_m * sigma_m;
+  m.variance[1] = sigma_m * sigma_m;
+  return m;
+}
+
+uint64_t SecToNs(double s) {
+  return static_cast<uint64_t>(s * 1e9);
+}
+
+// Lifecycle + seeding: no estimate before a measurement; the first measurement
+// seeds the state so estimate() at that instant returns it.
+void TestSeeding() {
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  Check(inst != nullptr, "create returns an instance");
+
+  IhsPosition out{};
+  Check(ops.estimate(inst, 0, &out) == 0, "no estimate before any measurement");
+
+  const IhsMeasurement m = PosMeas(kLat0, kLon0, 8.0, SecToNs(0.0));
+  ops.update(inst, &m);
+  Check(ops.estimate(inst, SecToNs(0.0), &out) == 1, "estimate after seed");
+  Check(MetersBetween(out.latitude, out.longitude, kLat0, kLon0, kLat0) < 1.0,
+        "seed estimate sits on the first measurement");
+  Check(out.mode == 2, "2-component position reports a 2D fix");
+  ops.destroy(inst);
+}
+
+// Noise reduction: filtered RMSE on a straight track must beat the raw fixes.
+void TestBeatsRawStraight() {
+  const auto truth =
+      ihs::location::test::StraightTrack(kLat0, kLon0, 8.0, 0.0, 120, 1.0);
+  Rng rng(0xC0FFEE);
+  const double sigma = 8.0;
+  const auto fixes = AddNoise(truth, sigma, rng);
+
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+
+  double sum_raw = 0.0;
+  double sum_kf = 0.0;
+  for (size_t i = 0; i < fixes.size(); ++i) {
+    const IhsMeasurement m =
+        PosMeas(fixes[i].lat, fixes[i].lon, sigma, fixes[i].t_ns);
+    ops.update(inst, &m);
+    IhsPosition out{};
+    ops.estimate(inst, fixes[i].t_ns, &out);
+    const double e_raw = MetersBetween(fixes[i].lat, fixes[i].lon, truth[i].lat,
+                                       truth[i].lon, kLat0);
+    const double e_kf = MetersBetween(out.latitude, out.longitude, truth[i].lat,
+                                      truth[i].lon, kLat0);
+    sum_raw += e_raw * e_raw;
+    sum_kf += e_kf * e_kf;
+  }
+  const double rmse_raw =
+      std::sqrt(sum_raw / static_cast<double>(fixes.size()));
+  const double rmse_kf = std::sqrt(sum_kf / static_cast<double>(fixes.size()));
+  std::printf("straight : rmse_raw=%.3f m  rmse_kf=%.3f m\n", rmse_raw,
+              rmse_kf);
+  Check(rmse_kf < rmse_raw * 0.8, "filtered RMSE materially below raw");
+  ops.destroy(inst);
+}
+
+// Velocity recovery: a steady eastward track drives the estimated speed toward
+// the truth and the course toward due east (90 deg).
+void TestVelocityRecovery() {
+  const double v_e = 12.0;  // m/s east
+  const auto truth =
+      ihs::location::test::StraightTrack(kLat0, kLon0, v_e, 0.0, 60, 1.0);
+  Rng rng(0x5EED);
+  const auto fixes = AddNoise(truth, 5.0, rng);
+
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  IhsPosition out{};
+  for (const auto& f : fixes) {
+    const IhsMeasurement m = PosMeas(f.lat, f.lon, 5.0, f.t_ns);
+    ops.update(inst, &m);
+    ops.estimate(inst, f.t_ns, &out);
+  }
+  std::printf("velocity : speed=%.2f m/s (truth %.1f)  bearing=%.1f deg\n",
+              out.speed_mps, v_e, out.bearing_deg);
+  Check(std::abs(out.speed_mps - v_e) < 2.0, "recovers the true speed");
+  Check(out.has_bearing != 0 && std::abs(out.bearing_deg - 90.0) < 10.0,
+        "recovers an eastward course");
+  ops.destroy(inst);
+}
+
+// Prediction between fixes: with a known eastward velocity, estimate() at a
+// time beyond the last fix advances the position forward by v*dt.
+void TestPredictionForward() {
+  const double v_e = 10.0;
+  const auto truth =
+      ihs::location::test::StraightTrack(kLat0, kLon0, v_e, 0.0, 40, 1.0);
+  // No noise: a clean velocity so the prediction is checkable to the meter.
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  for (const auto& s : truth) {
+    const IhsMeasurement m = PosMeas(s.lat, s.lon, 3.0, s.t_ns);
+    ops.update(inst, &m);
+  }
+  const uint64_t last_t = truth.back().t_ns;
+  IhsPosition at_last{};
+  IhsPosition at_plus{};
+  ops.estimate(inst, last_t, &at_last);
+  ops.estimate(inst, last_t + SecToNs(2.0), &at_plus);
+  const double advanced =
+      MetersBetween(at_plus.latitude, at_plus.longitude, at_last.latitude,
+                    at_last.longitude, kLat0);
+  std::printf("predict  : advanced %.2f m over 2 s (expect ~%.1f)\n", advanced,
+              v_e * 2.0);
+  Check(std::abs(advanced - v_e * 2.0) < 3.0,
+        "estimate predicts forward at the estimated velocity");
+  ops.destroy(inst);
+}
+
+// Outlier rejection: a single large spike is gated out (the estimate barely
+// moves), while the surrounding good fixes are tracked.
+void TestOutlierRejection() {
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  // Seed and settle on a stationary point.
+  for (int i = 0; i < 20; ++i) {
+    const IhsMeasurement m = PosMeas(kLat0, kLon0, 5.0, SecToNs(i));
+    ops.update(inst, &m);
+  }
+  IhsPosition before{};
+  ops.estimate(inst, SecToNs(20), &before);
+  // One gross outlier ~500 m north (well past the gate).
+  const double bad_lat = kLat0 + 500.0 / 111320.0;
+  const IhsMeasurement spike = PosMeas(bad_lat, kLon0, 5.0, SecToNs(21));
+  ops.update(inst, &spike);
+  IhsPosition after{};
+  ops.estimate(inst, SecToNs(21), &after);
+  const double moved = MetersBetween(after.latitude, after.longitude,
+                                     before.latitude, before.longitude, kLat0);
+  std::printf("outlier  : estimate moved %.2f m for a 500 m spike\n", moved);
+  Check(moved < 20.0, "a single gross outlier is gated out");
+  ops.destroy(inst);
+}
+
+// Coasting: with no new measurements the estimate holds its trajectory and the
+// reported accuracy grows monotonically (no confident wrong position).
+void TestCoastingGrowsSigma() {
+  const IhsLocationFilterOps& ops = KalmanCvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  const auto truth =
+      ihs::location::test::StraightTrack(kLat0, kLon0, 6.0, 0.0, 20, 1.0);
+  for (const auto& s : truth) {
+    const IhsMeasurement m = PosMeas(s.lat, s.lon, 5.0, s.t_ns);
+    ops.update(inst, &m);
+  }
+  const uint64_t last_t = truth.back().t_ns;
+  IhsPosition a{};
+  IhsPosition b{};
+  ops.estimate(inst, last_t + SecToNs(1.0), &a);
+  ops.estimate(inst, last_t + SecToNs(10.0), &b);
+  std::printf("coast    : sigma_e %.2f m -> %.2f m over +9 s\n", a.sigma_e_m,
+              b.sigma_e_m);
+  Check(b.sigma_e_m > a.sigma_e_m && b.sigma_n_m > a.sigma_n_m,
+        "reported accuracy degrades monotonically while coasting");
+  ops.destroy(inst);
+}
+
+}  // namespace
+
+int main() {
+  TestSeeding();
+  TestBeatsRawStraight();
+  TestVelocityRecovery();
+  TestPredictionForward();
+  TestOutlierRejection();
+  TestCoastingGrowsSigma();
+
+  if (g_failures == 0) {
+    std::printf("kalman_cv_test: all %d checks passed\n", g_tests);
+  } else {
+    std::fprintf(stderr, "kalman_cv_test: %d/%d checks FAILED\n", g_failures,
+                 g_tests);
+  }
+  return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The first real estimator behind the location filter ABI — a constant-velocity Kalman filter registered under `kalman.cv`. This is where the harness from #351/#352 flips from "no better than raw" to a **measured win**.

## The filter

State `x = [e, n, v_e, v_n]` in a local east/north tangent plane, anchored at the first fix, so it is fully linear (no Jacobians) and tuned in meters — not degrees, which are not a Euclidean space. Corrects from GNSS position measurements with a continuous white-noise-acceleration process model (one knob, `q=<value>`, default suited to a road vehicle). `estimate(t)` predicts the state forward to `t`, so a UI-rate poll gets a fresh, smooth position between 1 Hz fixes and a stationary vehicle stops wandering.

Robustness the plan calls out:
- **NIS gate** — a single measurement past the 2-DOF chi-square bound is rejected as an outlier; a persistent run resets the filter to the raw measurement (a diverged filter is worse than none).
- **Monotonic clock** drives `dt`, so a wall-clock step can't corrupt the state; out-of-order measurements are dropped; the tangent plane re-anchors past ~10 km.
- **No new deps** — a ~150-line fixed 4×4 matrix implementation, no Eigen, keeping `ihs_shared` thin.

Internal (not exported by the `ihs_*` version script). **Public ABI unchanged** — abidiff verified: zero new exported symbols.

## The deferred sampling seam

`Manager` gains `Estimate(out, at_monotonic_ns)`: read the estimate at a chosen time. `Latest()` is now `Estimate(out, MonotonicNs())`. This is the seam deferred from the harness in #351 — a filter's estimate must be sampled on the caller's timeline, not the wall clock, or a CV filter extrapolates garbage across the synthetic/wall-clock epoch gap. The passthrough is time-independent, so it's unaffected.

## Verification (measured, in CI, <30 ms)

`kalman_cv_test` drives the ops table directly:
```
straight : rmse_raw=12.163 m  rmse_kf=6.239 m       (49% below raw)
velocity : speed=12.61 m/s (truth 12.0)  bearing=90.9 deg
predict  : advanced 20.00 m over 2 s (expect ~20.0)  (exact)
outlier  : estimate moved 0.00 m for a 500 m spike   (gated)
coast    : sigma_e 4.70 m -> 26.26 m over +9 s        (grows)
```

`filter_test` flips its kalman.cv path from the passthrough baseline to a measured win **through the Manager**:
```
straight : raw=11.492 m  passthrough=11.492 m  kalman.cv=7.003 m
stationary: raw(late)=11.190 m  passthrough(late)=11.190 m  kalman.cv(late)=6.176 m
outage   : passthrough gap error=34.514 m  kalman.cv gap error=14.069 m
```

The three plan acceptance criteria — filtered RMSE materially below raw, stationary variance collapse, and coasting-with-growing-accuracy through an outage — are asserted, not eyeballed.

## Notes

- Pre-push review: matrix math validated by the exact-prediction and RMSE tests; C-ABI boundary guards exceptions (`create`) and NULLs; filter runs single-threaded under the Manager mutex; re-anchor uses the pre-update latitude for the longitude scale; dropped a write-only counter.
- clang-tidy-19 + clang-format-19 clean; all 7 location tests pass.

Next (backlog): wire `kalman.cv` / `gnss.file` into `ihs_location_start` via config, and the EKF (`kalman.ctrv`) once a yaw-rate source exists.