### PR TITLE
drm-kms-vulkan: close the scanout barrier's sync_file

### DIFF
--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -75,6 +75,33 @@ const auto& d() {
   return vk::detail::defaultDispatchLoaderDynamic;
 }
 
+// Owns a file descriptor for the rest of its scope.
+//
+// The scanout barrier hands back an owned sync_file on every explicit-sync
+// frame, and each of the present path's exits owes it a close --- including the
+// two early returns taken while the presenting layer is still being created.
+// drm::sync::SyncFence cannot serve here: import_fd() dups, so handing the fd
+// to it leaves the original this side's problem.
+class ScopedFd {
+ public:
+  explicit ScopedFd(const int fd) noexcept : fd_(fd) {}
+  ~ScopedFd() {
+    if (fd_ >= 0) {
+      ::close(fd_);
+    }
+  }
+
+  ScopedFd(const ScopedFd&) = delete;
+  ScopedFd& operator=(const ScopedFd&) = delete;
+  ScopedFd(ScopedFd&&) = delete;
+  ScopedFd& operator=(ScopedFd&&) = delete;
+
+  [[nodiscard]] int get() const noexcept { return fd_; }
+
+ private:
+  int fd_{-1};
+};
+
 // Map a rotation in degrees (validated to 0|90|180|270 at config time) to the
 // KMS plane rotation bitflag. drm-cxx lowers DisplayParams::rotation to the
 // plane's `rotation` property (or software pre-rotation if the plane lacks it).
@@ -1323,9 +1350,11 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
   // already retired; this barrier only makes the writes visible to KMS. On the
   // explicit-sync path it returns a sync_file the scene hands to IN_FENCE_FD so
   // the kernel — not the raster thread — waits on it; -1 means CPU-fenced.
-  const int scanout_fence_fd =
+  // Owned here so every exit below closes it exactly once --- the early returns
+  // during layer creation included.
+  const ScopedFd scanout_fence(
       SubmitScanoutBarrier(c, store->image(), store->view(), store->width(),
-                           store->height(), layers, count);
+                           store->height(), layers, count));
 
   // The engine's raster thread pipelines: it hands us frame N+1 while flip N is
   // still in flight, and a single plane can hold only one flip, so we wait for
@@ -1373,12 +1402,12 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
 
   // Mark the slot ready. On the explicit-sync path, hand its render-done
   // sync_file to the source as the acquire fence (the scene lowers it to the
-  // plane's IN_FENCE_FD); SyncFence takes ownership of the fd.
-  if (scanout_fence_fd >= 0) {
-    if (auto fence = drm::sync::SyncFence::import_fd(scanout_fence_fd)) {
+  // plane's IN_FENCE_FD). import_fd dups, so the fence the ring receives is its
+  // own; ours is closed by ScopedFd on the way out either way.
+  if (scanout_fence.get() >= 0) {
+    if (auto fence = drm::sync::SyncFence::import_fd(scanout_fence.get())) {
       c.ring->SetReady(slot, std::move(fence.value()));
     } else {
-      ::close(scanout_fence_fd);
       c.ring->SetReady(slot);
     }
   } else {


### PR DESCRIPTION
## Problem

`PresentLayers` leaks **one `sync_file` per composited frame** on the explicit-sync path.

`SubmitScanoutBarrier` returns an owned fd. The success branch handed it to `SyncFence::import_fd` and then dropped it:

```cpp
if (scanout_fence_fd >= 0) {
  if (auto fence = drm::sync::SyncFence::import_fd(scanout_fence_fd)) {
    c.ring->SetReady(slot, std::move(fence.value()));   // original never closed
  } else {
    ::close(scanout_fence_fd);                          // only on import failure
    c.ring->SetReady(slot);
  }
}
```

`import_fd` **dups** — it does not adopt:

```cpp
int const duped = ::dup(fence_fd);
...
return SyncFence(duped);
```

So the ring's fence is its own and the original stays open forever. Only the import-*failure* branch closed it, which is the branch that essentially never runs.

The comment above the block asserted the opposite — *"SyncFence takes ownership of the fd"* — which is how the missing close survived review. `layer_scene.cpp` gets the identical pattern right, closing `out_fd` unconditionally outside the `if`.

## Impact

Proportional to composite rate, independent of content. On a Pi 5 at 1280x1440 it ran ~60 fds/s and exhausted the default 1024-descriptor limit in **~17 seconds**, after which every dma-buf import failed with `EMFILE`.

Platform views are not involved — a stock Flutter app reproduces it — but they make it *visible*, since a view whose buffer cannot be imported composites as black.

## Change

Own the fd in a scoped holder where `SubmitScanoutBarrier` returns it, rather than closing it on each path. Two early returns during layer creation sit between the barrier and the import and leaked it too; a holder covers them without spreading closes across every exit.

## Verification

Pi 5, `drm-kms-vulkan`, explicit sync, 1280x1440.

**Stock Flutter app (no platform views)** — `sync_file` fds held:

| t (s) | before | after |
|---|---|---|
| 8  | 173  | 7 |
| 18 | 377  | 7 |
| 28 | 688  | 7 |
| 38 | 1025 | 7 |

**Four platform views, default 1024 limit** — after the fix: flat at ~10 `sync_file` / ~70 total across 60s, `EMFILE=0`, all four views submitting. Before: saturated the limit in ~17s and every view went black.