### PR TITLE
headless-egl: default to the Impeller renderer

### DIFF
--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "flutter_view.h"
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include "logging/logging.h"
@@ -44,6 +45,9 @@
 #include "backend/software/sink_factory.h"
 #include "backend/software/software_backend.h"
 #include "display/software_display.h"
+#endif
+#if BUILD_BACKEND_HEADLESS_EGL
+#include "backend/headless_egl/headless_egl.h"
 #endif
 #if BUILD_BACKEND_WAYLAND_EGL
 #include "backend/wayland_egl/wayland_egl.h"
@@ -365,11 +369,38 @@ Display* FlutterView::GetDisplay() const {
 void FlutterView::Initialize() {
   // Engine / Dart VM switches -> command_line_argv. argv[0] is the app id.
   std::vector<const char*> m_command_line_args_c;
-  m_command_line_args_c.reserve(m_config.view.engine_args.size() + 1);
+  m_command_line_args_c.reserve(m_config.view.engine_args.size() + 2);
   m_command_line_args_c.push_back(m_config.app_id.c_str());
   for (const auto& arg : m_config.view.engine_args) {
     m_command_line_args_c.push_back(arg.c_str());
   }
+
+#if BUILD_BACKEND_HEADLESS_EGL
+  // The headless-EGL encode backend requires Impeller. Under the Skia GL
+  // renderer a startup race in the raster cache intermittently drops static
+  // layers -- e.g. a whole-run black background on ~half of cold starts --
+  // because a cached layer image is captured empty. Impeller GLES has no such
+  // cache and paints the full layer tree every frame, which is also what an
+  // encoder wants. Default it on for this backend unless the deployment pinned
+  // the flag either way (e.g.
+  // --enable-impeller=false to opt back into Skia). The literal has static
+  // storage, so its pointer stays valid for the synchronous Engine
+  // construction.
+  static constexpr char kImpellerSwitch[] = "--enable-impeller";
+  if (dynamic_cast<HeadlessEglBackend*>(m_backend.get()) != nullptr) {
+    const auto& args = m_config.view.engine_args;
+    const bool pinned =
+        std::any_of(args.begin(), args.end(), [](const std::string& a) {
+          return a == kImpellerSwitch || a.rfind("--enable-impeller=", 0) == 0;
+        });
+    if (!pinned) {
+      m_command_line_args_c.push_back(kImpellerSwitch);
+      ihs::log::info(
+          "[FlutterView] headless-egl: enabling Impeller (Skia GL raster cache "
+          "intermittently drops static layers on this path)");
+    }
+  }
+#endif
 
   // Arguments to the Dart entrypoint main(List<String>) -> dart_entrypoint_argv
   // (no argv[0] convention).


### PR DESCRIPTION
## Problem

The headless-EGL encode backend intermittently loses static layers under the **Skia GL** renderer: on roughly half of cold starts the whole-run background comes up **black**. Widgets composite correctly (single, upright, no trails), but the static background layer never appears.

Root cause (confirmed on a Raspberry Pi 4): it is a **Skia GL raster-cache** startup race, not a partial-repaint or buffer-age problem. The backend already runs full-repaint (`gl_populate_existing_damage` is deliberately null, so `supports_partial_repaint` is false), yet the bg still drops — because the raster cache promotes the static background layer to a cached image (`RasterCache::Rasterize` → offscreen `RenderTarget` → `Clear(kTransparent)` → `makeImageSnapshot`) and that capture intermittently comes back empty, then gets reused for the whole run. A magenta-clear diagnostic proved the engine clears the framebuffer before compositing, so no embedder-side preserve/damage trick can recover it.

Every embedder-level lever failed (damage hints, `EGL_BUFFER_PRESERVED` — unsupported on mesa/gbm V3D, preserve-blit, `--disable-partial-repaint`).

## Fix

**Impeller GLES has no `flow` raster cache** and paints the full layer tree every frame — which is also exactly what the encoder wants. So default the headless-egl backend to Impeller: inject `--enable-impeller` into the engine command line when the active backend is headless-egl, unless the deployment already pinned the flag (`--enable-impeller=false` still opts back into Skia). The prebuilt engine already ships Impeller GLES, so no engine rebuild is needed, and the `Present()` import path and synthetic vsync are renderer-agnostic and work unchanged.

## Validation (Raspberry Pi 4, WebRTC receiver)

A/B on one clean binary:

| Renderer | Background |
|---|---|
| Skia GL (previous default) | ~50% whole-run black (5/9) |
| Impeller GLES (this change, auto) | **10/10 green, 0 black** |

Frame quality under Impeller is complete and correct: gradient present, all widgets, upright, single-instance, no doubling/trails. Logs confirm the injection (`headless-egl: enabling Impeller ...`) and `Using the Impeller rendering backend (OpenGL)`.