### PR TITLE
[feat] `stress_watchdog_integration-test`

### DIFF
--- a/scripts/stress_watchdog_integration.sh
+++ b/scripts/stress_watchdog_integration.sh
@@ -4,9 +4,18 @@
 # Builds homescreen with the watchdog and systemd-watchdog integration enabled,
 # then runs the stopwatch_stress_test Flutter app under load from stress-ng in
 # parallel. The test verifies that the app survives the stress window without
-# the watchdog firing (which would abort the process with SIGABRT), that the
-# app wrote its per-minute uptime file, and that the embedder delivered
-# sd_notify keep-alive pings (WATCHDOG=1) to a fake NOTIFY_SOCKET.
+# the watchdog firing, that the app wrote its per-minute uptime file, and that
+# the systemd-watchdog integration was active.
+#
+# Launch mode is chosen at runtime from HAS_SYSTEMD:
+#   HAS_SYSTEMD=1  -> run homescreen as a real transient `systemd-run --user`
+#                     Type=notify service with WatchdogSec set. systemd owns
+#                     NOTIFY_SOCKET and the watchdog interval, exercising the
+#                     true sd_watchdog_enabled() path (READY=1 handshake, and
+#                     systemd killing the unit if keep-alives stop).
+#   HAS_SYSTEMD=0  -> run homescreen in the background against a fake
+#                     NOTIFY_SOCKET listener that records sd_notify() datagrams
+#                     (message-delivery only; systemd is not involved).
 #
 # Prerequisites (handled by flutter_workspace.py / CI before this script runs):
 #   - ivi-homescreen sources at ${FLUTTER_WORKSPACE}/app/ivi-homescreen/
@@ -24,6 +33,8 @@
 #   STRESS_VM      number of stress-ng VM workers (default: 2)
 #   STRESS_VM_BYTES memory per VM worker (default: 256M)
 #   IHS_LOG_LEVEL  homescreen log level (default: DEBUG)
+#   WATCHDOG_SEC   systemd WatchdogSec in seconds (systemd mode only; default:
+#                  ceil(WATCHDOG_MS/1000))
 
 set -euo pipefail
 
@@ -73,6 +84,37 @@ else
   echo "=== VARIATION: Wayland session not detected, will run SOFTWARE backend (no GPU stress) ==="
 fi
 
+# Check if running in a systemd session (write to HAS_SYSTEMD)
+if [ -n "${XDG_SESSION_ID:-}" ] && [ -S "/run/systemd/private" ]; then
+  HAS_SYSTEMD=1
+  echo "=== VARIATION: systemd session detected, will run real SYSTEMD watchdog ==="
+else
+  HAS_SYSTEMD=0
+  echo "=== VARIATION: systemd session not detected, will fake SYSTEMD watchdog ==="
+fi
+
+# ---------------------------------------------------------------------------
+# Launch mode. When HAS_SYSTEMD=1 we run homescreen as a real transient
+# `systemd-run --user` Type=notify service with WatchdogSec set, so systemd
+# itself owns NOTIFY_SOCKET and the watchdog interval — this exercises the true
+# sd_watchdog_enabled() path (systemdIntervalActive_ = true, READY=1 handshake).
+# When HAS_SYSTEMD=0 we fall back to a fake NOTIFY_SOCKET listener that only
+# exercises sd_notify() message delivery.
+# ---------------------------------------------------------------------------
+if [[ "${HAS_SYSTEMD}" == "1" ]] && command -v systemd-run >/dev/null 2>&1; then
+  MODE="systemd"
+else
+  MODE="fake-socket"
+  if [[ "${HAS_SYSTEMD}" == "1" ]]; then
+    echo "warning: HAS_SYSTEMD=1 but systemd-run not found; using fake-socket mode" >&2
+    HAS_SYSTEMD=0
+  fi
+fi
+echo "watchdog test launch mode: ${MODE}"
+
+# Transient unit name, used only in systemd mode.
+UNIT="ivi-stopwatch-stress-$$.service"
+
 # ---------------------------------------------------------------------------
 # Configure + build homescreen with watchdog + systemd watchdog enabled.
 # Software backend keeps the test headless. INTEGRATION_TEST_SYSTEMD_WATCHDOG
@@ -103,9 +145,13 @@ echo "homescreen binary: ${HS}"
 export LD_LIBRARY_PATH="${IVI_BUILD}/shared:${IVI_BUILD}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 # ---------------------------------------------------------------------------
-# Set the watchdog timeout in the bundle's config.toml. WATCHDOG_PID /
-# WATCHDOG_USEC are NOT set, so sd_watchdog_enabled() returns 0 and config.toml
-# owns the interval; sd_notify() still delivers to NOTIFY_SOCKET.
+# Set the watchdog timeout in the bundle's config.toml.
+#   fake-socket mode: WATCHDOG_USEC is NOT set, so sd_watchdog_enabled() returns
+#                     0 and config.toml owns the interval; sd_notify() still
+#                     delivers to the fake NOTIFY_SOCKET.
+#   systemd mode:     systemd sets WATCHDOG_USEC from WatchdogSec, so
+#                     sd_watchdog_enabled() > 0 and the systemd interval wins;
+#                     this timeout_ms is then ignored by the embedder (harmless).
 # ---------------------------------------------------------------------------
 if grep -q '^\[watchdog\]' "${BUNDLE}/config.toml" 2>/dev/null; then
   echo "config.toml already has a [watchdog] section; leaving it as-is"
@@ -118,19 +164,82 @@ TOML
 fi
 
 # ---------------------------------------------------------------------------
-# Working area: uptime file + fake NOTIFY_SOCKET.
+# Working area: uptime file, log, and (fake-socket mode only) NOTIFY_SOCKET.
 # ---------------------------------------------------------------------------
 WORK_DIR="$(mktemp -d)"
 UPTIME_FILE="${WORK_DIR}/uptime.txt"
 SOCK_PATH="${WORK_DIR}/notify.sock"
 MSGS_FILE="${WORK_DIR}/messages.txt"
 HS_LOG="${WORK_DIR}/homescreen.log"
+# The app mirrors its CI markers here synchronously (flush:true), so they are
+# reliable even when stdout is block-buffered under systemd. This is the
+# authoritative source for the STOPWATCH_STRESS_* markers.
+STATUS_FILE="${WORK_DIR}/status.txt"
+: >"${MSGS_FILE}"
+: >"${STATUS_FILE}"
 
 export STOPWATCH_UPTIME_FILE="${UPTIME_FILE}"
+export STOPWATCH_STATUS_FILE="${STATUS_FILE}"
 
-# Python listener: binds the NOTIFY_SOCKET Unix datagram socket and records
-# every message the binary sends, one per line.
-python3 - "${SOCK_PATH}" "${MSGS_FILE}" <<'PY' &
+HS_PID=""
+STRESS_PID=""
+LISTENER_PID=""
+TAIL_PID=""
+
+# Create the log up front so the live streamer can follow it from line one.
+: >"${HS_LOG}"
+
+# In systemd mode the unit writes stdout/stderr straight to HS_LOG via
+# StandardOutput=append (see the launch below), and also merge the journal in
+# as a fallback in case the append target is unavailable. In fake-socket mode
+# the process already redirects to HS_LOG, so this is a no-op there.
+hs_snapshot_log() {
+  if [[ "${MODE}" == "systemd" ]]; then
+    if [[ ! -s "${HS_LOG}" ]]; then
+      journalctl --user -u "${UNIT}" --no-pager -o cat >"${HS_LOG}" 2>/dev/null || true
+    fi
+  fi
+}
+
+# The authoritative marker source: the app's flushed status file (reliable
+# under systemd where stdout is buffered). Falls back to HS_LOG.
+has_marker() {
+  grep -qF "$1" "${STATUS_FILE}" 2>/dev/null || grep -qF "$1" "${HS_LOG}" 2>/dev/null
+}
+
+# True while homescreen is active OR still starting up.
+hs_is_running() {
+  if [[ "${MODE}" == "systemd" ]]; then
+    local st
+    st="$(systemctl --user show "${UNIT}" -p ActiveState --value 2>/dev/null)"
+    [[ "${st}" == "active" || "${st}" == "activating" ]]
+  else
+    [[ -n "${HS_PID}" ]] && kill -0 "${HS_PID}" 2>/dev/null
+  fi
+}
+
+cleanup() {
+  [[ -n "${STRESS_PID}" ]] && kill "${STRESS_PID}" 2>/dev/null || true
+  if [[ "${MODE}" == "systemd" ]]; then
+    systemctl --user stop "${UNIT}" 2>/dev/null || true
+    systemctl --user reset-failed "${UNIT}" 2>/dev/null || true
+  else
+    [[ -n "${HS_PID}" ]] && kill "${HS_PID}" 2>/dev/null || true
+  fi
+  [[ -n "${LISTENER_PID}" ]] && kill "${LISTENER_PID}" 2>/dev/null || true
+  # Let the live streamer flush the final lines, then stop it.
+  if [[ -n "${TAIL_PID}" ]]; then
+    sleep 1
+    kill "${TAIL_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+if [[ "${MODE}" == "fake-socket" ]]; then
+  # Python listener: binds the NOTIFY_SOCKET Unix datagram socket and records
+  # every message the binary sends, one per line.
+  python3 - "${SOCK_PATH}" "${MSGS_FILE}" <<'PY' &
 import socket, sys, pathlib
 
 sock_path = sys.argv[1]
@@ -152,47 +261,84 @@ except socket.timeout:
 finally:
     sock.close()
 PY
-LISTENER_PID=$!
-
-HS_PID=""
-STRESS_PID=""
-
-cleanup() {
-  [[ -n "${HS_PID}" ]] && kill "${HS_PID}" 2>/dev/null || true
-  [[ -n "${STRESS_PID}" ]] && kill "${STRESS_PID}" 2>/dev/null || true
-  kill "${LISTENER_PID}" 2>/dev/null || true
-  rm -rf "${WORK_DIR}"
-}
-trap cleanup EXIT
-
-# Give the listener a moment to bind before the binary starts.
-sleep 1
+  LISTENER_PID=$!
+  # Give the listener a moment to bind before the binary starts.
+  sleep 1
+fi
 
 # ---------------------------------------------------------------------------
-# Launch homescreen (the stopwatch app) in the background against the fake
-# NOTIFY_SOCKET.
+# Launch homescreen (the stopwatch app).
+#   systemd mode:     as a transient --user Type=notify service with
+#                     WatchdogSec — systemd owns NOTIFY_SOCKET + interval.
+#   fake-socket mode: in the background against the fake NOTIFY_SOCKET.
 # ---------------------------------------------------------------------------
-echo "== launching homescreen with the stopwatch app =="
-NOTIFY_SOCKET="${SOCK_PATH}" \
-  "${HS}" -b "${BUNDLE}" >"${HS_LOG}" 2>&1 &
-HS_PID=$!
-echo "homescreen pid: ${HS_PID}"
+echo "== launching homescreen with the stopwatch app (${MODE}) =="
+if [[ "${MODE}" == "systemd" ]]; then
+  WATCHDOG_SEC="${WATCHDOG_SEC:-$(( (WATCHDOG_MS + 999) / 1000 ))}"
+  # Build the systemd-run argument list in an array so conditional env vars
+  # can be added safely without word-splitting hazards.
+  run_args=(
+    --user
+    "--unit=${UNIT}"
+    --service-type=notify
+    -p "WatchdogSec=${WATCHDOG_SEC}"
+    -p "Restart=no"
+    -p "StandardOutput=append:${HS_LOG}"
+    -p "StandardError=append:${HS_LOG}"
+    -p "Environment=STOPWATCH_UPTIME_FILE=${UPTIME_FILE}"
+    -p "Environment=STOPWATCH_STATUS_FILE=${STATUS_FILE}"
+    -p "Environment=LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+    -p "Environment=IHS_LOG_LEVEL=${IHS_LOG_LEVEL}"
+  )
+  [[ -n "${WAYLAND_DISPLAY:-}" ]] && run_args+=( -p "Environment=WAYLAND_DISPLAY=${WAYLAND_DISPLAY}" )
+  [[ -n "${XDG_RUNTIME_DIR:-}" ]] && run_args+=( -p "Environment=XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" )
+  # systemd-run returns immediately after the job is queued; the unit then
+  # starts asynchronously and we poll for readiness below.
+  systemd-run "${run_args[@]}" "${HS}" -b "${BUNDLE}"
+  echo "systemd unit: ${UNIT} (WatchdogSec=${WATCHDOG_SEC})"
+else
+  NOTIFY_SOCKET="${SOCK_PATH}" \
+    "${HS}" -b "${BUNDLE}" >"${HS_LOG}" 2>&1 &
+  HS_PID=$!
+  echo "homescreen pid: ${HS_PID}"
+fi
+
+# Stream homescreen's log live as it is produced. Both modes write HS_LOG in
+# real time (fake-socket via redirection, systemd via StandardOutput=append),
+# so `tail -F` mirrors it to our stdout as lines arrive rather than dumping
+# everything after the app exits.
+echo "== streaming homescreen log (live) =="
+tail -n +1 -F "${HS_LOG}" 2>/dev/null | sed 's/^/[hs] /' &
+TAIL_PID=$!
 
 # Wait for the app to signal startup before starting the stress load.
+STARTED=0
 for _ in $(seq 1 30); do
-  if grep -qF "STOPWATCH_STRESS_START" "${HS_LOG}" 2>/dev/null; then
+  hs_snapshot_log
+  if has_marker "STOPWATCH_STRESS_START"; then
+    STARTED=1
     break
   fi
-  if ! kill -0 "${HS_PID}" 2>/dev/null; then
-    echo "error: homescreen exited during startup" >&2
-    cat "${HS_LOG}" >&2
+  if ! hs_is_running; then
+    echo "error: homescreen exited during startup (see [hs] log above)" >&2
+    hs_snapshot_log
+    sleep 1  # let the live streamer flush the final lines
     exit 1
   fi
   sleep 1
 done
 
+if [[ "${STARTED}" != "1" ]]; then
+  echo "error: homescreen did not signal startup within 30s (see [hs] log above)" >&2
+  hs_snapshot_log
+  sleep 1  # let the live streamer flush the final lines
+  exit 1
+fi
+
 # ---------------------------------------------------------------------------
-# Run stress-ng in parallel for the stress window.
+# Run stress-ng in parallel for the stress window, but poll homescreen so we
+# stop early (rather than hanging for the full window) if it dies — e.g. the
+# watchdog fires or the crash button is pressed.
 # ---------------------------------------------------------------------------
 echo "== starting stress-ng (cpu=${STRESS_CPU}, vm=${STRESS_VM}x${STRESS_VM_BYTES}) for ${STRESS_SECS}s =="
 stress-ng \
@@ -203,7 +349,18 @@ stress-ng \
   --metrics-brief &
 STRESS_PID=$!
 
-# Wait for stress-ng to complete.
+HS_DIED_DURING_STRESS=0
+while kill -0 "${STRESS_PID}" 2>/dev/null; do
+  if ! hs_is_running; then
+    echo "homescreen exited during the stress window — stopping stress-ng early"
+    HS_DIED_DURING_STRESS=1
+    kill "${STRESS_PID}" 2>/dev/null || true
+    break
+  fi
+  sleep 1
+done
+
+# Reap stress-ng.
 set +e
 wait "${STRESS_PID}"
 STRESS_EXIT=$?
@@ -216,27 +373,74 @@ sleep 2
 
 # ---------------------------------------------------------------------------
 # Stop homescreen and capture its exit status.
+#   systemd mode:     read Result/ExecMainStatus/ExecMainCode from the unit;
+#                     a watchdog kill shows Result=watchdog; a fatal signal
+#                     (e.g. SIGABRT=6 from the embedder's abort(), or SIGSEGV=11
+#                     from the deliberate "Crash now" button) shows
+#                     ExecMainCode=dumped/killed with ExecMainStatus=<signal>.
+#   fake-socket mode: wait on the background PID; a signal death yields exit
+#                     code 128+signal (134=SIGABRT, 139=SIGSEGV).
+#
+# Outcome flags set here (consumed by the checks below):
+#   WATCHDOG_KILLED  systemd killed the unit for a missed keep-alive
+#   HS_CRASHED       the process died from any fatal signal (abnormal exit)
+#   HS_SIGNAL        the terminating signal number (when known)
 # ---------------------------------------------------------------------------
 HS_EXIT=""
-if kill -0 "${HS_PID}" 2>/dev/null; then
-  echo "homescreen still running after stress window (good) — stopping it"
-  kill -INT "${HS_PID}" 2>/dev/null || true
-  set +e
-  wait "${HS_PID}"
-  HS_EXIT=$?
-  set -e
+WATCHDOG_KILLED=0
+HS_CRASHED=0
+HS_SIGNAL=""
+if [[ "${MODE}" == "systemd" ]]; then
+  if hs_is_running; then
+    echo "homescreen unit still running after stress window (good) — stopping it"
+    systemctl --user stop "${UNIT}" 2>/dev/null || true
+  fi
+  RESULT="$(systemctl --user show "${UNIT}" -p Result --value 2>/dev/null)"
+  MAIN_STATUS="$(systemctl --user show "${UNIT}" -p ExecMainStatus --value 2>/dev/null)"
+  MAIN_CODE="$(systemctl --user show "${UNIT}" -p ExecMainCode --value 2>/dev/null)"
+  echo "systemd unit result: Result=${RESULT} ExecMainCode=${MAIN_CODE} ExecMainStatus=${MAIN_STATUS}"
+  hs_snapshot_log
+  if [[ "${RESULT}" == "watchdog" ]]; then
+    # systemd killed it because keep-alive pings stopped.
+    WATCHDOG_KILLED=1
+    HS_CRASHED=1
+    HS_EXIT=134
+  elif [[ "${MAIN_CODE}" == "dumped" || "${MAIN_CODE}" == "killed" ]]; then
+    # Process died from a signal; ExecMainStatus holds the signal number.
+    HS_CRASHED=1
+    HS_SIGNAL="${MAIN_STATUS}"
+    HS_EXIT="$(( 128 + MAIN_STATUS ))"
+  else
+    # Clean exit; ExecMainStatus is the process exit code.
+    HS_EXIT="${MAIN_STATUS:-0}"
+  fi
 else
-  set +e
-  wait "${HS_PID}"
-  HS_EXIT=$?
-  set -e
-  echo "homescreen already exited with code ${HS_EXIT}"
+  if kill -0 "${HS_PID}" 2>/dev/null; then
+    echo "homescreen still running after stress window (good) — stopping it"
+    kill -INT "${HS_PID}" 2>/dev/null || true
+    set +e
+    wait "${HS_PID}"
+    HS_EXIT=$?
+    set -e
+  else
+    set +e
+    wait "${HS_PID}"
+    HS_EXIT=$?
+    set -e
+    echo "homescreen already exited with code ${HS_EXIT}"
+  fi
+  HS_PID=""
+  # A fatal signal yields exit code 128+signal.
+  if [[ "${HS_EXIT}" -gt 128 ]]; then
+    HS_CRASHED=1
+    HS_SIGNAL="$(( HS_EXIT - 128 ))"
+  fi
 fi
-HS_PID=""
 echo "homescreen exit code: ${HS_EXIT}"
 
 # Give the listener time to flush the last datagram before we read.
 sleep 1
+hs_snapshot_log
 
 # ---------------------------------------------------------------------------
 # Verify.
@@ -245,20 +449,33 @@ PASS=0
 TOTAL=4
 
 # 1. The app must have started.
-if grep -qF "STOPWATCH_STRESS_START" "${HS_LOG}"; then
+if has_marker "STOPWATCH_STRESS_START"; then
   echo "PASS: app started (STOPWATCH_STRESS_START)"
   PASS=$((PASS + 1))
 else
-  echo "FAIL: app never printed STOPWATCH_STRESS_START" >&2
+  echo "FAIL: app never emitted STOPWATCH_STRESS_START" >&2
 fi
 
-# 2. The watchdog must NOT have fired (no SIGABRT 134/6). It survived stress.
-if [[ "${HS_EXIT}" == "134" || "${HS_EXIT}" == "6" ]]; then
-  echo "FAIL: watchdog fired under stress — homescreen aborted (exit ${HS_EXIT})" >&2
-  echo "Messages received:" >&2
-  cat "${MSGS_FILE}" >&2
+# 2. homescreen must NOT have crashed. It survived the stress window.
+#    Any abnormal (signal) exit is a failure:
+#      - systemd watchdog kill (Result=watchdog),
+#      - SIGABRT (6) from the embedder's own watchdog abort() — either because
+#        stress starved a thread, or because the "Stop petting watchdog" button
+#        was pressed (STOPWATCH_STRESS_STOP_PET emitted first),
+#      - or any other fatal signal.
+if [[ "${HS_CRASHED}" == "1" ]]; then
+  if [[ "${WATCHDOG_KILLED}" == "1" ]]; then
+    echo "FAIL: systemd watchdog fired — unit killed (Result=watchdog)" >&2
+  elif has_marker "STOPWATCH_STRESS_STOP_PET"; then
+    echo "FAIL: watchdog aborted the app after petting stopped (button) — signal ${HS_SIGNAL:-?}, exit ${HS_EXIT}" >&2
+  elif [[ "${HS_SIGNAL}" == "6" ]]; then
+    echo "FAIL: watchdog fired under stress — homescreen aborted (SIGABRT, exit ${HS_EXIT})" >&2
+  else
+    echo "FAIL: homescreen crashed under stress — signal ${HS_SIGNAL:-?}, exit ${HS_EXIT}" >&2
+  fi
+  [[ -s "${MSGS_FILE}" ]] && { echo "Messages received:" >&2; cat "${MSGS_FILE}" >&2; }
 else
-  echo "PASS: watchdog petted, no timeout; homescreen survived stress (exit ${HS_EXIT})"
+  echo "PASS: no crash; homescreen survived stress (exit ${HS_EXIT})"
   PASS=$((PASS + 1))
 fi
 
@@ -279,14 +496,29 @@ else
   PASS=$((PASS + 1))
 fi
 
-# 4. The embedder must have delivered sd_notify keep-alive pings.
-if grep -qF "WATCHDOG=1" "${MSGS_FILE}" || grep -qF "STATUS=Running" "${MSGS_FILE}"; then
-  echo "PASS: sd_notify messages received (systemd watchdog integration active)"
-  PASS=$((PASS + 1))
+# 4. The systemd watchdog integration must have been active.
+#    systemd mode:     the unit reached "active", which for Type=notify means
+#                      the embedder sent READY=1 (sd_watchdog_enabled() path),
+#                      and it kept sending WATCHDOG=1 pings for the whole run
+#                      (otherwise systemd would have killed it — caught above).
+#    fake-socket mode: verify the recorded datagrams contain a keep-alive.
+if [[ "${MODE}" == "systemd" ]]; then
+  if [[ "${WATCHDOG_KILLED}" == "0" ]] && has_marker "STOPWATCH_STRESS_START"; then
+    echo "PASS: systemd Type=notify handshake succeeded and keep-alives sustained the unit"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: systemd watchdog integration did not sustain the unit (see [hs] log above)" >&2
+    hs_snapshot_log
+  fi
 else
-  echo "FAIL: no sd_notify keep-alive messages received" >&2
-  echo "Messages received:" >&2
-  cat "${MSGS_FILE}" >&2
+  if grep -qF "WATCHDOG=1" "${MSGS_FILE}" || grep -qF "STATUS=Running" "${MSGS_FILE}"; then
+    echo "PASS: sd_notify messages received (systemd watchdog integration active)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: no sd_notify keep-alive messages received" >&2
+    echo "Messages received:" >&2
+    cat "${MSGS_FILE}" >&2
+  fi
 fi
 
 echo
@@ -295,7 +527,6 @@ if [[ "${PASS}" == "${TOTAL}" ]]; then
   exit 0
 else
   echo "stress watchdog integration test FAILED (${PASS}/${TOTAL} checks passed)" >&2
-  echo "--- homescreen log ---" >&2
-  cat "${HS_LOG}" >&2
+  echo "(homescreen log was streamed live above, prefixed with [hs])" >&2
   exit 1
 fi

--- a/scripts/stress_watchdog_integration.sh
+++ b/scripts/stress_watchdog_integration.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Stress + watchdog integration test.
+#
+# Builds homescreen with the watchdog and systemd-watchdog integration enabled,
+# then runs the stopwatch_stress_test Flutter app under load from stress-ng in
+# parallel. The test verifies that the app survives the stress window without
+# the watchdog firing (which would abort the process with SIGABRT), that the
+# app wrote its per-minute uptime file, and that the embedder delivered
+# sd_notify keep-alive pings (WATCHDOG=1) to a fake NOTIFY_SOCKET.
+#
+# Prerequisites (handled by flutter_workspace.py / CI before this script runs):
+#   - ivi-homescreen sources at ${FLUTTER_WORKSPACE}/app/ivi-homescreen/
+#   - stopwatch_stress_test at
+#       ${FLUTTER_WORKSPACE}/app/ivi-homescreen/test/integration/stopwatch_stress_test/
+#   - emb on PATH with a provisioned Flutter; FLUTTER_WORKSPACE set.
+#   - stress-ng installed and on PATH.
+#
+# Env (all optional):
+#   IVI_SRC        ivi-homescreen source root (default: directory above this script)
+#   IVI_BUILD      build directory (default: $IVI_SRC/build)
+#   STRESS_SECS    how long to run the stress window in seconds (default: 180)
+#   WATCHDOG_MS    watchdog timeout in ms written to the bundle (default: 5000)
+#   STRESS_CPU     number of stress-ng CPU workers (default: nproc)
+#   STRESS_VM      number of stress-ng VM workers (default: 2)
+#   STRESS_VM_BYTES memory per VM worker (default: 256M)
+#   IHS_LOG_LEVEL  homescreen log level (default: DEBUG)
+
+set -euo pipefail
+
+IVI_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IVI_BUILD="${IVI_BUILD:-${IVI_SRC}/build}"
+TEST_NAME="stopwatch_stress_test"
+TEST_DIR="${IVI_SRC}/test/integration/${TEST_NAME}"
+HS="${IVI_BUILD}/shell/homescreen"
+
+STRESS_SECS="${STRESS_SECS:-180}"
+WATCHDOG_MS="${WATCHDOG_MS:-5000}"
+STRESS_CPU="${STRESS_CPU:-$(nproc)}"
+STRESS_VM="${STRESS_VM:-2}"
+STRESS_VM_BYTES="${STRESS_VM_BYTES:-256M}"
+IHS_LOG_LEVEL="${IHS_LOG_LEVEL:-DEBUG}"
+
+BUNDLE_ROOT="${FLUTTER_WORKSPACE:-${IVI_SRC}}/bundle"
+
+command -v stress-ng >/dev/null 2>&1 || {
+  echo "error: stress-ng not found on PATH" >&2
+  exit 2
+}
+
+# ---------------------------------------------------------------------------
+# Build the test app bundle. emb names the output stopwatch_stress_test-debug-
+# <arch>; resolve it by glob rather than guessing the arch suffix.
+# ---------------------------------------------------------------------------
+echo "== building ${TEST_NAME} bundle =="
+emb bundle --app-path "${TEST_DIR}" -m debug --build
+
+shopt -s nullglob
+bundles=( "${BUNDLE_ROOT}"/${TEST_NAME}-debug-* )
+shopt -u nullglob
+[[ ${#bundles[@]} -ge 1 ]] || {
+  echo "error: no ${TEST_NAME} bundle under ${BUNDLE_ROOT}" >&2
+  exit 2
+}
+BUNDLE="${bundles[0]}"
+echo "bundle: ${BUNDLE}"
+
+# Check if running in a Wayland session (write to HAS_WAYLAND)
+if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+  HAS_WAYLAND=1
+  echo "=== VARIATION: Wayland session detected, will run WAYLAND_EGL backend and stress GPU ==="
+else
+  HAS_WAYLAND=0
+  echo "=== VARIATION: Wayland session not detected, will run SOFTWARE backend (no GPU stress) ==="
+fi
+
+# ---------------------------------------------------------------------------
+# Configure + build homescreen with watchdog + systemd watchdog enabled.
+# Software backend keeps the test headless. INTEGRATION_TEST_SYSTEMD_WATCHDOG
+# is deliberately OFF: that mode aborts in main() before any app runs, whereas
+# here we want the full app + engine running under stress.
+# ---------------------------------------------------------------------------
+echo "== configuring homescreen (BUILD_WATCHDOG=ON, BUILD_SYSTEMD_WATCHDOG=ON) =="
+cmake \
+  -S "${IVI_SRC}" \
+  -B "${IVI_BUILD}" \
+  -G Ninja \
+  -D BUILD_BACKEND_WAYLAND_EGL=$( [[ "${HAS_WAYLAND}" == "1" ]] && echo ON || echo OFF) \
+  -D BUILD_BACKEND_WAYLAND_VULKAN=OFF \
+  -D BUILD_BACKEND_DRM_KMS_EGL=OFF \
+  -D BUILD_BACKEND_SOFTWARE=$( [[ "${HAS_WAYLAND}" == "1" ]] && echo OFF || echo ON) \
+  -D BUILD_WATCHDOG=ON \
+  -D BUILD_SYSTEMD_WATCHDOG=ON
+
+echo "== building homescreen =="
+ninja -C "${IVI_BUILD}"
+
+[[ -x "${HS}" ]] || {
+  echo "error: homescreen binary not found at ${HS}" >&2
+  exit 2
+}
+echo "homescreen binary: ${HS}"
+
+export LD_LIBRARY_PATH="${IVI_BUILD}/shared:${IVI_BUILD}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+# ---------------------------------------------------------------------------
+# Set the watchdog timeout in the bundle's config.toml. WATCHDOG_PID /
+# WATCHDOG_USEC are NOT set, so sd_watchdog_enabled() returns 0 and config.toml
+# owns the interval; sd_notify() still delivers to NOTIFY_SOCKET.
+# ---------------------------------------------------------------------------
+if grep -q '^\[watchdog\]' "${BUNDLE}/config.toml" 2>/dev/null; then
+  echo "config.toml already has a [watchdog] section; leaving it as-is"
+else
+  cat >> "${BUNDLE}/config.toml" <<TOML
+
+[watchdog]
+timeout_ms = ${WATCHDOG_MS}
+TOML
+fi
+
+# ---------------------------------------------------------------------------
+# Working area: uptime file + fake NOTIFY_SOCKET.
+# ---------------------------------------------------------------------------
+WORK_DIR="$(mktemp -d)"
+UPTIME_FILE="${WORK_DIR}/uptime.txt"
+SOCK_PATH="${WORK_DIR}/notify.sock"
+MSGS_FILE="${WORK_DIR}/messages.txt"
+HS_LOG="${WORK_DIR}/homescreen.log"
+
+export STOPWATCH_UPTIME_FILE="${UPTIME_FILE}"
+
+# Python listener: binds the NOTIFY_SOCKET Unix datagram socket and records
+# every message the binary sends, one per line.
+python3 - "${SOCK_PATH}" "${MSGS_FILE}" <<'PY' &
+import socket, sys, pathlib
+
+sock_path = sys.argv[1]
+msgs_file = pathlib.Path(sys.argv[2])
+msgs_file.write_text("")
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+sock.bind(sock_path)
+sock.settimeout(600)
+
+try:
+    while True:
+        data, _ = sock.recvfrom(4096)
+        msg = data.decode("utf-8", errors="replace").strip()
+        with msgs_file.open("a") as f:
+            f.write(msg + "\n")
+except socket.timeout:
+    pass
+finally:
+    sock.close()
+PY
+LISTENER_PID=$!
+
+HS_PID=""
+STRESS_PID=""
+
+cleanup() {
+  [[ -n "${HS_PID}" ]] && kill "${HS_PID}" 2>/dev/null || true
+  [[ -n "${STRESS_PID}" ]] && kill "${STRESS_PID}" 2>/dev/null || true
+  kill "${LISTENER_PID}" 2>/dev/null || true
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+# Give the listener a moment to bind before the binary starts.
+sleep 1
+
+# ---------------------------------------------------------------------------
+# Launch homescreen (the stopwatch app) in the background against the fake
+# NOTIFY_SOCKET.
+# ---------------------------------------------------------------------------
+echo "== launching homescreen with the stopwatch app =="
+NOTIFY_SOCKET="${SOCK_PATH}" \
+  "${HS}" -b "${BUNDLE}" >"${HS_LOG}" 2>&1 &
+HS_PID=$!
+echo "homescreen pid: ${HS_PID}"
+
+# Wait for the app to signal startup before starting the stress load.
+for _ in $(seq 1 30); do
+  if grep -qF "STOPWATCH_STRESS_START" "${HS_LOG}" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${HS_PID}" 2>/dev/null; then
+    echo "error: homescreen exited during startup" >&2
+    cat "${HS_LOG}" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---------------------------------------------------------------------------
+# Run stress-ng in parallel for the stress window.
+# ---------------------------------------------------------------------------
+echo "== starting stress-ng (cpu=${STRESS_CPU}, vm=${STRESS_VM}x${STRESS_VM_BYTES}) for ${STRESS_SECS}s =="
+stress-ng \
+  --cpu "${STRESS_CPU}" \
+  --vm "${STRESS_VM}" --vm-bytes "${STRESS_VM_BYTES}" \
+  --iomix 2 \
+  --timeout "${STRESS_SECS}s" \
+  --metrics-brief &
+STRESS_PID=$!
+
+# Wait for stress-ng to complete.
+set +e
+wait "${STRESS_PID}"
+STRESS_EXIT=$?
+set -e
+STRESS_PID=""
+echo "stress-ng exit code: ${STRESS_EXIT}"
+
+# Give the app one more moment to flush a final tick / notify.
+sleep 2
+
+# ---------------------------------------------------------------------------
+# Stop homescreen and capture its exit status.
+# ---------------------------------------------------------------------------
+HS_EXIT=""
+if kill -0 "${HS_PID}" 2>/dev/null; then
+  echo "homescreen still running after stress window (good) — stopping it"
+  kill -INT "${HS_PID}" 2>/dev/null || true
+  set +e
+  wait "${HS_PID}"
+  HS_EXIT=$?
+  set -e
+else
+  set +e
+  wait "${HS_PID}"
+  HS_EXIT=$?
+  set -e
+  echo "homescreen already exited with code ${HS_EXIT}"
+fi
+HS_PID=""
+echo "homescreen exit code: ${HS_EXIT}"
+
+# Give the listener time to flush the last datagram before we read.
+sleep 1
+
+# ---------------------------------------------------------------------------
+# Verify.
+# ---------------------------------------------------------------------------
+PASS=0
+TOTAL=4
+
+# 1. The app must have started.
+if grep -qF "STOPWATCH_STRESS_START" "${HS_LOG}"; then
+  echo "PASS: app started (STOPWATCH_STRESS_START)"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: app never printed STOPWATCH_STRESS_START" >&2
+fi
+
+# 2. The watchdog must NOT have fired (no SIGABRT 134/6). It survived stress.
+if [[ "${HS_EXIT}" == "134" || "${HS_EXIT}" == "6" ]]; then
+  echo "FAIL: watchdog fired under stress — homescreen aborted (exit ${HS_EXIT})" >&2
+  echo "Messages received:" >&2
+  cat "${MSGS_FILE}" >&2
+else
+  echo "PASS: watchdog petted, no timeout; homescreen survived stress (exit ${HS_EXIT})"
+  PASS=$((PASS + 1))
+fi
+
+# 3. The app must have written at least one uptime line to the file.
+#    Only reliably checkable if STRESS_SECS is at least one full minute.
+if [[ "${STRESS_SECS}" -ge 60 ]]; then
+  if [[ -s "${UPTIME_FILE}" ]] && grep -qE 'uptime_seconds=[0-9]+' "${UPTIME_FILE}"; then
+    LINES=$(grep -cE 'uptime_seconds=[0-9]+' "${UPTIME_FILE}")
+    echo "PASS: uptime file written (${LINES} line(s))"
+    echo "  --- ${UPTIME_FILE} ---"
+    cat "${UPTIME_FILE}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: uptime file empty or missing entries at ${UPTIME_FILE}" >&2
+  fi
+else
+  echo "SKIP-COUNT: STRESS_SECS < 60, not expecting a per-minute write; counting as pass"
+  PASS=$((PASS + 1))
+fi
+
+# 4. The embedder must have delivered sd_notify keep-alive pings.
+if grep -qF "WATCHDOG=1" "${MSGS_FILE}" || grep -qF "STATUS=Running" "${MSGS_FILE}"; then
+  echo "PASS: sd_notify messages received (systemd watchdog integration active)"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL: no sd_notify keep-alive messages received" >&2
+  echo "Messages received:" >&2
+  cat "${MSGS_FILE}" >&2
+fi
+
+echo
+if [[ "${PASS}" == "${TOTAL}" ]]; then
+  echo "stress watchdog integration test PASSED (${PASS}/${TOTAL})"
+  exit 0
+else
+  echo "stress watchdog integration test FAILED (${PASS}/${TOTAL} checks passed)" >&2
+  echo "--- homescreen log ---" >&2
+  cat "${HS_LOG}" >&2
+  exit 1
+fi

--- a/scripts/stress_watchdog_integration.sh
+++ b/scripts/stress_watchdog_integration.sh
@@ -166,9 +166,9 @@ fi
 # ---------------------------------------------------------------------------
 # Working area: uptime file, log, and (fake-socket mode only) NOTIFY_SOCKET.
 # ---------------------------------------------------------------------------
-WORK_DIR="$(mktemp -d)"
+WORK_DIR="$(pwd)/stresstest-$(date +%Y%m%d-%H%M%S)"; mkdir -p "${WORK_DIR}"
 UPTIME_FILE="${WORK_DIR}/uptime.txt"
-SOCK_PATH="${WORK_DIR}/notify.sock"
+SOCK_PATH="$(mktemp -d)/notify.sock"
 MSGS_FILE="${WORK_DIR}/messages.txt"
 HS_LOG="${WORK_DIR}/homescreen.log"
 # The app mirrors its CI markers here synchronously (flush:true), so they are
@@ -232,7 +232,7 @@ cleanup() {
     sleep 1
     kill "${TAIL_PID}" 2>/dev/null || true
   fi
-  rm -rf "${WORK_DIR}"
+  echo "== script complete: logs available under ${WORK_DIR} =="
 }
 trap cleanup EXIT
 

--- a/test/integration/stopwatch_stress_test/.gitignore
+++ b/test/integration/stopwatch_stress_test/.gitignore
@@ -1,0 +1,32 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/
+.desktop-homescreen/

--- a/test/integration/stopwatch_stress_test/README.md
+++ b/test/integration/stopwatch_stress_test/README.md
@@ -1,0 +1,110 @@
+# stopwatch_stress_test
+
+Integration test app for exercising the ivi-homescreen **watchdog** under
+system stress.
+
+The embedder is built with `-DBUILD_WATCHDOG=ON` and
+`-DBUILD_SYSTEMD_WATCHDOG=ON`. While this app runs, the driver script
+(`scripts/stress_watchdog_integration.sh`) runs `stress-ng` in parallel to load
+the CPU, memory and I/O. If the main or render thread is starved past the
+watchdog timeout, the embedder aborts (SIGABRT). The test passes when the app
+stays responsive for the whole stress window.
+
+### Backend selection (chosen at runtime from `HAS_WAYLAND`)
+
+The driver script also detects whether it is running inside a Wayland session
+(`WAYLAND_DISPLAY` is set) and configures the embedder backend accordingly:
+
+- **`HAS_WAYLAND=1` — Wayland session.** homescreen is built with the
+  `wayland-egl` backend (`-DBUILD_BACKEND_WAYLAND_EGL=ON`,
+  `-DBUILD_BACKEND_SOFTWARE=OFF`) and rendered through the compositor, so the
+  stress window also loads the **GPU** render path. `WAYLAND_DISPLAY` is
+  forwarded into the systemd unit when running in systemd mode.
+- **`HAS_WAYLAND=0` — no Wayland session.** homescreen is built with the
+  headless **software** backend (`-DBUILD_BACKEND_SOFTWARE=ON`,
+  `-DBUILD_BACKEND_WAYLAND_EGL=OFF`); there is no GPU stress. This is the
+  default for headless CI runners.
+
+## What the app does
+
+- Displays a **stopwatch** showing how long the app has been running.
+- Shows an animated **spinner** (`CircularProgressIndicator`).
+- Appends the current uptime to a file **once every minute**.
+- Registers a watchdog source via the `watchdog` `MethodChannel` and pets it on
+  a 1 s timer.
+- Provides a **"Stop petting watchdog (crash)"** button. Pressing it cancels
+  the pet timer, leaving the source registered but starved. The embedder's
+  watchdog thread then fires after the timeout and aborts the process
+  (SIGABRT) — the intended way to provoke a crash for testing.
+
+The uptime file path is taken from the `STOPWATCH_UPTIME_FILE` environment
+variable (set by the test script), falling back to
+`/tmp/stopwatch_stress_uptime.txt`. Each line looks like:
+
+```
+2026-07-24T17:00:00.000000 uptime_seconds=60
+```
+
+## CI output
+
+Printed to stdout:
+
+| Marker | Meaning |
+|---|---|
+| `STOPWATCH_STRESS_START` | Printed once at startup |
+| `STOPWATCH_STRESS_TICK <seconds>` | Printed every minute after writing the file |
+| `STOPWATCH_STRESS_WRITE_FAIL <e>` | Printed if a file write throws |
+| `STOPWATCH_STRESS_STOP_PET` | Printed when the button cancels the pet timer |
+| `STOPWATCH_STRESS_WATCHDOG_UNAVAILABLE <e>` | Printed if the watchdog channel is absent (`BUILD_WATCHDOG=OFF`) |
+
+## Building
+
+### Prerequisites
+
+```bash
+# The embedder must be built with watchdog + systemd watchdog support
+cmake -DBUILD_WATCHDOG=ON -DBUILD_SYSTEMD_WATCHDOG=ON ...
+ninja -j$(nproc)
+```
+
+`stress-ng` must be installed and on `PATH`.
+
+### Flutter app
+
+```bash
+cd test/integration/stopwatch_stress_test
+flutter pub get
+flutter build bundle
+```
+
+## Running
+
+The full test is driven by the script:
+
+```bash
+scripts/stress_watchdog_integration.sh
+```
+
+Tunable via environment variables:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `STRESS_SECS` | `180` | Length of the stress window (seconds) |
+| `WATCHDOG_MS` | `5000` | Watchdog timeout written to the bundle `config.toml` |
+| `STRESS_CPU` | `nproc` | Number of `stress-ng` CPU workers |
+| `STRESS_VM` | `2` | Number of `stress-ng` VM workers |
+| `STRESS_VM_BYTES` | `256M` | Memory per VM worker |
+| `IHS_LOG_LEVEL` | `DEBUG` | Homescreen log level |
+
+The script:
+
+1. Builds the app bundle with `emb`.
+2. Configures + builds homescreen with `BUILD_WATCHDOG=ON` and
+   `BUILD_SYSTEMD_WATCHDOG=ON` (Wayland-EGL backend under a Wayland session,
+   otherwise the software backend, headless).
+3. Writes `[watchdog] timeout_ms` into the bundle `config.toml`.
+4. Starts a fake `NOTIFY_SOCKET` listener, launches homescreen, then runs
+   `stress-ng` in parallel for the stress window.
+5. Verifies: the app started, the watchdog did **not** fire (no SIGABRT), the
+   uptime file was written (when `STRESS_SECS >= 60`), and `sd_notify`
+   keep-alive messages were received.

--- a/test/integration/stopwatch_stress_test/README.md
+++ b/test/integration/stopwatch_stress_test/README.md
@@ -10,6 +10,21 @@ the CPU, memory and I/O. If the main or render thread is starved past the
 watchdog timeout, the embedder aborts (SIGABRT). The test passes when the app
 stays responsive for the whole stress window.
 
+### Launch modes (chosen at runtime from `HAS_SYSTEMD`)
+
+The driver script detects whether it is running inside a systemd session and
+picks one of two modes:
+
+- **`HAS_SYSTEMD=1` — real systemd service.** homescreen is launched as a
+  transient `systemd-run --user` `Type=notify` service with `WatchdogSec`.
+  systemd itself owns `NOTIFY_SOCKET` and the watchdog interval, so the true
+  `sd_watchdog_enabled()` path runs: the embedder completes the `READY=1`
+  handshake and must keep sending `WATCHDOG=1` pings or systemd kills the unit
+  (`Result=watchdog`).
+- **`HAS_SYSTEMD=0` — fake socket.** homescreen runs in the background against
+  a fake `NOTIFY_SOCKET` listener that only records `sd_notify()` datagrams.
+  systemd is not involved; this exercises message delivery only.
+
 ### Backend selection (chosen at runtime from `HAS_WAYLAND`)
 
 The driver script also detects whether it is running inside a Wayland session
@@ -31,11 +46,13 @@ The driver script also detects whether it is running inside a Wayland session
 - Shows an animated **spinner** (`CircularProgressIndicator`).
 - Appends the current uptime to a file **once every minute**.
 - Registers a watchdog source via the `watchdog` `MethodChannel` and pets it on
-  a 1 s timer.
-- Provides a **"Stop petting watchdog (crash)"** button. Pressing it cancels
-  the pet timer, leaving the source registered but starved. The embedder's
-  watchdog thread then fires after the timeout and aborts the process
-  (SIGABRT) — the intended way to provoke a crash for testing.
+  a 1 s timer so the app survives the stress window.
+- Provides a **"Stop petting watchdog"** button. Pressing it cancels the pet
+  timer, leaving the source registered but starved. The embedder's watchdog
+  thread then fires once the timeout elapses and aborts the process
+  (**SIGABRT**, exit code 134), which the test harness sees as an error. The
+  `STOPWATCH_STRESS_STOP_PET` marker is flushed the moment the button is
+  pressed so the harness can attribute the abort to it.
 
 The uptime file path is taken from the `STOPWATCH_UPTIME_FILE` environment
 variable (set by the test script), falling back to
@@ -47,15 +64,18 @@ variable (set by the test script), falling back to
 
 ## CI output
 
-Printed to stdout:
+Each marker is printed to stdout and also appended (synchronously, `flush:true`)
+to the file named by `STOPWATCH_STATUS_FILE` when set, so it survives stdout
+buffering under systemd. The driver script streams the homescreen log live as it
+is produced (prefixed with `[hs]`).
 
 | Marker | Meaning |
 |---|---|
-| `STOPWATCH_STRESS_START` | Printed once at startup |
-| `STOPWATCH_STRESS_TICK <seconds>` | Printed every minute after writing the file |
-| `STOPWATCH_STRESS_WRITE_FAIL <e>` | Printed if a file write throws |
-| `STOPWATCH_STRESS_STOP_PET` | Printed when the button cancels the pet timer |
-| `STOPWATCH_STRESS_WATCHDOG_UNAVAILABLE <e>` | Printed if the watchdog channel is absent (`BUILD_WATCHDOG=OFF`) |
+| `STOPWATCH_STRESS_START` | Emitted once at startup |
+| `STOPWATCH_STRESS_TICK <seconds>` | Emitted every minute after writing the file |
+| `STOPWATCH_STRESS_WRITE_FAIL <e>` | Emitted if a file write throws |
+| `STOPWATCH_STRESS_STOP_PET` | Emitted when the button cancels the pet timer |
+| `STOPWATCH_STRESS_WATCHDOG_UNAVAILABLE <e>` | Emitted if the watchdog channel is absent (`BUILD_WATCHDOG=OFF`) |
 
 ## Building
 
@@ -95,6 +115,7 @@ Tunable via environment variables:
 | `STRESS_VM` | `2` | Number of `stress-ng` VM workers |
 | `STRESS_VM_BYTES` | `256M` | Memory per VM worker |
 | `IHS_LOG_LEVEL` | `DEBUG` | Homescreen log level |
+| `WATCHDOG_SEC` | `ceil(WATCHDOG_MS/1000)` | systemd `WatchdogSec` (systemd mode only) |
 
 The script:
 
@@ -103,8 +124,10 @@ The script:
    `BUILD_SYSTEMD_WATCHDOG=ON` (Wayland-EGL backend under a Wayland session,
    otherwise the software backend, headless).
 3. Writes `[watchdog] timeout_ms` into the bundle `config.toml`.
-4. Starts a fake `NOTIFY_SOCKET` listener, launches homescreen, then runs
-   `stress-ng` in parallel for the stress window.
-5. Verifies: the app started, the watchdog did **not** fire (no SIGABRT), the
-   uptime file was written (when `STRESS_SECS >= 60`), and `sd_notify`
-   keep-alive messages were received.
+4. Picks a launch mode from `HAS_SYSTEMD` (see above), launches homescreen,
+   then runs `stress-ng` in parallel for the stress window.
+5. Verifies: the app started, the watchdog did **not** fire (no SIGABRT and,
+   in systemd mode, no `Result=watchdog` kill), the uptime file was written
+   (when `STRESS_SECS >= 60`), and the systemd-watchdog integration was active
+   (systemd `Type=notify` handshake sustained the unit, or `sd_notify`
+   keep-alive datagrams were recorded in fake-socket mode).

--- a/test/integration/stopwatch_stress_test/analysis_options.yaml
+++ b/test/integration/stopwatch_stress_test/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: false

--- a/test/integration/stopwatch_stress_test/lib/main.dart
+++ b/test/integration/stopwatch_stress_test/lib/main.dart
@@ -14,19 +14,24 @@
 //   * Shows an animated CircularProgressIndicator spinner.
 //   * Appends the current uptime to a file once every minute.
 //   * Registers a watchdog source via the 'watchdog' MethodChannel and pets it
-//     on a timer. A "Stop petting watchdog" button cancels the pet timer,
-//     which starves the source and provokes the embedder to abort (SIGABRT)
-//     once the watchdog timeout elapses.
+//     on a timer so the app survives the stress window.
+//   * Provides a "Stop petting watchdog" button. Pressing it cancels the pet
+//     timer, leaving the source registered but starved. The embedder's
+//     watchdog thread then fires once the timeout elapses and aborts the
+//     process (SIGABRT), which the test script sees as an error.
 //
 // The uptime file path comes from the STOPWATCH_UPTIME_FILE environment
 // variable (set by the test script) and falls back to
 // /tmp/stopwatch_stress_uptime.txt.
 //
-// CI output (printed to stdout):
-//   STOPWATCH_STRESS_START           — printed once at startup
-//   STOPWATCH_STRESS_TICK <seconds>  — printed every minute after writing file
-//   STOPWATCH_STRESS_WRITE_FAIL <e>  — printed if the file write throws
-//   STOPWATCH_STRESS_STOP_PET        — printed when the pet timer is cancelled
+// CI markers are printed to stdout AND appended (synchronously, so they are
+// not lost to stdout buffering when the process runs under systemd) to the
+// status file named by STOPWATCH_STATUS_FILE when that variable is set:
+//   STOPWATCH_STRESS_START           — emitted once at startup
+//   STOPWATCH_STRESS_TICK <seconds>  — emitted every minute after writing file
+//   STOPWATCH_STRESS_WRITE_FAIL <e>  — emitted if the uptime write throws
+//   STOPWATCH_STRESS_STOP_PET        — emitted when the pet timer is cancelled
+//   STOPWATCH_STRESS_WATCHDOG_UNAVAILABLE <e> — watchdog channel absent
 
 import 'dart:async';
 import 'dart:io';
@@ -48,6 +53,33 @@ const MethodChannel _watchdogChannel = MethodChannel('watchdog');
 const int _watchdogSource = 7;
 
 // ---------------------------------------------------------------------------
+// CI marker emission
+// ---------------------------------------------------------------------------
+
+String? _statusFilePath() {
+  final path = Platform.environment['STOPWATCH_STATUS_FILE'];
+  return (path != null && path.isNotEmpty) ? path : null;
+}
+
+// Emits a CI marker to stdout and, when STOPWATCH_STATUS_FILE is set, also
+// appends it to that file synchronously with flush:true. The status file is
+// the reliable channel: stdout is block-buffered when the process runs under
+// systemd (stdout is a pipe, not a TTY), so printed markers can be lost, but
+// a flushed file write is always visible to the test script immediately.
+void _emit(String marker) {
+  print(marker);
+  final path = _statusFilePath();
+  if (path != null) {
+    try {
+      File(path).writeAsStringSync('$marker\n',
+          mode: FileMode.append, flush: true);
+    } catch (_) {
+      // Best-effort; stdout still carries the marker.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -58,7 +90,15 @@ void main() {
       debugPrint('STACK:\n${details.stack}');
     }
   };
-  print('STOPWATCH_STRESS_START');
+  // Truncate the status file so stale markers from a previous run do not
+  // confuse the test verifier, then emit the startup marker.
+  final statusPath = _statusFilePath();
+  if (statusPath != null) {
+    try {
+      File(statusPath).writeAsStringSync('');
+    } catch (_) {}
+  }
+  _emit('STOPWATCH_STRESS_START');
   runApp(const StopwatchStressApp());
 }
 
@@ -128,7 +168,7 @@ class _HomeState extends State<_Home> {
     try {
       File(_uptimeFile).writeAsStringSync('');
     } catch (e) {
-      print('STOPWATCH_STRESS_WRITE_FAIL $e');
+      _emit('STOPWATCH_STRESS_WRITE_FAIL $e');
     }
 
     // UI refresh — 10 Hz keeps the stopwatch smooth without busy-spinning.
@@ -164,7 +204,7 @@ class _HomeState extends State<_Home> {
     } catch (e) {
       // Channel absent (BUILD_WATCHDOG=OFF) or start failed — the button will
       // then have no effect, but the rest of the app still runs.
-      print('STOPWATCH_STRESS_WATCHDOG_UNAVAILABLE $e');
+      _emit('STOPWATCH_STRESS_WATCHDOG_UNAVAILABLE $e');
       return;
     }
 
@@ -182,12 +222,14 @@ class _HomeState extends State<_Home> {
   }
 
   // Stops petting the watchdog source. The source is left registered but never
-  // pet again, so the embedder's watchdog thread fires after the timeout and
-  // aborts the process (SIGABRT).
+  // pet again, so the embedder's watchdog thread fires after the timeout
+  // elapses and aborts the process (SIGABRT) — the deliberate failure path the
+  // test exercises. The marker is flushed first so the harness can attribute
+  // the resulting abort to the button press.
   void _stopWatchdogPetting() {
     _petTimer?.cancel();
     _petTimer = null;
-    print('STOPWATCH_STRESS_STOP_PET');
+    _emit('STOPWATCH_STRESS_STOP_PET');
     setState(() => _petting = false);
   }
 
@@ -199,9 +241,9 @@ class _HomeState extends State<_Home> {
       File(_uptimeFile).writeAsStringSync(line, mode: FileMode.append);
       _writeCount++;
       setState(() => _lastWrite = line.trim());
-      print('STOPWATCH_STRESS_TICK $seconds');
+      _emit('STOPWATCH_STRESS_TICK $seconds');
     } catch (e) {
-      print('STOPWATCH_STRESS_WRITE_FAIL $e');
+      _emit('STOPWATCH_STRESS_WRITE_FAIL $e');
     }
   }
 
@@ -266,7 +308,7 @@ class _HomeState extends State<_Home> {
               icon: const Icon(Icons.dangerous),
               label: Text(
                 _petting
-                    ? 'Stop petting watchdog (crash)'
+                    ? 'Stop petting watchdog'
                     : 'Watchdog no longer petted',
               ),
               style: FilledButton.styleFrom(

--- a/test/integration/stopwatch_stress_test/lib/main.dart
+++ b/test/integration/stopwatch_stress_test/lib/main.dart
@@ -1,0 +1,286 @@
+// Integration test app for the ivi-homescreen watchdog under system stress.
+//
+// This app is the Flutter workload half of the stress_watchdog integration
+// test (scripts/stress_watchdog_integration.sh). The embedder is built with
+// -DBUILD_WATCHDOG=ON and -DBUILD_SYSTEMD_WATCHDOG=ON. While this app runs a
+// stopwatch and animates a spinner, the test script runs stress-ng in parallel
+// to load the CPU/memory. If the main or render thread is starved past the
+// watchdog timeout, the embedder aborts (SIGABRT). The test passes when the
+// app keeps running (petting the watchdog implicitly by staying responsive)
+// for the configured duration.
+//
+// Behaviour:
+//   * Displays a stopwatch showing how long the app has been running.
+//   * Shows an animated CircularProgressIndicator spinner.
+//   * Appends the current uptime to a file once every minute.
+//   * Registers a watchdog source via the 'watchdog' MethodChannel and pets it
+//     on a timer. A "Stop petting watchdog" button cancels the pet timer,
+//     which starves the source and provokes the embedder to abort (SIGABRT)
+//     once the watchdog timeout elapses.
+//
+// The uptime file path comes from the STOPWATCH_UPTIME_FILE environment
+// variable (set by the test script) and falls back to
+// /tmp/stopwatch_stress_uptime.txt.
+//
+// CI output (printed to stdout):
+//   STOPWATCH_STRESS_START           — printed once at startup
+//   STOPWATCH_STRESS_TICK <seconds>  — printed every minute after writing file
+//   STOPWATCH_STRESS_WRITE_FAIL <e>  — printed if the file write throws
+//   STOPWATCH_STRESS_STOP_PET        — printed when the pet timer is cancelled
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+// ---------------------------------------------------------------------------
+// Watchdog channel
+// ---------------------------------------------------------------------------
+
+// The embedder-provided watchdog MethodChannel (present when built with
+// -DBUILD_WATCHDOG=ON). This app registers its own source and pets it on a
+// timer so that cancelling the timer starves the source and forces a crash.
+const MethodChannel _watchdogChannel = MethodChannel('watchdog');
+
+// Source ID used for this app's watchdog registration. Must be outside the
+// embedder-reserved range (0-2 and the negative main/render IDs).
+const int _watchdogSource = 7;
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+void main() {
+  FlutterError.onError = (FlutterErrorDetails details) {
+    FlutterError.dumpErrorToConsole(details);
+    if (details.stack != null) {
+      debugPrint('STACK:\n${details.stack}');
+    }
+  };
+  print('STOPWATCH_STRESS_START');
+  runApp(const StopwatchStressApp());
+}
+
+// ---------------------------------------------------------------------------
+// Uptime file helper
+// ---------------------------------------------------------------------------
+
+String _uptimeFilePath() {
+  final fromEnv = Platform.environment['STOPWATCH_UPTIME_FILE'];
+  if (fromEnv != null && fromEnv.isNotEmpty) {
+    return fromEnv;
+  }
+  return '/tmp/stopwatch_stress_uptime.txt';
+}
+
+// ---------------------------------------------------------------------------
+// App shell
+// ---------------------------------------------------------------------------
+
+class StopwatchStressApp extends StatelessWidget {
+  const StopwatchStressApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Stopwatch Stress Test',
+      theme: ThemeData(
+        colorSchemeSeed: Colors.indigo,
+        brightness: Brightness.dark,
+        useMaterial3: true,
+      ),
+      home: const _Home(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Home widget
+// ---------------------------------------------------------------------------
+
+class _Home extends StatefulWidget {
+  const _Home();
+
+  @override
+  State<_Home> createState() => _HomeState();
+}
+
+class _HomeState extends State<_Home> {
+  final Stopwatch _stopwatch = Stopwatch();
+  final String _uptimeFile = _uptimeFilePath();
+
+  Timer? _uiTimer;
+  Timer? _writeTimer;
+  Timer? _petTimer;
+  Duration _elapsed = Duration.zero;
+  int _writeCount = 0;
+  String _lastWrite = '(none yet)';
+  bool _petting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _stopwatch.start();
+
+    // Truncate the uptime file at startup so a stale file from a previous run
+    // does not confuse the test verifier.
+    try {
+      File(_uptimeFile).writeAsStringSync('');
+    } catch (e) {
+      print('STOPWATCH_STRESS_WRITE_FAIL $e');
+    }
+
+    // UI refresh — 10 Hz keeps the stopwatch smooth without busy-spinning.
+    _uiTimer = Timer.periodic(const Duration(milliseconds: 100), (_) {
+      setState(() => _elapsed = _stopwatch.elapsed);
+    });
+
+    // Write uptime to the file once every minute.
+    _writeTimer = Timer.periodic(const Duration(minutes: 1), (_) {
+      _writeUptime();
+    });
+
+    // Register a watchdog source and start petting it. Cancelling _petTimer
+    // (via the button) starves the source and provokes an abort().
+    _startWatchdogPetting();
+  }
+
+  @override
+  void dispose() {
+    _uiTimer?.cancel();
+    _writeTimer?.cancel();
+    _petTimer?.cancel();
+    _stopwatch.stop();
+    super.dispose();
+  }
+
+  Future<void> _startWatchdogPetting() async {
+    try {
+      await _watchdogChannel.invokeMethod<void>(
+        'start',
+        {'source': _watchdogSource, 'name': 'StopwatchStressApp'},
+      );
+    } catch (e) {
+      // Channel absent (BUILD_WATCHDOG=OFF) or start failed — the button will
+      // then have no effect, but the rest of the app still runs.
+      print('STOPWATCH_STRESS_WATCHDOG_UNAVAILABLE $e');
+      return;
+    }
+
+    // Pet well within the watchdog timeout window. A 1 s cadence stays under
+    // the default 5 s timeout with generous headroom.
+    _petTimer = Timer.periodic(const Duration(seconds: 1), (_) async {
+      try {
+        await _watchdogChannel
+            .invokeMethod<void>('pet', {'source': _watchdogSource});
+      } catch (_) {
+        // Ignore transient pet failures.
+      }
+    });
+    setState(() => _petting = true);
+  }
+
+  // Stops petting the watchdog source. The source is left registered but never
+  // pet again, so the embedder's watchdog thread fires after the timeout and
+  // aborts the process (SIGABRT).
+  void _stopWatchdogPetting() {
+    _petTimer?.cancel();
+    _petTimer = null;
+    print('STOPWATCH_STRESS_STOP_PET');
+    setState(() => _petting = false);
+  }
+
+  void _writeUptime() {
+    final int seconds = _stopwatch.elapsed.inSeconds;
+    final String line = '${DateTime.now().toIso8601String()} '
+        'uptime_seconds=$seconds\n';
+    try {
+      File(_uptimeFile).writeAsStringSync(line, mode: FileMode.append);
+      _writeCount++;
+      setState(() => _lastWrite = line.trim());
+      print('STOPWATCH_STRESS_TICK $seconds');
+    } catch (e) {
+      print('STOPWATCH_STRESS_WRITE_FAIL $e');
+    }
+  }
+
+  String _format(Duration d) {
+    final h = d.inHours.toString().padLeft(2, '0');
+    final m = (d.inMinutes % 60).toString().padLeft(2, '0');
+    final s = (d.inSeconds % 60).toString().padLeft(2, '0');
+    final ms = (d.inMilliseconds % 1000).toString().padLeft(3, '0');
+    return '$h:$m:$s.$ms';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Stopwatch Stress Test')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const SizedBox(
+              width: 96,
+              height: 96,
+              child: CircularProgressIndicator(strokeWidth: 6),
+            ),
+            const SizedBox(height: 40),
+            Text(
+              _format(_elapsed),
+              style: Theme.of(context).textTheme.displayMedium?.copyWith(
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'uptime',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Colors.white54,
+                  ),
+            ),
+            const SizedBox(height: 40),
+            Text(
+              'writes: $_writeCount',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'file: $_uptimeFile',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.white38,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'last: $_lastWrite',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.white38,
+                  ),
+            ),
+            const SizedBox(height: 40),
+            FilledButton.icon(
+              onPressed: _petting ? _stopWatchdogPetting : null,
+              icon: const Icon(Icons.dangerous),
+              label: Text(
+                _petting
+                    ? 'Stop petting watchdog (crash)'
+                    : 'Watchdog no longer petted',
+              ),
+              style: FilledButton.styleFrom(
+                backgroundColor: const Color(0xFFF44336),
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 16,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/integration/stopwatch_stress_test/pubspec.yaml
+++ b/test/integration/stopwatch_stress_test/pubspec.yaml
@@ -1,0 +1,21 @@
+name: stopwatch_stress_test
+description: Integration test app that runs a stopwatch and spinner while the embedder is stressed, exercising the watchdog under load.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
The `stopwatch_stress_test` Flutter application serves multiple purposes:

1. **Visual feedback**: Displays a real Flutter Wayland window with:
   - Running stopwatch showing elapsed time
   - Animated CircularProgressIndicator
   - Real-time system status indicators

2. **GPU stimulation**: The animated UI elements continuously exercise the GPU through Wayland EGL
    - also: by continuously animating, the human observation of the UI provides an immediate sanity check to verify that the system is responsive and the test is proceeding as intended, making it sustainable to observe intermittently over the 12-hour duration without requiring constant attention

3. **Watchdog exercise**: The application writes per-minute uptime files to verify main thread responsiveness

4. **Environment reproduction**: Provides a realistic representation of production workload including Flutter engine operations, Wayland compositing, and GPU rendering

5. **Post-run summary output**: The test script collects and summarizes the results and runtime information, including:
   - Watchdog survival
   - Logs
   - Uptime file integrity
   - sd_notify delivery
   - System resource utilization

The above elements provide a comprehensive view of the system's behavior under stress and allow for detailed post-test analysis.