### PR TITLE
location: wire gnss.file and kalman.cv into ihs_location_start

### DIFF
--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -80,7 +80,7 @@ jobs:
           export LD_LIBRARY_PATH="$PWD/prefix/lib:$PWD/prefix/lib64:$PWD/prefix/lib/x86_64-linux-gnu"
           ctest --test-dir sbuild --output-on-failure
 
-      - name: Location unit tests (parser / registry / manager / fallback / filter / file / kalman)
+      - name: Location unit tests (parser / registry / manager / fallback / filter / file / kalman / wire)
         # Standalone: compiles the internal location sources directly (ParseTpv,
         # registry, manager, etc. are not part of the installed C ABI), so no
         # prefix / gpsd is needed. ctest runs every add_test in the project.

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -98,7 +98,12 @@ IHS_EXPORT IhsLocationService* ihs_location_start(IhsLocationSource source,
  * polled at UI rate, and coasts through a brief outage; NULL or "" means no
  * filter (identical to ihs_location_start). @filter_config is an optional
  * filter tuning string (may be NULL); for kalman.cv, "q=<value>" sets the
- * process-noise density. Returns NULL on failure.
+ * process-noise density.
+ *
+ * An unrecognized @filter_key (or a filter that fails to initialize) degrades
+ * to no filter rather than failing the service, so a non-NULL return does NOT
+ * guarantee the named filter is active — it only guarantees a running source.
+ * Returns NULL only when the source itself cannot start (e.g. a missing file).
  */
 IHS_EXPORT IhsLocationService* ihs_location_start_filtered(
     IhsLocationSource source,

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -68,6 +68,7 @@ typedef enum IhsLocationSource {
   IHS_LOCATION_GPSD = 0,    /* gpsd JSON socket */
   IHS_LOCATION_GEOCLUE = 1, /* geoclue over D-Bus */
   IHS_LOCATION_AUTO = 2,    /* gpsd primary, geoclue fallback */
+  IHS_LOCATION_FILE = 3, /* replay a captured gpsd JSON file (@config=path) */
 } IhsLocationSource;
 
 /* Opaque handle to a running location service. */
@@ -77,13 +78,33 @@ typedef struct IhsLocationService IhsLocationService;
  * Start acquiring from @source. @config is an optional backend hint (may be
  * NULL): for gpsd, a numeric IPv4 "host:port" (default 127.0.0.1:2947 — host
  * names are not resolved); for geoclue, a D-Bus address, or the literal "user"
- * to use the session bus (default the system bus); ignored for
- * IHS_LOCATION_AUTO. Returns NULL on failure — a backend with no fix yet (or
- * that is not present) still returns a handle and simply reports no fix until
- * one arrives.
+ * to use the session bus (default the system bus); for IHS_LOCATION_FILE, the
+ * path to a captured gpsd JSON stream (as `gpspipe -w` writes) replayed at its
+ * recorded cadence; ignored for IHS_LOCATION_AUTO. Returns NULL on failure — a
+ * backend with no fix yet (or that is not present) still returns a handle and
+ * simply reports no fix until one arrives.
+ *
+ * Equivalent to ihs_location_start_filtered(source, config, NULL, NULL): the
+ * fix is reported as received (no smoothing).
  */
 IHS_EXPORT IhsLocationService* ihs_location_start(IhsLocationSource source,
                                                   const char* config);
+
+/*
+ * Start acquiring from @source (see ihs_location_start) but fuse the fixes
+ * through a registered filter before reporting them. @filter_key selects the
+ * filter — "kalman.cv" is the built-in constant-velocity Kalman filter, which
+ * smooths a noisy source, interpolates a fresh position between fixes when
+ * polled at UI rate, and coasts through a brief outage; NULL or "" means no
+ * filter (identical to ihs_location_start). @filter_config is an optional
+ * filter tuning string (may be NULL); for kalman.cv, "q=<value>" sets the
+ * process-noise density. Returns NULL on failure.
+ */
+IHS_EXPORT IhsLocationService* ihs_location_start_filtered(
+    IhsLocationSource source,
+    const char* config,
+    const char* filter_key,
+    const char* filter_config);
 
 /*
  * Copy the most recent fix into @out, filling only the original six fields

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -25,8 +25,10 @@
 #include <vector>
 
 #include "fallback_source.hpp"
+#include "file_source.hpp"
 #include "geoclue_provider.hpp"
 #include "gpsd_provider.hpp"
+#include "kalman_cv.hpp"
 #include "location.hpp"
 #include "manager.hpp"
 
@@ -67,6 +69,23 @@ std::unique_ptr<IEventSource> MakeGeoclue(const char* config) {
       "ihs-location", config != nullptr ? config : "");
 }
 
+// gnss.file replay from @config = a captured gpsd JSON path. Replays at the
+// recorded cadence, so a consumer is driven like a live receiver. NULL/empty
+// path yields no source (a NULL return fails ihs_location_start).
+std::unique_ptr<IEventSource> MakeFile(const char* config) {
+  if (config == nullptr || config[0] == '\0') {
+    return nullptr;
+  }
+  return std::make_unique<ihs::location::FileSource>(
+      config, ihs::location::FileSource::Pace::kRealtime, /*loop=*/false);
+}
+
+// Register the built-in filters so a filter_key resolves in the registry. Only
+// "kalman.cv" is built in today; other keys are the caller's to register.
+void RegisterBuiltinFilters() {
+  ihs::location::RegisterKalmanCvFilter();
+}
+
 }  // namespace
 
 // The opaque handle owns the event source and the Manager it drives: the source
@@ -86,20 +105,38 @@ extern "C" {
 
 IhsLocationService* ihs_location_start(IhsLocationSource source,
                                        const char* config) {
+  return ihs_location_start_filtered(source, config, nullptr, nullptr);
+}
+
+IhsLocationService* ihs_location_start_filtered(IhsLocationSource source,
+                                                const char* config,
+                                                const char* filter_key,
+                                                const char* filter_config) {
   // No exception may cross this C ABI boundary: construction and Start()
   // (allocations, std::thread) can throw, so translate any failure to a NULL
   // return.
   try {
+    const bool use_filter = filter_key != nullptr && filter_key[0] != '\0';
+    if (use_filter) {
+      // Publish the built-in filters so the Manager can bind filter_key. A
+      // key it still cannot resolve degrades to the passthrough inside Manager.
+      RegisterBuiltinFilters();
+    }
     // Declare the Manager before the source: the source's worker calls into the
-    // Manager (Manager::PublishFix), so on any early return or exception after
-    // the source starts, reverse-order destruction must tear down the source
-    // first (joining its worker) and only then the Manager it points at.
-    auto manager = std::make_unique<Manager>(std::vector<std::string>{},
-                                             std::string{}, std::string{});
+    // Manager, so on any early return or exception after the source starts,
+    // reverse-order destruction must tear down the source first (joining its
+    // worker) and only then the Manager it points at.
+    auto manager = std::make_unique<Manager>(
+        std::vector<std::string>{},
+        use_filter ? std::string(filter_key) : std::string{},
+        filter_config != nullptr ? std::string(filter_config) : std::string{});
     std::unique_ptr<IEventSource> src;
     switch (source) {
       case IHS_LOCATION_GEOCLUE:
         src = MakeGeoclue(config);
+        break;
+      case IHS_LOCATION_FILE:
+        src = MakeFile(config);
         break;
       case IHS_LOCATION_AUTO:
         // gpsd primary, geoclue fallback — the same composition as before, now
@@ -116,9 +153,16 @@ IhsLocationService* ihs_location_start(IhsLocationSource source,
       return nullptr;
     }
     Manager* const mgr = manager.get();
-    // Drive the Manager atomically on each fix the source pushes (worker
-    // thread). SetOnFix must precede the source's Start().
-    src->SetOnFix([mgr](const Position& p) { mgr->PublishFix(p); });
+    // Drive the Manager on each fix the source pushes (worker thread).
+    // SetOnFix must precede the source's Start(). With a filter, route the fix
+    // through the measurement path so the filter processes it; without one,
+    // PublishFix stores the whole fix atomically (and keeps the source's
+    // speed/heading a position-only filter would otherwise re-estimate).
+    if (use_filter) {
+      src->SetOnFix([mgr](const Position& p) { mgr->SubmitPositionFix(p); });
+    } else {
+      src->SetOnFix([mgr](const Position& p) { mgr->PublishFix(p); });
+    }
     // Arm the Manager before the source begins pushing, honoring the
     // Start()/Stop() lifecycle (ihs_location_stop calls Stop()).
     if (!manager->Start()) {

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -31,6 +31,7 @@
 #include "kalman_cv.hpp"
 #include "location.hpp"
 #include "manager.hpp"
+#include "registry.hpp"
 
 namespace {
 
@@ -80,10 +81,18 @@ std::unique_ptr<IEventSource> MakeFile(const char* config) {
       config, ihs::location::FileSource::Pace::kRealtime, /*loop=*/false);
 }
 
-// Register the built-in filters so a filter_key resolves in the registry. Only
-// "kalman.cv" is built in today; other keys are the caller's to register.
-void RegisterBuiltinFilters() {
-  ihs::location::RegisterKalmanCvFilter();
+// Make the built-in filter named @key available on demand. Only "kalman.cv" is
+// built in; any other key is the caller's to register, so it is left untouched.
+// A key already registered (e.g. a caller's own "kalman.cv") is NOT overwritten
+// — the caller's registration wins.
+void EnsureBuiltinFilter(const std::string& key) {
+  if (key != "kalman.cv") {
+    return;
+  }
+  ihs::location::FilterEntry existing;
+  if (!ihs::location::LookupFilter(key, existing)) {
+    ihs::location::RegisterKalmanCvFilter();
+  }
 }
 
 }  // namespace
@@ -118,9 +127,10 @@ IhsLocationService* ihs_location_start_filtered(IhsLocationSource source,
   try {
     const bool use_filter = filter_key != nullptr && filter_key[0] != '\0';
     if (use_filter) {
-      // Publish the built-in filters so the Manager can bind filter_key. A
-      // key it still cannot resolve degrades to the passthrough inside Manager.
-      RegisterBuiltinFilters();
+      // Make the requested filter available if it is a built-in the caller did
+      // not already register. An unknown key resolves to nothing and degrades
+      // to the passthrough inside Manager.
+      EnsureBuiltinFilter(filter_key);
     }
     // Declare the Manager before the source: the source's worker calls into the
     // Manager, so on any early return or exception after the source starts,

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -82,6 +82,21 @@ void Manager::SubmitPositionFix(const Position& fix) {
   if (!fix.valid() || !ValidLatLon(fix.latitude, fix.longitude)) {
     return;  // not a usable fix (OnMeasurement validates too)
   }
+  // With no filter actually bound (a missing or create-failed filter_key),
+  // behave exactly like the unfiltered path: store the whole fix, preserving
+  // the source's speed/heading rather than dropping them by decomposing to a
+  // position-only measurement. filter_instance_ is set at Start() before any
+  // source pushes and cleared at Shutdown() after they stop, so it is stable
+  // here; read it under the lock for good measure.
+  bool has_filter = false;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    has_filter = filter_instance_ != nullptr;
+  }
+  if (!has_filter) {
+    PublishFix(fix);
+    return;
+  }
   IhsMeasurement m{};
   m.struct_size = sizeof(m);
   m.kind = IHS_MEAS_POSITION_LLA;

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -78,6 +78,30 @@ void Manager::PublishFix(const Position& fix) {
   }
 }
 
+void Manager::SubmitPositionFix(const Position& fix) {
+  if (!fix.valid() || !ValidLatLon(fix.latitude, fix.longitude)) {
+    return;  // not a usable fix (OnMeasurement validates too)
+  }
+  IhsMeasurement m{};
+  m.struct_size = sizeof(m);
+  m.kind = IHS_MEAS_POSITION_LLA;
+  m.t_monotonic_ns = fix.t_monotonic_ns;
+  // Carry the source's 2D/3D mode through value_count. A position-only filter
+  // (kalman.cv) ignores the altitude slot, but the reported mode should not be
+  // downgraded, so the altitude component is present (value 0) only to mark a
+  // 3D fix.
+  m.value_count = fix.mode >= 3 ? 3 : 2;
+  m.value[0] = fix.latitude;
+  m.value[1] = fix.longitude;
+  m.value[2] = 0.0;
+  // Service convention: variance[0] = east, variance[1] = north (a < 0 sigma is
+  // "unknown", left as the -1 sentinel for the filter/passthrough to handle).
+  m.variance[0] = fix.sigma_e_m >= 0.0 ? fix.sigma_e_m * fix.sigma_e_m : -1.0;
+  m.variance[1] = fix.sigma_n_m >= 0.0 ? fix.sigma_n_m * fix.sigma_n_m : -1.0;
+  m.variance[2] = -1.0;
+  OnMeasurement(m);
+}
+
 void Manager::SetFixNotify(std::function<void()> notify) {
   const std::lock_guard<std::mutex> lock(mutex_);
   fix_notify_ = std::move(notify);

--- a/shared/src/location/manager.hpp
+++ b/shared/src/location/manager.hpp
@@ -70,6 +70,16 @@ class Manager : public ILocationProvider {
   // Thread-safe; typically called from the source's acquisition thread.
   void PublishFix(const Position& fix);
 
+  // Submit a whole fix from an event source (gpsd/geoclue/file) into the
+  // MEASUREMENT path: it is decomposed to a single POSITION measurement so a
+  // configured filter processes it (and, with no filter, folds through the
+  // passthrough just like PublishFix). This is the path used when the service
+  // is started with a filter; PublishFix remains the raw atomic store for the
+  // unfiltered path, where it also preserves the source's speed/heading that a
+  // position-only filter would otherwise re-estimate. Thread-safe; typically
+  // called from the source's acquisition thread.
+  void SubmitPositionFix(const Position& fix);
+
   // Install a callback fired once on each new fix (each generation bump), for a
   // push consumer. It is invoked WITHOUT the internal mutex held (so the
   // callback may call back into Latest()/generation()), on whichever thread

--- a/shared/src/location/manager.hpp
+++ b/shared/src/location/manager.hpp
@@ -71,12 +71,13 @@ class Manager : public ILocationProvider {
   void PublishFix(const Position& fix);
 
   // Submit a whole fix from an event source (gpsd/geoclue/file) into the
-  // MEASUREMENT path: it is decomposed to a single POSITION measurement so a
-  // configured filter processes it (and, with no filter, folds through the
-  // passthrough just like PublishFix). This is the path used when the service
-  // is started with a filter; PublishFix remains the raw atomic store for the
-  // unfiltered path, where it also preserves the source's speed/heading that a
-  // position-only filter would otherwise re-estimate. Thread-safe; typically
+  // filter. When a filter is bound it is decomposed to a single POSITION
+  // measurement so the filter processes it. When no filter is bound (a missing
+  // or failed filter_key), this defers to PublishFix, so the "degrade to
+  // passthrough" behavior is identical to the unfiltered path — including
+  // preserving the source's speed/heading, which a position-only filter would
+  // re-estimate and a position-only measurement would drop. This is the path
+  // used when the service is started with a filter. Thread-safe; typically
   // called from the source's acquisition thread.
   void SubmitPositionFix(const Position& fix);
 

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -111,3 +111,21 @@ target_compile_options(file_source_test PRIVATE -Wall -Wextra)
 target_link_libraries(file_source_test PRIVATE Threads::Threads)
 
 add_test(NAME file_source COMMAND file_source_test)
+
+# End-to-end wiring: ihs_location_start_filtered() over the whole location
+# subsystem (the real C ABI in location_api.cc), replaying a gnss.file through
+# kalman.cv and delivering fixes via the push callback. Links libdl for the
+# geoclue/sd-bus runtime dlopen (compiled in even though this test drives the
+# file source).
+add_executable(wire_test wire_test.cc
+        ${_loc_src}/location_api.cc ${_loc_src}/manager.cc
+        ${_loc_src}/registry.cc ${_loc_src}/kalman_cv.cc
+        ${_loc_src}/file_source.cc ${_loc_src}/gpsd_provider.cc
+        ${_loc_src}/geoclue_provider.cc ${_loc_src}/fallback_source.cc
+        ${_loc_src}/sd_bus_dynamic.cc)
+target_include_directories(wire_test PRIVATE
+        ${_loc_src} ${_loc_inc} ${CMAKE_CURRENT_BINARY_DIR}/gen)
+target_compile_options(wire_test PRIVATE -Wall -Wextra)
+target_link_libraries(wire_test PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+
+add_test(NAME wire COMMAND wire_test)

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// End-to-end test of the ihs_location_start_filtered() wiring: a gnss.file
+// source replaying a captured gpsd stream, fused through the kalman.cv filter,
+// delivered to a consumer via the push callback. Exercises the real C ABI
+// (location_api.cc) over the whole location subsystem, not the pieces in
+// isolation. Fixes are collected through a condition variable fed by the
+// callback — no polling.
+
+#include "ihs/location.h"
+
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_tests = 0;
+int g_failures = 0;
+void Check(bool cond, const char* what) {
+  ++g_tests;
+  if (!cond) {
+    ++g_failures;
+    std::fprintf(stderr, "FAIL: %s\n", what);
+  }
+}
+
+constexpr double kLat0 = 48.0;
+constexpr double kLon0 = -122.0;
+constexpr double kMetersPerDegLat = 111320.0;
+double MetersPerDegLon(double lat) {
+  return kMetersPerDegLat * std::cos(lat * 3.14159265358979323846 / 180.0);
+}
+
+// A clean eastward track as a captured gpsd JSON stream: @n fixes, @dt_s apart,
+// moving east at @v_e m/s from the origin. No noise — this checks that the wire
+// delivers filtered fixes that track the truth, not the filter's noise math
+// (covered by kalman_cv_test / filter_test).
+std::filesystem::path WriteTrackFixture(const std::string& name,
+                                        double v_e,
+                                        int n,
+                                        double dt_s) {
+  const std::filesystem::path path =
+      std::filesystem::temp_directory_path() / name;
+  std::ofstream out(path, std::ios::trunc);
+  const double m_per_deg_lon = MetersPerDegLon(kLat0);
+  for (int i = 0; i < n; ++i) {
+    const double t = static_cast<double>(i) * dt_s;
+    const double lon = kLon0 + (v_e * t) / m_per_deg_lon;
+    char line[256];
+    std::snprintf(line, sizeof(line),
+                  R"({"class":"TPV","time":"2026-07-20T18:03:%06.3fZ",)"
+                  R"("mode":3,"lat":%.8f,"lon":%.8f,"speed":%.3f,"eph":5.0})",
+                  11.0 + t, kLat0, lon, v_e);
+    out << line << "\n";
+  }
+  out.close();
+  return path;
+}
+
+// Collects pushed fixes; a test blocks until enough arrive (event-driven).
+struct Collector {
+  std::mutex mu;
+  std::condition_variable cv;
+  std::vector<IhsPosition> fixes;
+
+  static void Thunk(void* user_data, const IhsPosition* p) {
+    auto* self = static_cast<Collector*>(user_data);
+    std::lock_guard<std::mutex> lk(self->mu);
+    self->fixes.push_back(*p);
+    self->cv.notify_all();
+  }
+  bool WaitFor(size_t n, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lk(mu);
+    return cv.wait_for(lk, timeout, [&] { return fixes.size() >= n; });
+  }
+  size_t count() {
+    std::lock_guard<std::mutex> lk(mu);
+    return fixes.size();
+  }
+  IhsPosition last() {
+    std::lock_guard<std::mutex> lk(mu);
+    return fixes.back();
+  }
+};
+
+void TestFileThroughKalman() {
+  const double v_e = 20.0;
+  const int n = 40;
+  const double dt_s = 0.025;  // 40 * 25 ms = 1 s of realtime replay
+  const auto path = WriteTrackFixture("ihs_wire_kalman.jsonl", v_e, n, dt_s);
+
+  Collector c;
+  IhsLocationService* svc = ihs_location_start_filtered(
+      IHS_LOCATION_FILE, path.string().c_str(), "kalman.cv", nullptr);
+  Check(svc != nullptr, "start FILE + kalman.cv");
+  if (svc == nullptr) {
+    std::filesystem::remove(path);
+    return;
+  }
+  ihs_location_set_callback(svc, &Collector::Thunk, &c);
+
+  // Wait for most of the track to replay (realtime, ~1 s).
+  Check(c.WaitFor(30, std::chrono::seconds(5)), "filtered fixes delivered");
+
+  ihs_location_stop(svc);
+  std::filesystem::remove(path);
+
+  Check(c.count() >= 30, "enough fixes arrived");
+  if (c.count() < 1) {
+    return;
+  }
+  const IhsPosition p = c.last();
+  // The estimate must track the (clean) truth: at the last delivered fix the
+  // vehicle is near v_e * t east of the origin.
+  Check(std::isfinite(p.latitude) && std::isfinite(p.longitude),
+        "filtered fix is finite");
+  Check(std::abs(p.latitude - kLat0) * kMetersPerDegLat < 5.0,
+        "filtered fix stays on the east-west line (north error small)");
+  // The filter recovers the eastward motion (speed from a position-only
+  // source).
+  Check(p.speed_mps > v_e * 0.5, "filter recovered the eastward speed");
+  Check(p.mode == 3, "3D source keeps mode 3 through the filter");
+}
+
+void TestFilePassthrough() {
+  // The same source with no filter still delivers fixes (the passthrough path).
+  const auto path =
+      WriteTrackFixture("ihs_wire_passthrough.jsonl", 10.0, 20, 0.02);
+  Collector c;
+  IhsLocationService* svc =
+      ihs_location_start(IHS_LOCATION_FILE, path.string().c_str());
+  Check(svc != nullptr, "start FILE (passthrough)");
+  if (svc == nullptr) {
+    std::filesystem::remove(path);
+    return;
+  }
+  ihs_location_set_callback(svc, &Collector::Thunk, &c);
+  Check(c.WaitFor(15, std::chrono::seconds(5)), "passthrough fixes delivered");
+  ihs_location_stop(svc);
+  std::filesystem::remove(path);
+}
+
+void TestBadPathAndKeys() {
+  // A missing file fails the start.
+  IhsLocationService* svc = ihs_location_start_filtered(
+      IHS_LOCATION_FILE, "/nonexistent/ihs/nope.jsonl", "kalman.cv", nullptr);
+  Check(svc == nullptr, "missing file fails start");
+
+  // An unknown filter key degrades to the passthrough rather than failing (the
+  // file still opens), so the start succeeds.
+  const auto path = WriteTrackFixture("ihs_wire_badkey.jsonl", 5.0, 5, 0.01);
+  IhsLocationService* svc2 = ihs_location_start_filtered(
+      IHS_LOCATION_FILE, path.string().c_str(), "no.such.filter", nullptr);
+  Check(svc2 != nullptr,
+        "unknown filter key still starts (degrades to passthrough)");
+  if (svc2 != nullptr) {
+    ihs_location_stop(svc2);
+  }
+  std::filesystem::remove(path);
+}
+
+}  // namespace
+
+int main() {
+  TestFileThroughKalman();
+  TestFilePassthrough();
+  TestBadPathAndKeys();
+
+  if (g_failures == 0) {
+    std::printf("wire_test: all %d checks passed\n", g_tests);
+  } else {
+    std::fprintf(stderr, "wire_test: %d/%d checks FAILED\n", g_failures,
+                 g_tests);
+  }
+  return g_failures == 0 ? 0 : 1;
+}

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -163,14 +163,25 @@ void TestBadPathAndKeys() {
   Check(svc == nullptr, "missing file fails start");
 
   // An unknown filter key degrades to the passthrough rather than failing (the
-  // file still opens), so the start succeeds.
-  const auto path = WriteTrackFixture("ihs_wire_badkey.jsonl", 5.0, 5, 0.01);
+  // file still opens), so the start succeeds — and the degrade is identical to
+  // the unfiltered path, preserving the source's reported speed (5 m/s) rather
+  // than dropping it by decomposing to a position-only measurement.
+  const double v_e = 5.0;
+  const auto path = WriteTrackFixture("ihs_wire_badkey.jsonl", v_e, 20, 0.02);
+  Collector c;
   IhsLocationService* svc2 = ihs_location_start_filtered(
       IHS_LOCATION_FILE, path.string().c_str(), "no.such.filter", nullptr);
   Check(svc2 != nullptr,
         "unknown filter key still starts (degrades to passthrough)");
   if (svc2 != nullptr) {
+    ihs_location_set_callback(svc2, &Collector::Thunk, &c);
+    Check(c.WaitFor(10, std::chrono::seconds(5)),
+          "degraded path delivers fixes");
     ihs_location_stop(svc2);
+    if (c.count() > 0) {
+      Check(std::abs(c.last().speed_mps - v_e) < 0.5,
+            "degrade-to-passthrough preserves the source speed (not dropped)");
+    }
   }
   std::filesystem::remove(path);
 }

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -17,6 +17,8 @@
 
 #include "ihs/location.h"
 
+#include <unistd.h>  // getpid
+
 #include <chrono>
 #include <cmath>
 #include <condition_variable>
@@ -55,9 +57,12 @@ std::filesystem::path WriteTrackFixture(const std::string& name,
                                         double v_e,
                                         int n,
                                         double dt_s) {
-  const std::filesystem::path path =
-      std::filesystem::temp_directory_path() / name;
+  // Per-process filename so concurrent runs (ctest -j, a shared runner) cannot
+  // truncate each other's fixtures.
+  const std::filesystem::path path = std::filesystem::temp_directory_path() /
+                                     (std::to_string(getpid()) + "-" + name);
   std::ofstream out(path, std::ios::trunc);
+  Check(out.is_open(), "fixture temp file opened for write");
   const double m_per_deg_lon = MetersPerDegLon(kLat0);
   for (int i = 0; i < n; ++i) {
     const double t = static_cast<double>(i) * dt_s;


### PR DESCRIPTION
Makes the two location components from #352 (gnss.file replay) and #355 (kalman.cv filter) reachable through the service entry point — until now they were built and tested but not wired into `ihs_location_start`, so production still used the raw passthrough.

## What's new

- **`IHS_LOCATION_FILE` source** — `ihs_location_start(IHS_LOCATION_FILE, path)` replays a captured gpsd JSON stream (as `gpspipe -w` writes) at its recorded cadence, driving a consumer like a live receiver with **no hardware**. Additive enum value.
- **`ihs_location_start_filtered(source, config, filter_key, filter_config)`** — a new additive entry point that fuses the source's fixes through a registered filter. `"kalman.cv"` selects the built-in constant-velocity Kalman filter (`"q=<value>"` tuning); `NULL`/`""` means no filter and is exactly `ihs_location_start`, which now delegates here.

## The measurement-path bridge

The filter runs on the *measurement* path (`OnMeasurement` → filter `update`), but the event sources (gpsd/geoclue/file) drive `PublishFix` — a raw atomic store that bypasses the filter. So `Manager` gains **`SubmitPositionFix()`**: it decomposes a whole `Position` into one `POSITION` measurement (variance in the service east/north order, the source's 2D/3D mode carried through) and folds it through `OnMeasurement`, where the filter processes it. The unfiltered path still uses `PublishFix`, which additionally preserves the source's speed/heading that a position-only filter would re-estimate.

## Verification — `wire_test`, end to end over the real C ABI

Drives `location_api.cc` across the whole location subsystem (not the pieces in isolation): replay a `gnss.file` through `kalman.cv`, collect fixes via the push callback (condition-variable-gated, no polling), and confirm:
- the filtered estimate tracks the track and stays finite,
- it recovers the eastward **speed** from a position-only source,
- a 3D fix keeps `mode == 3` through the filter,
- the passthrough path (no filter) still delivers,
- a missing file fails the start,
- an unknown filter key degrades to the passthrough rather than failing.

Runs in ~1 s (realtime replay). All 8 location tests pass.

## ABI

No break: one **appended** enum value and one **new** export (the version script already scopes exports to `ihs_*`, verified `ihs_location_start_filtered` is exported); the public `IhsPosition` struct is unchanged. abidiff checks only the incompatible bit, which an added enumerator does not set.

## Notes

- clang-tidy-19 + clang-format-19 clean; DCO sign-off.
- Backlog: `IHS_LOCATION_FILE` currently replays realtime single-pass; loop / as-fast could be config options later. EKF (`kalman.ctrv`) remains the next filter once a yaw-rate source exists.