### PR TITLE
backend: headless-EGL gbm_surface swap chain + synthetic vsync

### DIFF
--- a/shell/backend/headless_egl/headless_egl.cc
+++ b/shell/backend/headless_egl/headless_egl.cc
@@ -276,7 +276,7 @@ bool HeadlessEglBackend::Present(const FlutterPresentInfo* /*info*/) {
   // buffer is linear (forced at surface creation), so pass its modifier through
   // for an exact import.
   const int fd = gbm_bo_get_fd(bo);
-  const EGLint stride = static_cast<EGLint>(gbm_bo_get_stride(bo));
+  const auto stride = static_cast<EGLint>(gbm_bo_get_stride(bo));
   const uint64_t modifier = gbm_bo_get_modifier(bo);
   const bool has_modifier = modifier != DRM_FORMAT_MOD_INVALID;
   std::vector<EGLint> attrs = {EGL_WIDTH,
@@ -298,12 +298,14 @@ bool HeadlessEglBackend::Present(const FlutterPresentInfo* /*info*/) {
     attrs.push_back(static_cast<EGLint>(modifier >> 32));
   }
   attrs.push_back(EGL_NONE);
-  auto create_image = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(
+  // Resolved once (raster thread) rather than per frame.
+  static const auto create_image = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(
       eglGetProcAddress("eglCreateImageKHR"));
-  auto destroy_image = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(
+  static const auto destroy_image = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(
       eglGetProcAddress("eglDestroyImageKHR"));
-  auto image_target = reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(
-      eglGetProcAddress("glEGLImageTargetTexture2DOES"));
+  static const auto image_target =
+      reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(
+          eglGetProcAddress("glEGLImageTargetTexture2DOES"));
   if (create_image != nullptr && destroy_image != nullptr &&
       image_target != nullptr) {
     EGLImageKHR image = create_image(
@@ -376,9 +378,12 @@ void HeadlessEglBackend::StartVsyncIfReady() {
       platform_task_runner_->GetIoContext() == nullptr) {
     return;
   }
-  vsync_.SetEngine(engine_handle_, platform_task_runner_);
-  vsync_.SetSourcePending(true);  // batons park; the timer returns them
+  // Mark the source pending + set the period before wiring the engine, so any
+  // baton that arrives once wired parks for the timer rather than draining
+  // inline unpaced.
+  vsync_.SetSourcePending(true);
   vsync_.SetPeriodNs(vsync_period_ns_);
+  vsync_.SetEngine(engine_handle_, platform_task_runner_);
   vsync_timer_ = std::make_unique<asio::steady_timer>(
       *platform_task_runner_->GetIoContext());
   vsync_running_.store(true, std::memory_order_release);

--- a/shell/backend/headless_egl/headless_egl.cc
+++ b/shell/backend/headless_egl/headless_egl.cc
@@ -17,6 +17,8 @@
 #include "backend/headless_egl/headless_egl.h"
 
 #include <EGL/eglext.h>
+#include <GLES2/gl2ext.h>
+#include <drm_fourcc.h>
 #include <fcntl.h>
 #include <gbm.h>
 #include <unistd.h>
@@ -24,6 +26,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <vector>
 
 #include "backend/gl_process_resolver.h"
 #include "engine.h"
@@ -103,19 +106,13 @@ bool HeadlessEglBackend::InitEgl(const char* render_node) {
     ihs::log::error("[HeadlessEgl] no EGL_EXT_image_dma_buf_import");
     return false;
   }
-  // We render with no surface (eglMakeCurrent with EGL_NO_SURFACE), which needs
-  // EGL 1.5 or the EGL_KHR_surfaceless_context extension. Check up front rather
-  // than failing opaquely at the first MakeCurrent.
-  const bool surfaceless =
-      major > 1 || (major == 1 && minor >= 5) ||
-      std::strstr(exts, "EGL_KHR_surfaceless_context") != nullptr;
-  if (!surfaceless) {
-    ihs::log::error(
-        "[HeadlessEgl] no surfaceless-context support (need EGL 1.5 or "
-        "EGL_KHR_surfaceless_context)");
-    return false;
-  }
   eglBindAPI(EGL_OPENGL_ES_API);
+  // An OPAQUE window-surface config (no alpha), native visual XRGB8888.
+  // Opacity matters: an alpha surface lets a translucent app background (e.g. a
+  // withOpacity gradient over a transparent Scaffold) composite to
+  // premultiplied near-zero and vanish on the destroyed swap buffers; an opaque
+  // surface makes the engine composite a full opaque frame, so the background
+  // is present.
   const EGLint cfg_attrs[] = {EGL_SURFACE_TYPE,
                               EGL_WINDOW_BIT,
                               EGL_RENDERABLE_TYPE,
@@ -127,24 +124,75 @@ bool HeadlessEglBackend::InitEgl(const char* render_node) {
                               EGL_BLUE_SIZE,
                               8,
                               EGL_ALPHA_SIZE,
-                              8,
+                              0,
                               EGL_NONE};
-  EGLConfig cfg = nullptr;
-  EGLint ncfg = 0;
-  if (eglChooseConfig(dpy_, cfg_attrs, &cfg, 1, &ncfg) == 0 || ncfg == 0) {
-    ihs::log::error("[HeadlessEgl] eglChooseConfig failed");
+  EGLint total = 0;
+  if (eglChooseConfig(dpy_, cfg_attrs, nullptr, 0, &total) == 0 || total == 0) {
+    ihs::log::error("[HeadlessEgl] eglChooseConfig found no configs");
     return false;
   }
+  std::vector<EGLConfig> configs(static_cast<size_t>(total));
+  eglChooseConfig(dpy_, cfg_attrs, configs.data(), total, &total);
+  gbm_format_ = GBM_FORMAT_XRGB8888;
+  for (EGLConfig c : configs) {
+    EGLint vid = 0;
+    EGLint alpha = 0;
+    eglGetConfigAttrib(dpy_, c, EGL_NATIVE_VISUAL_ID, &vid);
+    eglGetConfigAttrib(dpy_, c, EGL_ALPHA_SIZE, &alpha);
+    if (alpha == 0 && static_cast<uint32_t>(vid) == GBM_FORMAT_XRGB8888) {
+      config_ = c;
+      gbm_format_ = GBM_FORMAT_XRGB8888;
+      break;
+    }
+  }
+  if (config_ == nullptr) {
+    config_ = configs.front();  // fall back; the surface create may still work
+  }
+
   const EGLint ctx_attrs[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE};
-  ctx_ = eglCreateContext(dpy_, cfg, EGL_NO_CONTEXT, ctx_attrs);
+  ctx_ = eglCreateContext(dpy_, config_, EGL_NO_CONTEXT, ctx_attrs);
   // The engine's resource thread needs its own context sharing objects with
   // the render context.
-  resource_ctx_ = eglCreateContext(dpy_, cfg, ctx_, ctx_attrs);
+  resource_ctx_ = eglCreateContext(dpy_, config_, ctx_, ctx_attrs);
   if (ctx_ == EGL_NO_CONTEXT || resource_ctx_ == EGL_NO_CONTEXT) {
     ihs::log::error("[HeadlessEgl] eglCreateContext failed");
     return false;
   }
-  ihs::log::info("[HeadlessEgl] EGL {}.{} ready on {}", major, minor,
+
+  // The swap chain: a gbm_surface the driver double-buffers, wrapped in an EGL
+  // window surface. Force a LINEAR modifier so the presented buffers are
+  // untiled and can be re-imported per frame as a plain GL_TEXTURE_2D for the
+  // NV12 pack (see Present); V3D otherwise hands back a tiled buffer that an
+  // implicit-modifier import mis-reads as dashed/blocky garbage. Fall back to a
+  // plain create if the driver rejects the forced modifier.
+  const uint64_t linear_mod = DRM_FORMAT_MOD_LINEAR;
+  gbm_surface_ = gbm_surface_create_with_modifiers(gbm_, width_, height_,
+                                                   gbm_format_, &linear_mod, 1);
+  if (gbm_surface_ == nullptr) {
+    gbm_surface_ = gbm_surface_create(gbm_, width_, height_, gbm_format_,
+                                      GBM_BO_USE_RENDERING | GBM_BO_USE_LINEAR);
+  }
+  if (gbm_surface_ == nullptr) {
+    ihs::log::error("[HeadlessEgl] gbm_surface_create {}x{} failed", width_,
+                    height_);
+    return false;
+  }
+  auto create_platform_surface =
+      reinterpret_cast<PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC>(
+          eglGetProcAddress("eglCreatePlatformWindowSurfaceEXT"));
+  egl_surface_ =
+      create_platform_surface != nullptr
+          ? create_platform_surface(dpy_, config_, gbm_surface_, nullptr)
+          : eglCreateWindowSurface(
+                dpy_, config_,
+                reinterpret_cast<EGLNativeWindowType>(gbm_surface_), nullptr);
+  if (egl_surface_ == EGL_NO_SURFACE) {
+    ihs::log::error("[HeadlessEgl] eglCreateWindowSurface failed: {:#x}",
+                    eglGetError());
+    return false;
+  }
+
+  ihs::log::info("[HeadlessEgl] EGL {}.{} ready on {} (XRGB8888)", major, minor,
                  render_node);
   return true;
 }
@@ -156,21 +204,9 @@ bool HeadlessEglBackend::InitRenderTarget() {
   if (width_ == 0 || height_ == 0 || consumer_ == nullptr) {
     return false;
   }
-  glGenTextures(1, &render_tex_);
-  glBindTexture(GL_TEXTURE_2D, render_tex_);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, static_cast<GLsizei>(width_),
-               static_cast<GLsizei>(height_), 0, GL_RGBA, GL_UNSIGNED_BYTE,
-               nullptr);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glGenFramebuffers(1, &render_fbo_);
-  glBindFramebuffer(GL_FRAMEBUFFER, render_fbo_);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                         render_tex_, 0);
-  if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-    ihs::log::error("[HeadlessEgl] render FBO incomplete");
-    return false;
-  }
+  // A single reusable texture the presented (linear) gbm_bo is imported into
+  // each frame for the pack.
+  glGenTextures(1, &import_tex_);
   if (!packer_.Init(dpy_, width_, height_, consumer_.get())) {
     ihs::log::error("[HeadlessEgl] packer init failed");
     return false;
@@ -181,8 +217,8 @@ bool HeadlessEglBackend::InitRenderTarget() {
 }
 
 bool HeadlessEglBackend::MakeCurrent() {
-  if (dpy_ == EGL_NO_DISPLAY ||
-      eglMakeCurrent(dpy_, EGL_NO_SURFACE, EGL_NO_SURFACE, ctx_) == 0) {
+  if (dpy_ == EGL_NO_DISPLAY || egl_surface_ == EGL_NO_SURFACE ||
+      eglMakeCurrent(dpy_, egl_surface_, egl_surface_, ctx_) == 0) {
     return false;
   }
   return InitRenderTarget();
@@ -195,32 +231,91 @@ bool HeadlessEglBackend::ClearCurrent() {
 }
 
 bool HeadlessEglBackend::MakeResourceCurrent() {
+  // The resource context does no windowed rendering, so keep it surfaceless.
   return dpy_ != EGL_NO_DISPLAY &&
          eglMakeCurrent(dpy_, EGL_NO_SURFACE, EGL_NO_SURFACE, resource_ctx_) !=
              0;
 }
 
-bool HeadlessEglBackend::Present() {
+bool HeadlessEglBackend::Present(const FlutterPresentInfo* /*info*/) {
   if (!target_ready_) {
     return false;
   }
-  packer_.PackAndSubmit(render_tex_, MonotonicUs(),
-                        /*force_keyframe=*/frame_index_ == 0);
+  // Advance the swap chain: the driver publishes the frame the engine just
+  // composited as the new front buffer (the full frame lands here on swap, not
+  // in the pre-swap back buffer).
+  if (eglSwapBuffers(dpy_, egl_surface_) == 0) {
+    ihs::log::error("[HeadlessEgl] eglSwapBuffers failed: {:#x}",
+                    eglGetError());
+    return false;
+  }
+  gbm_bo* bo = gbm_surface_lock_front_buffer(gbm_surface_);
+  if (bo == nullptr) {
+    ihs::log::error("[HeadlessEgl] lock_front_buffer failed");
+    return false;
+  }
+
+  // Import the presented (linear) buffer as a plain 2D texture and pack it. The
+  // buffer is linear (forced at surface creation), so pass its modifier through
+  // for an exact import.
+  const int fd = gbm_bo_get_fd(bo);
+  const EGLint stride = static_cast<EGLint>(gbm_bo_get_stride(bo));
+  const uint64_t modifier = gbm_bo_get_modifier(bo);
+  const bool has_modifier = modifier != DRM_FORMAT_MOD_INVALID;
+  std::vector<EGLint> attrs = {EGL_WIDTH,
+                               static_cast<EGLint>(width_),
+                               EGL_HEIGHT,
+                               static_cast<EGLint>(height_),
+                               EGL_LINUX_DRM_FOURCC_EXT,
+                               static_cast<EGLint>(gbm_bo_get_format(bo)),
+                               EGL_DMA_BUF_PLANE0_FD_EXT,
+                               fd,
+                               EGL_DMA_BUF_PLANE0_OFFSET_EXT,
+                               0,
+                               EGL_DMA_BUF_PLANE0_PITCH_EXT,
+                               stride};
+  if (has_modifier) {
+    attrs.push_back(EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT);
+    attrs.push_back(static_cast<EGLint>(modifier & 0xffffffff));
+    attrs.push_back(EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT);
+    attrs.push_back(static_cast<EGLint>(modifier >> 32));
+  }
+  attrs.push_back(EGL_NONE);
+  auto create_image = reinterpret_cast<PFNEGLCREATEIMAGEKHRPROC>(
+      eglGetProcAddress("eglCreateImageKHR"));
+  auto destroy_image = reinterpret_cast<PFNEGLDESTROYIMAGEKHRPROC>(
+      eglGetProcAddress("eglDestroyImageKHR"));
+  auto image_target = reinterpret_cast<PFNGLEGLIMAGETARGETTEXTURE2DOESPROC>(
+      eglGetProcAddress("glEGLImageTargetTexture2DOES"));
+  if (create_image != nullptr && destroy_image != nullptr &&
+      image_target != nullptr) {
+    EGLImageKHR image = create_image(
+        dpy_, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attrs.data());
+    if (image != EGL_NO_IMAGE_KHR) {
+      glBindTexture(GL_TEXTURE_2D, import_tex_);
+      image_target(GL_TEXTURE_2D, static_cast<GLeglImageOES>(image));
+      // The presented gbm_bo is top-left origin, so no vertical flip.
+      packer_.PackAndSubmit(import_tex_, MonotonicUs(),
+                            /*force_keyframe=*/frame_index_ == 0,
+                            /*flip_rows=*/false);
+      destroy_image(dpy_, image);
+    } else {
+      ihs::log::error("[HeadlessEgl] import eglCreateImageKHR failed: {:#x}",
+                      eglGetError());
+    }
+  }
+  if (fd >= 0) {
+    ::close(fd);
+  }
+
+  // Release the buffer we held last frame; keep this one locked until the next
+  // swap so the import's read is stable.
+  if (locked_bo_ != nullptr) {
+    gbm_surface_release_buffer(gbm_surface_, locked_bo_);
+  }
+  locked_bo_ = bo;
   ++frame_index_;
   return true;
-}
-
-void HeadlessEglBackend::PopulateExistingDamage(FlutterDamage* out) {
-  // The render target is one FBO we reuse every frame, so from the engine's
-  // point of view it is a swap chain of age 1: the buffer already holds the
-  // last presented frame and nothing in it is stale. Reporting an empty
-  // existing-damage region tells the engine exactly that, so it repaints only
-  // what actually changed (including the vacated region when a widget moves)
-  // onto the intact buffer -- no full-frame cost, and no stale trails.
-  existing_damage_ = FlutterRect{0.0, 0.0, 0.0, 0.0};
-  out->struct_size = sizeof(FlutterDamage);
-  out->num_rects = 1;
-  out->damage = &existing_damage_;
 }
 
 FlutterRendererConfig HeadlessEglBackend::GetRenderConfig() {
@@ -236,26 +331,23 @@ FlutterRendererConfig HeadlessEglBackend::GetRenderConfig() {
   config.open_gl.make_resource_current = [](void* user_data) -> bool {
     return BackendOf(user_data)->MakeResourceCurrent();
   };
-  // The frame-info present variants let us report existing damage for our
-  // single persistent FBO. PopulateExistingDamage reports an EMPTY region: the
-  // buffer already holds the last presented frame (an age-1 swap chain), so the
-  // engine repaints only what actually changed into the intact buffer. A plain
-  // fbo_callback + present pair (no damage) instead lets the engine clip to
-  // partial damage against a buffer it assumes it cannot keep, which is what
-  // left ghosting.
-  config.open_gl.fbo_with_frame_info_callback =
-      [](void* user_data, const FlutterFrameInfo* /*info*/) -> uint32_t {
-    return BackendOf(user_data)->Fbo();
+  // Render into the window surface's default framebuffer (FBO 0); the driver
+  // rotates the gbm buffers on eglSwapBuffers and Present() imports the
+  // published front buffer. populate_existing_damage reports the whole surface
+  // as stale so the engine composites a complete frame each time (an encoder
+  // wants a full frame per buffer, not a partial repaint).
+  config.open_gl.fbo_callback = [](void* /*user_data*/) -> uint32_t {
+    return 0;
   };
   config.open_gl.present_with_info =
-      [](void* user_data, const FlutterPresentInfo* /*info*/) -> bool {
-    return BackendOf(user_data)->Present();
+      [](void* user_data, const FlutterPresentInfo* info) -> bool {
+    return BackendOf(user_data)->Present(info);
   };
-  config.open_gl.populate_existing_damage =
-      [](void* user_data, intptr_t /*fbo_id*/,
-         FlutterDamage* existing_damage) -> void {
-    BackendOf(user_data)->PopulateExistingDamage(existing_damage);
-  };
+  // Deliberately NOT providing populate_existing_damage: partial repaint
+  // against the rotated (destroyed) swap buffers intermittently dropped the
+  // static background layer (a whole-run black background on ~1 in 4 starts).
+  // Without it the engine composites a complete frame into the buffer every
+  // time, which is what an encoder wants anyway.
   config.open_gl.fbo_reset_after_present = false;
   config.open_gl.gl_proc_resolver = [](void* /*user_data*/,
                                        const char* name) -> void* {
@@ -265,8 +357,8 @@ FlutterRendererConfig HeadlessEglBackend::GetRenderConfig() {
 }
 
 FlutterCompositor HeadlessEglBackend::GetCompositorConfig() {
-  // Single-FBO rendering: no platform-view layer compositing (the encode path
-  // wants one composited frame). A software/GL compositor could be added later.
+  // Single-surface rendering: no platform-view layer compositing (the encode
+  // path wants one composited frame). A GL compositor could be added later.
   FlutterCompositor compositor{};
   compositor.struct_size = sizeof(FlutterCompositor);
   return compositor;
@@ -281,8 +373,8 @@ void HeadlessEglBackend::Resize(size_t /*index*/,
   if (w == width_ && h == height_) {
     return;
   }
-  // Geometry changes are not yet supported mid-run (the packer/consumer would
-  // need re-init). Log and keep the initial size.
+  // Geometry changes are not yet supported mid-run (the swap chain / packer /
+  // consumer would need re-init). Log and keep the initial size.
   ihs::log::warn("[HeadlessEgl] resize to {}x{} ignored (fixed at {}x{})", w, h,
                  width_, height_);
 }
@@ -291,8 +383,8 @@ void HeadlessEglBackend::CreateSurface(size_t /*index*/,
                                        wl_surface* /*surface*/,
                                        int32_t /*width*/,
                                        int32_t /*height*/) {
-  // No display surface: rendering targets our own FBO, set up lazily on the
-  // first MakeCurrent from the raster thread.
+  // No display surface: rendering targets our own gbm-backed EGL window
+  // surface, set up in InitEgl and bound on the first MakeCurrent.
 }
 
 bool HeadlessEglBackend::TextureMakeCurrent() {
@@ -316,17 +408,15 @@ void HeadlessEglBackend::Teardown() {
     const bool ctx_current =
         ctx_ != EGL_NO_CONTEXT &&
         eglMakeCurrent(dpy_, EGL_NO_SURFACE, EGL_NO_SURFACE, ctx_) != 0;
-    if (ctx_current) {
-      if (render_fbo_ != 0) {
-        glDeleteFramebuffers(1, &render_fbo_);
-      }
-      if (render_tex_ != 0) {
-        glDeleteTextures(1, &render_tex_);
-      }
+    if (ctx_current && import_tex_ != 0) {
+      glDeleteTextures(1, &import_tex_);
     }
-    render_fbo_ = 0;
-    render_tex_ = 0;
+    import_tex_ = 0;
     eglMakeCurrent(dpy_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    if (egl_surface_ != EGL_NO_SURFACE) {
+      eglDestroySurface(dpy_, egl_surface_);
+      egl_surface_ = EGL_NO_SURFACE;
+    }
     if (resource_ctx_ != EGL_NO_CONTEXT) {
       eglDestroyContext(dpy_, resource_ctx_);
       resource_ctx_ = EGL_NO_CONTEXT;
@@ -337,6 +427,16 @@ void HeadlessEglBackend::Teardown() {
     }
     eglTerminate(dpy_);
     dpy_ = EGL_NO_DISPLAY;
+  }
+  // The front buffer must be released back to the surface before it is
+  // destroyed.
+  if (locked_bo_ != nullptr && gbm_surface_ != nullptr) {
+    gbm_surface_release_buffer(gbm_surface_, locked_bo_);
+  }
+  locked_bo_ = nullptr;
+  if (gbm_surface_ != nullptr) {
+    gbm_surface_destroy(gbm_surface_);
+    gbm_surface_ = nullptr;
   }
   if (gbm_ != nullptr) {
     gbm_device_destroy(gbm_);

--- a/shell/backend/headless_egl/headless_egl.cc
+++ b/shell/backend/headless_egl/headless_egl.cc
@@ -23,15 +23,20 @@
 #include <gbm.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <vector>
 
+#include "asio/bind_executor.hpp"
+#include "asio/post.hpp"
+
 #include "backend/gl_process_resolver.h"
 #include "engine.h"
 #include "logging/logging.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
+#include "task_runner.h"
 
 namespace {
 
@@ -56,6 +61,18 @@ HeadlessEglBackend::HeadlessEglBackend(uint32_t initial_width,
     : width_(initial_width & ~1u),
       height_(initial_height & ~1u),
       consumer_(std::move(consumer)) {
+  // Pace the engine to the encode rate (IVI_ENC_MAX_FPS, default 30 -- the same
+  // knob the packer caps at) via a synthetic vsync, so it does not render
+  // wall-clock and waste GPU on frames the packer would drop.
+  // IVI_HEADLESS_VSYNC=0 (or a non-positive fps) disables it and leaves
+  // Flutter's wall-clock scheduler.
+  const char* vsync_off = std::getenv("IVI_HEADLESS_VSYNC");
+  const char* fps_env = std::getenv("IVI_ENC_MAX_FPS");
+  const int fps = fps_env != nullptr ? std::atoi(fps_env) : 30;
+  if ((vsync_off == nullptr || vsync_off[0] != '0') && fps > 0) {
+    vsync_period_ns_ = static_cast<uint32_t>(1'000'000'000LL / fps);
+  }
+
   const char* node = std::getenv("IVI_ENC_RENDER_NODE");
   if (!InitEgl(node != nullptr ? node : "/dev/dri/renderD128")) {
     ihs::log::error("[HeadlessEgl] EGL init failed; backend inert");
@@ -316,6 +333,93 @@ bool HeadlessEglBackend::Present(const FlutterPresentInfo* /*info*/) {
   locked_bo_ = bo;
   ++frame_index_;
   return true;
+}
+
+VsyncCallback HeadlessEglBackend::GetVsyncCallback() const {
+  return vsync_period_ns_ != 0 ? &VsyncTrampoline : nullptr;
+}
+
+void HeadlessEglBackend::VsyncTrampoline(void* user_data,
+                                         const intptr_t baton) {
+  // user_data is the FlutterDesktopEngineState* handed to the engine. Recover
+  // the engine + backend; if either is gone (shutdown race) drop the baton (a
+  // leaked baton is the documented cost, but the only safe option here).
+  auto* state = static_cast<FlutterDesktopEngineState*>(user_data);
+  if (state == nullptr || state->view_controller == nullptr ||
+      state->view_controller->engine == nullptr) {
+    return;
+  }
+  auto* engine_obj = state->view_controller->engine;
+  auto* backend = dynamic_cast<HeadlessEglBackend*>(engine_obj->GetBackend());
+  if (backend == nullptr) {
+    return;
+  }
+  // The timer is the source, so the baton parks (SetSourcePending(true)) and
+  // the next tick delivers it.
+  backend->vsync_.SubmitBaton(engine_obj->GetFlutterEngine(), baton);
+}
+
+void HeadlessEglBackend::SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine)
+                                             engine) {
+  engine_handle_ = engine;
+  StartVsyncIfReady();
+}
+
+void HeadlessEglBackend::SetPlatformTaskRunner(TaskRunner* runner) {
+  platform_task_runner_ = runner;
+  StartVsyncIfReady();
+}
+
+void HeadlessEglBackend::StartVsyncIfReady() {
+  if (vsync_period_ns_ == 0 || vsync_running_.load() ||
+      engine_handle_ == nullptr || platform_task_runner_ == nullptr ||
+      platform_task_runner_->GetIoContext() == nullptr) {
+    return;
+  }
+  vsync_.SetEngine(engine_handle_, platform_task_runner_);
+  vsync_.SetSourcePending(true);  // batons park; the timer returns them
+  vsync_.SetPeriodNs(vsync_period_ns_);
+  vsync_timer_ = std::make_unique<asio::steady_timer>(
+      *platform_task_runner_->GetIoContext());
+  vsync_running_.store(true, std::memory_order_release);
+  // Arm on the strand so every timer + OnVsync touch stays on the runner thread
+  // (Flutter rejects OnVsync from any other thread).
+  asio::post(*platform_task_runner_->GetStrandContext(),
+             [this]() { ArmVsyncTimer(); });
+  ihs::log::info("[HeadlessEgl] synthetic vsync at {} fps",
+                 1'000'000'000u / vsync_period_ns_);
+}
+
+void HeadlessEglBackend::ArmVsyncTimer() {
+  if (!vsync_running_.load(std::memory_order_acquire)) {
+    return;
+  }
+  vsync_timer_->expires_after(std::chrono::nanoseconds(vsync_period_ns_));
+  vsync_timer_->async_wait(asio::bind_executor(
+      *platform_task_runner_->GetStrandContext(),
+      [this](const asio::error_code& ec) {
+        if (ec || !vsync_running_.load(std::memory_order_acquire)) {
+          return;  // cancelled (teardown) or io_context stopped
+        }
+        vsync_.DeliverParkedBaton();  // no-op if the engine is idle
+        ArmVsyncTimer();
+      }));
+}
+
+void HeadlessEglBackend::StopVsyncMonitor() {
+  // Called from FlutterView::~FlutterView before the engine + runner are torn
+  // down. Stop re-arming and cancel the pending wait on the strand; the aborted
+  // handler sees vsync_running_ == false and does not re-arm.
+  if (vsync_running_.exchange(false, std::memory_order_acq_rel) &&
+      platform_task_runner_ != nullptr &&
+      platform_task_runner_->GetStrandContext() != nullptr) {
+    asio::post(*platform_task_runner_->GetStrandContext(), [this]() {
+      if (vsync_timer_ != nullptr) {
+        vsync_timer_->cancel();
+      }
+    });
+  }
+  vsync_.Stop();
 }
 
 FlutterRendererConfig HeadlessEglBackend::GetRenderConfig() {

--- a/shell/backend/headless_egl/headless_egl.h
+++ b/shell/backend/headless_egl/headless_egl.h
@@ -91,7 +91,7 @@ class HeadlessEglBackend final : public Backend {
   // pace the engine to the encode rate with a timer (IVI_ENC_MAX_FPS, default
   // 30; IVI_HEADLESS_VSYNC=0 disables and falls back to wall-clock). The engine
   // stays demand-driven -- an idle UI still schedules nothing.
-  VsyncCallback GetVsyncCallback() const override;
+  [[nodiscard]] VsyncCallback GetVsyncCallback() const override;
   void SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine) engine) override;
   void SetPlatformTaskRunner(TaskRunner* runner) override;
   void StopVsyncMonitor() override;

--- a/shell/backend/headless_egl/headless_egl.h
+++ b/shell/backend/headless_egl/headless_egl.h
@@ -19,12 +19,16 @@
 #include <EGL/egl.h>
 #include <GLES3/gl3.h>
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
+
+#include "asio/steady_timer.hpp"
 
 #include "backend/backend.h"
 #include "backend/software/nv12_consumer.h"
 #include "backend/software/nv12_gl_packer.h"
+#include "vsync/ivsync_provider.h"
 
 struct gbm_device;
 struct gbm_surface;
@@ -82,12 +86,29 @@ class HeadlessEglBackend final : public Backend {
   // Frame done: swap the window surface, import the presented buffer, pack it.
   bool Present(const FlutterPresentInfo* info);
 
+  // Synthetic vsync: without a display there is no vblank, so the engine would
+  // render wall-clock (~60fps) and the packer would drop most frames. Instead
+  // pace the engine to the encode rate with a timer (IVI_ENC_MAX_FPS, default
+  // 30; IVI_HEADLESS_VSYNC=0 disables and falls back to wall-clock). The engine
+  // stays demand-driven -- an idle UI still schedules nothing.
+  VsyncCallback GetVsyncCallback() const override;
+  void SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine) engine) override;
+  void SetPlatformTaskRunner(TaskRunner* runner) override;
+  void StopVsyncMonitor() override;
+
  private:
   bool InitEgl(
       const char* render_node);  // display, config, contexts, swapchain
   bool
   InitRenderTarget();  // packer + import texture; GL context must be current
   void Teardown();
+
+  // The engine's vsync_callback trampoline: parks the baton with vsync_.
+  static void VsyncTrampoline(void* user_data, intptr_t baton);
+  // Start the timer once both the engine handle and the runner are wired.
+  void StartVsyncIfReady();
+  // Schedule the next tick; the handler runs on the runner's strand.
+  void ArmVsyncTimer();
 
   uint32_t width_{0};
   uint32_t height_{0};
@@ -109,6 +130,15 @@ class HeadlessEglBackend final : public Backend {
       nullptr};  // front buffer held until the next swap frees it
 
   bool target_ready_{false};
+
+  // Synthetic-vsync pacing. vsync_ holds the baton machinery; a steady_timer on
+  // the platform runner's strand delivers it at the target rate.
+  ivi::IVsyncProvider vsync_;
+  FLUTTER_API_SYMBOL(FlutterEngine) engine_handle_ { nullptr };
+  TaskRunner* platform_task_runner_{nullptr};
+  std::unique_ptr<asio::steady_timer> vsync_timer_;
+  std::atomic<bool> vsync_running_{false};
+  uint32_t vsync_period_ns_{0};  // 0 = disabled (wall-clock scheduler)
 
   std::unique_ptr<INv12Consumer> consumer_;
   Nv12GlPacker packer_;

--- a/shell/backend/headless_egl/headless_egl.h
+++ b/shell/backend/headless_egl/headless_egl.h
@@ -27,19 +27,28 @@
 #include "backend/software/nv12_gl_packer.h"
 
 struct gbm_device;
+struct gbm_surface;
+struct gbm_bo;
 class Engine;
 
 // GPU headless encode backend: the Flutter engine renders each frame on the GPU
-// (kOpenGL) into an FBO this backend owns -- no display, no Wayland, no scanout
-// -- and on present the frame is packed RGBA->NV12 on the GPU straight into a
-// dma-buf and handed to an INv12Consumer (a file encoder or a WebRTC send). It
-// is the zero-copy counterpart of the software backend's CPU EncoderSink: the
-// GPU both rasterizes and colour-converts, so no CPU touches the pixels.
+// (kOpenGL) into a real EGL window surface backed by a gbm_surface -- no
+// display, no Wayland, no scanout. On present the frame is eglSwapBuffers'd,
+// the just-presented gbm_bo is imported as a texture and packed RGBA->NV12 on
+// the GPU straight into a dma-buf handed to an INv12Consumer (a file encoder or
+// a WebRTC send). It is the zero-copy counterpart of the software backend's CPU
+// EncoderSink: the GPU both rasterizes and colour-converts, no CPU touches the
+// pixels.
 //
-// Surfaceless GBM/EGL on the render node (like pi_gl_encode). Consumer selected
-// by IVI_ENC_SINK, which is the bare consumer spec -- "file:<path>" (default
-// "file:out.h264") or "webrtc:<host>:<port>" -- i.e. the part after "encoder:"
-// in the software backend's IVI_SW_SINK grammar.
+// A real swap chain (gbm_surface + eglSwapBuffers) is used rather than a single
+// reused FBO: rendering into an FBO made the engine composite incrementally
+// against a buffer it wrongly assumed it could keep, leaving doubled widgets
+// and motion trails. A window surface composites a full frame each present
+// instead.
+//
+// Surfaceless GBM/EGL on the render node. Consumer selected by IVI_ENC_SINK,
+// which is the bare consumer spec -- "file:<path>" (default "file:out.h264") or
+// "webrtc:<host>:<port>".
 class HeadlessEglBackend final : public Backend {
  public:
   HeadlessEglBackend(uint32_t initial_width,
@@ -70,18 +79,14 @@ class HeadlessEglBackend final : public Backend {
   bool MakeCurrent();
   bool ClearCurrent();
   bool MakeResourceCurrent();
-  uint32_t Fbo() const { return render_fbo_; }
-  bool Present();  // engine finished the frame -> pack + submit
-  // Existing-damage query for the engine's partial-repaint path. The render
-  // target is one FBO reused every frame (a swap chain of age 1 that already
-  // holds the last frame), so this reports nothing stale and the engine does
-  // correct incremental repaints instead of leaving trails from prior frames.
-  void PopulateExistingDamage(FlutterDamage* out);
+  // Frame done: swap the window surface, import the presented buffer, pack it.
+  bool Present(const FlutterPresentInfo* info);
 
  private:
-  bool InitEgl(const char* render_node);
+  bool InitEgl(
+      const char* render_node);  // display, config, contexts, swapchain
   bool
-  InitRenderTarget();  // the RGBA FBO + the packer; GL context must be current
+  InitRenderTarget();  // packer + import texture; GL context must be current
   void Teardown();
 
   uint32_t width_{0};
@@ -90,15 +95,20 @@ class HeadlessEglBackend final : public Backend {
 
   int render_fd_{-1};
   gbm_device* gbm_{nullptr};
+  gbm_surface* gbm_surface_{nullptr};
+  uint32_t gbm_format_{0};  // DRM fourcc of the swap-chain buffers
+
   EGLDisplay dpy_{EGL_NO_DISPLAY};
+  EGLConfig config_{nullptr};
+  EGLSurface egl_surface_{EGL_NO_SURFACE};
   EGLContext ctx_{EGL_NO_CONTEXT};
   EGLContext resource_ctx_{EGL_NO_CONTEXT};
 
-  GLuint render_tex_{0};  // RGBA colour attachment the engine draws into
-  GLuint render_fbo_{0};
+  GLuint import_tex_{0};  // GL_TEXTURE_2D the presented bo is imported into
+  gbm_bo* locked_bo_{
+      nullptr};  // front buffer held until the next swap frees it
+
   bool target_ready_{false};
-  FlutterRect
-      existing_damage_{};  // stable storage for populate_existing_damage
 
   std::unique_ptr<INv12Consumer> consumer_;
   Nv12GlPacker packer_;

--- a/shell/backend/software/nv12_gl_packer.cc
+++ b/shell/backend/software/nv12_gl_packer.cc
@@ -75,29 +75,31 @@ const char* kVert =
     "void main(){ gl_Position = vec4(pos, 0.0, 1.0); }\n";
 
 // Pack RGBA -> NV12 into a stride x (H*3/2) R8 target. gl_FragCoord.xy is the
-// destination byte (column, row). Limited-range BT.601. The source is a GL FBO
-// texture, whose origin is bottom-left, so sample with the row flipped to keep
-// NV12 (top-down) upright.
+// destination byte (column, row). Limited-range BT.601. uFlip controls the
+// vertical sampling: a GL FBO texture has a bottom-left origin so it must be
+// flipped (uFlip=1) to keep NV12 (top-down) upright, whereas a gbm_bo presented
+// through a window surface is already top-left (uFlip=0).
 const char* kFrag =
     "#version 300 es\n"
     "precision highp float;\n"
     "uniform sampler2D src;\n"
-    "uniform float uW, uH;\n"
+    "uniform float uW, uH, uFlip;\n"
     "out vec4 frag;\n"
     "float luma(vec3 c){ return (0.257*c.r+0.504*c.g+0.098*c.b)+16.0/255.0; }\n"
     "float cb(vec3 c){ return (-0.148*c.r-0.291*c.g+0.439*c.b)+128.0/255.0; }\n"
     "float cr(vec3 c){ return (0.439*c.r-0.368*c.g-0.071*c.b)+128.0/255.0; }\n"
+    "float vcoord(float v){ return uFlip > 0.5 ? 1.0 - v : v; }\n"
     "void main(){\n"
     "  float x = floor(gl_FragCoord.x);\n"
     "  float y = floor(gl_FragCoord.y);\n"
     "  float outv;\n"
     "  if (y < uH) {\n"
-    "    vec2 s = vec2((x+0.5)/uW, 1.0-(y+0.5)/uH);\n"
+    "    vec2 s = vec2((x+0.5)/uW, vcoord((y+0.5)/uH));\n"
     "    outv = luma(texture(src, s).rgb);\n"
     "  } else {\n"
     "    float cyf = y - uH;\n"
     "    float cxf = floor(x*0.5);\n"
-    "    vec2 s = vec2((cxf*2.0+1.0)/uW, 1.0-(cyf*2.0+1.0)/uH);\n"
+    "    vec2 s = vec2((cxf*2.0+1.0)/uW, vcoord((cyf*2.0+1.0)/uH));\n"
     "    vec3 c = texture(src, s).rgb;\n"
     "    outv = (mod(x,2.0) < 1.0) ? cb(c) : cr(c);\n"
     "  }\n"
@@ -193,6 +195,7 @@ bool Nv12GlPacker::Init(EGLDisplay dpy,
   u_src_ = glGetUniformLocation(program_, "src");
   u_w_ = glGetUniformLocation(program_, "uW");
   u_h_ = glGetUniformLocation(program_, "uH");
+  u_flip_ = glGetUniformLocation(program_, "uFlip");
 
   // Own VAO so the pack draw is isolated from whatever vertex-array state the
   // Flutter engine leaves bound. Sharing the engine's VAO means its still-
@@ -240,7 +243,8 @@ void Nv12GlPacker::ReleaseSlot(uint32_t index) {
 
 void Nv12GlPacker::PackAndSubmit(GLuint rgba_tex,
                                  uint64_t timestamp_us,
-                                 bool force_keyframe) {
+                                 bool force_keyframe,
+                                 bool flip_rows) {
   if (!ready_) {
     return;
   }
@@ -291,6 +295,7 @@ void Nv12GlPacker::PackAndSubmit(GLuint rgba_tex,
   glUniform1i(u_src_, 0);
   glUniform1f(u_w_, static_cast<float>(width_));
   glUniform1f(u_h_, static_cast<float>(height_));
+  glUniform1f(u_flip_, flip_rows ? 1.0f : 0.0f);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, rgba_tex);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);

--- a/shell/backend/software/nv12_gl_packer.h
+++ b/shell/backend/software/nv12_gl_packer.h
@@ -54,11 +54,14 @@ class Nv12GlPacker {
 
   // Convert `rgba_tex` (a GL_TEXTURE_2D RGBA of the configured size) to NV12 in
   // a free ring slot and submit it to the consumer. `timestamp_us` and
-  // `force_keyframe` pass through. Drops the frame if no slot is free. Must run
-  // with the packer's GL context current.
+  // `force_keyframe` pass through. `flip_rows` flips the vertical sampling:
+  // true for a bottom-left-origin GL FBO, false for a top-left gbm_bo presented
+  // via a window surface. Drops the frame if no slot is free. Must run with the
+  // packer's GL context current.
   void PackAndSubmit(GLuint rgba_tex,
                      uint64_t timestamp_us,
-                     bool force_keyframe);
+                     bool force_keyframe,
+                     bool flip_rows = true);
 
   // Release all GL/EGL/dma-buf resources. The owner must call this while the
   // packer's GL context is still current, before destroying that context;
@@ -107,5 +110,6 @@ class Nv12GlPacker {
   GLint u_src_{-1};
   GLint u_w_{-1};
   GLint u_h_{-1};
+  GLint u_flip_{-1};
   bool ready_{false};
 };


### PR DESCRIPTION
Two commits on the headless-EGL encode backend.

## 1. Render through a gbm_surface (correctness)
The backend rendered every frame into one reused FBO. Flutter's compositor treated that as a swap chain it could keep and composited incrementally against a buffer it could not actually rely on, so presented frames showed **doubled widgets and motion trails** once anything animated.

Render into a real EGL **window surface** backed by a `gbm_surface`: FBO 0 + `eglSwapBuffers`, and `Present()` imports the presented `gbm_bo` as a texture for the RGBA→NV12 pack. A window surface composites a **complete frame every present**, so doubling/trails are gone.
- **Linear buffers** (forced via `gbm_surface_create_with_modifiers`, imported with modifier) — V3D otherwise returns tiled buffers that mis-read as dashed/blocky garbage.
- **Opaque config** (XRGB8888, no alpha) — a translucent app background otherwise premultiplies to ~0 and vanishes on the destroyed swap buffers.
- **Orientation** — the presented `gbm_bo` is top-left origin, so `Nv12GlPacker::PackAndSubmit` gains a `flip_rows` arg; the headless path passes `false`.

## 2. Synthetic vsync (efficiency)
Headless has no vblank, so the engine used Flutter's wall-clock scheduler and rendered ~42 fps (Pi 4), with the packer dropping the excess. A per-backend vsync source (an asio `steady_timer` on the platform runner's strand, handing batons back via `IVsyncProvider`) paces the engine to the encode rate. It stays **demand-driven** (idle UI = no frames). Rate is `IVI_ENC_MAX_FPS` (default 30); `IVI_HEADLESS_VSYNC=0` restores wall-clock. Measured: 42 fps → a steady **30.0 fps**, every produced frame now passing the packer.

## Verification (Pi 4, bcm2835, WebRTC end-to-end)
Upright, single-instance widgets, no doubling/ghosting/trails; pre-encode NV12 clean; engine paced to 30.0 fps.

## Known issue (real bug, needs a fix)

On roughly 1 in 3 cold starts the STATIC background layer is dropped for the whole run: the received frame shows correct, single-instance widgets on a black background. Verified NOT specific to a translucent background (reproduces with an opaque gradient too), and NOT GPU contention (persists with no competing GPU client). The dynamic widgets always composite; only the static background intermittently does not, which points at the engine not compositing a non-dirty layer into the rotated EGL_BUFFER_DESTROYED buffers at startup. The damage-hint levers (populate_existing_damage full/empty/absent) do not change it, and EGL_BUFFER_PRESERVED is unsupported on mesa/gbm V3D. Under investigation.
A test app whose background is a `withOpacity()` gradient over a `Colors.transparent` Scaffold occasionally (~1 in 8 starts) comes up black for a whole run — a Flutter compositing startup race, not GPU contention. Opaque apps are unaffected.