### PR TITLE
drm_kms_egl: scan ihs_pv platform views out on a KMS plane

### DIFF
--- a/shared/include/ihs/platform_view.h
+++ b/shared/include/ihs/platform_view.h
@@ -499,13 +499,17 @@ typedef struct IhsFrame {
  * Hand the registry a produced @frame for @view. Used by all kinds
  * (TEXTURE_DMABUF_IMPORT, SOFTWARE_SHM, and the registry-driven DRM_PLANE).
  * @acquire_fence_fd signals when the plugin's production completed (-1 for
- * implicit sync); the registry takes ownership of the fd. On an explicit-sync
- * grant *out_release_fence_fd is set to a fence that fires when the buffer is
- * free to reuse — the plugin owns and closes it, and waits on it before
- * overwriting that buffer; on implicit paths it is -1 and release rides
- * IhsPvCallbacks / the native protocol. The plugin keeps whatever buffer ring
- * it wants (double, triple, N); the registry never counts them. Returns
- * IHS_PV_OK or a negative IhsPvResult.
+ * implicit sync); the registry takes ownership of the fd. *out_release_fence_fd,
+ * when the registry sets it to a non-negative fd, is a release fence that fires
+ * when the buffer is free to reuse: the plugin owns that fd and must close it
+ * (waiting on it first before overwriting the buffer). The registry may return
+ * one under any sync mode — the DRM_PLANE path returns a per-buffer release
+ * eventfd even on an implicit-sync grant, since it has no other back-channel to
+ * the producer. -1 means no fence for this submit and release rides
+ * IhsPvCallbacks / the native protocol; a plugin must therefore always close a
+ * returned fd regardless of the negotiated sync mode. The plugin keeps whatever
+ * buffer ring it wants (double, triple, N); the registry never counts them.
+ * Returns IHS_PV_OK or a negative IhsPvResult.
  */
 IHS_EXPORT int ihs_pv_submit(IhsPlatformView* view,
                              const IhsFrame* frame,

--- a/shared/include/ihs/platform_view.h
+++ b/shared/include/ihs/platform_view.h
@@ -499,17 +499,17 @@ typedef struct IhsFrame {
  * Hand the registry a produced @frame for @view. Used by all kinds
  * (TEXTURE_DMABUF_IMPORT, SOFTWARE_SHM, and the registry-driven DRM_PLANE).
  * @acquire_fence_fd signals when the plugin's production completed (-1 for
- * implicit sync); the registry takes ownership of the fd. *out_release_fence_fd,
- * when the registry sets it to a non-negative fd, is a release fence that fires
- * when the buffer is free to reuse: the plugin owns that fd and must close it
- * (waiting on it first before overwriting the buffer). The registry may return
- * one under any sync mode — the DRM_PLANE path returns a per-buffer release
- * eventfd even on an implicit-sync grant, since it has no other back-channel to
- * the producer. -1 means no fence for this submit and release rides
- * IhsPvCallbacks / the native protocol; a plugin must therefore always close a
- * returned fd regardless of the negotiated sync mode. The plugin keeps whatever
- * buffer ring it wants (double, triple, N); the registry never counts them.
- * Returns IHS_PV_OK or a negative IhsPvResult.
+ * implicit sync); the registry takes ownership of the fd.
+ * *out_release_fence_fd, when the registry sets it to a non-negative fd, is a
+ * release fence that fires when the buffer is free to reuse: the plugin owns
+ * that fd and must close it (waiting on it first before overwriting the
+ * buffer). The registry may return one under any sync mode — the DRM_PLANE path
+ * returns a per-buffer release eventfd even on an implicit-sync grant, since it
+ * has no other back-channel to the producer. -1 means no fence for this submit
+ * and release rides IhsPvCallbacks / the native protocol; a plugin must
+ * therefore always close a returned fd regardless of the negotiated sync mode.
+ * The plugin keeps whatever buffer ring it wants (double, triple, N); the
+ * registry never counts them. Returns IHS_PV_OK or a negative IhsPvResult.
  */
 IHS_EXPORT int ihs_pv_submit(IhsPlatformView* view,
                              const IhsFrame* frame,

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2657,6 +2657,12 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
             "[DrmCompositor] ExternalDmaBufPool::create (pv): {}; routing "
             "through GL fallback",
             pool.error().message());
+        // GetDmabuf already delivered this frame, so it won't be superseded and
+        // no pool exists to fire OnScanoutRelease -- release it here or the
+        // producer blocks forever waiting to reuse the slot.
+        if (fl.pv_surface) {
+          fl.pv_surface->OnScanoutRelease(db.buffer_id);
+        }
         return PresentViaGlFallback(layers, layer_count);
       }
       auto* pool_raw = pool.value().get();
@@ -2673,6 +2679,10 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       if (!handle) {
         ihs::log::warn("[DrmCompositor] LayerScene::add_layer (pv): {}",
                        handle.error().message());
+        // Delivered but never reached a pool that would release it (see above).
+        if (fl.pv_surface) {
+          fl.pv_surface->OnScanoutRelease(db.buffer_id);
+        }
         return PresentViaGlFallback(layers, layer_count);
       }
       scene_pv_tags_.push_back(fl.pv_tag);

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2368,10 +2368,21 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     ~PvFdCloser() {
       for (auto& fl : fls) {
         if (fl.pv_tag != nullptr) {
+          // Close each distinct fd once. GetDmabuf dups every plane, so these
+          // are normally all distinct, but the Dmabuf contract permits a
+          // single-handle layout to repeat one fd across planes -- closing it
+          // twice could reap an unrelated fd that reused the number. Clear
+          // every entry holding a value as it is closed.
           for (int& pfd : fl.pv_db.fd) {
-            if (pfd >= 0) {
-              ::close(pfd);
-              pfd = -1;
+            if (pfd < 0) {
+              continue;
+            }
+            const int fd = pfd;
+            ::close(fd);
+            for (int& other : fl.pv_db.fd) {
+              if (other == fd) {
+                other = -1;
+              }
             }
           }
         }

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -39,6 +39,7 @@
 #include <xf86drmMode.h>
 
 #include <drm-cxx/core/format.hpp>
+#include <drm-cxx/scene/external_dma_buf_pool.hpp>
 #include <drm-cxx/scene/external_dma_buf_source.hpp>
 #include <drm-cxx/sync/fence.hpp>
 
@@ -2337,7 +2338,7 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   // tag didn't appear this frame. Backing stores are keyed by their
   // StoreBaton; platform views by their ICompositorSurface pointer. A
   // platform view that exports a dma-buf goes onto a KMS overlay plane
-  // via ExternalDmaBufSource; one that can't (GL-only, or no frame yet)
+  // via an ExternalDmaBufPool; one that can't (GL-only, or no frame yet)
   // drops the whole frame to GL composition — the same all-or-nothing
   // rule the backing-store overflow uses below.
   struct FrameLayer {
@@ -2346,6 +2347,9 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     GbmBackingStore* store;            // non-null for backing-store layers
     void* pv_tag;                      // PV surface* identity tag (null for BS)
     ICompositorSurface::Dmabuf pv_db;  // PV frame (valid when pv_tag != null)
+    // Keeps the PV surface alive so the pool's OnBufferRelease (which calls
+    // back into it) is safe even if the view is disposed this frame.
+    std::shared_ptr<ICompositorSurface> pv_surface;
   };
   std::vector<FrameLayer> frame_layers;
   frame_layers.reserve(layer_count);
@@ -2357,16 +2361,20 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   frame_pv_tags.reserve(layer_count);
 
   // GetDmabuf hands back an owned (dup'd) fd per platform view; close them on
-  // every exit path (each GL-fallback return below, and the normal exit).
-  // ExternalDmaBufSource::create dups again for the KMS framebuffer, so closing
-  // after the scene layer is built is correct.
+  // every exit path (each GL-fallback return below, and the normal exit). The
+  // pool's first-sight import dups again for the KMS framebuffer, so closing
+  // after the frame is submitted is correct.
   struct PvFdCloser {
     std::vector<FrameLayer>& fls;
     ~PvFdCloser() {
       for (auto& fl : fls) {
-        if (fl.pv_tag != nullptr && fl.pv_db.fd >= 0) {
-          ::close(fl.pv_db.fd);
-          fl.pv_db.fd = -1;
+        if (fl.pv_tag != nullptr) {
+          for (int& pfd : fl.pv_db.fd) {
+            if (pfd >= 0) {
+              ::close(pfd);
+              pfd = -1;
+            }
+          }
         }
         // Close the producer's acquire fence. drm::sync::SyncFence::import_fd
         // (used by set_acquire_fence below) DUPS the fd rather than taking
@@ -2392,7 +2400,7 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       if (!baton || !baton->store) {
         continue;
       }
-      frame_layers.push_back({fl, baton, baton->store, nullptr, {}});
+      frame_layers.push_back({fl, baton, baton->store, nullptr, {}, nullptr});
       frame_batons.push_back(baton);
     } else if (fl->type == kFlutterLayerContentTypePlatformView &&
                fl->platform_view) {
@@ -2431,7 +2439,8 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
         // samples the surface's GL texture / Vulkan image.
         return PresentViaGlFallback(layers, layer_count);
       }
-      frame_layers.push_back({fl, nullptr, nullptr, surface.get(), db});
+      frame_layers.push_back(
+          {fl, nullptr, nullptr, surface.get(), db, surface});
       frame_pv_tags.push_back(surface.get());
     }
   }
@@ -2461,6 +2470,10 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   };
   const int bs_pruned = prune(scene_layer_batons_, frame_batons);
   const int pv_pruned = prune(scene_pv_tags_, frame_pv_tags);
+  // A pruned PV's layer (removed above) carries its ExternalDmaBufPool into the
+  // scene's source-retire ring; the scene release_with_fence()es the pool's
+  // in-flight buffer as it retires, firing OnBufferRelease back to the
+  // producer. So there is no separate scanout history to drain here.
 
   // Add new layers; update geometry/zpos on existing ones. dst_rect is
   // in CRTC coordinates; the non-framed path has no letterbox so
@@ -2480,6 +2493,37 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   // on the primary plane, whose zpos is immutable on some drivers.
   int bs_reused = 0, bs_new = 0, pv_reused = 0, pv_new = 0;
   int z_index = -1;
+  // Hand a freshly-delivered platform-view frame to its pool. The pool imports
+  // each decoder ring slot (keyed by buffer_id) once and reuses the cached
+  // fb_id on every recycle, so there is no per-frame AddFB2 and no
+  // deduped-GEM-handle double-close. The producer's acquire fence (if any)
+  // rides submit; the pool's OnBufferRelease returns each buffer_id to the
+  // producer when it leaves scanout. import_fd / the pool's dup keep our fds
+  // valid, so PvFdCloser still closes the originals at scope exit.
+  const auto submit_pv_pool = [](drm::scene::ExternalDmaBufPool* pool,
+                                 const ICompositorSurface::Dmabuf& db) {
+    const uint32_t np = db.plane_count < 4 ? db.plane_count : 4;
+    std::array<drm::scene::ExternalPlaneInfo, 4> planes{};
+    for (uint32_t p = 0; p < np; ++p) {
+      planes[p] =
+          drm::scene::ExternalPlaneInfo{db.fd[p], db.offset[p], db.stride[p]};
+    }
+    std::optional<drm::sync::SyncFence> acquire;
+    if (db.acquire_fence_fd >= 0) {
+      if (auto f = drm::sync::SyncFence::import_fd(db.acquire_fence_fd); f) {
+        acquire = std::move(f.value());
+      } else {
+        ihs::log::warn(
+            "[DrmCompositor] pv acquire-fence import failed ({}); implicit "
+            "sync this frame",
+            f.error().message());
+      }
+    }
+    pool->submit(
+        db.buffer_id,
+        drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(), np),
+        std::move(acquire));
+  };
   for (auto& fl : frame_layers) {
     ++z_index;
     const bool is_ui = (z_index == 0);
@@ -2532,59 +2576,39 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     } else {
       // ── Platform view: wrap the dma-buf as a scene buffer source ──
       if (auto* layer = scene_->find_by_identity_tag(fl.pv_tag)) {
-        // Reused layer: swap in this frame's dma-buf so a per-frame producer
-        // (a decoder, a camera) scans out fresh content instead of the first
-        // frame forever. replace_source retires the displaced source only once
-        // its in-flight buffers release (with their release fences), so nothing
-        // is freed while the kernel may still scan it. ExternalDmaBufSource
-        // dups the fds and does its own AddFB2WithModifiers; the pv_fd_closer
-        // closes our dup at scope exit.
+        // Reused layer: the pool created on first sight owns this PV's imports.
+        // Submit this frame's buffer_id; the pool reuses the cached fb_id when
+        // the decoder recycles a ring slot (no re-import, no double-close) and
+        // returns each buffer to the producer via OnBufferRelease when it
+        // leaves scanout -- so there is no RecordPvScanout / depth-history
+        // here.
         const auto& db = fl.pv_db;
         // GetDmabuf is deliver-once: a valid descriptor here means a fresh
         // frame this present. When it's empty (fd < 0 — the producer had no new
-        // frame), keep the source already on the plane rather than tearing the
-        // layer down, so the last frame holds until the next one arrives.
-        if (db.fd >= 0 && db.plane_count > 0) {
-          const uint32_t np = db.plane_count;
-          std::array<drm::scene::ExternalPlaneInfo, 4> planes{};
-          for (uint32_t p = 0; p < np && p < 4; ++p) {
-            planes[p] = drm::scene::ExternalPlaneInfo{db.fd, db.offset[p],
-                                                      db.stride[p]};
-          }
-          auto src = drm::scene::ExternalDmaBufSource::create(
-              backend_->device(), db.width, db.height, db.fourcc, db.modifier,
-              drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(),
-                                                             np));
-          if (src) {
-            // Explicit sync: the producer's acquire fence rides the plane's
-            // IN_FENCE_FD (scene CPU-waits as a fallback). import_fd dups, so
-            // PvFdCloser still closes our original fd.
-            if (db.acquire_fence_fd >= 0) {
-              if (auto f = drm::sync::SyncFence::import_fd(db.acquire_fence_fd);
-                  f) {
-                src.value()->set_acquire_fence(std::move(f.value()));
-              } else {
-                // Fall back to implicit sync for this frame (the producer
-                // synced, or scanout may tear); log so it's diagnosable.
-                ihs::log::warn(
-                    "[DrmCompositor] pv acquire-fence import failed ({}); "
-                    "implicit sync this frame",
-                    f.error().message());
-              }
-            }
-            if (auto r = scene_->replace_source(layer->handle(),
-                                                std::move(src.value()));
-                !r) {
-              ihs::log::warn(
-                  "[DrmCompositor] LayerScene::replace_source (pv): {}",
-                  r.error().message());
-            }
+        // frame), don't submit; the pool holds the last buffer until the next
+        // arrives.
+        if (db.fd[0] >= 0 && db.plane_count > 0) {
+          auto* pool =
+              dynamic_cast<drm::scene::ExternalDmaBufPool*>(&layer->source());
+          if (pool != nullptr && pool->format().width == db.width &&
+              pool->format().height == db.height &&
+              pool->format().drm_fourcc == db.fourcc &&
+              pool->format().modifier == db.modifier) {
+            submit_pv_pool(pool, db);
           } else {
-            ihs::log::warn(
-                "[DrmCompositor] pv ExternalDmaBufSource::create failed "
-                "({}): {}x{} fourcc=0x{:08x} mod=0x{:016x} planes={}",
-                src.error().message(), db.width, db.height, db.fourcc,
-                db.modifier, np);
+            // Source isn't our pool, or the producer's geometry changed under a
+            // fixed-generation pool (an ABR rendition switch). Drop the layer
+            // so the new loop re-adds it at the new geometry next present, and
+            // release this frame's buffer so its ring slot isn't leaked.
+            scene_->remove_layer(layer->handle());
+            scene_pv_tags_.erase(std::remove(scene_pv_tags_.begin(),
+                                             scene_pv_tags_.end(), fl.pv_tag),
+                                 scene_pv_tags_.end());
+            if (fl.pv_surface) {
+              fl.pv_surface->OnScanoutRelease(db.buffer_id);
+            }
+            ++pv_reused;
+            continue;
           }
         }
         layer->set_dst_rect_if_changed(dst_rect);
@@ -2594,42 +2618,34 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       }
       ++pv_new;
       const auto& db = fl.pv_db;
-      // GetDmabuf guarantees a valid single-handle plane set (1..4 planes); it
-      // returns false rather than a zero-plane frame.
-      const uint32_t np = db.plane_count;
-      std::array<drm::scene::ExternalPlaneInfo, 4> planes{};
-      for (uint32_t p = 0; p < np && p < 4; ++p) {
-        planes[p] =
-            drm::scene::ExternalPlaneInfo{db.fd, db.offset[p], db.stride[p]};
-      }
-      // ExternalDmaBufSource dups the fds and does its own
-      // AddFB2WithModifiers; the producer keeps ownership of the originals.
-      auto src = drm::scene::ExternalDmaBufSource::create(
+      // First sight of this platform view: stand up a persistent pool for its
+      // decoder ring. Each ring slot (keyed by buffer_id) is imported once and
+      // its fb_id reused on every recycle -- the drm-cxx tool built for a
+      // rotating V4L2/MPP producer. OnBufferRelease returns each buffer to the
+      // producer when it leaves scanout, which drives the ihs_pv release path.
+      // The retained surface shared_ptr keeps the view alive across a release
+      // even if it is concurrently disposed.
+      drm::scene::ExternalDmaBufPool::Options opts{};
+      opts.on_release = [surface = fl.pv_surface](
+                            std::uintptr_t key,
+                            std::optional<drm::sync::SyncFence>) {
+        if (surface) {
+          surface->OnScanoutRelease(static_cast<uint32_t>(key));
+        }
+      };
+      auto pool = drm::scene::ExternalDmaBufPool::create(
           backend_->device(), db.width, db.height, db.fourcc, db.modifier,
-          drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(), np));
-      if (!src) {
+          std::move(opts));
+      if (!pool) {
         ihs::log::warn(
-            "[DrmCompositor] ExternalDmaBufSource::create (pv): {}; routing "
+            "[DrmCompositor] ExternalDmaBufPool::create (pv): {}; routing "
             "through GL fallback",
-            src.error().message());
+            pool.error().message());
         return PresentViaGlFallback(layers, layer_count);
       }
-      // Explicit sync: hand the producer's acquire fence to the source so the
-      // scene wires it to the plane's IN_FENCE_FD (CPU-wait fallback).
-      // import_fd dups, so PvFdCloser still closes our original fd.
-      if (db.acquire_fence_fd >= 0) {
-        if (auto f = drm::sync::SyncFence::import_fd(db.acquire_fence_fd); f) {
-          src.value()->set_acquire_fence(std::move(f.value()));
-        } else {
-          // Fall back to implicit sync for this frame; log so it's diagnosable.
-          ihs::log::warn(
-              "[DrmCompositor] pv acquire-fence import failed ({}); implicit "
-              "sync this frame",
-              f.error().message());
-        }
-      }
+      auto* pool_raw = pool.value().get();
       drm::scene::LayerDesc desc{};
-      desc.source = std::move(src.value());
+      desc.source = std::move(pool.value());
       desc.display.dst_rect = dst_rect;
       // Producer hands scanout-oriented (top-down) pixels — no REFLECT_Y,
       // unlike GL backing stores.
@@ -2644,6 +2660,8 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
         return PresentViaGlFallback(layers, layer_count);
       }
       scene_pv_tags_.push_back(fl.pv_tag);
+      // Submit the first frame: imports this slot and caches its fb_id.
+      submit_pv_pool(pool_raw, db);
       if (backend_->cfg_.debug_backend) {
         ihs::log::debug(
             "[DrmCompositor] platform-view scene layer added: {}x{} "
@@ -2715,18 +2733,27 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   // so the embedder doesn't manage plane_mode_set_ for this path.
   const bool was_first_commit_pre = !plane_mode_set_;
 
-  // Two-phase flags, mirroring the legacy direct-scanout path: the
-  // first commit is a blocking ALLOW_MODESET with NO PAGE_FLIP_EVENT.
-  // The kernel doesn't deliver a flip event across a modeset on most
-  // drivers (the commit returning is our signal), and combining the
-  // ALLOW_MODESET that LayerScene ORs in for first_commit_ with
-  // NONBLOCK makes rockchip's atomic path return EBUSY against the
-  // modeset's still-pending flip — wedging the CRTC. Steady state:
-  // NONBLOCK + PAGE_FLIP_EVENT for vsync-locked flips.
+  // A mid-session change in the plane set -- a platform-view overlay plane
+  // appearing (pv_new) or leaving (pv_pruned) -- must go through the same
+  // blocking ALLOW_MODESET commit as the very first commit. The steady-state
+  // NONBLOCK path returns EBUSY when it brings a plane up/down (observed on V3D
+  // as the GL->scene transition adds the video plane), and latching GL fallback
+  // on that transient error kills the plane path for the whole session. Only
+  // the PV plane's presence matters here; backing-store FB swaps on an
+  // already-live plane stay on the fast NONBLOCK path.
+  const bool plane_topology_changed = (pv_new != 0 || pv_pruned != 0);
+  const bool blocking_modeset = was_first_commit_pre || plane_topology_changed;
+
+  // Two-phase flags, mirroring the legacy direct-scanout path: a modeset commit
+  // is a blocking ALLOW_MODESET with NO PAGE_FLIP_EVENT. The kernel doesn't
+  // deliver a flip event across a modeset on most drivers (the commit returning
+  // is our signal), and combining the ALLOW_MODESET that LayerScene ORs in for
+  // first_commit_ with NONBLOCK makes the atomic path return EBUSY against the
+  // modeset's still-pending flip — wedging the CRTC. Steady state: NONBLOCK +
+  // PAGE_FLIP_EVENT for vsync-locked flips.
   const uint32_t commit_flags =
-      was_first_commit_pre
-          ? DRM_MODE_ATOMIC_ALLOW_MODESET
-          : (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK);
+      blocking_modeset ? DRM_MODE_ATOMIC_ALLOW_MODESET
+                       : (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK);
   const uint64_t t2 = profile ? NsNow() : 0;
 
   auto report = scene_->commit(commit_flags, static_cast<IFlipSink*>(this));
@@ -2739,6 +2766,23 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       }
       return false;
     }
+    // EBUSY: a commit collided with a still-pending flip. The modeset path
+    // above handles the known plane-topology case; this is the safety net for
+    // any residual transient EBUSY. It clears once the pending flip retires, so
+    // skip this frame and retry next present rather than permanently latching
+    // GL fallback (which would kill the plane path for the whole session on a
+    // single transient error). Drive the next frame ourselves -- no commit
+    // landed, so no PAGE_FLIP_EVENT will arrive to return the vsync baton.
+    // Latch if it persists.
+    if (report.error() == std::errc::device_or_resource_busy) {
+      if (++scene_ebusy_streak_ <= kSceneEbusyRetryLimit) {
+        (void)backend_->vsync_.DeliverParkedBaton();  // keep the loop alive
+        return false;                                 // retry next present
+      }
+      ihs::log::warn(
+          "[DrmCompositor] LayerScene::commit EBUSY x{}; latching GL fallback",
+          scene_ebusy_streak_);
+    }
     ihs::log::warn(
         "[DrmCompositor] LayerScene::commit failed ({}); latching GL "
         "fallback for remaining session",
@@ -2746,14 +2790,19 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     fallback_latched_ = true;
     return PresentViaGlFallback(layers, layer_count);
   }
+  scene_ebusy_streak_ = 0;  // a clean commit clears the transient-EBUSY streak
 
-  if (was_first_commit_pre) {
-    // First commit landed; LayerScene's implicit ALLOW_MODESET cycle
-    // is blocking, so no PAGE_FLIP_EVENT is in flight. Latch + verify
-    // + kick the initial vsync baton, same as the legacy path.
-    plane_mode_set_ = true;
+  if (blocking_modeset) {
+    // A blocking ALLOW_MODESET commit landed (first commit, or a plane-topology
+    // change). It carries no PAGE_FLIP_EVENT, so no flip completion will arrive
+    // to return the vsync baton -- kick it ourselves, same as the legacy path
+    // and PresentDirectOverlay. The genuine first commit also latches
+    // plane_mode_set_ and verifies the pipe.
+    if (was_first_commit_pre) {
+      plane_mode_set_ = true;
+      VerifyPipeRunning();
+    }
     flip_pending_.store(false, std::memory_order_release);
-    VerifyPipeRunning();
     (void)backend_->vsync_.DeliverParkedBaton();
   } else {
     flip_pending_.store(true, std::memory_order_release);

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -40,7 +40,6 @@
 
 #include <drm-cxx/core/format.hpp>
 #include <drm-cxx/scene/external_dma_buf_pool.hpp>
-#include <drm-cxx/scene/external_dma_buf_source.hpp>
 #include <drm-cxx/sync/fence.hpp>
 
 #include "backend/drm_kms_egl/driver_probe.h"
@@ -2469,7 +2468,10 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     return pruned;
   };
   const int bs_pruned = prune(scene_layer_batons_, frame_batons);
-  const int pv_pruned = prune(scene_pv_tags_, frame_pv_tags);
+  // Not const: the add loop below may remove another PV layer mid-frame (a
+  // geometry change under a fixed-generation pool), which is also a plane-
+  // topology change and must feed the blocking-modeset decision at commit time.
+  int pv_pruned = prune(scene_pv_tags_, frame_pv_tags);
   // A pruned PV's layer (removed above) carries its ExternalDmaBufPool into the
   // scene's source-retire ring; the scene release_with_fence()es the pool's
   // in-flight buffer as it retires, firing OnBufferRelease back to the
@@ -2599,7 +2601,10 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
             // Source isn't our pool, or the producer's geometry changed under a
             // fixed-generation pool (an ABR rendition switch). Drop the layer
             // so the new loop re-adds it at the new geometry next present, and
-            // release this frame's buffer so its ring slot isn't leaked.
+            // release this frame's buffer so its ring slot isn't leaked. Count
+            // it as a prune: removing the plane is a topology change, so this
+            // frame must take the blocking ALLOW_MODESET commit below rather
+            // than a NONBLOCK one that could hit a transient EBUSY.
             scene_->remove_layer(layer->handle());
             scene_pv_tags_.erase(std::remove(scene_pv_tags_.begin(),
                                              scene_pv_tags_.end(), fl.pv_tag),
@@ -2607,7 +2612,7 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
             if (fl.pv_surface) {
               fl.pv_surface->OnScanoutRelease(db.buffer_id);
             }
-            ++pv_reused;
+            ++pv_pruned;
             continue;
           }
         }

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -461,6 +461,11 @@ class DrmCompositor : public IFlipSink {
   // that vanished from the frame must be pruned by tag.
   std::vector<void*> scene_pv_tags_;
 
+  // Per-platform-view buffer release is handled by each PV layer's
+  // ExternalDmaBufPool (its OnBufferRelease returns a buffer_id to the producer
+  // when it leaves scanout) plus the scene's source-retire ring on prune, so no
+  // per-buffer scanout history is tracked here.
+
   // DRM plane id of an externally-managed cursor to reserve from the
   // scene allocator's disable-unused pass. Set by ReserveCursorPlane()
   // (from DrmBackend, once the cursor exists); applied to scene_ each
@@ -543,6 +548,15 @@ class DrmCompositor : public IFlipSink {
   // Set once we hit an unrecoverable atomic-commit failure. All future
   // frames route through PresentViaGlFallback until restart.
   bool fallback_latched_{false};
+
+  // Consecutive scene-commit EBUSY count. EBUSY is transient -- a new plane
+  // (e.g. a platform view appearing) committed NONBLOCK against a still-pending
+  // flip during the GL->scene transition. Such a frame is skipped and retried
+  // next present rather than permanently latching GL fallback; the latch is
+  // taken only if EBUSY persists past kSceneEbusyRetryLimit frames. Reset on
+  // any successful scene commit.
+  static constexpr unsigned kSceneEbusyRetryLimit = 60;  // ~1s at 60fps
+  unsigned scene_ebusy_streak_{0};
 
   // Session-pause gate. Set by DrmBackend::OnSessionPaused (libseat
   // disable_seat) and cleared by OnResume on libseat enable_seat. Read

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -485,7 +485,15 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     if (it == release_efds.end()) {
       return;
     }
-    (void)eventfd_write(it->second, 1);
+    // Should never fail for a live, blocking eventfd with a small counter, but
+    // if it did the producer would stall forever on its dup with no clue why --
+    // so log rather than swallow it.
+    if (eventfd_write(it->second, 1) != 0) {
+      ihs::log::warn(
+          "[ihs_pv] eventfd_write(release bid={}) failed (errno={}); producer "
+          "may stall on this ring slot",
+          buffer_id, errno);
+    }
     close(it->second);
     release_efds.erase(it);
   }

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -30,6 +30,7 @@
 #if BUILD_COMPOSITOR
 
 #include <poll.h>
+#include <sys/eventfd.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -234,6 +235,11 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     // dispose, or by the GL-fallback wait in GetGlTextureName. -1 when the
     // producer synced before submit.
     int acquire_fence_fd{-1};
+    // submit_seq when this frame was stashed. Compared against
+    // dmabuf_delivered_seq to tell a frame the DRM scene path took (its release
+    // rides OnScanoutRelease) from one superseded before it was ever scanned
+    // out (its release eventfd must be signalled at supersede instead).
+    uint64_t stash_seq{0};
   };
   mutable PendingEglFrame pending_egl;
   mutable std::map<uint32_t, EglDmabufImporter::ImportedTexture> buffers_egl;
@@ -255,6 +261,13 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // sampled this view. Polled at dispose so imports are not freed while a
   // compositor frame still binds them. -1 when none yet.
   int release_fence_fd{-1};
+
+  // DRM scene (KMS plane) release path: a per-frame eventfd keyed by the
+  // producer's buffer_id. HostSubmit creates one and hands the producer a dup
+  // as its release fence; the compositor signals it (OnScanoutRelease) when the
+  // plane stops scanning that frame out, so the producer reuses the slot only
+  // then. Guarded by `mutex`. Any left over are closed at dispose.
+  mutable std::map<uint32_t, int> release_efds;
 
   // ICompositorSurface — a Vulkan producer (no backing store, no GL texture).
   bool OnCreateBackingStore(const FlutterBackingStoreConfig*,
@@ -373,28 +386,38 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     if (f.plane_count == 0 || f.plane_fd[0] < 0) {
       return false;
     }
-    // The Dmabuf descriptor carries a single fd shared across planes (the
-    // v4l2 / libcamera / Chromium single-handle layout). A genuine per-plane-fd
-    // frame can't be represented here, so bail — the caller falls back to the
-    // GL import path, which handles multiple fds. Clamp to the 4 planes the
-    // descriptor holds (a DRM fourcc has at most 4).
+    // Per-plane fds. A single-handle frame (v4l2/libcamera/Chromium) repeats
+    // one fd across planes with distinct offsets; a multi-handle frame (e.g.
+    // rpi-hevc-dec, which exports the Y and C planes as separate dma-bufs)
+    // carries a distinct fd per plane. Dup each so the caller owns its copies;
+    // AddFB2 resolves each to a GEM handle, so both layouts scan out. Clamp to
+    // the 4 planes the descriptor holds (a DRM fourcc has at most 4).
     const uint32_t np = f.plane_count < 4 ? f.plane_count : 4;
-    for (uint32_t i = 1; i < np; ++i) {
-      if (f.plane_fd[i] != f.plane_fd[0]) {
+    for (uint32_t i = 0; i < np; ++i) {
+      if (f.plane_fd[i] < 0) {
+        return false;  // a plane without a handle can't be scanned out
+      }
+    }
+    int duped[4] = {-1, -1, -1, -1};
+    for (uint32_t i = 0; i < np; ++i) {
+      duped[i] = ::dup(f.plane_fd[i]);
+      if (duped[i] < 0) {
+        for (uint32_t j = 0; j < i; ++j) {
+          ::close(duped[j]);
+        }
         return false;
       }
     }
-
-    const int dup_fd = ::dup(f.plane_fd[0]);
-    if (dup_fd < 0) {
-      return false;
+    for (uint32_t i = 0; i < np; ++i) {
+      out->fd[i] = duped[i];  // owned by the caller
     }
-    out->fd = dup_fd;  // owned by the caller
     out->fourcc = f.format.fourcc;
     out->modifier = f.format.modifier;
     out->width = f.width;
     out->height = f.height;
     out->plane_count = np;
+    out->buffer_id =
+        f.buffer_id;  // the compositor hands it to OnScanoutRelease
     for (uint32_t i = 0; i < np; ++i) {
       out->offset[i] = f.plane_offset[i];
       out->stride[i] = f.plane_stride[i];
@@ -447,6 +470,51 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     release_fence_fd = fd;
   }
 
+  // The DRM scene path retired this frame; wake the producer's release fence
+  // for its ring slot. Compositor thread.
+  void OnScanoutRelease(uint32_t buffer_id) override {
+    const std::lock_guard<std::mutex> lock(mutex);
+    SignalRelease(buffer_id);
+  }
+
+  // Signal and drop the release eventfd for `buffer_id` (a no-op if there is
+  // none). Writing wakes the producer's poll on its dup; closing our copy
+  // retires it. Caller holds `mutex`.
+  void SignalRelease(uint32_t buffer_id) {
+    const auto it = release_efds.find(buffer_id);
+    if (it == release_efds.end()) {
+      return;
+    }
+    (void)eventfd_write(it->second, 1);
+    close(it->second);
+    release_efds.erase(it);
+  }
+
+  // Create this frame's release eventfd, hand the producer a dup as its release
+  // fence (via *out_fd), and keep our copy keyed on buffer_id to signal later.
+  // A stale entry for the same slot is retired first. Caller holds `mutex`.
+  void HandBackReleaseEventfd(uint32_t buffer_id, int* out_fd) {
+    SignalRelease(buffer_id);  // retire any stale eventfd for this slot
+    const int ef = eventfd(0, EFD_CLOEXEC);
+    if (ef < 0) {
+      ihs::log::warn(
+          "[ihs_pv] eventfd() failed (errno={}); producer throttles "
+          "conservatively this frame",
+          errno);
+      return;  // *out_fd stays -1
+    }
+    release_efds[buffer_id] = ef;
+    if (out_fd != nullptr) {
+      const int dup_fd = ::dup(ef);
+      if (dup_fd < 0) {
+        ihs::log::warn("[ihs_pv] dup(release eventfd) failed (errno={})",
+                       errno);
+        return;
+      }
+      *out_fd = dup_fd;
+    }
+  }
+
  private:
   int32_t id_;
   bool disposed_{false};
@@ -481,6 +549,14 @@ IhsPluginView::~IhsPluginView() {
     close(pending_acquire_fd);
     pending_acquire_fd = -1;
   }
+  // The producer has been stopped (DisposePlugin above), so just retire any
+  // release eventfds it never got to wait on; it owns and closes its own dups.
+  for (const auto& [buffer_id, fd] : release_efds) {
+    if (fd >= 0) {
+      close(fd);
+    }
+  }
+  release_efds.clear();
 #if IVI_HAVE_VULKAN
   // With explicit-sync acquire the compositor's read of these imports is gated
   // on the producer's fence, so a re-create can dispose this view while a
@@ -937,6 +1013,14 @@ int HostSubmit(void* user_data,
     std::unique_lock<std::mutex> lock(v->mutex);
     ++v->submit_seq;
     if (v->pending_egl.valid) {
+      // A frame the DRM scene path never took (superseded before GetDmabuf
+      // delivered it) is never scanned out, so no OnScanoutRelease will fire
+      // for it -- signal its release here so the producer reclaims that slot. A
+      // frame that WAS delivered rides OnScanoutRelease and must not be
+      // double-signalled.
+      if (v->dmabuf_delivered_seq < v->pending_egl.stash_seq) {
+        v->SignalRelease(v->pending_egl.frame.buffer_id);
+      }
       CloseFrameFds(&v->pending_egl.frame);  // superseded before import
       if (v->pending_egl.acquire_fence_fd >= 0) {
         close(v->pending_egl.acquire_fence_fd);
@@ -945,7 +1029,13 @@ int HostSubmit(void* user_data,
     v->pending_egl.frame = *frame;       // take ownership of the plane fds
     v->pending_egl.frame.hdr = nullptr;  // do not retain the plugin's hdr ptr
     v->pending_egl.acquire_fence_fd = acquire_fence_fd;  // ownership moves here
+    v->pending_egl.stash_seq = v->submit_seq;
     v->pending_egl.valid = true;
+    // Per-frame release eventfd: hand the producer a dup to wait on before it
+    // reuses this ring slot; the compositor signals our copy from
+    // OnScanoutRelease. A stale entry for this buffer_id (the producer reused
+    // the slot without our having signalled) is retired first.
+    v->HandBackReleaseEventfd(frame->buffer_id, out_release_fence_fd);
     lock.unlock();  // don't call into the engine holding the view lock
     ScheduleEngineFrame(user_data);
     return IHS_PV_OK;

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -503,16 +503,17 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
           errno);
       return;  // *out_fd stays -1
     }
-    release_efds[buffer_id] = ef;
     if (out_fd != nullptr) {
       const int dup_fd = ::dup(ef);
       if (dup_fd < 0) {
         ihs::log::warn("[ihs_pv] dup(release eventfd) failed (errno={})",
                        errno);
-        return;
+        close(ef);  // don't leak ef or leave a stale release_efds entry the
+        return;     // producer never got a fence to wait on
       }
       *out_fd = dup_fd;
     }
+    release_efds[buffer_id] = ef;
   }
 
  private:

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -206,10 +206,11 @@ class ICompositorSurface {
    *
    * @c acquire_fence_fd, when >= 0, is a sync_file naming when the producer's
    * writes complete — intended for the atomic commit's @c IN_FENCE_FD so
-   * scanout is tear-free without a CPU stall. Not every present path consumes
-   * it yet: the DRM scene path is implicit-sync today and ignores it (leave it
-   * -1 for an implicit-sync producer). When a path does consume it, ownership
-   * stays with the surface and the compositor dups it.
+   * scanout is tear-free without a CPU stall. The DRM scene path imports it and
+   * hands it to the plane source (wired to @c IN_FENCE_FD, with a CPU wait as a
+   * fallback on drivers lacking that property); leave it -1 for a producer that
+   * has already synced. Ownership stays with the surface — the compositor dups
+   * what it needs.
    */
   struct Dmabuf {
     int fd[4]{-1, -1, -1, -1};  // one owned handle per plane (see above)

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -297,12 +297,15 @@ class ICompositorSurface {
    * @brief The plane has stopped scanning out the frame the producer submitted
    * with @p buffer_id (Dmabuf::buffer_id); that ring slot is free to reuse.
    *
-   * The DRM scene path calls this once per submitted frame, from the compositor
-   * thread, when the frame is retired (a later frame replaced it on the plane).
-   * It is the per-buffer complement of the per-submit @c SetReleaseFenceFd: on
-   * the plane path a producer waits on the release fence handed back at submit,
-   * so a surface backing that path signals that fence here. The default ignores
-   * it (surfaces whose producer does not track per-buffer releases).
+   * The DRM scene path calls this once per submitted frame when the frame is
+   * retired (a later frame replaced it on the plane) -- normally on the
+   * compositor thread, but scene/pool teardown (e.g. ~DrmCompositor draining
+   * in-flight buffers) can call it from another thread, so an implementation
+   * must be thread-safe. It is the per-buffer complement of the per-submit
+   * @c SetReleaseFenceFd: on the plane path a producer waits on the release
+   * fence handed back at submit, so a surface backing that path signals that
+   * fence here. The default ignores it (surfaces whose producer does not track
+   * per-buffer releases).
    */
   virtual void OnScanoutRelease(uint32_t /*buffer_id*/) {}
 };

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -190,9 +190,13 @@ class ICompositorSurface {
    * @brief A single dma-buf frame a surface can hand to a KMS overlay plane.
    *
    * Plain data so this header stays free of DRM/GBM includes. Multi-planar
-   * (YUV) frames fill @c plane_count entries of @c offset / @c stride, all
-   * sharing one @c fd (the common single-handle layout v4l2/libcamera and
-   * Chromium's accelerated paint produce). @c fourcc is a @c DRM_FORMAT_* code
+   * (YUV) frames fill @c plane_count entries of @c fd / @c offset / @c stride,
+   * one per plane. A single-handle layout (v4l2/libcamera contiguous,
+   * Chromium's accelerated paint) repeats the same handle in every @c fd entry
+   * with the planes separated by @c offset; a multi-handle layout (e.g. the
+   * rpi-hevc-dec, which exports the Y and C planes as distinct dma-bufs) fills
+   * each @c fd with its own handle. AddFB2 resolves each fd to a GEM handle, so
+   * both cases scan out. @c fourcc is a @c DRM_FORMAT_* code
    * and @c modifier a @c DRM_FORMAT_MOD_* value — @c DRM_FORMAT_MOD_LINEAR (0)
    * for a plain linear buffer, @c DRM_FORMAT_MOD_INVALID only when the modifier
    * is unknown/unspecified (let the importer infer). @c width / @c height are
@@ -206,7 +210,7 @@ class ICompositorSurface {
    * stays with the surface and the compositor dups it.
    */
   struct Dmabuf {
-    int fd{-1};
+    int fd[4]{-1, -1, -1, -1};  // one owned handle per plane (see above)
     uint32_t fourcc{0};
     uint64_t modifier{0};
     uint32_t width{0};
@@ -215,6 +219,10 @@ class ICompositorSurface {
     uint32_t offset[4]{};
     uint32_t stride[4]{};
     int acquire_fence_fd{-1};
+    // The producer's identity for this frame (IhsFrame.buffer_id, its ring
+    // slot). The compositor hands it back via OnScanoutRelease when the plane
+    // stops scanning the frame out, so the producer can reuse that slot.
+    uint32_t buffer_id{0};
   };
 
   /**
@@ -282,4 +290,17 @@ class ICompositorSurface {
       ::close(fd);
     }
   }
+
+  /**
+   * @brief The plane has stopped scanning out the frame the producer submitted
+   * with @p buffer_id (Dmabuf::buffer_id); that ring slot is free to reuse.
+   *
+   * The DRM scene path calls this once per submitted frame, from the compositor
+   * thread, when the frame is retired (a later frame replaced it on the plane).
+   * It is the per-buffer complement of the per-submit @c SetReleaseFenceFd: on
+   * the plane path a producer waits on the release fence handed back at submit,
+   * so a surface backing that path signals that fence here. The default ignores
+   * it (surfaces whose producer does not track per-buffer releases).
+   */
+  virtual void OnScanoutRelease(uint32_t /*buffer_id*/) {}
 };

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -196,7 +196,9 @@ class ICompositorSurface {
    * with the planes separated by @c offset; a multi-handle layout (e.g. the
    * rpi-hevc-dec, which exports the Y and C planes as distinct dma-bufs) fills
    * each @c fd with its own handle. AddFB2 resolves each fd to a GEM handle, so
-   * both cases scan out. @c fourcc is a @c DRM_FORMAT_* code
+   * both cases scan out. GetDmabuf transfers ownership of every populated @c fd
+   * (all @c plane_count of them, not just @c fd[0]) to the caller, which must
+   * close each after importing the frame. @c fourcc is a @c DRM_FORMAT_* code
    * and @c modifier a @c DRM_FORMAT_MOD_* value — @c DRM_FORMAT_MOD_LINEAR (0)
    * for a plain linear buffer, @c DRM_FORMAT_MOD_INVALID only when the modifier
    * is unknown/unspecified (let the importer infer). @c width / @c height are


### PR DESCRIPTION
Routes an ihs_pv platform-view producer's dma-buf onto a KMS overlay plane via the drm-cxx `LayerScene`, instead of GL-compositing it. Brings up zero-copy video on a hardware plane (validated on Pi 4 with rpi-hevc-dec HEVC).

## What changed
- **Per-plane fds** — `GetDmabuf` and the scene path carry one fd per plane, so a multi-handle NV12 buffer (rpi-hevc-dec exports Y and C as *separate* dma-bufs) scans out instead of falling back to GL.
- **Per-buffer release** — `HostSubmit` hands the producer a release eventfd per submit; `OnScanoutRelease` signals it when the frame leaves scanout, and a frame superseded before scanout is released at supersede. Implicit-sync producers get a deterministic per-buffer "free" signal without an ABI change.
- **`ExternalDmaBufPool` per view** (keyed by `buffer_id`) — a rotating decoder ring imports each slot once and reuses its cached `fb_id`, replacing the single-use `ExternalDmaBufSource` that re-imported every frame and double-closed the deduped GEM handle (AddFB2 started failing once the ring wrapped).
- **Plane-topology commits** — bringing the overlay plane up/down uses a blocking `ALLOW_MODESET` commit (as the first commit does); a transient `EBUSY` (GL→scene transition racing a pending flip) is retried a bounded number of times instead of permanently latching GL fallback for the whole session.

## Notes
- Not included here: the `emb.lock` `rpi4-trixie` target entry (build-infra, machine-specific keys) — happy to add if wanted.
