### PR TITLE
platform-views: scan out YUV platform-view frames on a KMS plane with the right CSC

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <mutex>
+#include <optional>
 #include <string_view>
 #include <system_error>
 #include <thread>
@@ -48,6 +49,7 @@
 #include "backend/drm_kms_egl/scene_layer_source_gl.h"
 #include "display/drm_display.h"
 #include "drm-cxx/src/modeset/atomic.hpp"
+#include "ihs/platform_view.h"
 #include "libflutter_engine.h"
 #include "logging.h"
 #include "profiling/frame_profile.h"
@@ -58,6 +60,52 @@ namespace {
 bool AllocDebug() {
   static const bool enabled = std::getenv("DRM_ALLOC_DEBUG") != nullptr;
   return enabled;
+}
+
+// Map the ABI's container colorimetry (IhsColorSpace/IhsColorRange, carried on
+// the platform view's Dmabuf) to the drm-cxx plane CSC. DEFAULT -> nullopt lets
+// LayerScene write its own default (BT.709 / limited). Only meaningful for YUV
+// frames; RGB layers leave color_encoding/range unset.
+std::optional<drm::planes::ColorEncoding> ToColorEncoding(uint8_t color_space) {
+  switch (color_space) {
+    case IHS_COLOR_SPACE_BT601:
+      return drm::planes::ColorEncoding::BT_601;
+    case IHS_COLOR_SPACE_BT709:
+      return drm::planes::ColorEncoding::BT_709;
+    case IHS_COLOR_SPACE_BT2020:
+      return drm::planes::ColorEncoding::BT_2020;
+    default:
+      return std::nullopt;
+  }
+}
+
+std::optional<drm::planes::ColorRange> ToColorRange(uint8_t color_range) {
+  switch (color_range) {
+    case IHS_COLOR_RANGE_FULL:
+      return drm::planes::ColorRange::Full;
+    case IHS_COLOR_RANGE_LIMITED:
+      return drm::planes::ColorRange::Limited;
+    default:
+      return std::nullopt;
+  }
+}
+
+// The planar/packed YUV fourccs a video producer submits — so the scene
+// allocator prefers an overlay plane with the best YUV coverage (ContentType::
+// Video) and applies the plane CSC. RGB frames stay Generic.
+bool IsYuvFourcc(uint32_t fourcc) {
+  switch (fourcc) {
+    case DRM_FORMAT_NV12:
+    case DRM_FORMAT_NV21:
+    case DRM_FORMAT_NV16:
+    case DRM_FORMAT_P010:
+    case DRM_FORMAT_P016:
+    case DRM_FORMAT_YUYV:
+    case DRM_FORMAT_UYVY:
+      return true;
+    default:
+      return false;
+  }
 }
 
 // Per-frame composite profiling (IVI_DRM_PROFILE, or the IVI_PROFILE umbrella).
@@ -2673,7 +2721,15 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       // unlike GL backing stores.
       desc.display.rotation = DRM_MODE_ROTATE_0;
       desc.display.zpos = overlay_zpos;
-      desc.content_type = drm::planes::ContentType::Generic;
+      // YUV video: hint the allocator toward a YUV-capable overlay and set the
+      // plane's YCbCr->RGB CSC from the frame's colorimetry. RGB stays Generic
+      // and leaves the CSC unset (the scene writes its default). A plane that
+      // cannot scan out the fourcc/modifier force-composites in the allocator.
+      const bool is_yuv = IsYuvFourcc(db.fourcc);
+      desc.content_type = is_yuv ? drm::planes::ContentType::Video
+                                 : drm::planes::ContentType::Generic;
+      desc.display.color_encoding = ToColorEncoding(db.color_space);
+      desc.display.color_range = ToColorRange(db.color_range);
       desc.identity_tag = fl.pv_tag;
       auto handle = scene_->add_layer(std::move(desc));
       if (!handle) {

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -414,6 +414,8 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     }
     out->fourcc = f.format.fourcc;
     out->modifier = f.format.modifier;
+    out->color_space = f.color_space;  // YUV colorimetry for the plane CSC
+    out->color_range = f.color_range;
     out->width = f.width;
     out->height = f.height;
     out->plane_count = np;

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -221,6 +221,11 @@ class ICompositorSurface {
     uint32_t plane_count{0};
     uint32_t offset[4]{};
     uint32_t stride[4]{};
+    // Container colorimetry of the pixels (IhsColorSpace / IhsColorRange). Only
+    // meaningful for YUV frames; the DRM scene path lowers these to the plane's
+    // COLOR_ENCODING / COLOR_RANGE CSC. DEFAULT (0) leaves the scene's default.
+    uint8_t color_space{0};
+    uint8_t color_range{0};
     int acquire_fence_fd{-1};
     // The producer's identity for this frame (IhsFrame.buffer_id, its ring
     // slot). The compositor hands it back via OnScanoutRelease when the plane


### PR DESCRIPTION
## Summary

First slice of the video-player DRM plane bridge: let a platform view that submits a **YUV dma-buf** (NV12/P010 video) scan out on a KMS overlay plane with the correct color conversion, instead of losing its colorimetry on the way to the compositor.

Before this, a submitted frame's `color_space`/`color_range` never left the `ihs_pv` host — so the scene path set no plane CSC (the plane kept whatever a previous compositor left on `COLOR_ENCODING`/`COLOR_RANGE`), and the allocator had no hint the layer was video.

## Changes
- **`Dmabuf` descriptor** (`compositor_surface_interface.h`): carry `color_space`/`color_range` (the `IhsColorSpace`/`IhsColorRange` the producer submits).
- **`GetDmabuf`** (`platform_view_host.cc`): fill them from the stored `IhsFrame`.
- **Scene path** (`drm_compositor.cc`): map them to the drm-cxx layer's `COLOR_ENCODING`/`COLOR_RANGE`, and set `ContentType::Video` for a YUV fourcc so the allocator prefers an overlay with the best YUV coverage. RGB frames stay `Generic` and leave the CSC unset (the scene writes its default).

drm-cxx's `DisplayParams` already lowers `color_encoding`/`color_range` to the plane properties, so this is just the plumbing from the ABI to that seam. A plane that can't scan out the fourcc/modifier still force-composites in the allocator, as before.

## Status / validation
- Compiles and links into `homescreen`; the shell starts on **vkms** (mode-set + capture armed), and **vkms advertises NV12/P010 on its planes**, so the plane-scanout path is exercisable there.
- The end-to-end vkms golden capture needs an **x86_64** layer_playground bundle + NV12 stub producer (the paired plugin change); the bundle on hand is aarch64. The runtime capture is a follow-up (x86_64 bundle, or validate on a Pi target).
- HDR (connector `HDR_OUTPUT_METADATA`) is the next increment — the ABI fields and drm-cxx `source_eotf`/`amd_color` machinery already exist.