### PR TITLE
drm-kms-vulkan: teardown segfault, --drm-explicit-sync, CPU-fence compositing

### DIFF
--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -367,13 +367,23 @@ VulkanDrmBackend::VulkanDrmBackend(std::string drm_device,
 VulkanDrmBackend::~VulkanDrmBackend() {
   // Cadence profile summary (no-op unless IVI_PROFILE / IVI_DRMVK_PROFILE ran).
   frame_profile_.LogSessionSummary("VulkanDrmBackend");
-#if BUILD_HUD
-  // Free the HUD while the Vulkan device is still alive (Teardown destroys it):
-  // ~VulkanHud runs ImGui_ImplVulkan_Shutdown, which frees device memory.
+  // Anything holding Vulkan objects has to be freed while the device is still
+  // alive, because Teardown() destroys it and members outlive this body. Wait
+  // for the GPU first: the last frame's command buffer may still reference the
+  // render pass and descriptors being freed just below.
   if (device_ != VK_NULL_HANDLE) {
     d().vkDeviceWaitIdle(device_);
   }
+#if BUILD_HUD
+  // ~VulkanHud runs ImGui_ImplVulkan_Shutdown, which frees device memory.
   hud_.reset();
+#endif
+#if BUILD_COMPOSITOR
+  // ~LayerCompositor destroys its render pass, pipelines, samplers, descriptor
+  // pools and cached framebuffers/views. As a member it would otherwise be
+  // destroyed after this body -- and so after Teardown() -- calling vkDestroy*
+  // on a dead device.
+  layer_compositor_.reset();
 #endif
   // Tear the cursor down first: it commits on compositor_'s DRM device, so it
   // must not outlive it.

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -399,10 +399,11 @@ std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
     const bool enable_validation,
     homescreen::DrmSession* session,
     const std::string& mode_spec,
-    const int rotation) {
+    const int rotation,
+    const drm_config::TriState explicit_sync) {
   auto backend = std::shared_ptr<VulkanDrmBackend>(new VulkanDrmBackend(
       drm_device, enable_validation, session, mode_spec, rotation));
-
+  backend->explicit_sync_pref_ = explicit_sync;
   return FinishCreate(std::move(backend));
 }
 
@@ -414,7 +415,8 @@ std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
     const std::string& mode_spec,
     const int rotation,
     const uint32_t connector_id,
-    std::function<bool()> revoked) {
+    std::function<bool()> revoked,
+    const drm_config::TriState explicit_sync) {
   if (drm_fd < 0) {
     ihs::log::critical("[VulkanDrmBackend] Create: invalid lease fd {}",
                        drm_fd);
@@ -431,6 +433,7 @@ std::shared_ptr<VulkanDrmBackend> VulkanDrmBackend::Create(
   // the connector.
   backend->lease_connector_id_ = connector_id;
   backend->lease_revoked_ = std::move(revoked);
+  backend->explicit_sync_pref_ = explicit_sync;
   return FinishCreate(std::move(backend));
 }
 
@@ -808,8 +811,15 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
   // than the raster thread CPU-blocking. If the device can't export a SYNC_FD
   // semaphore, explicit_sync stays false and the CPU-fence path (barrier_fence)
   // runs — same output, one raster-thread stall per frame.
-  if (d().vkGetSemaphoreFdKHR != nullptr &&
-      std::getenv("IVI_DRMVK_NO_EXPLICIT_SYNC") == nullptr) {
+  // --drm-explicit-sync / [view] drm_explicit_sync. kNo takes the CPU-fence
+  // path outright; kYes is a demand, and is answered below rather than here so
+  // a device that cannot export a SYNC_FD semaphore fails loudly instead of
+  // quietly running the fallback the operator just ruled out. The env var stays
+  // as the older spelling of kNo.
+  const bool sync_forced_off =
+      explicit_sync_pref_ == drm_config::TriState::kNo ||
+      std::getenv("IVI_DRMVK_NO_EXPLICIT_SYNC") != nullptr;
+  if (d().vkGetSemaphoreFdKHR != nullptr && !sync_forced_off) {
     VkCommandBufferAllocateInfo cbai{};
     cbai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
     cbai.commandPool = state->barrier_pool;
@@ -838,8 +848,21 @@ bool VulkanDrmBackend::SetupCompositor(std::string& err) {
     }
     state->explicit_sync = ok;
   }
-  ihs::log::info("[VulkanDrmBackend] scanout sync: {}",
-                 state->explicit_sync ? "explicit (IN_FENCE_FD)" : "CPU fence");
+  // An explicit demand that the device cannot meet is an error, not a silent
+  // downgrade: the operator asked for KMS-side waits, and the CPU-fence path
+  // stalls the raster thread every frame instead. Saying so beats leaving them
+  // to infer it from a log line they did not know to read.
+  if (!state->explicit_sync &&
+      explicit_sync_pref_ == drm_config::TriState::kYes) {
+    err =
+        "--drm-explicit-sync=yes but the device cannot export a SYNC_FD "
+        "semaphore (VK_KHR_external_semaphore_fd); pass auto to fall back to "
+        "the CPU-fence path";
+    return false;
+  }
+  ihs::log::info("[VulkanDrmBackend] scanout sync: {}{}",
+                 state->explicit_sync ? "explicit (IN_FENCE_FD)" : "CPU fence",
+                 sync_forced_off ? " (forced off by configuration)" : "");
 
   // Page-flip event routing: the commit passes `this` as user_data (see
   // present), so the handler recovers the backend and returns the vsync baton

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.cc
@@ -214,13 +214,16 @@ VkImageMemoryBarrier ColorBarrier(VkImage image,
 // until the GPU has executed it. Used to walk a backing-store image between the
 // layout the Flutter Vulkan renderer leaves it in (COLOR_ATTACHMENT_OPTIMAL)
 // and a flushed layout whose writes are visible to the KMS scanout engine.
-void SubmitImageBarrier(VkDevice device,
-                        VkCommandPool pool,
-                        VkFence fence,
-                        VkQueue queue,
-                        const VkImageMemoryBarrier& barrier,
-                        VkPipelineStageFlags src_stage,
-                        VkPipelineStageFlags dst_stage) {
+// Record @p record into a one-shot command buffer, submit it, and block until
+// it retires. The CPU-fence scanout path needs more than a bare barrier in that
+// buffer (the platform-view blend goes there too), so the recording is the
+// caller's to supply.
+template <typename Record>
+void SubmitOneShot(VkDevice device,
+                   VkCommandPool pool,
+                   VkFence fence,
+                   VkQueue queue,
+                   Record&& record) {
   VkCommandBufferAllocateInfo cbai{};
   cbai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
   cbai.commandPool = pool;
@@ -234,8 +237,7 @@ void SubmitImageBarrier(VkDevice device,
   bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
   bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
   d().vkBeginCommandBuffer(cmd, &bi);
-  d().vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr,
-                           1, &barrier);
+  record(cmd);
   d().vkEndCommandBuffer(cmd);
 
   VkSubmitInfo si{};
@@ -246,6 +248,19 @@ void SubmitImageBarrier(VkDevice device,
   d().vkQueueSubmit(queue, 1, &si, fence);
   d().vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
   d().vkFreeCommandBuffers(device, pool, 1, &cmd);
+}
+
+void SubmitImageBarrier(VkDevice device,
+                        VkCommandPool pool,
+                        VkFence fence,
+                        VkQueue queue,
+                        const VkImageMemoryBarrier& barrier,
+                        VkPipelineStageFlags src_stage,
+                        VkPipelineStageFlags dst_stage) {
+  SubmitOneShot(device, pool, fence, queue, [&](VkCommandBuffer cmd) {
+    d().vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0,
+                             nullptr, 1, &barrier);
+  });
 }
 
 // One layer, many buffers: a LayerBufferSource that owns a ring of
@@ -1170,17 +1185,36 @@ int VulkanDrmBackend::SubmitScanoutBarrier(CompositorState& c,
                                            const FlutterLayer** layers,
                                            size_t count) {
   if (!c.explicit_sync) {
-    // CPU-fence fallback: submit + block until the barrier retires, then the
+    // CPU-fence fallback: submit + block until the work retires, then the
     // caller marks the slot ready with no in-fence. (The HUD is folded only
     // into the explicit-sync path, where the scanout fence covers its draw.)
-    const VkImageMemoryBarrier barrier = ColorBarrier(
-        image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-        VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-        VK_ACCESS_MEMORY_READ_BIT);
-    SubmitImageBarrier(device_, c.barrier_pool, c.barrier_fence,
-                       graphics_queue_, barrier,
-                       VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                       VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    //
+    // The platform-view blend belongs here as much as it does on the explicit
+    // path -- it is the same layer stack, and a compositor that drops it shows
+    // black views. This branch used to return before reaching it, so any target
+    // without IN_FENCE_FD composited the base backing store alone.
+    SubmitOneShot(
+        device_, c.barrier_pool, c.barrier_fence, graphics_queue_,
+        [&](VkCommandBuffer cmd) {
+          bool composited = false;
+#if BUILD_COMPOSITOR
+          composited = CompositeOverlays(cmd, layers, count, image, view, width,
+                                         height, c.frame);
+#endif
+          // The blend's render pass ends in GENERAL, so when it runs it is
+          // itself the transition and the barrier would repeat it from a layout
+          // the image no longer has.
+          if (!composited) {
+            const VkImageMemoryBarrier barrier = ColorBarrier(
+                image, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                VK_IMAGE_LAYOUT_GENERAL, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                VK_ACCESS_MEMORY_READ_BIT);
+            d().vkCmdPipelineBarrier(
+                cmd, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr,
+                1, &barrier);
+          }
+        });
     return -1;
   }
 

--- a/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
+++ b/shell/backend/drm_kms_vulkan/vulkan_drm_backend.h
@@ -29,6 +29,9 @@
 #include <vulkan/vulkan.h>
 
 #include "backend/backend.h"
+// drm_config::TriState — the yes/no/auto knobs both DRM backends share. The
+// EGL backend's header is where they are declared; only the enum is used here.
+#include "backend/drm_kms_egl/drm_backend.h"
 #include "backend/drm_kms_vulkan/device_caps.h"
 #if BUILD_COMPOSITOR
 // Pure-Vulkan blend pipeline; despite living beside the Wayland backend it
@@ -67,12 +70,17 @@ class VulkanDrmBackend final : public Backend {
   // drm_kms_egl backend does on DrmBackend::Create returning null. @p session
   // may be null when no libseat session is available. @p mode_spec selects the
   // scanout mode ("<W>x<H>[@<R>]"); empty uses the connector's preferred mode.
+  //
+  // @p explicit_sync forces the scanout hand-off: kYes fails init when the
+  // device cannot export a SYNC_FD semaphore rather than degrading silently,
+  // kNo takes the CPU-fence path, kAuto uses explicit sync when available.
   static std::shared_ptr<VulkanDrmBackend> Create(
       const std::string& drm_device,
       bool enable_validation,
       homescreen::DrmSession* session,
       const std::string& mode_spec,
-      int rotation);
+      int rotation,
+      drm_config::TriState explicit_sync = drm_config::TriState::kAuto);
 
   // wayland-leased-drm: drive an externally-owned DRM fd (the master fd from
   // wp_drm_lease_v1.lease_fd) instead of opening a card by path.
@@ -103,7 +111,8 @@ class VulkanDrmBackend final : public Backend {
       const std::string& mode_spec,
       int rotation,
       uint32_t connector_id,
-      std::function<bool()> revoked);
+      std::function<bool()> revoked,
+      drm_config::TriState explicit_sync = drm_config::TriState::kAuto);
 
   ~VulkanDrmBackend() override;
 
@@ -252,6 +261,10 @@ class VulkanDrmBackend final : public Backend {
   // viewport extent against the CRTC mode; lowered to the plane rotation
   // property at present time.
   int rotation_ = 0;
+  // --drm-explicit-sync. Read once in SetupCompositor: kNo forces the CPU-fence
+  // scanout path, kYes refuses to start when the device cannot export a SYNC_FD
+  // semaphore, kAuto uses explicit sync when it is available.
+  drm_config::TriState explicit_sync_pref_ = drm_config::TriState::kAuto;
   // Unified cadence profiler (IVI_PROFILE / legacy IVI_DRMVK_PROFILE). Written
   // from the rasterizer thread (PresentLayersImpl) only.
   profiling::FrameProfile frame_profile_;

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -79,6 +79,28 @@
 namespace {
 
 #if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
+// Parse a yes/no/auto knob. File scope because both DRM backends read the same
+// spellings from the same config fields, and the Vulkan one cannot reach a
+// helper that lives inside the EGL backend's factory --- which is how
+// --drm-explicit-sync came to be parsed, plumbed, and then silently dropped on
+// the Vulkan path.
+drm_config::TriState ParseTriState(
+    const std::optional<std::string>& s,
+    const drm_config::TriState def = drm_config::TriState::kAuto) {
+  if (!s.has_value() || s->empty() || *s == "auto") {
+    return def;
+  }
+  if (*s == "yes" || *s == "true" || *s == "on") {
+    return drm_config::TriState::kYes;
+  }
+  if (*s == "no" || *s == "false" || *s == "off") {
+    return drm_config::TriState::kNo;
+  }
+  ihs::log::warn("[FlutterView] drm tri-state '{}' unrecognized; using auto",
+                 *s);
+  return drm_config::TriState::kAuto;
+}
+
 // DRM/KMS does not have a compositor-level display concept. The refresh
 // rate and mode are owned by the backend; the DrmDisplay stub answers
 // queries the shell issues (metrics, cursor activation, event loop) with
@@ -293,18 +315,7 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
   std::shared_ptr<Backend> m_backend;
   auto parse_tri = [](const std::optional<std::string>& s,
                       drm_config::TriState def = drm_config::TriState::kAuto) {
-    if (!s.has_value() || s->empty() || *s == "auto") {
-      return def;
-    }
-    if (*s == "yes" || *s == "true" || *s == "on") {
-      return drm_config::TriState::kYes;
-    }
-    if (*s == "no" || *s == "false" || *s == "off") {
-      return drm_config::TriState::kNo;
-    }
-    ihs::log::warn("[FlutterView] drm tri-state '{}' unrecognized; using auto",
-                   *s);
-    return drm_config::TriState::kAuto;
+    return ParseTriState(s, def);
   };
   auto parse_compositor = [](const std::optional<std::string>& s) {
     if (!s.has_value() || s->empty() || *s == "auto") {
@@ -531,11 +542,13 @@ std::shared_ptr<Backend> MakeDrmVulkanBackend(
                 drm_display->device_path(),
                 config.debug_backend.value_or(false), drm_mode,
                 config.view.drm_rotation.value_or(0),
-                drm_display->lease_connector_id(), drm_display->lease_revoked())
-          : VulkanDrmBackend::Create(drm_display->device_path(),
-                                     config.debug_backend.value_or(false),
-                                     drm_display->session(), drm_mode,
-                                     config.view.drm_rotation.value_or(0));
+                drm_display->lease_connector_id(), drm_display->lease_revoked(),
+                ParseTriState(config.view.drm_explicit_sync))
+          : VulkanDrmBackend::Create(
+                drm_display->device_path(),
+                config.debug_backend.value_or(false), drm_display->session(),
+                drm_mode, config.view.drm_rotation.value_or(0),
+                ParseTriState(config.view.drm_explicit_sync));
 
   // Create returns nullptr on any init failure (unsupported device, no
   // zero-copy scanout path). Continuing would dereference a null backend in

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -38,6 +38,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <iterator>  // std::size over the advertised format table
 #include <map>
 #include <memory>
 #include <mutex>
@@ -849,6 +850,37 @@ void HostUnregisterFactory(void* user_data, const char* view_type) {
   }
 }
 
+// The packed-RGB fourccs every import path here accepts unconditionally: the
+// Vulkan importer maps all four to a VkFormat, and the EGL importer takes them
+// on a plain GL_TEXTURE_2D (its format switch only separates YUV, which needs
+// GL_TEXTURE_EXTERNAL_OES).
+//
+// This list exists so a plugin that passes no formats -- documented as "any the
+// backend offers" -- gets told which one it got. Without it caps.format_count
+// is 0, choose_format falls through to a zeroed IhsFormatModifier, and the
+// grant reports fourcc 0: a plugin then either guesses or allocates against
+// zero, which gbm accepts and eglCreateImageKHR later rejects with
+// EGL_BAD_MATCH, surfacing as a driver fault far from the cause.
+//
+// LINEAR per the IhsFormatModifier contract ("DRM_FORMAT_MOD_LINEAR when
+// unsure"): it is what every importer can read, and scanout modifier
+// negotiation is a separate step the grant already carries. YUV producers are
+// unaffected -- they name their format explicitly rather than asking for any.
+constexpr uint32_t HostFourcc(const char a,
+                              const char b,
+                              const char c,
+                              const char d) {
+  return static_cast<uint32_t>(a) | (static_cast<uint32_t>(b) << 8) |
+         (static_cast<uint32_t>(c) << 16) | (static_cast<uint32_t>(d) << 24);
+}
+
+constexpr IhsFormatModifier kDmabufImportFormats[] = {
+    {HostFourcc('X', 'R', '2', '4'), 0, 0},  // DRM_FORMAT_XRGB8888, LINEAR
+    {HostFourcc('A', 'R', '2', '4'), 0, 0},  // DRM_FORMAT_ARGB8888, LINEAR
+    {HostFourcc('X', 'B', '2', '4'), 0, 0},  // DRM_FORMAT_XBGR8888, LINEAR
+    {HostFourcc('A', 'B', '2', '4'), 0, 0},  // DRM_FORMAT_ABGR8888, LINEAR
+};
+
 int HostQueryCapabilities(void* user_data, IhsPvCapabilities* out) {
   out->backend_key = "";
   out->kinds =
@@ -889,6 +921,14 @@ int HostQueryCapabilities(void* user_data, IhsPvCapabilities* out) {
       }
     }
 #endif
+  }
+  // Name the formats behind the dma-buf kinds. Only when one was actually
+  // offered: advertising formats for a capability the backend does not have
+  // would hand a plugin a format it can never submit.
+  if ((out->kinds & IHS_PV_KIND_TEXTURE_DMABUF_IMPORT) != 0U ||
+      (out->kinds & IHS_PV_KIND_DRM_PLANE) != 0U) {
+    out->formats = kDmabufImportFormats;
+    out->format_count = std::size(kDmabufImportFormats);
   }
   return IHS_PV_OK;
 }


### PR DESCRIPTION
Three fixes to the DRM Vulkan backend, one commit each. They were found in sequence — each one made the next visible.

## 1. Teardown segfault with platform views on screen — a regression from #371

`LayerCompositor` owns a render pass, pipelines, samplers, descriptor pools and cached framebuffers/views, and it is a **member**. Members are destroyed *after* `~VulkanDrmBackend`'s body has run `Teardown()`, which destroys the `VkDevice` — so every `vkDestroy*` in `~LayerCompositor` ran against a dead device.

The destructor already stated the rule one line above, for the HUD:

```cpp
// Free the HUD while the Vulkan device is still alive (Teardown destroys it)
```

#371 added the layer compositor without following it. The fix hoists `vkDeviceWaitIdle` out of the HUD-only guard (any compositing build needs it now) and resets the compositor beside the HUD. Waiting first matters independently: the last frame's command buffer can still reference the render pass and descriptor sets being freed.

**Why it survived review and a day of hardware testing:** it only fires at shutdown. Verification measured descriptors and frame rates *while running* and never checked exit status. `exit=139` every run before; `exit=0` on three consecutive runs after.

## 2. `--drm-explicit-sync` was accepted and ignored

Parsed, validated, plumbed into the DRM config struct at `register_backends.cc:407` — then never read by this backend, which decided the scanout hand-off from device capability plus an undocumented env var (`IVI_DRMVK_NO_EXPLICIT_SYNC`). `=no` was accepted in silence and changed nothing; the log still said `explicit (IN_FENCE_FD)`. A flag that takes input and does nothing is worse than one that rejects it, because it reads as a ruled-out variable.

The parser was the cause: `parse_tri` is a lambda local to `MakeDrmEglBackend` inside `#if BUILD_BACKEND_DRM_KMS_EGL`, so a Vulkan-only build has no parser to call. Hoisted to `ParseTriState` at file scope under the guard both DRM backends share; the EGL lambda forwards to it, so its call sites and behavior are unchanged and the accepted spellings stay single-sourced.

`kYes` is a **demand**, not a preference: a device that cannot export a `SYNC_FD` semaphore now refuses to start rather than silently running the fallback the operator just ruled out.

## 3. The CPU-fence path dropped every platform-view layer

`SubmitScanoutBarrier` returns before reaching the blend when there is no explicit-sync path, so a target without `IN_FENCE_FD` composited the base backing store alone — the same defect the blend was added to fix, still live on the fallback. It stayed hidden because this hardware negotiates explicit sync, and because **the fallback was not reachable on purpose until fix 2 landed**.

The blend belongs on both paths: it is the same layer stack, and which fence carries the frame to KMS says nothing about what the frame should contain.

The fallback built its command buffer via `SubmitImageBarrier`, which records only a barrier. Rather than reshape that helper and disturb its two other callers, `SubmitOneShot` takes the recording as a callback and `SubmitImageBarrier` becomes a wrapper over it.

## Verification

Pi 5, `drm-kms-vulkan`, four shader platform views. Re-verified after clang-format, which touched two files.

```
<auto>                    scanout sync: explicit (IN_FENCE_FD)                   exit=0
--drm-explicit-sync=no    scanout sync: CPU fence (forced off by configuration)  exit=0
--drm-explicit-sync=yes   scanout sync: explicit (IN_FENCE_FD)                   exit=0
```

The `no` row previously reported `explicit`. On that forced CPU-fence path: four views render, menus draw and respond, 62 descriptors flat, validation silent — where the same command line previously drew the Flutter UI over four black rectangles.