### PR TITLE
build: keep the embedded git stamp honest

### DIFF
--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -31,3 +31,106 @@ if (GIT_COMMIT_HASH)
 else ()
     set(GIT_COMMIT_HASH "unknown")
 endif ()
+
+#
+# Dirty tree
+#
+# A build from a modified tree is not the commit it names. Without this a
+# developer build and the tagged release it was derived from are
+# indistinguishable in the binary, which is exactly the moment the stamp is
+# being consulted. Untracked files are excluded: build directories and local
+# scratch are not modifications to the source the binary was compiled from.
+execute_process(
+        COMMAND git status --porcelain --untracked-files=no
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_TREE_STATUS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+)
+
+if (GIT_TREE_STATUS)
+    set(GIT_COMMIT_HASH "${GIT_COMMIT_HASH}-dirty")
+    message(STATUS "GIT Tree ............... dirty")
+endif ()
+
+#
+# Re-configure when the checkout moves
+#
+# Everything above is captured at configure time, and nothing re-runs configure
+# when HEAD moves. A build tree configured on one commit therefore keeps
+# stamping that commit into every binary built afterwards. A binary that
+# confidently names the wrong commit is worse than one that names none, because
+# it defeats the very check it exists to support.
+#
+# Two paths matter and both are needed. HEAD changes on checkout and detach.
+# Committing, amending, or resetting on a branch leaves HEAD alone and moves
+# the branch ref instead, so watching HEAD by itself misses the most common
+# case. Ask git for both paths rather than assuming a layout: in a linked
+# worktree .git is a file, HEAD lives in that worktree's own git directory, and
+# refs/heads lives in the common one.
+set(_git_watch "")
+
+execute_process(
+        COMMAND git rev-parse --git-path HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE _git_head_path
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+)
+if (_git_head_path)
+    list(APPEND _git_watch "${_git_head_path}")
+endif ()
+
+# The ref HEAD resolves to, when HEAD is symbolic. A detached HEAD has none,
+# and then HEAD alone is the whole story.
+execute_process(
+        COMMAND git symbolic-ref --quiet HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE _git_symref
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+)
+if (_git_symref)
+    execute_process(
+            COMMAND git rev-parse --git-path "${_git_symref}"
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE _git_ref_path
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+    )
+    if (_git_ref_path)
+        list(APPEND _git_watch "${_git_ref_path}")
+    endif ()
+endif ()
+
+# A packed ref has no loose file to watch, which is what a fresh clone with no
+# local commits looks like.
+execute_process(
+        COMMAND git rev-parse --git-path packed-refs
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE _git_packed_path
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+)
+if (_git_packed_path)
+    list(APPEND _git_watch "${_git_packed_path}")
+endif ()
+
+# `git rev-parse --git-path` may answer relative to the directory it ran in, so
+# anchor anything relative back to that same directory.
+foreach (_git_path IN LISTS _git_watch)
+    if (NOT IS_ABSOLUTE "${_git_path}")
+        set(_git_path "${CMAKE_SOURCE_DIR}/${_git_path}")
+    endif ()
+    if (EXISTS "${_git_path}")
+        set_property(DIRECTORY "${CMAKE_SOURCE_DIR}"
+                APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${_git_path}")
+    endif ()
+endforeach ()
+
+unset(_git_watch)
+unset(_git_head_path)
+unset(_git_symref)
+unset(_git_ref_path)
+unset(_git_packed_path)
+unset(_git_path)


### PR DESCRIPTION
## Problem

`kGitBranch` / `kGitCommitHash` are captured by `execute_process` at **configure** time, and nothing re-runs configure when the checkout moves. A build tree configured on one commit keeps stamping that commit into every binary built afterwards.

This surfaced while trying to identify which commit a binary deployed to a target had been built from. The stamp is consulted exactly when someone needs that answer, and a confident wrong answer sends them reading the wrong source — which is worse than carrying no stamp at all.

## Change

- Register the checkout's `HEAD`, its branch ref, and `packed-refs` as `CMAKE_CONFIGURE_DEPENDS`, so a commit or checkout re-runs configure and restamps.
- Add a `-dirty` suffix when the tracked tree is modified, so a developer build is distinguishable from the commit it derives from.

Both ref paths are needed. `HEAD` moves on checkout and detach; committing, amending, or resetting on a branch leaves `HEAD` alone and moves the **branch ref** instead — the common case, which watching `HEAD` alone misses entirely.

Paths come from `git rev-parse --git-path`, not from assuming a layout. In a linked worktree `.git` is a file, `HEAD` lives in that worktree's own git directory, and `refs/heads` lives in the common one — all three of which a hand-built `${CMAKE_SOURCE_DIR}/.git/HEAD` gets wrong.

## Verification

Configured against this worktree and confirmed the resolved watch set spans the worktree/common-dir split:

```
/…/.git/worktrees/ihs-gitver/HEAD          <- worktree-local HEAD
/…/.git/refs/heads/jw/git-hash-provenance  <- common-dir branch ref
/…/.git/packed-refs
```

Committing then re-ran CMake unprompted and restamped `0bb33f31` -> `f68ae3e6`; before this change it kept reporting `0bb33f31`. Also exercised detached HEAD (no symbolic ref — degrades to watching `HEAD` alone) and a dirty tree (`0bb33f31-dirty`).

## Cost

One configure re-run after each commit, in exchange for a stamp that can be trusted. Every added command is `ERROR_QUIET`, so a source tarball with no git present still configures and reports the same `unknown` it does today.