### PR TITLE
drm-kms-vulkan: composite platform views

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -331,6 +331,10 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN)
             backend/drm_kms_vulkan/modifier_format.cc
             backend/drm_kms_egl/scene_layer_source_vk.cc
             backend/drm_kms_egl/drm_session.cc
+            # Shared with the Wayland Vulkan backend, which is where it lives.
+            # It is pure Vulkan (no Wayland headers), and the two backends are
+            # mutually exclusive, so it is only ever compiled once.
+            $<$<BOOL:${BUILD_COMPOSITOR}>:backend/wayland_vulkan/wl_layer_compositor.cc>
             backend/drm_kms_egl/driver_probe.cc
             display/drm_display.cc
             display/drm_output_provider.cc

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -75,6 +75,33 @@ const auto& d() {
   return vk::detail::defaultDispatchLoaderDynamic;
 }
 
+// Owns a file descriptor for the rest of its scope.
+//
+// The scanout barrier hands back an owned sync_file on every explicit-sync
+// frame, and each of the present path's exits owes it a close --- including the
+// two early returns taken while the presenting layer is still being created.
+// drm::sync::SyncFence cannot serve here: import_fd() dups, so handing the fd
+// to it leaves the original this side's problem.
+class ScopedFd {
+ public:
+  explicit ScopedFd(const int fd) noexcept : fd_(fd) {}
+  ~ScopedFd() {
+    if (fd_ >= 0) {
+      ::close(fd_);
+    }
+  }
+
+  ScopedFd(const ScopedFd&) = delete;
+  ScopedFd& operator=(const ScopedFd&) = delete;
+  ScopedFd(ScopedFd&&) = delete;
+  ScopedFd& operator=(ScopedFd&&) = delete;
+
+  [[nodiscard]] int get() const noexcept { return fd_; }
+
+ private:
+  int fd_{-1};
+};
+
 // Map a rotation in degrees (validated to 0|90|180|270 at config time) to the
 // KMS plane rotation bitflag. drm-cxx lowers DisplayParams::rotation to the
 // plane's `rotation` property (or software pre-rotation if the plane lacks it).
@@ -1323,9 +1350,11 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
   // already retired; this barrier only makes the writes visible to KMS. On the
   // explicit-sync path it returns a sync_file the scene hands to IN_FENCE_FD so
   // the kernel — not the raster thread — waits on it; -1 means CPU-fenced.
-  const int scanout_fence_fd =
+  // Owned here so every exit below closes it exactly once --- the early returns
+  // during layer creation included.
+  const ScopedFd scanout_fence(
       SubmitScanoutBarrier(c, store->image(), store->view(), store->width(),
-                           store->height(), layers, count);
+                           store->height(), layers, count));
 
   // The engine's raster thread pipelines: it hands us frame N+1 while flip N is
   // still in flight, and a single plane can hold only one flip, so we wait for
@@ -1373,12 +1402,12 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
 
   // Mark the slot ready. On the explicit-sync path, hand its render-done
   // sync_file to the source as the acquire fence (the scene lowers it to the
-  // plane's IN_FENCE_FD); SyncFence takes ownership of the fd.
-  if (scanout_fence_fd >= 0) {
-    if (auto fence = drm::sync::SyncFence::import_fd(scanout_fence_fd)) {
+  // plane's IN_FENCE_FD). import_fd dups, so the fence the ring receives is its
+  // own; ours is closed by ScopedFd on the way out either way.
+  if (scanout_fence.get() >= 0) {
+    if (auto fence = drm::sync::SyncFence::import_fd(scanout_fence.get())) {
       c.ring->SetReady(slot, std::move(fence.value()));
     } else {
-      ::close(scanout_fence_fd);
       c.ring->SetReady(slot);
     }
   } else {

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -1174,17 +1174,30 @@ int VulkanDrmBackend::SubmitScanoutBarrier(CompositorState& c,
 #else
   const bool hud_active = false;
 #endif
-  const VkImageMemoryBarrier barrier = ColorBarrier(
-      image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL,
-      VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-      hud_active ? (VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT)
-                 : VK_ACCESS_MEMORY_READ_BIT);
-  d().vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                           hud_active
-                               ? VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
-                               : VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                           0, 0, nullptr, 0, nullptr, 1, &barrier);
+#if BUILD_COMPOSITOR
+  // Blend the platform views and any Flutter overlay stores over the engine's
+  // render, which is already resident in this image. The blend's render pass
+  // consumes the image as a color attachment and declares GENERAL as its final
+  // layout, so when it runs it *is* the transition and the explicit barrier
+  // below would be a redundant second one from the wrong source layout.
+  const bool composited = CompositeOverlays(cmd, layers, count, image, view,
+                                            width, height, c.frame);
+#else
+  const bool composited = false;
+#endif
+  if (!composited) {
+    const VkImageMemoryBarrier barrier = ColorBarrier(
+        image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        hud_active ? (VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                      VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT)
+                   : VK_ACCESS_MEMORY_READ_BIT);
+    d().vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                             hud_active
+                                 ? VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+                                 : VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &barrier);
+  }
 
 #if BUILD_HUD
   // Draw the HUD into the same command buffer (image is now GENERAL), so the
@@ -1304,6 +1317,210 @@ bool VulkanDrmBackend::RecordHud(VkCommandBuffer cmd,
 }
 #endif  // BUILD_HUD
 
+#if BUILD_COMPOSITOR
+void VulkanDrmBackend::RegisterCompositorSurface(
+    const FlutterPlatformViewIdentifier id,
+    std::shared_ptr<ICompositorSurface> surface) {
+  const std::lock_guard<std::mutex> lock(compositor_surfaces_mu_);
+  compositor_surfaces_[id] = std::move(surface);
+}
+
+void VulkanDrmBackend::UnregisterCompositorSurface(
+    const FlutterPlatformViewIdentifier id) {
+  const std::lock_guard<std::mutex> lock(compositor_surfaces_mu_);
+  compositor_surfaces_.erase(id);
+}
+
+void VulkanDrmBackend::ResizeCompositorSurface(
+    const FlutterPlatformViewIdentifier id,
+    const int32_t width,
+    const int32_t height) {
+  std::shared_ptr<ICompositorSurface> surface;
+  {
+    const std::lock_guard<std::mutex> lock(compositor_surfaces_mu_);
+    if (const auto it = compositor_surfaces_.find(id);
+        it != compositor_surfaces_.end()) {
+      surface = it->second;
+    }
+  }
+  // Called without the lock held: OnResize reaches into the plugin, which may
+  // call back into the registry.
+  if (surface) {
+    surface->OnResize(width, height);
+  }
+}
+
+bool VulkanDrmBackend::CompositeOverlays(VkCommandBuffer cmd,
+                                         const FlutterLayer** layers,
+                                         const size_t count,
+                                         VkImage target_image,
+                                         VkImageView target_view,
+                                         const uint32_t width,
+                                         const uint32_t height,
+                                         const uint64_t frame) {
+  if (layers == nullptr || count < 2) {
+    return false;  // base backing store only — nothing to blend over it
+  }
+
+  struct Draw {
+    VkImage src;
+    VkFormat format;
+    int32_t dx, dy, dw, dh;
+    bool restore_color_attachment;  // a Flutter store the engine renders into
+    VkSamplerYcbcrModelConversion ycbcr_model;
+    VkSamplerYcbcrRange ycbcr_range;
+  };
+  std::vector<Draw> draws;
+  draws.reserve(count);
+
+  const auto barrier =
+      [&](VkImage image, VkImageLayout old_layout, VkImageLayout new_layout,
+          VkAccessFlags src_access, VkPipelineStageFlags src_stage,
+          VkAccessFlags dst_access, VkPipelineStageFlags dst_stage) {
+        VkImageMemoryBarrier b{};
+        b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        b.oldLayout = old_layout;
+        b.newLayout = new_layout;
+        b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        b.image = image;
+        b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        b.srcAccessMask = src_access;
+        b.dstAccessMask = dst_access;
+        d().vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0,
+                                 nullptr, 1, &b);
+      };
+
+  CompositorState& c = *compositor_;
+  // Phase 1: move every source to SHADER_READ_ONLY. Layout transitions cannot
+  // happen inside a render pass, so they all precede phase 2.
+  for (size_t i = 0; i < count; ++i) {
+    const FlutterLayer* layer = layers[i];
+    if (layer == nullptr) {
+      continue;
+    }
+    const auto dx = static_cast<int32_t>(layer->offset.x);
+    const auto dy = static_cast<int32_t>(layer->offset.y);
+    const auto dw = static_cast<int32_t>(layer->size.width);
+    const auto dh = static_cast<int32_t>(layer->size.height);
+    if (dw <= 0 || dh <= 0) {
+      continue;
+    }
+
+    if (layer->type == kFlutterLayerContentTypeBackingStore &&
+        layer->backing_store != nullptr) {
+      const auto it = c.key_to_slot.find(layer->backing_store->user_data);
+      if (it == c.key_to_slot.end()) {
+        continue;
+      }
+      drm_kms_vulkan::VulkanBackingStore* store =
+          c.slots[it->second].store.get();
+      if (store == nullptr || store->image() == target_image) {
+        continue;  // the base store, already resident in the target
+      }
+      barrier(store->image(), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+              VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+              VK_ACCESS_SHADER_READ_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+      draws.push_back({store->image(), store->vk_format(), dx, dy, dw, dh, true,
+                       VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY,
+                       VK_SAMPLER_YCBCR_RANGE_ITU_NARROW});
+    } else if (layer->type == kFlutterLayerContentTypePlatformView &&
+               layer->platform_view != nullptr) {
+      std::shared_ptr<ICompositorSurface> surface;
+      {
+        const std::lock_guard<std::mutex> lock(compositor_surfaces_mu_);
+        if (const auto it =
+                compositor_surfaces_.find(layer->platform_view->identifier);
+            it != compositor_surfaces_.end()) {
+          surface = it->second;
+        }
+      }
+      if (!surface) {
+        continue;
+      }
+      int32_t pw = 0;
+      int32_t ph = 0;
+      void* vk_img = surface->GetVulkanImage(&pw, &ph);
+      if (vk_img == nullptr || pw <= 0 || ph <= 0) {
+        continue;  // no Vulkan image yet, or a GL-only producer
+      }
+      auto src = reinterpret_cast<VkImage>(vk_img);
+      // 0 keeps the historical B8G8R8A8_UNORM contract for RGB producers; a
+      // planar producer reports its own format plus the conversion parameters.
+      const uint32_t pv_fmt = surface->GetVulkanImageFormat();
+      const VkFormat src_format = pv_fmt != 0 ? static_cast<VkFormat>(pv_fmt)
+                                              : VK_FORMAT_B8G8R8A8_UNORM;
+      const auto cur =
+          static_cast<VkImageLayout>(surface->GetVulkanImageLayout());
+      if (cur != VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
+        const bool from_preinit = cur == VK_IMAGE_LAYOUT_PREINITIALIZED;
+        barrier(src, cur, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                from_preinit ? VK_ACCESS_HOST_WRITE_BIT : 0,
+                from_preinit ? VK_PIPELINE_STAGE_HOST_BIT
+                             : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                VK_ACCESS_SHADER_READ_BIT,
+                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+        surface->SetVulkanImageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+      }
+      draws.push_back(
+          {src, src_format, dx, dy, dw, dh, false,
+           static_cast<VkSamplerYcbcrModelConversion>(
+               surface->GetVulkanYcbcrModel()),
+           static_cast<VkSamplerYcbcrRange>(surface->GetVulkanYcbcrRange())});
+    }
+  }
+
+  if (draws.empty()) {
+    return false;
+  }
+
+  // Built here rather than at init: the pipeline is keyed to the slot format,
+  // and a failure must not be retried every frame.
+  if (!layer_compositor_ && !layer_compositor_failed_) {
+    std::string err;
+    layer_compositor_ = wl_vulkan::LayerCompositor::Create(
+        device_, VK_FORMAT_B8G8R8A8_UNORM, err,
+        wl_vulkan::LayerCompositor::ContentMode::kPreserve);
+    if (!layer_compositor_) {
+      layer_compositor_failed_ = true;
+      ihs::log::error(
+          "[VulkanDrmBackend] platform-view blend unavailable ({}); views will "
+          "not composite",
+          err);
+    }
+  }
+  if (!layer_compositor_) {
+    return false;
+  }
+
+  // Phase 2: one render pass, layers blended in z-order over the base.
+  bool opened = false;
+  if (layer_compositor_->BeginFrame(cmd, target_view, width, height, frame)) {
+    opened = true;
+    for (const Draw& dr : draws) {
+      layer_compositor_->DrawLayer(cmd, dr.src, dr.format, dr.ycbcr_model,
+                                   dr.ycbcr_range, dr.dx, dr.dy, dr.dw, dr.dh);
+    }
+    wl_vulkan::LayerCompositor::EndFrame(cmd);
+  }
+
+  // Phase 3: hand the Flutter stores back as color attachments for the engine's
+  // next render. Runs even if the pass never opened, since phase 1 moved them.
+  for (const Draw& dr : draws) {
+    if (dr.restore_color_attachment) {
+      barrier(dr.src, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+              VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+              VK_ACCESS_SHADER_READ_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    }
+  }
+  return opened;
+}
+#endif  // BUILD_COMPOSITOR
+
 bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
                                          size_t count) {
   if (!compositor_ || !compositor_->scene) {
@@ -1328,6 +1545,18 @@ bool VulkanDrmBackend::PresentLayersImpl(const FlutterLayer** layers,
     return true;
   }
   CompositorState& c = *compositor_;
+  {  // TEMP DIAGNOSTIC -- not for commit
+    std::string sig;
+    for (size_t i = 0; i < count; ++i) {
+      sig += (layers[i]->type == kFlutterLayerContentTypeBackingStore) ? "BS "
+                                                                       : "PV ";
+    }
+    static std::string last;
+    if (sig != last) {
+      last = sig;
+      ihs::log::info("[LAYERDIAG] count={} kinds=[{}]", count, sig);
+    }
+  }
   const FlutterLayer* bs_layer = nullptr;
   for (size_t i = 0; i < count; ++i) {
     if (layers[i]->type == kFlutterLayerContentTypeBackingStore) {

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -21,13 +21,22 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <vulkan/vulkan.h>
 
 #include "backend/backend.h"
 #include "backend/drm_kms_vulkan/device_caps.h"
+#if BUILD_COMPOSITOR
+// Pure-Vulkan blend pipeline; despite living beside the Wayland backend it
+// pulls in no Wayland headers, so the DRM backend shares it rather than
+// carrying a second copy of the same render pass.
+#include "backend/wayland_vulkan/wl_layer_compositor.h"
+#include "view/compositor_surface_interface.h"
+#endif
 #include "profiling/frame_profile.h"
 #include "vsync/ivsync_provider.h"
 
@@ -123,6 +132,19 @@ class VulkanDrmBackend final : public Backend {
   // an exported dma-buf, and submit it for zero-copy import — the same seam
   // WaylandVulkanBackend provides.
   bool GetVulkanContext(BackendVulkanContext* out) const override;
+
+#if BUILD_COMPOSITOR
+  // Platform-view surfaces. Backend's default implementations are no-ops, so
+  // without these every surface the registry hands over is dropped and the
+  // views composite as nothing.
+  void RegisterCompositorSurface(
+      FlutterPlatformViewIdentifier id,
+      std::shared_ptr<ICompositorSurface> surface) override;
+  void UnregisterCompositorSurface(FlutterPlatformViewIdentifier id) override;
+  void ResizeCompositorSurface(FlutterPlatformViewIdentifier id,
+                               int32_t width,
+                               int32_t height) override;
+#endif
 
   // Vsync: drive Flutter's frame scheduling from the real page-flip event
   // instead of its wall-clock fallback, so frames align to the connector's
@@ -293,6 +315,40 @@ class VulkanDrmBackend final : public Backend {
                  uint32_t height,
                  const FlutterLayer** layers,
                  size_t count);
+#endif
+
+#if BUILD_COMPOSITOR
+  // Platform-view surfaces, keyed by the engine's view identifier. Registered
+  // from the platform thread and read on the raster thread during compositing,
+  // hence the mutex.
+  std::mutex compositor_surfaces_mu_;
+  std::unordered_map<FlutterPlatformViewIdentifier,
+                     std::shared_ptr<ICompositorSurface>>
+      compositor_surfaces_;
+
+  // src-over blend of the platform views (and any Flutter overlay stores) on
+  // top of the base backing store. Built lazily on first use because it is
+  // keyed to the slot format, which is not known until the scanout target has
+  // been negotiated. kPreserve: the base layer is already in the target.
+  std::unique_ptr<wl_vulkan::LayerCompositor> layer_compositor_;
+  bool layer_compositor_failed_{false};
+
+  // Blend every layer above the base backing store into @p target_view.
+  //
+  // Any backing store whose image is @p target_image is the base and is skipped
+  // --- it is already resident there, and sampling it would mean reading the
+  // image being rendered into. Records into @p cmd and reports whether it
+  // opened a render pass, which the caller needs because that pass leaves the
+  // target in GENERAL and so replaces the explicit scanout barrier. Raster
+  // thread.
+  bool CompositeOverlays(VkCommandBuffer cmd,
+                         const FlutterLayer** layers,
+                         size_t count,
+                         VkImage target_image,
+                         VkImageView target_view,
+                         uint32_t width,
+                         uint32_t height,
+                         uint64_t frame);
 #endif
 
   // Flutter's vsync_callback -> parks the baton in vsync_. Static C ABI; the

--- a/shell/backend/wayland_vulkan/wl_layer_compositor.cc
+++ b/shell/backend/wayland_vulkan/wl_layer_compositor.cc
@@ -144,21 +144,30 @@ VkPipeline MakePipeline(VkDevice device,
 
 std::unique_ptr<LayerCompositor> LayerCompositor::Create(VkDevice device,
                                                          VkFormat color_format,
-                                                         std::string& err) {
+                                                         std::string& err,
+                                                         ContentMode mode) {
   std::unique_ptr<LayerCompositor> c(new LayerCompositor(device));
   c->color_format_ = color_format;
 
-  // Render pass: one color attachment (the slot), cleared then blended into,
-  // left in GENERAL for the dma-buf present. initialLayout UNDEFINED because
-  // the clear discards any prior content.
+  // Render pass: one color attachment (the slot), blended into and left in
+  // GENERAL for the dma-buf present.
+  //
+  // kClear discards prior content, so initialLayout can be UNDEFINED. kPreserve
+  // keeps it, which means the layout has to be declared honestly: the content
+  // being preserved was just written as a color attachment, and UNDEFINED would
+  // permit the driver to throw it away -- the one thing this mode exists to
+  // prevent.
+  const bool preserve = mode == ContentMode::kPreserve;
   VkAttachmentDescription att{};
   att.format = color_format;
   att.samples = VK_SAMPLE_COUNT_1_BIT;
-  att.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+  att.loadOp =
+      preserve ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
   att.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
   att.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
   att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-  att.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  att.initialLayout = preserve ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+                               : VK_IMAGE_LAYOUT_UNDEFINED;
   att.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
   VkAttachmentReference ref{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
   VkSubpassDescription sub{};
@@ -175,6 +184,14 @@ std::unique_ptr<LayerCompositor> LayerCompositor::Create(VkDevice device,
   deps[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
   deps[0].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
   deps[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+  if (preserve) {
+    // The content being loaded is the engine's render into this same image, so
+    // the load has to wait on those color writes. The clear path never reads
+    // prior content and so has nothing to wait for here.
+    deps[0].srcStageMask |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    deps[0].srcAccessMask |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    deps[0].dstAccessMask |= VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+  }
   deps[1].srcSubpass = 0;
   deps[1].dstSubpass = VK_SUBPASS_EXTERNAL;
   deps[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;

--- a/shell/backend/wayland_vulkan/wl_layer_compositor.h
+++ b/shell/backend/wayland_vulkan/wl_layer_compositor.h
@@ -37,11 +37,24 @@ namespace wl_vulkan {
 // per frame: BeginFrame -> DrawLayer per layer (in z-order) -> EndFrame.
 class LayerCompositor {
  public:
+  // What the render pass does with the target's existing content.
+  //
+  // kClear suits a compositor that owns a scratch slot and draws the whole
+  // layer stack into it. kPreserve suits one whose base layer is already in the
+  // target --- the DRM/KMS Vulkan backend renders Flutter's backing store
+  // straight into the scanout image, so it can only blend the platform views
+  // and overlays on top; clearing would discard the frame it is compositing
+  // onto, and blending the base in instead would mean sampling the very image
+  // being rendered to.
+  enum class ContentMode { kClear, kPreserve };
+
   // Build the render pass / pipeline / sampler for @p color_format (the slot
   // format). Returns nullptr and sets @p err on failure.
-  static std::unique_ptr<LayerCompositor> Create(VkDevice device,
-                                                 VkFormat color_format,
-                                                 std::string& err);
+  static std::unique_ptr<LayerCompositor> Create(
+      VkDevice device,
+      VkFormat color_format,
+      std::string& err,
+      ContentMode mode = ContentMode::kClear);
   ~LayerCompositor();
   LayerCompositor(const LayerCompositor&) = delete;
   LayerCompositor& operator=(const LayerCompositor&) = delete;


### PR DESCRIPTION
> Stacked on **#370** (the scanout `sync_file` leak). Platform views exhaust the default 1024-descriptor limit in ~17s without that fix, so this branch includes it. Rebase onto `v2.0` once #370 lands.

## Problem

The DRM/KMS Vulkan backend never composited platform views:

```cpp
for (size_t i = 0; i < count; ++i) {
  if (layers[i]->type == kFlutterLayerContentTypeBackingStore) {
    bs_layer = layers[i];
    break;            // first backing store wins; everything else discarded
  }
}
```

Every platform-view layer and every Flutter *overlay* backing store above it was dropped. The backend's only `kFlutterLayerContentTypePlatformView` reference lives in the HUD block, which counts views for a readout and draws nothing.

Nothing reported an error, because nothing failed. `ihs_pv` is backend-agnostic, so plugins negotiated, allocated dma-bufs and submitted frames normally — the buffers were just never drawn. `Backend::RegisterCompositorSurface` and its siblings are empty defaults, so every surface the registry handed over was dropped.

Measured on a Pi 5 with four shader views, the engine delivers:

```
count=5 kinds=[BS PV PV PV PV ]              idle
count=6 kinds=[BS PV PV PV PV BS ]           dropdown open
```

Hence both symptoms: platform views composite as black, and an open dropdown — rendered into that trailing overlay store — never appears, so the menu takes clicks and shows nothing.

## Change

- **Surface registry** on `VulkanDrmBackend` (`Register` / `Unregister` / `ResizeCompositorSurface`). `ResizeCompositorSurface` drops the lock before calling `OnResize`, which re-enters the plugin.
- **`CompositeOverlays`** — three phases, modelled on `wayland_vulkan.cc`: barrier sources to `SHADER_READ_ONLY`, one render pass blending in z-order, restore Flutter stores to `COLOR_ATTACHMENT_OPTIMAL`. Any store whose image *is* the target is skipped.
- **`LayerCompositor::ContentMode`** — shared rather than copied (it needs no Wayland headers, and the two backends are mutually exclusive). Its existing behavior clears the target, which is wrong here: this backend renders Flutter's backing store straight into the scanout image, so the base is already in the target. Clearing would discard the frame being composited onto; blending the base in instead would mean sampling the image being rendered into. `kPreserve` loads, declares `COLOR_ATTACHMENT_OPTIMAL` as `initialLayout` (`UNDEFINED` would license the driver to discard exactly what the mode preserves), and extends the external subpass dependency to wait on the engine's color writes. `kClear` remains the default — **the Wayland backend is unchanged**.

The blend records into the scanout-barrier command buffer so the exported scanout fence covers it. Its render pass takes the image as a color attachment and names `GENERAL` as `finalLayout`, so when it runs it *is* the scanout transition; the explicit barrier is skipped rather than reissued from a layout the image no longer has.

## Known limitations

Stated rather than papered over:

1. **Explicit-sync path only.** `SubmitScanoutBarrier` returns early on the CPU-fence fallback before reaching the blend, so a target without `IN_FENCE_FD` still drops PV layers. Left unwritten rather than written blind — this hardware negotiates explicit sync, so the fallback would ship unverified.
2. **Producer acquire fence not yet waited on** in the compositor's submit. An implicit-sync producer stalls before submitting, so the current path is correct; an explicit-sync producer will need that wait.

## Verification

Pi 5, `drm-kms-vulkan`, 1280x1440, explicit sync, four concurrent shader platform views:

- all four views render
- dropdown menu draws and responds
- Flutter UI flicker-free
- descriptors flat at 68 (10 `sync_file`) across 30s
- Vulkan validation silent (0 VUIDs)
- stock Flutter app with no platform views takes the untouched path — the blend returns immediately when nothing sits above the base