### PR TITLE
drm_kms_egl: don't GL-fallback a not-ready platform view

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2492,9 +2492,26 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
           scene_->find_by_identity_tag(surface.get()) == nullptr;
       const bool have_db = surface->GetDmabuf(&db);
       if (is_new && !have_db) {
-        // New platform view with no dma-buf (GL-only surface, or none ready
-        // this present): route the whole frame through GL composition, which
-        // samples the surface's GL texture / Vulkan image.
+        // New platform view with no dma-buf to place this present.
+        //
+        // On a plane-capable target (planes_available_) this is a dma-buf
+        // producer -- a decoder/camera -- that just hasn't delivered its first
+        // frame, or is momentarily between frames while its layer is not yet in
+        // the scene. Such a producer also exposes a GL-fallback texture, so a
+        // GetGlTextureName()!=0 test can't tell it apart from a genuine GL-only
+        // surface -- but routing the whole frame through GL here would flip the
+        // primary via GL on every such present until a buffer lands: the
+        // startup flicker. Skip the not-ready view and keep the frame on the
+        // plane/scene path; its plane lights up once GetDmabuf starts returning
+        // frames. Nothing is latched in the scene for an is_new view, so
+        // skipping it turns no plane off (the prune runs over this frame's tags
+        // only).
+        //
+        // With no overlay planes (e.g. software vkms) GL composition of the
+        // surface's texture is the only way to show it, so fall back.
+        if (planes_available_) {
+          continue;
+        }
         return PresentViaGlFallback(layers, layer_count);
       }
       frame_layers.push_back(


### PR DESCRIPTION
## Summary
On the scene/plane path, a new platform view with no dma-buf this present routed the **whole frame** through GL composition. That fallback returns before the surface is added to the scene, so the surface stayed "new" on every present until the first decoded buffer arrived — meaning from startup until the first frame the entire UI composited via GL, flipping the primary CRTC (`drmModePageFlip` EINVAL) and flashing black.

On a plane-capable target, skip the not-ready view instead and keep the frame on the plane/scene path. Nothing is latched in the scene for a new view, so the video region simply stays dark until its first buffer, then the plane lights up with no fallback. With no overlay planes (software vkms) GL composition remains the only way to show the surface, so it still falls back there.

## Test plan
Verified on a Raspberry Pi (KMS overlay-plane path, HLS video platform view): the startup black-flash is gone — steady plane-path presents (`scanout`, zero `drmModePageFlip EINVAL`, zero GL fallback) across repeated launches. vkms/no-plane path is unaffected (still GL-composites).