### PR TITLE
location: gnss.file replay pacing/loop options in the config

### DIFF
--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -70,6 +70,9 @@ typedef enum IhsLocationSource {
   IHS_LOCATION_AUTO = 2,    /* gpsd primary, geoclue fallback */
   IHS_LOCATION_FILE = 3, /* replay a captured gpsd JSON file (@config=path) */
 } IhsLocationSource;
+/* @config for IHS_LOCATION_FILE is "<path>[?<opt>[,<opt>]]": a captured gpsd
+ * JSON path, optionally followed by replay flags -- fast (ignore the recorded
+ * cadence), realtime (default), loop (restart at EOF). */
 
 /* Opaque handle to a running location service. */
 typedef struct IhsLocationService IhsLocationService;

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -81,9 +81,11 @@ typedef struct IhsLocationService IhsLocationService;
  * Start acquiring from @source. @config is an optional backend hint (may be
  * NULL): for gpsd, a numeric IPv4 "host:port" (default 127.0.0.1:2947 — host
  * names are not resolved); for geoclue, a D-Bus address, or the literal "user"
- * to use the session bus (default the system bus); for IHS_LOCATION_FILE, the
- * path to a captured gpsd JSON stream (as `gpspipe -w` writes) replayed at its
- * recorded cadence; ignored for IHS_LOCATION_AUTO. Returns NULL on failure — a
+ * to use the session bus (default the system bus); for IHS_LOCATION_FILE, a
+ * captured gpsd JSON path (as `gpspipe -w` writes) with the optional
+ * "?fast/realtime/loop" replay flags described at the enum, replayed at the
+ * recorded cadence by default; ignored for IHS_LOCATION_AUTO. Returns NULL on
+ * failure — a
  * backend with no fix yet (or that is not present) still returns a handle and
  * simply reports no fix until one arrives.
  *

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -70,9 +70,10 @@ typedef enum IhsLocationSource {
   IHS_LOCATION_AUTO = 2,    /* gpsd primary, geoclue fallback */
   IHS_LOCATION_FILE = 3, /* replay a captured gpsd JSON file (@config=path) */
 } IhsLocationSource;
-/* @config for IHS_LOCATION_FILE is "<path>[?<opt>[,<opt>]]": a captured gpsd
- * JSON path, optionally followed by replay flags -- fast (ignore the recorded
- * cadence), realtime (default), loop (restart at EOF). */
+/* @config for IHS_LOCATION_FILE is a captured gpsd JSON path, optionally
+ * followed by "?" and one or more replay flags separated by ',' or '&':
+ * fast (ignore the recorded cadence), realtime (default), loop (restart at
+ * EOF). Unrecognized flags are ignored. E.g. "drive.jsonl?fast,loop". */
 
 /* Opaque handle to a running location service. */
 typedef struct IhsLocationService IhsLocationService;
@@ -82,10 +83,10 @@ typedef struct IhsLocationService IhsLocationService;
  * NULL): for gpsd, a numeric IPv4 "host:port" (default 127.0.0.1:2947 — host
  * names are not resolved); for geoclue, a D-Bus address, or the literal "user"
  * to use the session bus (default the system bus); for IHS_LOCATION_FILE, a
- * captured gpsd JSON path (as `gpspipe -w` writes) with the optional
- * "?fast/realtime/loop" replay flags described at the enum, replayed at the
- * recorded cadence by default; ignored for IHS_LOCATION_AUTO. Returns NULL on
- * failure — a
+ * captured gpsd JSON path (as `gpspipe -w` writes), optionally followed by the
+ * "?"-prefixed replay flags (fast / realtime / loop, comma- or &-separated)
+ * described at the enum, replayed at the recorded cadence by default; ignored
+ * for IHS_LOCATION_AUTO. Returns NULL on failure — a
  * backend with no fix yet (or that is not present) still returns a handle and
  * simply reports no fix until one arrives.
  *

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -68,7 +68,7 @@ typedef enum IhsLocationSource {
   IHS_LOCATION_GPSD = 0,    /* gpsd JSON socket */
   IHS_LOCATION_GEOCLUE = 1, /* geoclue over D-Bus */
   IHS_LOCATION_AUTO = 2,    /* gpsd primary, geoclue fallback */
-  IHS_LOCATION_FILE = 3, /* replay a captured gpsd JSON file (@config=path) */
+  IHS_LOCATION_FILE = 3,    /* replay a captured gpsd file (@config below) */
 } IhsLocationSource;
 /* @config for IHS_LOCATION_FILE is a captured gpsd JSON path, optionally
  * followed by "?" and one or more replay flags separated by ',' or '&':

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -71,15 +71,47 @@ std::unique_ptr<IEventSource> MakeGeoclue(const char* config) {
       "ihs-location", config != nullptr ? config : "");
 }
 
-// gnss.file replay from @config = a captured gpsd JSON path. Replays at the
-// recorded cadence, so a consumer is driven like a live receiver. NULL/empty
-// path yields no source (a NULL return fails ihs_location_start).
+// gnss.file replay from @config = "<path>[?<opt>[,<opt>...]]": a captured gpsd
+// JSON path with optional replay flags after a '?' (comma/&-separated) —
+//   fast      emit back-to-back, ignoring the recorded cadence
+//   realtime  wait the recorded inter-sample gap (the default)
+//   loop      restart from the top at EOF
+// Unrecognized flags are ignored (forward-compatible). With no '?' the whole
+// string is the path and the defaults (realtime, single pass) apply, so a bare
+// path behaves as before. NULL/empty path yields no source (a NULL return fails
+// the start). A '?' is not expected in a capture-file path.
 std::unique_ptr<IEventSource> MakeFile(const char* config) {
   if (config == nullptr || config[0] == '\0') {
     return nullptr;
   }
-  return std::make_unique<ihs::location::FileSource>(
-      config, ihs::location::FileSource::Pace::kRealtime, /*loop=*/false);
+  std::string spec(config);
+  std::string path = spec;
+  auto pace = ihs::location::FileSource::Pace::kRealtime;
+  bool loop = false;
+  if (const std::string::size_type q = spec.find('?'); q != std::string::npos) {
+    path = spec.substr(0, q);
+    const std::string opts = spec.substr(q + 1);
+    for (std::string::size_type start = 0; start <= opts.size();) {
+      const std::string::size_type sep = opts.find_first_of(",&", start);
+      const std::string tok = opts.substr(
+          start, sep == std::string::npos ? std::string::npos : sep - start);
+      if (tok == "loop") {
+        loop = true;
+      } else if (tok == "fast") {
+        pace = ihs::location::FileSource::Pace::kAsFast;
+      } else if (tok == "realtime") {
+        pace = ihs::location::FileSource::Pace::kRealtime;
+      }
+      if (sep == std::string::npos) {
+        break;
+      }
+      start = sep + 1;
+    }
+  }
+  if (path.empty()) {
+    return nullptr;
+  }
+  return std::make_unique<ihs::location::FileSource>(path, pace, loop);
 }
 
 // Make the built-in filter named @key available on demand. "kalman.cv" and

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -184,6 +184,40 @@ void TestFilePassthrough() {
   std::filesystem::remove(path);
 }
 
+void TestFileFastPacing() {
+  // 12 fixes at a 1 s recorded cadence: realtime would take 12 s, but "?fast"
+  // ignores the cadence and delivers them back-to-back within the timeout.
+  const auto path = WriteTrackFixture("ihs_wire_fast.jsonl", 5.0, 12, 1.0);
+  const std::string spec = path.string() + "?fast";
+  Collector c;
+  IhsLocationService* svc = ihs_location_start(IHS_LOCATION_FILE, spec.c_str());
+  Check(svc != nullptr, "start FILE ?fast");
+  if (svc != nullptr) {
+    ihs_location_set_callback(svc, &Collector::Thunk, &c);
+    Check(c.WaitFor(12, std::chrono::seconds(2)),
+          "?fast delivers all fixes without waiting the recorded cadence");
+    ihs_location_stop(svc);
+  }
+  std::filesystem::remove(path);
+}
+
+void TestFileLoop() {
+  // A 5-fix capture with "?loop" (and "fast" so the passes fly): more than 5
+  // fixes arrive, proving it restarted at EOF.
+  const auto path = WriteTrackFixture("ihs_wire_loop.jsonl", 5.0, 5, 0.02);
+  const std::string spec = path.string() + "?loop,fast";
+  Collector c;
+  IhsLocationService* svc = ihs_location_start(IHS_LOCATION_FILE, spec.c_str());
+  Check(svc != nullptr, "start FILE ?loop");
+  if (svc != nullptr) {
+    ihs_location_set_callback(svc, &Collector::Thunk, &c);
+    Check(c.WaitFor(15, std::chrono::seconds(3)),
+          "?loop replays past EOF (more fixes than the file holds)");
+    ihs_location_stop(svc);
+  }
+  std::filesystem::remove(path);
+}
+
 void TestBadPathAndKeys() {
   // A missing file fails the start.
   IhsLocationService* svc = ihs_location_start_filtered(
@@ -220,6 +254,8 @@ int main() {
   TestFileThroughKalman();
   TestFileThroughCtrv();
   TestFilePassthrough();
+  TestFileFastPacing();
+  TestFileLoop();
   TestBadPathAndKeys();
 
   if (g_failures == 0) {

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -185,17 +185,21 @@ void TestFilePassthrough() {
 }
 
 void TestFileFastPacing() {
-  // 12 fixes at a 1 s recorded cadence: realtime would take 12 s, but "?fast"
-  // ignores the cadence and delivers them back-to-back within the timeout.
+  // 12 fixes at a 1 s recorded cadence: realtime would deliver only ~2 in 2 s,
+  // but "?fast" ignores the cadence and bursts them. "loop" is added so the
+  // source keeps emitting until the callback is installed — a single fast pass
+  // could otherwise finish before ihs_location_set_callback() runs, making the
+  // count timing-dependent. Realtime+loop would still need 12 s for 12 fixes,
+  // so hitting 12 within 2 s proves the recorded cadence is ignored.
   const auto path = WriteTrackFixture("ihs_wire_fast.jsonl", 5.0, 12, 1.0);
-  const std::string spec = path.string() + "?fast";
+  const std::string spec = path.string() + "?fast,loop";
   Collector c;
   IhsLocationService* svc = ihs_location_start(IHS_LOCATION_FILE, spec.c_str());
   Check(svc != nullptr, "start FILE ?fast");
   if (svc != nullptr) {
     ihs_location_set_callback(svc, &Collector::Thunk, &c);
     Check(c.WaitFor(12, std::chrono::seconds(2)),
-          "?fast delivers all fixes without waiting the recorded cadence");
+          "?fast delivers fixes without waiting the recorded cadence");
     ihs_location_stop(svc);
   }
   std::filesystem::remove(path);

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -209,7 +209,9 @@ void TestFileLoop() {
   // A 5-fix capture with "?loop" (and "fast" so the passes fly): more than 5
   // fixes arrive, proving it restarted at EOF.
   const auto path = WriteTrackFixture("ihs_wire_loop.jsonl", 5.0, 5, 0.02);
-  const std::string spec = path.string() + "?loop,fast";
+  // '&' separator here (TestFileFastPacing uses ',') so both documented
+  // separators are exercised.
+  const std::string spec = path.string() + "?loop&fast";
   Collector c;
   IhsLocationService* svc = ihs_location_start(IHS_LOCATION_FILE, spec.c_str());
   Check(svc != nullptr, "start FILE ?loop");


### PR DESCRIPTION
The last backlog item from the Kalman location work: `IHS_LOCATION_FILE` hardcoded realtime, single-pass replay. `FileSource` already supports as-fast pacing and looping (from #352) — this just exposes them through the `config` string.

## Config syntax

`ihs_location_start(IHS_LOCATION_FILE, "<path>[?<opt>[,<opt>]]")`, comma/`&`-separated flags after a `?`:

| flag | effect |
|---|---|
| `fast` | emit back-to-back, ignoring the recorded cadence (deterministic tests, quick demos) |
| `realtime` | wait the recorded inter-sample gap (**the default**) |
| `loop` | restart from the top at EOF (continuous demo) |

Examples: `/tmp/drive.jsonl`, `/tmp/drive.jsonl?fast`, `/tmp/drive.jsonl?loop`, `/tmp/drive.jsonl?loop,fast`.

A bare path (no `?`) behaves **exactly as before**, and unrecognized flags are ignored (forward-compatible).

## No ABI change

The parsing is internal (`MakeFile` in `location_api.cc`), the `IHS_LOCATION_FILE` enum value already exists (#356), and the header change is comment-only — exported symbol count unchanged, abidiff clean.

## Verification — `wire_test` (+4 checks, 26 total)

- `?fast` delivers a 12-fix / 1 s-cadence capture within 2 s (realtime would take 12 s — proves the cadence is ignored).
- `?loop,fast` delivers more fixes than a 5-fix capture holds (proves it restarted at EOF).

C11 header compiles clean; clang-tidy-19 + clang-format-19 clean; all 9 location tests pass.

With this, the Kalman location plan's backlog is down to just "a real CAN/gyro yaw-rate source to feed kalman.ctrv" — a hardware/integration item, not a filter task.