### PR TITLE
[ci] Migrated apt installs to cached action

### DIFF
--- a/.github/workflows/ihs-logging-compat-matrix.yml
+++ b/.github/workflows/ihs-logging-compat-matrix.yml
@@ -64,21 +64,37 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Ensure toolchain
+        id: install
         run: |
           set -eux
-          # The runner images ship clang/cmake/ninja; install only what is
+          packages=""
+          # clang + cmake + ninja are preinstalled on 24.04; install only if
           # missing, and never libc++ (the build uses libstdc++).
           if ! command -v clang++-${{ matrix.clang_ver }} >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends \
-              clang-${{ matrix.clang_ver }}
+            packages="$packages clang-${{ matrix.clang_ver }}"
           fi
           if ! command -v cmake >/dev/null 2>&1 \
              || ! command -v ninja >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends cmake ninja-build
+            packages="$packages cmake ninja-build"
           fi
-          clang++-${{ matrix.clang_ver }} --version
+
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+
+      - name: Update apt package index
+        if: ${{ steps.install.outputs.packages != '' }}
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        if: ${{ steps.install.outputs.packages != '' }}
+        with:
+          packages: >-
+            ${{ steps.install.outputs.packages }}
 
       - name: Build + run compat_smoke
         run: |
@@ -109,6 +125,7 @@ jobs:
     name: "Clang-12 C++17"
     steps:
       - name: Add git + ninja
+        # NOTE: DO NOT use the cache-apt-pkgs-action here
         run: |
           set -eux
           apt-get update
@@ -151,19 +168,37 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Ensure toolchain
+        id: install
         run: |
           set -eux
-          # clang-17 + cmake + ninja are preinstalled on 24.04; install only if
+          packages=""
+          # clang + cmake + ninja are preinstalled on 24.04; install only if
           # missing, and never libc++ (the build uses libstdc++).
           if ! command -v clang++-17 >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends clang-17
+            packages="$packages clang-17"
           fi
           if ! command -v cmake >/dev/null 2>&1 \
              || ! command -v ninja >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends cmake ninja-build
+            packages="$packages cmake ninja-build"
           fi
+
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+
+      - name: Update apt package index
+        if: ${{ steps.install.outputs.packages != '' }}
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        if: ${{ steps.install.outputs.packages != '' }}
+        with:
+          packages: >-
+            ${{ steps.install.outputs.packages }}
 
       - name: Configure
         run: |

--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -40,10 +40,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake ninja-build g++
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            cmake ninja-build g++
 
       - name: Build + install ihs_shared
         run: |
@@ -103,10 +112,19 @@ jobs:
       - name: Fetch fmt submodule (raw-fmt reference)
         run: git submodule update --init --depth 1 third_party/fmt
 
-      - name: Install toolchain
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake ninja-build g++
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            cmake ninja-build g++
 
       - name: Build + install ihs_shared
         run: |
@@ -129,10 +147,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install toolchain + libabigail
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
             cmake ninja-build g++ abigail-tools
 
       - name: Build ihs_shared
@@ -185,17 +211,23 @@ jobs:
   # by the load harness against a libdlt stub.
   dlt-daemon-e2e:
     if: >-
-      ${{ github.server_url == 'https://github.com'
-          && (github.event_name == 'workflow_dispatch'
-              || github.event_name == 'push') }}
+      ${{ github.server_url == 'https://github.com' && (github.event_name == 'workflow_dispatch' || github.event_name == 'push') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install toolchain + dlt-daemon
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
             cmake ninja-build gcc g++ dlt-daemon dlt-tools
 
       - name: Build + install ihs_shared

--- a/.github/workflows/oss-codeql.yml
+++ b/.github/workflows/oss-codeql.yml
@@ -31,16 +31,26 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: recursive
-
+    - name: Update apt package index
+      # cache-apt-pkgs-action resolves package versions before it runs its
+      # own apt update, so it pins whatever the runner image's stale index
+      # lists. When Ubuntu supersedes a revision and drops the old .deb from
+      # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+      # and aborts the whole install. Refresh the index up front so it pins
+      # the version currently on the mirror.
+      run: sudo apt-get update
     - name: Install packages
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: >-
+          build-essential cmake ninja-build pkg-config
+          libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev
+          mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
+
+    - name: Show toolchain versions
       run: |
-        echo ${{ github.server_url }}
-        sudo apt-get update
-        sudo apt-get -y install ninja-build \
-        libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev \
-        mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
-        cmake --version
-        gcc --version
+          cmake --version
+          gcc --version
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/oss-integration.yaml
+++ b/.github/workflows/oss-integration.yaml
@@ -29,15 +29,23 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
       - name: Install build + test deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config git python3 \
-            curl ca-certificates xz-utils \
-            libxkbcommon-dev libwayland-dev wayland-protocols \
-            libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev \
-            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config git python3
+            curl ca-certificates xz-utils
+            libxkbcommon-dev libwayland-dev wayland-protocols
+            libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev
+            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev
             libpugixml-dev libcurl4-openssl-dev
 
       - name: Fetch emb
@@ -62,15 +70,23 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
       - name: Install build + test deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config git python3 \
-            curl ca-certificates unzip xz-utils \
-            libxkbcommon-dev libwayland-dev wayland-protocols \
-            libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev \
-            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config git python3
+            curl ca-certificates unzip xz-utils
+            libxkbcommon-dev libwayland-dev wayland-protocols
+            libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev
+            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev
             libpugixml-dev libcurl4-openssl-dev
 
       - name: Fetch emb
@@ -85,8 +101,11 @@ jobs:
           eval "$(./emb_cli/bootstrap.sh --shellenv)"
           ./scripts/watchdog_integration.sh
 
-      - name: Install systemd dev library
-        run: sudo apt-get install -y --no-install-recommends libsystemd-dev
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            libsystemd-dev
 
       - name: Run integration test for systemd watchdog
         shell: bash

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -22,16 +22,24 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install runtime packages
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            ninja-build
+            libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev
+            mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
+
+      - name: Show toolchain versions
         run: |
-          echo ${{ github.server_url }}
-          # Refresh the index first: the runner image's cached apt lists can
-          # reference superseded package versions (e.g. mesa security bumps),
-          # which 404 on the mirror and fail a bare `apt-get install`.
-          sudo apt-get update
-          sudo apt-get -y install ninja-build \
-          libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev \
-          mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
           cmake --version
           gcc --version
 
@@ -132,12 +140,21 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install packages
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install ninja-build \
-          libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev \
-          mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            ninja-build
+            libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev
+            mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
 
       - name: Configure (accessibility enabled)
         run: |
@@ -205,15 +222,23 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
       - name: Install build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config git python3 \
-            curl ca-certificates xz-utils \
-            libxkbcommon-dev libwayland-dev wayland-protocols \
-            libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev \
-            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config git python3
+            curl ca-certificates xz-utils
+            libxkbcommon-dev libwayland-dev wayland-protocols
+            libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev
+            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev
             libpugixml-dev libcurl4-openssl-dev
       - name: Fetch emb
         run: git clone --depth 1 https://github.com/toyota-connected/emb_cli.git emb_cli
@@ -255,15 +280,23 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
       - name: Install build deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build pkg-config git python3 \
-            curl ca-certificates xz-utils \
-            libxkbcommon-dev libwayland-dev wayland-protocols \
-            libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev \
-            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            build-essential cmake ninja-build pkg-config git python3
+            curl ca-certificates xz-utils
+            libxkbcommon-dev libwayland-dev wayland-protocols
+            libegl1-mesa-dev libgles2-mesa-dev mesa-common-dev
+            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev
             libpugixml-dev libcurl4-openssl-dev
       - name: Fetch emb
         run: git clone --depth 1 https://github.com/toyota-connected/emb_cli.git emb_cli
@@ -274,9 +307,13 @@ jobs:
           emb -v cross . --backend software \
             -D BUILD_WATCHDOG=ON \
             --build
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            libsystemd-dev
       - name: Build SystemD watchdog
         run: |
-          sudo apt install -y libsystemd-dev
           eval "$(./emb_cli/bootstrap.sh --shellenv)"
           emb --version
           emb -v cross . --backend software \

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -62,10 +62,18 @@ jobs:
           path: ivi-homescreen
           submodules: recursive
 
-      - name: Install emb resolve host tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+      - name: Update apt package index
+        # cache-apt-pkgs-action resolves package versions before it runs its
+        # own apt update, so it pins whatever the runner image's stale index
+        # lists. When Ubuntu supersedes a revision and drops the old .deb from
+        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
+        # and aborts the whole install. Refresh the index up front so it pins
+        # the version currently on the mirror.
+        run: sudo apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
             tar xz-utils rsync curl ca-certificates
 
       - name: Fetch emb


### PR DESCRIPTION
### Files Changed
| File | Change |
|------|--------|
| ihs-logging-compat-matrix.yml | Updated apt installs → cached action |
| ihs-shared.yml | Updated apt installs → cached action |
| oss-codeql.yml | Updated apt installs → cached action |
| oss-integration.yaml | Updated apt installs → cached action |
| oss-ivi-homescreen.yml | Updated apt installs → cached action |
| pios.yml | Updated apt installs → cached action |

### Summary
Migrated all GitHub Actions CI workflows to use cached action for apt package installations, replacing direct `apt-get install` calls with a caching mechanism for faster workflow execution.