### PR TITLE
location: CTRV extended Kalman filter (kalman.ctrv)

### DIFF
--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -80,7 +80,7 @@ jobs:
           export LD_LIBRARY_PATH="$PWD/prefix/lib:$PWD/prefix/lib64:$PWD/prefix/lib/x86_64-linux-gnu"
           ctest --test-dir sbuild --output-on-failure
 
-      - name: Location unit tests (parser / registry / manager / fallback / filter / file / kalman / wire)
+      - name: Location unit tests (parser / registry / manager / fallback / filter / file / kalman / ctrv / wire)
         # Standalone: compiles the internal location sources directly (ParseTpv,
         # registry, manager, etc. are not part of the installed C ABI), so no
         # prefix / gpsd is needed. ctest runs every add_test in the project.

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -148,6 +148,7 @@ target_sources(ihs_shared PRIVATE
         src/location/fallback_source.cc
         src/location/file_source.cc
         src/location/kalman_cv.cc
+        src/location/kalman_ctrv.cc
         src/location/sd_bus_dynamic.cc
 )
 target_link_libraries(ihs_shared PRIVATE ${CMAKE_DL_LIBS})

--- a/shared/src/location/kalman_ctrv.cc
+++ b/shared/src/location/kalman_ctrv.cc
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "kalman_ctrv.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+#include "location.hpp"  // ValidLatLon
+
+namespace ihs::location {
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kMetersPerDegLat = 111320.0;
+
+// Below this yaw rate the arc is straight; use the limit form to avoid a
+// 1/omega singularity.
+constexpr double kOmegaEps = 1.0e-4;  // rad/s
+
+// Process-noise densities (the two tuning knobs): longitudinal acceleration and
+// yaw acceleration, as 1-sigma^2. Defaults suit a road vehicle.
+constexpr double kDefaultQa = 2.0 * 2.0;    // (m/s^2)^2
+constexpr double kDefaultQw = 0.15 * 0.15;  // (rad/s^2)^2
+// Seed variances for the states a single position cannot observe.
+constexpr double kInitHeadingVar = kPi * kPi;   // rad^2 (heading unknown)
+constexpr double kInitSpeedVar = 50.0 * 50.0;   // (m/s)^2
+constexpr double kInitYawRateVar = 1.0 * 1.0;   // (rad/s)^2
+constexpr double kDefaultPosVar = 10.0 * 10.0;  // m^2
+// Chi-square gates: 2-DOF (position) and 1-DOF (scalar) at p=0.001.
+constexpr double kChi2Gate2Dof = 13.816;
+constexpr double kChi2Gate1Dof = 10.828;
+constexpr int kMaxConsecutiveRejects = 3;
+constexpr double kReanchorMeters = 10000.0;
+constexpr double kMinSpeedForBearing = 0.5;
+
+double MetersPerDegLon(double lat_deg) {
+  // Clamp near the poles (cos -> 0) so the meters<->degrees divisor stays
+  // finite.
+  constexpr double kMinMetersPerDegLon = 1.0;
+  const double scale = kMetersPerDegLat * std::cos(lat_deg * kPi / 180.0);
+  return scale > kMinMetersPerDegLon ? scale : kMinMetersPerDegLon;
+}
+
+double FiniteVarianceOr(double variance, double fallback) {
+  return (std::isfinite(variance) && variance >= 0.0) ? variance : fallback;
+}
+
+using Vec5 = std::array<double, 5>;
+using Mat5 = std::array<std::array<double, 5>, 5>;
+
+Mat5 Zero5() {
+  return Mat5{};
+}
+
+Mat5 Identity5() {
+  Mat5 m = Zero5();
+  for (std::size_t i = 0; i < 5; ++i) {
+    m[i][i] = 1.0;
+  }
+  return m;
+}
+
+Mat5 Mul(const Mat5& a, const Mat5& b) {
+  Mat5 c = Zero5();
+  for (std::size_t i = 0; i < 5; ++i) {
+    for (std::size_t k = 0; k < 5; ++k) {
+      const double aik = a[i][k];
+      for (std::size_t j = 0; j < 5; ++j) {
+        c[i][j] += aik * b[k][j];
+      }
+    }
+  }
+  return c;
+}
+
+Mat5 Transpose(const Mat5& a) {
+  Mat5 t = Zero5();
+  for (std::size_t i = 0; i < 5; ++i) {
+    for (std::size_t j = 0; j < 5; ++j) {
+      t[i][j] = a[j][i];
+    }
+  }
+  return t;
+}
+
+// Parse "qa=<v>" / "qw=<v>" out of the config (space/comma separated, any
+// order).
+double ParseNamed(const char* config, const char* key, double fallback) {
+  if (config == nullptr) {
+    return fallback;
+  }
+  const char* at = std::strstr(config, key);
+  if (at == nullptr) {
+    return fallback;
+  }
+  char* end = nullptr;
+  const double v = std::strtod(at + std::strlen(key), &end);
+  return (end != at + std::strlen(key) && std::isfinite(v) && v > 0.0)
+             ? v
+             : fallback;
+}
+
+// Constant-turn-rate-and-velocity extended Kalman filter.
+class KalmanCtrv {
+ public:
+  KalmanCtrv(double qa, double qw) : qa_(qa), qw_(qw) {}
+
+  void Update(const IhsMeasurement& m) {
+    switch (m.kind) {
+      case IHS_MEAS_POSITION_LLA:
+        UpdatePosition(m);
+        break;
+      case IHS_MEAS_YAW_RATE:
+        if (m.value_count >= 1) {
+          UpdateScalar(m, /*state=*/4, FiniteVarianceOr(m.variance[0], 0.01));
+        }
+        break;
+      case IHS_MEAS_SPEED:
+        if (m.value_count >= 1) {
+          UpdateScalar(m, /*state=*/3, FiniteVarianceOr(m.variance[0], 1.0));
+        }
+        break;
+      default:
+        break;  // other kinds are not CTRV inputs
+    }
+  }
+
+  int Estimate(uint64_t t_monotonic_ns, IhsPosition& out) const {
+    if (!have_state_) {
+      return 0;
+    }
+    double dt = SecondsSince(t_monotonic_ns);
+    if (dt < 0.0) {
+      dt = 0.0;
+    }
+    Vec5 x = x_;
+    Mat5 p = p_;
+    PredictInto(x_, p_, dt, x, p);
+
+    out.latitude = anchor_lat_ + x[1] / kMetersPerDegLat;
+    out.longitude = anchor_lon_ + x[0] / MetersPerDegLon(anchor_lat_);
+    out.mode = last_mode_;
+    const double v = x[3];
+    out.speed_mps = std::fabs(v);
+    const double ve = v * std::cos(x[2]);
+    const double vn = v * std::sin(x[2]);
+    if (out.speed_mps > kMinSpeedForBearing) {
+      double course = std::atan2(ve, vn) * 180.0 / kPi;  // clockwise from north
+      if (course < 0.0) {
+        course += 360.0;
+      }
+      out.bearing_deg = course;
+      out.has_bearing = 1;
+    } else {
+      out.bearing_deg = 0.0;
+      out.has_bearing = 0;
+    }
+    out.t_monotonic_ns = t_monotonic_ns;
+    out.sigma_e_m = std::sqrt(p[0][0] > 0.0 ? p[0][0] : 0.0);
+    out.sigma_n_m = std::sqrt(p[1][1] > 0.0 ? p[1][1] : 0.0);
+    out.sigma_v_mps = std::sqrt(p[3][3] > 0.0 ? p[3][3] : 0.0);
+    return 1;
+  }
+
+  // Exposed for the numerical-Jacobian unit test.
+  static Vec5 PredictStateFor(const Vec5& x, double dt) {
+    return PredictState(x, dt);
+  }
+  static Mat5 JacobianFor(const Vec5& x, double dt) { return Jacobian(x, dt); }
+
+ private:
+  [[nodiscard]] double SecondsSince(uint64_t t_monotonic_ns) const {
+    const int64_t d =
+        static_cast<int64_t>(t_monotonic_ns) - static_cast<int64_t>(last_t_ns_);
+    return static_cast<double>(d) * 1e-9;
+  }
+
+  // CTRV motion model: propagate the state forward by dt.
+  static Vec5 PredictState(const Vec5& x, double dt) {
+    const double px = x[0];
+    const double py = x[1];
+    const double psi = x[2];
+    const double v = x[3];
+    const double w = x[4];
+    Vec5 out = x;
+    if (std::fabs(w) > kOmegaEps) {
+      const double psi_new = psi + w * dt;
+      out[0] = px + (v / w) * (std::sin(psi_new) - std::sin(psi));
+      out[1] = py + (v / w) * (-std::cos(psi_new) + std::cos(psi));
+      out[2] = psi_new;
+    } else {
+      out[0] = px + v * std::cos(psi) * dt;
+      out[1] = py + v * std::sin(psi) * dt;
+      out[2] = psi + w * dt;
+    }
+    out[3] = v;
+    out[4] = w;
+    return out;
+  }
+
+  // Analytic Jacobian d f / d x of PredictState (verified numerically in
+  // tests).
+  static Mat5 Jacobian(const Vec5& x, double dt) {
+    const double psi = x[2];
+    const double v = x[3];
+    const double w = x[4];
+    Mat5 f = Identity5();
+    if (std::fabs(w) > kOmegaEps) {
+      const double a = psi + w * dt;
+      const double sa = std::sin(a);
+      const double ca = std::cos(a);
+      const double sp = std::sin(psi);
+      const double cp = std::cos(psi);
+      f[0][2] = (v / w) * (ca - cp);
+      f[0][3] = (1.0 / w) * (sa - sp);
+      f[0][4] = (v * dt / w) * ca - (v / (w * w)) * (sa - sp);
+      f[1][2] = (v / w) * (sa - sp);
+      f[1][3] = (1.0 / w) * (-ca + cp);
+      f[1][4] = (v * dt / w) * sa - (v / (w * w)) * (-ca + cp);
+    } else {
+      // Straight-line branch: PredictState uses px += v cos(psi) dt (no omega
+      // term), so d(px,py)/d(omega) is exactly 0 here — the Jacobian must match
+      // the predict actually used, not the w->0 limit of the arc form, or the
+      // covariance is inconsistent with the propagation. Omega stays observable
+      // across steps through psi' = psi + omega dt (f[2][4] below).
+      const double sp = std::sin(psi);
+      const double cp = std::cos(psi);
+      f[0][2] = -v * sp * dt;
+      f[0][3] = cp * dt;
+      f[1][2] = v * cp * dt;
+      f[1][3] = sp * dt;
+    }
+    f[2][4] = dt;
+    return f;
+  }
+
+  // Process noise Q(dt) = G diag(qa, qw) G^T from acceleration /
+  // yaw-acceleration.
+  [[nodiscard]] Mat5 ProcessNoise(double dt, double psi) const {
+    const double h = 0.5 * dt * dt;
+    // G columns: [accel, yaw-accel].
+    const double g0[5] = {h * std::cos(psi), h * std::sin(psi), 0.0, dt, 0.0};
+    const double g1[5] = {0.0, 0.0, h, 0.0, dt};
+    Mat5 q = Zero5();
+    for (std::size_t i = 0; i < 5; ++i) {
+      for (std::size_t j = 0; j < 5; ++j) {
+        q[i][j] = qa_ * g0[i] * g0[j] + qw_ * g1[i] * g1[j];
+      }
+    }
+    return q;
+  }
+
+  // Predict state and covariance forward by dt into @x_out, @p_out (may alias
+  // the inputs). P' = Fj P Fj^T + Q.
+  void PredictInto(const Vec5& x_in,
+                   const Mat5& p_in,
+                   double dt,
+                   Vec5& x_out,
+                   Mat5& p_out) const {
+    const Mat5 f = Jacobian(x_in, dt);
+    const Mat5 q = ProcessNoise(dt, x_in[2]);
+    const Vec5 xn = PredictState(x_in, dt);
+    const Mat5 fp = Mul(f, p_in);
+    Mat5 pn = Mul(fp, Transpose(f));
+    for (std::size_t i = 0; i < 5; ++i) {
+      for (std::size_t j = 0; j < 5; ++j) {
+        pn[i][j] += q[i][j];
+      }
+    }
+    x_out = xn;
+    p_out = pn;
+  }
+
+  void Predict(double dt) { PredictInto(x_, p_, dt, x_, p_); }
+
+  void Seed(double lat, double lon, double var_e, double var_n, uint64_t t_ns) {
+    anchor_lat_ = lat;
+    anchor_lon_ = lon;
+    x_ = {0.0, 0.0, 0.0, 0.0, 0.0};
+    p_ = Zero5();
+    p_[0][0] = var_e;
+    p_[1][1] = var_n;
+    p_[2][2] = kInitHeadingVar;
+    p_[3][3] = kInitSpeedVar;
+    p_[4][4] = kInitYawRateVar;
+    last_t_ns_ = t_ns;
+    have_state_ = true;
+    consecutive_rejects_ = 0;
+  }
+
+  void UpdatePosition(const IhsMeasurement& m) {
+    if (m.value_count < 2 || !ValidLatLon(m.value[0], m.value[1])) {
+      return;
+    }
+    const double lat = m.value[0];
+    const double lon = m.value[1];
+    // Service convention: variance[0] = east, variance[1] = north.
+    const double var_e = FiniteVarianceOr(m.variance[0], kDefaultPosVar);
+    const double var_n = FiniteVarianceOr(m.variance[1], kDefaultPosVar);
+    last_mode_ = m.value_count >= 3 ? 3 : 2;
+
+    if (!have_state_) {
+      Seed(lat, lon, var_e, var_n, m.t_monotonic_ns);
+      return;
+    }
+    const double dt = SecondsSince(m.t_monotonic_ns);
+    if (dt < 0.0) {
+      return;  // out of order: drop
+    }
+    Predict(dt);
+    last_t_ns_ = m.t_monotonic_ns;
+
+    const double z_e = (lon - anchor_lon_) * MetersPerDegLon(anchor_lat_);
+    const double z_n = (lat - anchor_lat_) * kMetersPerDegLat;
+    const double y_e = z_e - x_[0];
+    const double y_n = z_n - x_[1];
+    // S = H P H^T + R (top-left 2x2 of P plus R), H = [I2 | 0].
+    const double s00 = p_[0][0] + var_e;
+    const double s01 = p_[0][1];
+    const double s10 = p_[1][0];
+    const double s11 = p_[1][1] + var_n;
+    const double det = s00 * s11 - s01 * s10;
+    if (!(std::fabs(det) > 0.0)) {
+      return;
+    }
+    const double inv = 1.0 / det;
+    const double si00 = s11 * inv;
+    const double si01 = -s01 * inv;
+    const double si10 = -s10 * inv;
+    const double si11 = s00 * inv;
+    const double nis =
+        y_e * (si00 * y_e + si01 * y_n) + y_n * (si10 * y_e + si11 * y_n);
+    if (nis > kChi2Gate2Dof) {
+      if (++consecutive_rejects_ >= kMaxConsecutiveRejects) {
+        Seed(lat, lon, var_e, var_n, m.t_monotonic_ns);
+      }
+      return;
+    }
+    consecutive_rejects_ = 0;
+
+    // K = P H^T S^-1 (P H^T is the first two columns of P).
+    std::array<std::array<double, 2>, 5> k{};
+    for (std::size_t i = 0; i < 5; ++i) {
+      const double a = p_[i][0];
+      const double b = p_[i][1];
+      k[i][0] = a * si00 + b * si10;
+      k[i][1] = a * si01 + b * si11;
+    }
+    for (std::size_t i = 0; i < 5; ++i) {
+      x_[i] += k[i][0] * y_e + k[i][1] * y_n;
+    }
+    // P = (I - K H) P, H picks rows 0,1.
+    Mat5 ikh = Identity5();
+    for (std::size_t i = 0; i < 5; ++i) {
+      ikh[i][0] -= k[i][0];
+      ikh[i][1] -= k[i][1];
+    }
+    p_ = Mul(ikh, p_);
+    Symmetrize();
+    ReanchorIfFar();
+  }
+
+  // Linear scalar update on a single @state index (yaw rate = 4, speed = 3).
+  void UpdateScalar(const IhsMeasurement& m, std::size_t state, double r) {
+    if (!have_state_) {
+      return;  // no position anchor yet; a scalar alone cannot seed a fix
+    }
+    const double dt = SecondsSince(m.t_monotonic_ns);
+    if (dt < 0.0) {
+      return;
+    }
+    Predict(dt);
+    last_t_ns_ = m.t_monotonic_ns;
+
+    const double y = m.value[0] - x_[state];
+    const double s = p_[state][state] + r;
+    if (!(s > 0.0)) {
+      return;
+    }
+    const double nis = y * y / s;
+    if (nis > kChi2Gate1Dof) {
+      return;  // reject a scalar outlier (no reset: position drives the fix)
+    }
+    // K = P H^T / S = column `state` of P over S.
+    Vec5 kgain{};
+    for (std::size_t i = 0; i < 5; ++i) {
+      kgain[i] = p_[i][state] / s;
+    }
+    for (std::size_t i = 0; i < 5; ++i) {
+      x_[i] += kgain[i] * y;
+    }
+    // P = (I - K H) P, H = e_state^T.
+    Mat5 ikh = Identity5();
+    for (std::size_t i = 0; i < 5; ++i) {
+      ikh[i][state] -= kgain[i];
+    }
+    p_ = Mul(ikh, p_);
+    Symmetrize();
+  }
+
+  void Symmetrize() {
+    for (std::size_t i = 0; i < 5; ++i) {
+      for (std::size_t j = i + 1; j < 5; ++j) {
+        const double avg = 0.5 * (p_[i][j] + p_[j][i]);
+        p_[i][j] = avg;
+        p_[j][i] = avg;
+      }
+    }
+  }
+
+  void ReanchorIfFar() {
+    if (std::sqrt(x_[0] * x_[0] + x_[1] * x_[1]) <= kReanchorMeters) {
+      return;
+    }
+    const double old_anchor_lat = anchor_lat_;
+    anchor_lat_ += x_[1] / kMetersPerDegLat;
+    anchor_lon_ += x_[0] / MetersPerDegLon(old_anchor_lat);
+    x_[0] = 0.0;
+    x_[1] = 0.0;
+  }
+
+  double qa_;
+  double qw_;
+  Vec5 x_{{0.0, 0.0, 0.0, 0.0, 0.0}};
+  Mat5 p_ = Zero5();
+  double anchor_lat_ = 0.0;
+  double anchor_lon_ = 0.0;
+  uint64_t last_t_ns_ = 0;
+  int last_mode_ = 2;
+  bool have_state_ = false;
+  int consecutive_rejects_ = 0;
+};
+
+void* Create(void* /*user_data*/, const char* config) {
+  try {
+    return new KalmanCtrv(ParseNamed(config, "qa=", kDefaultQa),
+                          ParseNamed(config, "qw=", kDefaultQw));
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void Destroy(void* instance) {
+  delete static_cast<KalmanCtrv*>(instance);
+}
+
+void Update(void* instance, const IhsMeasurement* m) {
+  if (instance != nullptr && m != nullptr) {
+    static_cast<KalmanCtrv*>(instance)->Update(*m);
+  }
+}
+
+int Estimate(void* instance, uint64_t t_monotonic_ns, IhsPosition* out) {
+  if (instance == nullptr || out == nullptr) {
+    return 0;
+  }
+  return static_cast<const KalmanCtrv*>(instance)->Estimate(t_monotonic_ns,
+                                                            *out);
+}
+
+}  // namespace
+
+const IhsLocationFilterOps& KalmanCtrvFilterOps() {
+  static const IhsLocationFilterOps ops = [] {
+    IhsLocationFilterOps o{};
+    o.struct_size = sizeof(o);
+    o.create = &Create;
+    o.destroy = &Destroy;
+    o.update = &Update;
+    o.estimate = &Estimate;
+    return o;
+  }();
+  return ops;
+}
+
+bool RegisterKalmanCtrvFilter() {
+  return ihs_location_register_filter("kalman.ctrv", &KalmanCtrvFilterOps(),
+                                      nullptr) == 1;
+}
+
+void KalmanCtrvPredictForTest(const double x[5], double dt, double out5[5]) {
+  Vec5 xin;
+  for (std::size_t i = 0; i < 5; ++i) {
+    xin[i] = x[i];
+  }
+  const Vec5 xout = KalmanCtrv::PredictStateFor(xin, dt);
+  for (std::size_t i = 0; i < 5; ++i) {
+    out5[i] = xout[i];
+  }
+}
+
+void KalmanCtrvJacobianForTest(const double x[5], double dt, double out25[25]) {
+  Vec5 xin;
+  for (std::size_t i = 0; i < 5; ++i) {
+    xin[i] = x[i];
+  }
+  const Mat5 f = KalmanCtrv::JacobianFor(xin, dt);
+  for (std::size_t i = 0; i < 5; ++i) {
+    for (std::size_t j = 0; j < 5; ++j) {
+      out25[i * 5 + j] = f[i][j];
+    }
+  }
+}
+
+}  // namespace ihs::location

--- a/shared/src/location/kalman_ctrv.cc
+++ b/shared/src/location/kalman_ctrv.cc
@@ -310,10 +310,13 @@ class KalmanCtrv {
     // Service convention: variance[0] = east, variance[1] = north.
     const double var_e = FiniteVarianceOr(m.variance[0], kDefaultPosVar);
     const double var_n = FiniteVarianceOr(m.variance[1], kDefaultPosVar);
-    last_mode_ = m.value_count >= 3 ? 3 : 2;
+    // mode describes the last ACCEPTED fix, so it is set only on seed/reset and
+    // on acceptance below — never for a rejected or out-of-order measurement.
+    const int mode = m.value_count >= 3 ? 3 : 2;
 
     if (!have_state_) {
       Seed(lat, lon, var_e, var_n, m.t_monotonic_ns);
+      last_mode_ = mode;
       return;
     }
     const double dt = SecondsSince(m.t_monotonic_ns);
@@ -346,10 +349,12 @@ class KalmanCtrv {
     if (nis > kChi2Gate2Dof) {
       if (++consecutive_rejects_ >= kMaxConsecutiveRejects) {
         Seed(lat, lon, var_e, var_n, m.t_monotonic_ns);
+        last_mode_ = mode;  // reset adopts the measurement
       }
       return;
     }
     consecutive_rejects_ = 0;
+    last_mode_ = mode;  // measurement accepted
 
     // K = P H^T S^-1 (P H^T is the first two columns of P).
     std::array<std::array<double, 2>, 5> k{};

--- a/shared/src/location/kalman_ctrv.cc
+++ b/shared/src/location/kalman_ctrv.cc
@@ -30,10 +30,11 @@ constexpr double kMetersPerDegLat = 111320.0;
 // 1/omega singularity.
 constexpr double kOmegaEps = 1.0e-4;  // rad/s
 
-// Process-noise densities (the two tuning knobs): longitudinal acceleration and
-// yaw acceleration, as 1-sigma^2. Defaults suit a road vehicle.
-constexpr double kDefaultQa = 2.0 * 2.0;    // (m/s^2)^2
-constexpr double kDefaultQw = 0.15 * 0.15;  // (rad/s^2)^2
+// Process-noise 1-sigma (the two tuning knobs): longitudinal acceleration and
+// yaw acceleration. The "qa="/"qw=" config values are these sigmas, squared to
+// variances in Create(). Defaults suit a road vehicle.
+constexpr double kDefaultSigmaA = 2.0;   // m/s^2
+constexpr double kDefaultSigmaW = 0.15;  // rad/s^2
 // Seed variances for the states a single position cannot observe.
 constexpr double kInitHeadingVar = kPi * kPi;   // rad^2 (heading unknown)
 constexpr double kInitSpeedVar = 50.0 * 50.0;   // (m/s)^2
@@ -116,7 +117,9 @@ double ParseNamed(const char* config, const char* key, double fallback) {
 // Constant-turn-rate-and-velocity extended Kalman filter.
 class KalmanCtrv {
  public:
-  KalmanCtrv(double qa, double qw) : qa_(qa), qw_(qw) {}
+  // @qa_var / @qw_var are the acceleration / yaw-acceleration noise variances
+  // (1-sigma^2) used by the process-noise model.
+  KalmanCtrv(double qa_var, double qw_var) : qa_(qa_var), qw_(qw_var) {}
 
   void Update(const IhsMeasurement& m) {
     switch (m.kind) {
@@ -451,8 +454,11 @@ class KalmanCtrv {
 
 void* Create(void* /*user_data*/, const char* config) {
   try {
-    return new KalmanCtrv(ParseNamed(config, "qa=", kDefaultQa),
-                          ParseNamed(config, "qw=", kDefaultQw));
+    // The config knobs are 1-sigma accelerations; square them to the variances
+    // the process-noise model uses, so "qa=2" means 2 m/s^2 (the default).
+    const double sigma_a = ParseNamed(config, "qa=", kDefaultSigmaA);
+    const double sigma_w = ParseNamed(config, "qw=", kDefaultSigmaW);
+    return new KalmanCtrv(sigma_a * sigma_a, sigma_w * sigma_w);
   } catch (...) {
     return nullptr;
   }

--- a/shared/src/location/kalman_ctrv.hpp
+++ b/shared/src/location/kalman_ctrv.hpp
@@ -39,8 +39,10 @@ namespace ihs::location {
 // ~10 km. A 5x5 fixed-size matrix implementation, no Eigen.
 //
 // config (optional, may be NULL/empty): "qa=<value>" sets the longitudinal
-// acceleration noise density and "qw=<value>" the yaw-acceleration noise
-// (space- or comma-separated), the two manoeuvring tuning knobs.
+// acceleration process noise as a 1-sigma in m/s^2 (default 2) and "qw=<value>"
+// the yaw-acceleration 1-sigma in rad/s^2 (default 0.15) — the two manoeuvring
+// tuning knobs, space- or comma-separated. So qa=2 is the default; the values
+// are squared to variances internally.
 
 // Register the filter under "kalman.ctrv" in the process-wide location
 // registry. Idempotent (re-registration replaces the entry). Returns true on

--- a/shared/src/location/kalman_ctrv.hpp
+++ b/shared/src/location/kalman_ctrv.hpp
@@ -29,10 +29,9 @@ namespace ihs::location {
 // It corrects from GNSS position (IHS_MEAS_POSITION_LLA), and — the reason the
 // model earns its keep — directly from a yaw-rate (IHS_MEAS_YAW_RATE) or ground
 // speed (IHS_MEAS_SPEED) measurement when a gyro/CAN source provides one, each
-// a scalar linear update on omega / v. estimate(t) predicts the state forward
-// to
-// @t, so a UI-rate poll gets a fresh position that curves correctly between
-// fixes.
+// a scalar linear update on omega / v. estimate() predicts the state forward to
+// the requested time, so a UI-rate poll gets a fresh position that curves
+// correctly between fixes.
 //
 // The same robustness as kalman.cv: a per-measurement chi-square gate rejects
 // outliers and a persistent run resets to the raw fix; CLOCK_MONOTONIC drives

--- a/shared/src/location/kalman_ctrv.hpp
+++ b/shared/src/location/kalman_ctrv.hpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef IHS_LOC_KALMAN_CTRV_H_
+#define IHS_LOC_KALMAN_CTRV_H_
+
+#include "ihs/location.h"
+
+namespace ihs::location {
+
+// The constant-turn-rate-and-velocity (CTRV) extended Kalman filter, registered
+// under "kalman.ctrv".
+//
+// State x = [px, py, psi, v, omega]: position east/north (meters) in a local
+// tangent plane anchored at the first fix, heading psi (rad, CCW from east),
+// speed v (m/s), and yaw rate omega (rad/s). Unlike kalman.cv's straight-line
+// model, CTRV follows a constant-radius arc, so it tracks a turning vehicle
+// without lagging the corner — the right model for a car. The motion model is
+// nonlinear, so predict uses its analytic Jacobian (an EKF); the measurement
+// updates are all linear.
+//
+// It corrects from GNSS position (IHS_MEAS_POSITION_LLA), and — the reason the
+// model earns its keep — directly from a yaw-rate (IHS_MEAS_YAW_RATE) or ground
+// speed (IHS_MEAS_SPEED) measurement when a gyro/CAN source provides one, each
+// a scalar linear update on omega / v. estimate(t) predicts the state forward
+// to
+// @t, so a UI-rate poll gets a fresh position that curves correctly between
+// fixes.
+//
+// The same robustness as kalman.cv: a per-measurement chi-square gate rejects
+// outliers and a persistent run resets to the raw fix; CLOCK_MONOTONIC drives
+// dt; out-of-order measurements are dropped; the tangent plane re-anchors past
+// ~10 km. A 5x5 fixed-size matrix implementation, no Eigen.
+//
+// config (optional, may be NULL/empty): "qa=<value>" sets the longitudinal
+// acceleration noise density and "qw=<value>" the yaw-acceleration noise
+// (space- or comma-separated), the two manoeuvring tuning knobs.
+
+// Register the filter under "kalman.ctrv" in the process-wide location
+// registry. Idempotent (re-registration replaces the entry). Returns true on
+// success.
+bool RegisterKalmanCtrvFilter();
+
+// The filter's ops table, exposed so it can be unit-tested directly (create /
+// update / estimate / destroy) without going through the registry or a Manager.
+const IhsLocationFilterOps& KalmanCtrvFilterOps();
+
+// Test hooks over the CTRV motion model: @x is the 5-state [px, py, psi, v,
+// omega]. Predict fills @out5 with the state propagated by @dt; Jacobian fills
+// @out25 (row-major 5x5) with the analytic d f / d x. Exposed so a unit test
+// can finite-difference the predict and compare to the analytic Jacobian — an
+// EKF's Jacobian is its most error-prone part, and a silent sign/index slip
+// there is exactly what a behavioral test on a gentle track can miss.
+void KalmanCtrvPredictForTest(const double x[5], double dt, double out5[5]);
+void KalmanCtrvJacobianForTest(const double x[5], double dt, double out25[25]);
+
+}  // namespace ihs::location
+
+#endif  // IHS_LOC_KALMAN_CTRV_H_

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -28,6 +28,7 @@
 #include "file_source.hpp"
 #include "geoclue_provider.hpp"
 #include "gpsd_provider.hpp"
+#include "kalman_ctrv.hpp"
 #include "kalman_cv.hpp"
 #include "location.hpp"
 #include "manager.hpp"
@@ -81,17 +82,24 @@ std::unique_ptr<IEventSource> MakeFile(const char* config) {
       config, ihs::location::FileSource::Pace::kRealtime, /*loop=*/false);
 }
 
-// Make the built-in filter named @key available on demand. Only "kalman.cv" is
-// built in; any other key is the caller's to register, so it is left untouched.
-// A key already registered (e.g. a caller's own "kalman.cv") is NOT overwritten
-// — the caller's registration wins.
+// Make the built-in filter named @key available on demand. "kalman.cv" and
+// "kalman.ctrv" are built in; any other key is the caller's to register, so it
+// is left untouched. A key already registered (e.g. a caller's own "kalman.cv")
+// is NOT overwritten — the caller's registration wins.
 void EnsureBuiltinFilter(const std::string& key) {
-  if (key != "kalman.cv") {
+  const bool is_cv = key == "kalman.cv";
+  const bool is_ctrv = key == "kalman.ctrv";
+  if (!is_cv && !is_ctrv) {
     return;
   }
   ihs::location::FilterEntry existing;
-  if (!ihs::location::LookupFilter(key, existing)) {
+  if (ihs::location::LookupFilter(key, existing)) {
+    return;  // a caller already registered this key
+  }
+  if (is_cv) {
     ihs::location::RegisterKalmanCvFilter();
+  } else {
+    ihs::location::RegisterKalmanCtrvFilter();
   }
 }
 

--- a/shared/tests/location/CMakeLists.txt
+++ b/shared/tests/location/CMakeLists.txt
@@ -101,6 +101,18 @@ target_link_libraries(kalman_cv_test PRIVATE Threads::Threads)
 
 add_test(NAME kalman_cv COMMAND kalman_cv_test)
 
+# CTRV extended Kalman filter: numerical-Jacobian check + turn tracking (beats
+# the CV filter). Compiles both filters (kalman_ctrv.cc + kalman_cv.cc).
+add_executable(kalman_ctrv_test kalman_ctrv_test.cc track_gen.cc
+        ${_loc_src}/kalman_ctrv.cc ${_loc_src}/kalman_cv.cc
+        ${_loc_src}/registry.cc)
+target_include_directories(kalman_ctrv_test PRIVATE
+        ${_loc_src} ${_loc_inc} ${CMAKE_CURRENT_BINARY_DIR}/gen)
+target_compile_options(kalman_ctrv_test PRIVATE -Wall -Wextra)
+target_link_libraries(kalman_ctrv_test PRIVATE Threads::Threads)
+
+add_test(NAME kalman_ctrv COMMAND kalman_ctrv_test)
+
 # gnss.file replay source: parses captured gpsd JSON and re-emits fixes as an
 # event source. Compiles file_source.cc + gpsd_provider.cc (ParseTpv) directly.
 add_executable(file_source_test file_source_test.cc
@@ -120,6 +132,7 @@ add_test(NAME file_source COMMAND file_source_test)
 add_executable(wire_test wire_test.cc
         ${_loc_src}/location_api.cc ${_loc_src}/manager.cc
         ${_loc_src}/registry.cc ${_loc_src}/kalman_cv.cc
+        ${_loc_src}/kalman_ctrv.cc
         ${_loc_src}/file_source.cc ${_loc_src}/gpsd_provider.cc
         ${_loc_src}/geoclue_provider.cc ${_loc_src}/fallback_source.cc
         ${_loc_src}/sd_bus_dynamic.cc)

--- a/shared/tests/location/kalman_ctrv_test.cc
+++ b/shared/tests/location/kalman_ctrv_test.cc
@@ -86,6 +86,9 @@ double RmseThroughOps(const IhsLocationFilterOps& ops,
                       const std::vector<TruthSample>& truth,
                       const std::vector<NoisyFix>& fixes) {
   void* inst = ops.create(nullptr, nullptr);
+  // Without this a create() failure would make update/estimate no-ops and the
+  // helper return 0, which a "< threshold" assertion would read as a pass.
+  Check(inst != nullptr, "filter instance created");
   double sum = 0.0;
   std::size_t n = 0;
   for (std::size_t i = 0; i < fixes.size(); ++i) {

--- a/shared/tests/location/kalman_ctrv_test.cc
+++ b/shared/tests/location/kalman_ctrv_test.cc
@@ -234,6 +234,30 @@ void TestYawRateCurvesPrediction() {
   ops.destroy(inst);
 }
 
+// A single gross position spike must be gated out by the 2-DOF NIS check.
+void TestOutlierRejection() {
+  const IhsLocationFilterOps& ops = KalmanCtrvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  // Settle on a stationary point.
+  for (int i = 0; i < 20; ++i) {
+    const IhsMeasurement m = PosMeas(kLat0, kLon0, 5.0, SecToNs(i));
+    ops.update(inst, &m);
+  }
+  IhsPosition before{};
+  ops.estimate(inst, SecToNs(20), &before);
+  // One gross outlier ~500 m north.
+  const double bad_lat = kLat0 + 500.0 / ihs::location::test::MetersPerDegLat();
+  const IhsMeasurement spike = PosMeas(bad_lat, kLon0, 5.0, SecToNs(21));
+  ops.update(inst, &spike);
+  IhsPosition after{};
+  ops.estimate(inst, SecToNs(21), &after);
+  const double moved = MetersBetween(after.latitude, after.longitude,
+                                     before.latitude, before.longitude, kLat0);
+  std::printf("outlier  : estimate moved %.2f m for a 500 m spike\n", moved);
+  Check(moved < 20.0, "a single gross outlier is gated out");
+  ops.destroy(inst);
+}
+
 void TestCoastingGrowsSigma() {
   const IhsLocationFilterOps& ops = KalmanCtrvFilterOps();
   void* inst = ops.create(nullptr, nullptr);
@@ -264,6 +288,7 @@ int main() {
   TestBeatsCvOnTurn();
   TestSpeedUpdate();
   TestYawRateCurvesPrediction();
+  TestOutlierRejection();
   TestCoastingGrowsSigma();
 
   if (g_failures == 0) {

--- a/shared/tests/location/kalman_ctrv_test.cc
+++ b/shared/tests/location/kalman_ctrv_test.cc
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Unit tests for the CTRV extended Kalman filter. The load-bearing one is the
+// numerical Jacobian check: an EKF's analytic Jacobian is its most error-prone
+// piece, so it is finite-differenced against the predict function. The rest are
+// behavioral: seeding, beating the raw fixes, beating the constant-velocity
+// filter on a turn (the reason CTRV exists), the scalar speed/yaw-rate updates
+// a CAN source drives, and a growing covariance while coasting.
+
+#include "kalman_ctrv.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "ihs/location.h"
+#include "kalman_cv.hpp"
+#include "track_gen.hpp"
+
+namespace {
+
+using ihs::location::KalmanCtrvFilterOps;
+using ihs::location::KalmanCtrvJacobianForTest;
+using ihs::location::KalmanCtrvPredictForTest;
+using ihs::location::KalmanCvFilterOps;
+using ihs::location::test::AddNoise;
+using ihs::location::test::MetersBetween;
+using ihs::location::test::NoisyFix;
+using ihs::location::test::Rng;
+using ihs::location::test::TruthSample;
+
+int g_tests = 0;
+int g_failures = 0;
+void Check(bool cond, const char* what) {
+  ++g_tests;
+  if (!cond) {
+    ++g_failures;
+    std::fprintf(stderr, "FAIL: %s\n", what);
+  }
+}
+
+constexpr double kLat0 = 48.0;
+constexpr double kLon0 = -122.0;
+
+uint64_t SecToNs(double s) {
+  return static_cast<uint64_t>(s * 1e9);
+}
+
+IhsMeasurement PosMeas(double lat, double lon, double sigma_m, uint64_t t_ns) {
+  IhsMeasurement m{};
+  m.struct_size = sizeof(m);
+  m.kind = IHS_MEAS_POSITION_LLA;
+  m.t_monotonic_ns = t_ns;
+  m.value_count = 2;
+  m.value[0] = lat;
+  m.value[1] = lon;
+  m.variance[0] = sigma_m * sigma_m;
+  m.variance[1] = sigma_m * sigma_m;
+  return m;
+}
+
+IhsMeasurement ScalarMeas(uint32_t kind, double v, double var, uint64_t t_ns) {
+  IhsMeasurement m{};
+  m.struct_size = sizeof(m);
+  m.kind = kind;
+  m.t_monotonic_ns = t_ns;
+  m.value_count = 1;
+  m.value[0] = v;
+  m.variance[0] = var;
+  return m;
+}
+
+// RMSE (meters) of a filter's estimate vs truth, feeding each noisy fix and
+// sampling the estimate at that fix's time.
+double RmseThroughOps(const IhsLocationFilterOps& ops,
+                      const std::vector<TruthSample>& truth,
+                      const std::vector<NoisyFix>& fixes) {
+  void* inst = ops.create(nullptr, nullptr);
+  double sum = 0.0;
+  std::size_t n = 0;
+  for (std::size_t i = 0; i < fixes.size(); ++i) {
+    const IhsMeasurement m =
+        PosMeas(fixes[i].lat, fixes[i].lon, fixes[i].sigma_m, fixes[i].t_ns);
+    ops.update(inst, &m);
+    IhsPosition out{};
+    if (ops.estimate(inst, fixes[i].t_ns, &out) == 1) {
+      const double d = MetersBetween(out.latitude, out.longitude, truth[i].lat,
+                                     truth[i].lon, kLat0);
+      sum += d * d;
+      ++n;
+    }
+  }
+  ops.destroy(inst);
+  return n == 0 ? 0.0 : std::sqrt(sum / static_cast<double>(n));
+}
+
+// The load-bearing test: the analytic Jacobian must match a central-difference
+// of the predict function, at both turning and near-straight states.
+void TestJacobianNumeric() {
+  const double states[][5] = {
+      {10.0, 20.0, 0.5, 12.0, 0.20},   // turning left
+      {-5.0, 8.0, 2.5, 9.0, -0.35},    // turning right
+      {3.0, -4.0, 1.0, 15.0, 1.0e-6},  // near-straight (limit branch)
+      {0.0, 0.0, 0.0, 0.0, 0.0},       // at rest
+      {1.0, 1.0, -1.2, 20.0, 0.05},    // fast, gentle turn
+  };
+  const double dt = 0.1;
+  bool ok = true;
+  for (const auto& s : states) {
+    double ja[25];
+    KalmanCtrvJacobianForTest(s, dt, ja);
+    for (int j = 0; j < 5; ++j) {
+      double xp[5];
+      double xm[5];
+      for (int c = 0; c < 5; ++c) {
+        xp[c] = s[c];
+        xm[c] = s[c];
+      }
+      const double h = 1.0e-6 * (std::fabs(s[j]) + 1.0e-3);
+      xp[j] += h;
+      xm[j] -= h;
+      double fp[5];
+      double fm[5];
+      KalmanCtrvPredictForTest(xp, dt, fp);
+      KalmanCtrvPredictForTest(xm, dt, fm);
+      for (int i = 0; i < 5; ++i) {
+        const double num = (fp[i] - fm[i]) / (2.0 * h);
+        if (std::fabs(num - ja[i * 5 + j]) > 1.0e-4) {
+          ok = false;
+        }
+      }
+    }
+  }
+  Check(ok, "analytic Jacobian matches the numerical derivative");
+}
+
+void TestSeeding() {
+  const IhsLocationFilterOps& ops = KalmanCtrvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  IhsPosition out{};
+  Check(ops.estimate(inst, 0, &out) == 0, "no estimate before a measurement");
+  const IhsMeasurement m = PosMeas(kLat0, kLon0, 8.0, SecToNs(0.0));
+  ops.update(inst, &m);
+  Check(ops.estimate(inst, SecToNs(0.0), &out) == 1, "estimate after seed");
+  Check(MetersBetween(out.latitude, out.longitude, kLat0, kLon0, kLat0) < 1.0,
+        "seed estimate sits on the first measurement");
+  ops.destroy(inst);
+}
+
+void TestBeatsRawStraight() {
+  const auto truth =
+      ihs::location::test::StraightTrack(kLat0, kLon0, 10.0, 0.0, 120, 1.0);
+  Rng rng(0xCC77);
+  const double sigma = 8.0;
+  const auto fixes = AddNoise(truth, sigma, rng);
+  const double rmse = RmseThroughOps(KalmanCtrvFilterOps(), truth, fixes);
+  std::printf("straight : rmse_ctrv=%.3f m (sigma=%.1f)\n", rmse, sigma);
+  Check(rmse < sigma * 1.2, "CTRV beats raw on a straight track");
+}
+
+// The reason CTRV exists: on a constant-radius turn it should track the corner
+// the straight-line CV filter lags.
+void TestBeatsCvOnTurn() {
+  const auto truth = ihs::location::test::ConstantTurnTrack(
+      kLat0, kLon0, /*speed_mps=*/15.0, /*yaw_rate_dps=*/12.0,
+      /*heading0_deg=*/0.0, /*n=*/120, /*dt_s=*/0.5);
+  Rng rng(0x7717);
+  const auto fixes = AddNoise(truth, 6.0, rng);
+  const double rmse_ctrv = RmseThroughOps(KalmanCtrvFilterOps(), truth, fixes);
+  const double rmse_cv = RmseThroughOps(KalmanCvFilterOps(), truth, fixes);
+  std::printf("turn     : rmse_ctrv=%.3f m  rmse_cv=%.3f m\n", rmse_ctrv,
+              rmse_cv);
+  Check(rmse_ctrv < rmse_cv, "CTRV tracks a turn better than CV");
+}
+
+// A CAN ground-speed measurement is a scalar update on v: feeding it drives the
+// reported speed toward the measured value.
+void TestSpeedUpdate() {
+  const IhsLocationFilterOps& ops = KalmanCtrvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  // Seed with a position, then feed speed measurements of 18 m/s.
+  const IhsMeasurement seed = PosMeas(kLat0, kLon0, 5.0, SecToNs(0.0));
+  ops.update(inst, &seed);
+  for (int i = 1; i <= 20; ++i) {
+    const IhsMeasurement s = ScalarMeas(IHS_MEAS_SPEED, 18.0, 0.25, SecToNs(i));
+    ops.update(inst, &s);
+  }
+  IhsPosition out{};
+  ops.estimate(inst, SecToNs(20), &out);
+  std::printf("speed    : reported=%.2f m/s (measured 18.0)\n", out.speed_mps);
+  Check(std::abs(out.speed_mps - 18.0) < 2.0, "speed measurement converges v");
+  ops.destroy(inst);
+}
+
+// A yaw-rate measurement (gyro/CAN) sets omega, so a coasted estimate curves.
+// Seed a straight eastward track (bearing 90 deg), inject a yaw rate, then
+// coast and confirm the heading rotated.
+void TestYawRateCurvesPrediction() {
+  const IhsLocationFilterOps& ops = KalmanCtrvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  const auto truth =
+      ihs::location::test::StraightTrack(kLat0, kLon0, 12.0, 0.0, 20, 0.5);
+  for (const auto& s : truth) {
+    const IhsMeasurement m = PosMeas(s.lat, s.lon, 3.0, s.t_ns);
+    ops.update(inst, &m);
+  }
+  const uint64_t t = truth.back().t_ns;
+  IhsPosition before{};
+  ops.estimate(inst, t, &before);
+  // Strong left yaw for a few samples (tight variance so omega moves).
+  for (int i = 1; i <= 5; ++i) {
+    const IhsMeasurement y =
+        ScalarMeas(IHS_MEAS_YAW_RATE, 0.5, 0.0025, t + SecToNs(i * 0.1));
+    ops.update(inst, &y);
+  }
+  IhsPosition after{};
+  ops.estimate(inst, t + SecToNs(1.5), &after);
+  std::printf("yaw-rate : bearing %.1f deg -> %.1f deg after a coasted turn\n",
+              before.bearing_deg, after.bearing_deg);
+  Check(before.has_bearing != 0 && after.has_bearing != 0,
+        "bearing valid before and after");
+  Check(std::abs(after.bearing_deg - before.bearing_deg) > 10.0,
+        "a yaw-rate measurement curves the coasted heading");
+  ops.destroy(inst);
+}
+
+void TestCoastingGrowsSigma() {
+  const IhsLocationFilterOps& ops = KalmanCtrvFilterOps();
+  void* inst = ops.create(nullptr, nullptr);
+  const auto truth =
+      ihs::location::test::StraightTrack(kLat0, kLon0, 6.0, 0.0, 20, 1.0);
+  for (const auto& s : truth) {
+    const IhsMeasurement m = PosMeas(s.lat, s.lon, 5.0, s.t_ns);
+    ops.update(inst, &m);
+  }
+  const uint64_t t = truth.back().t_ns;
+  IhsPosition a{};
+  IhsPosition b{};
+  ops.estimate(inst, t + SecToNs(1.0), &a);
+  ops.estimate(inst, t + SecToNs(10.0), &b);
+  std::printf("coast    : sigma_e %.2f m -> %.2f m over +9 s\n", a.sigma_e_m,
+              b.sigma_e_m);
+  Check(b.sigma_e_m > a.sigma_e_m && b.sigma_n_m > a.sigma_n_m,
+        "reported accuracy degrades while coasting");
+  ops.destroy(inst);
+}
+
+}  // namespace
+
+int main() {
+  TestJacobianNumeric();
+  TestSeeding();
+  TestBeatsRawStraight();
+  TestBeatsCvOnTurn();
+  TestSpeedUpdate();
+  TestYawRateCurvesPrediction();
+  TestCoastingGrowsSigma();
+
+  if (g_failures == 0) {
+    std::printf("kalman_ctrv_test: all %d checks passed\n", g_tests);
+  } else {
+    std::fprintf(stderr, "kalman_ctrv_test: %d/%d checks FAILED\n", g_failures,
+                 g_tests);
+  }
+  return g_failures == 0 ? 0 : 1;
+}

--- a/shared/tests/location/kalman_ctrv_test.cc
+++ b/shared/tests/location/kalman_ctrv_test.cc
@@ -104,6 +104,9 @@ double RmseThroughOps(const IhsLocationFilterOps& ops,
     }
   }
   ops.destroy(inst);
+  // Guard the empty case: with no successful estimate(), an RMSE of 0 would let
+  // a "< threshold" assertion pass even though the filter produced nothing.
+  Check(n > 0, "filter produced estimates");
   return n == 0 ? 0.0 : std::sqrt(sum / static_cast<double>(n));
 }
 

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -143,6 +143,29 @@ void TestFileThroughKalman() {
   Check(p.mode == 3, "3D source keeps mode 3 through the filter");
 }
 
+void TestFileThroughCtrv() {
+  // The other built-in filter is reachable the same way end to end.
+  const auto path = WriteTrackFixture("ihs_wire_ctrv.jsonl", 15.0, 40, 0.025);
+  Collector c;
+  IhsLocationService* svc = ihs_location_start_filtered(
+      IHS_LOCATION_FILE, path.string().c_str(), "kalman.ctrv", nullptr);
+  Check(svc != nullptr, "start FILE + kalman.ctrv");
+  if (svc == nullptr) {
+    std::filesystem::remove(path);
+    return;
+  }
+  ihs_location_set_callback(svc, &Collector::Thunk, &c);
+  Check(c.WaitFor(30, std::chrono::seconds(5)), "ctrv fixes delivered");
+  ihs_location_stop(svc);
+  std::filesystem::remove(path);
+  if (c.count() > 0) {
+    const IhsPosition p = c.last();
+    Check(std::isfinite(p.latitude) && std::isfinite(p.longitude) &&
+              p.speed_mps > 15.0 * 0.5,
+          "ctrv delivers a finite fix with recovered speed");
+  }
+}
+
 void TestFilePassthrough() {
   // The same source with no filter still delivers fixes (the passthrough path).
   const auto path =

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -218,6 +218,7 @@ void TestBadPathAndKeys() {
 
 int main() {
   TestFileThroughKalman();
+  TestFileThroughCtrv();
   TestFilePassthrough();
   TestBadPathAndKeys();
 


### PR DESCRIPTION
Where `kalman.cv` (#355) assumes a straight line and lags a corner, the CTRV EKF follows a constant-radius arc, so it tracks a turn without cutting it. State `[px, py, ψ, v, ω]`: position east/north (local tangent plane), heading, speed, yaw rate.

## What's new

- **`kalman_ctrv.{hpp,cc}`** — a constant-turn-rate-and-velocity EKF. The motion model is nonlinear, so predict uses its analytic Jacobian; the measurement updates are all linear.
- **Corrects from GNSS position**, and — the reason the richer model earns its keep — **directly from a yaw-rate (`IHS_MEAS_YAW_RATE`) or ground-speed (`IHS_MEAS_SPEED`) measurement** when a gyro/CAN source provides one, each a scalar linear update on ω / v.
- Same robustness as `kalman.cv`: per-measurement chi-square gate (2-DOF position, 1-DOF scalar) with persistent-divergence reset, monotonic-clock `dt`, out-of-order drop, pole-clamped scale, ~10 km re-anchor. A 5×5 fixed-size matrix implementation, **no Eigen**.
- Registered as a built-in, reachable through the **existing** `ihs_location_start_filtered(source, config, "kalman.ctrv", ...)`. **No new ABI** — no new export or enum; filter symbols are internal (verified 0 exported).

## Verification — `kalman_ctrv_test`

The load-bearing test **finite-differences the predict function and compares to the analytic Jacobian** at turning and near-straight states. An EKF's Jacobian is its most error-prone piece, and this caught a real bug: the straight-line predict branch dropped ω's effect on position while the Jacobian kept the arc-form limit — an inconsistency a behavioral test on a gentle track would miss (and which was also corrupting straight-track tracking).

Measured:
```
straight : rmse_ctrv=7.60 m (sigma=8.0)          -> beats raw
turn     : rmse_ctrv=4.97 m  rmse_cv=11.68 m      -> less than half CV's error
speed    : reported=18.00 m/s (measured 18.0)     -> scalar update converges
yaw-rate : bearing 90.0 -> 14.4 deg after coast   -> yaw-rate curves the prediction
coast    : sigma_e 5.98 m -> ... growing          -> honest accuracy
```

`wire_test` also drives `kalman.ctrv` end to end through the real C ABI (`ihs_location_start_filtered(IHS_LOCATION_FILE, ..., "kalman.ctrv")`).

## Notes

- The two `KalmanCtrv*ForTest` hooks are internal (not exported), like `KalmanCvFilterOps` — they exist so the Jacobian can be verified numerically, which for an EKF is not optional.
- Tuning: default yaw-acceleration noise `qw` was lowered from an initial guess so the filter doesn't fit position noise as spurious turns on a straight; `"qa=<v>"` / `"qw=<v>"` config overrides both knobs.
- clang-tidy-19 + clang-format-19 clean; all 9 location tests pass in ~1.2 s.

This is the last filter increment in the Kalman location plan — the core arc (measurement/registry → Manager → subscribe → gnss.file + harness → kalman.cv → wiring → kalman.ctrv) is now complete.