### PR TITLE
headless-egl: opt-in consumer-paced vsync (encode-ring backpressure)

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(${PROJECT_NAME}
         # Backend-spanning vsync baton machinery (Wayland/DRM/software providers
         # inherit it). Source-agnostic, so always compiled.
         vsync/ivsync_provider.cc
+        # Consumer-paced vsync source (encode-ring backpressure -> baton timing).
+        vsync/consumer_paced_vsync.cc
         timer.cc
         view/flutter_view.cc
         watchdog.cc

--- a/shell/backend/headless_egl/headless_egl.cc
+++ b/shell/backend/headless_egl/headless_egl.cc
@@ -72,6 +72,12 @@ HeadlessEglBackend::HeadlessEglBackend(uint32_t initial_width,
   if ((vsync_off == nullptr || vsync_off[0] != '0') && fps > 0) {
     vsync_period_ns_ = static_cast<uint32_t>(1'000'000'000LL / fps);
   }
+  // IVI_HEADLESS_PACED=1 drives the vsync from encode-ring backpressure (a free
+  // slot releases the next baton) with the fps above as a ceiling, instead of a
+  // free-running timer -- so the engine renders at the consumer's real rate and
+  // stalls cleanly when it backs up. Opt-in for now.
+  const char* paced_env = std::getenv("IVI_HEADLESS_PACED");
+  paced_ = paced_env != nullptr && paced_env[0] == '1';
 
   const char* node = std::getenv("IVI_ENC_RENDER_NODE");
   if (!InitEgl(node != nullptr ? node : "/dev/dri/renderD128")) {
@@ -228,6 +234,18 @@ bool HeadlessEglBackend::InitRenderTarget() {
     ihs::log::error("[HeadlessEgl] packer init failed");
     return false;
   }
+  if (paced_) {
+    // Consumer-paced vsync: each freed ring slot is a credit for the pacer, and
+    // the pacer -- not the packer -- limits the rate. (StartVsyncIfReady may
+    // run before or after this; the lambda re-checks pacer_ at call time, and
+    // AddCredit no-ops until the pacer is running.)
+    packer_.SetExternalPacing(true);
+    packer_.SetOnSlotFree([this]() {
+      if (pacer_ != nullptr) {
+        pacer_->AddCredit();
+      }
+    });
+  }
   target_ready_ = true;
   ihs::log::info("[HeadlessEgl] render target ready {}x{}", width_, height_);
   return true;
@@ -356,9 +374,13 @@ void HeadlessEglBackend::VsyncTrampoline(void* user_data,
   if (backend == nullptr) {
     return;
   }
-  // The timer is the source, so the baton parks (SetSourcePending(true)) and
-  // the next tick delivers it.
-  backend->vsync_.SubmitBaton(engine_obj->GetFlutterEngine(), baton);
+  // The source (timer or consumer-paced) keeps the baton parked
+  // (SetSourcePending(true)) and delivers it under its own timing.
+  if (backend->paced_ && backend->pacer_ != nullptr) {
+    backend->pacer_->SubmitBaton(engine_obj->GetFlutterEngine(), baton);
+  } else {
+    backend->vsync_.SubmitBaton(engine_obj->GetFlutterEngine(), baton);
+  }
 }
 
 void HeadlessEglBackend::SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine)
@@ -378,6 +400,16 @@ void HeadlessEglBackend::StartVsyncIfReady() {
       platform_task_runner_->GetIoContext() == nullptr) {
     return;
   }
+  vsync_running_.store(true, std::memory_order_release);
+  if (paced_) {
+    // Consumer-paced: the ring depth is the credit budget, vsync_period_ns_ the
+    // rate ceiling. The pacer wires vsync_ (SetSourcePending/SetPeriodNs/
+    // SetEngine) itself.
+    pacer_ = std::make_unique<ivi::ConsumerPacedVsyncSource>(
+        vsync_, vsync_period_ns_, Nv12GlPacker::RingSize());
+    pacer_->Start(engine_handle_, platform_task_runner_);
+    return;
+  }
   // Mark the source pending + set the period before wiring the engine, so any
   // baton that arrives once wired parks for the timer rather than draining
   // inline unpaced.
@@ -386,7 +418,6 @@ void HeadlessEglBackend::StartVsyncIfReady() {
   vsync_.SetEngine(engine_handle_, platform_task_runner_);
   vsync_timer_ = std::make_unique<asio::steady_timer>(
       *platform_task_runner_->GetIoContext());
-  vsync_running_.store(true, std::memory_order_release);
   // Arm on the strand so every timer + OnVsync touch stays on the runner thread
   // (Flutter rejects OnVsync from any other thread).
   asio::post(*platform_task_runner_->GetStrandContext(),
@@ -418,6 +449,9 @@ void HeadlessEglBackend::StopVsyncMonitor() {
   if (vsync_running_.exchange(false, std::memory_order_acq_rel) &&
       platform_task_runner_ != nullptr &&
       platform_task_runner_->GetStrandContext() != nullptr) {
+    if (paced_ && pacer_ != nullptr) {
+      pacer_->Stop();
+    }
     asio::post(*platform_task_runner_->GetStrandContext(), [this]() {
       if (vsync_timer_ != nullptr) {
         vsync_timer_->cancel();

--- a/shell/backend/headless_egl/headless_egl.cc
+++ b/shell/backend/headless_egl/headless_egl.cc
@@ -78,6 +78,11 @@ HeadlessEglBackend::HeadlessEglBackend(uint32_t initial_width,
   // stalls cleanly when it backs up. Opt-in for now.
   const char* paced_env = std::getenv("IVI_HEADLESS_PACED");
   paced_ = paced_env != nullptr && paced_env[0] == '1';
+  // IVI_HEADLESS_FREERUN=1 starts the paced source in ceiling-only (detached)
+  // mode -- the free-run fallback a headless_vulkan backend uses before a
+  // consumer attaches. Exercises the mode on this backend for validation.
+  const char* freerun_env = std::getenv("IVI_HEADLESS_FREERUN");
+  free_run_ = freerun_env != nullptr && freerun_env[0] == '1';
 
   const char* node = std::getenv("IVI_ENC_RENDER_NODE");
   if (!InitEgl(node != nullptr ? node : "/dev/dri/renderD128")) {
@@ -408,6 +413,9 @@ void HeadlessEglBackend::StartVsyncIfReady() {
     pacer_ = std::make_unique<ivi::ConsumerPacedVsyncSource>(
         vsync_, vsync_period_ns_, Nv12GlPacker::RingSize());
     pacer_->Start(engine_handle_, platform_task_runner_);
+    if (free_run_) {
+      pacer_->SetFreeRun(true);
+    }
     return;
   }
   // Mark the source pending + set the period before wiring the engine, so any

--- a/shell/backend/headless_egl/headless_egl.h
+++ b/shell/backend/headless_egl/headless_egl.h
@@ -28,6 +28,7 @@
 #include "backend/backend.h"
 #include "backend/software/nv12_consumer.h"
 #include "backend/software/nv12_gl_packer.h"
+#include "vsync/consumer_paced_vsync.h"
 #include "vsync/ivsync_provider.h"
 
 struct gbm_device;
@@ -131,14 +132,20 @@ class HeadlessEglBackend final : public Backend {
 
   bool target_ready_{false};
 
-  // Synthetic-vsync pacing. vsync_ holds the baton machinery; a steady_timer on
-  // the platform runner's strand delivers it at the target rate.
+  // Synthetic-vsync pacing. vsync_ holds the baton machinery. Two drivers of
+  // it: the default free-running steady_timer (fixed target rate), or -- when
+  // paced_ (IVI_HEADLESS_PACED=1) -- a ConsumerPacedVsyncSource that only
+  // delivers a baton when the encode ring has a free slot (backpressure), with
+  // the same rate as a ceiling. The pacer is the backend-agnostic path a future
+  // Vulkan encoder reuses.
   ivi::IVsyncProvider vsync_;
   FLUTTER_API_SYMBOL(FlutterEngine) engine_handle_ { nullptr };
   TaskRunner* platform_task_runner_{nullptr};
   std::unique_ptr<asio::steady_timer> vsync_timer_;
   std::atomic<bool> vsync_running_{false};
   uint32_t vsync_period_ns_{0};  // 0 = disabled (wall-clock scheduler)
+  bool paced_{false};            // consumer-paced vsync instead of the timer
+  std::unique_ptr<ivi::ConsumerPacedVsyncSource> pacer_;
 
   std::unique_ptr<INv12Consumer> consumer_;
   Nv12GlPacker packer_;

--- a/shell/backend/headless_egl/headless_egl.h
+++ b/shell/backend/headless_egl/headless_egl.h
@@ -145,6 +145,7 @@ class HeadlessEglBackend final : public Backend {
   std::atomic<bool> vsync_running_{false};
   uint32_t vsync_period_ns_{0};  // 0 = disabled (wall-clock scheduler)
   bool paced_{false};            // consumer-paced vsync instead of the timer
+  bool free_run_{false};         // paced source in ceiling-only (detached) mode
   std::unique_ptr<ivi::ConsumerPacedVsyncSource> pacer_;
 
   std::unique_ptr<INv12Consumer> consumer_;

--- a/shell/backend/software/nv12_gl_packer.cc
+++ b/shell/backend/software/nv12_gl_packer.cc
@@ -237,8 +237,16 @@ void Nv12GlPacker::ReleaseSlotTrampoline(void* ctx) {
 }
 
 void Nv12GlPacker::ReleaseSlot(uint32_t index) {
-  std::lock_guard<std::mutex> lock(ring_mu_);
-  ring_[index].in_flight = false;
+  {
+    std::lock_guard<std::mutex> lock(ring_mu_);
+    ring_[index].in_flight = false;
+  }
+  // A slot is free again: hand a credit to a consumer-paced source. Fired
+  // outside the lock -- the callback hops to the vsync strand, and a
+  // synchronous consumer calls this from PackAndSubmit's own thread.
+  if (on_slot_free_) {
+    on_slot_free_();
+  }
 }
 
 void Nv12GlPacker::PackAndSubmit(GLuint rgba_tex,
@@ -255,7 +263,7 @@ void Nv12GlPacker::PackAndSubmit(GLuint rgba_tex,
   static const char* max_fps_env = std::getenv("IVI_ENC_MAX_FPS");
   static const int max_fps =
       max_fps_env != nullptr ? std::atoi(max_fps_env) : 30;
-  if (max_fps > 0) {
+  if (max_fps > 0 && !external_pacing_) {
     const uint64_t min_interval = 1000000ULL / static_cast<uint64_t>(max_fps);
     if (last_push_us_ != 0 && timestamp_us > last_push_us_ &&
         timestamp_us - last_push_us_ < min_interval) {
@@ -272,10 +280,20 @@ void Nv12GlPacker::PackAndSubmit(GLuint rgba_tex,
         break;
       }
     }
-    if (idx == kRingSize) {
-      return;  // ring full: drop
+    if (idx != kRingSize) {
+      ring_[idx].in_flight = true;
     }
-    ring_[idx].in_flight = true;
+  }
+  if (idx == kRingSize) {
+    // Ring full: drop this frame. Under external pacing a delivered baton was
+    // already charged a credit for the slot this frame would have taken, so
+    // return that credit -- otherwise a drop would leak it and eventually stall
+    // the pacer. (In steady state the pacer keeps a slot free, so this is a
+    // self-correcting safety net, not the common path.)
+    if (external_pacing_ && on_slot_free_) {
+      on_slot_free_();
+    }
+    return;
   }
 
   Slot& slot = ring_[idx];

--- a/shell/backend/software/nv12_gl_packer.h
+++ b/shell/backend/software/nv12_gl_packer.h
@@ -21,6 +21,7 @@
 #include <GLES3/gl3.h>
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -73,6 +74,22 @@ class Nv12GlPacker {
   uint32_t width() const { return width_; }
   uint32_t height() const { return height_; }
 
+  // The ring depth -- the pipeline's credit budget for a consumer-paced source.
+  static constexpr uint32_t RingSize() { return kRingSize; }
+
+  // Called (from any thread) each time a frame slot is released back to the
+  // ring
+  // -- a credit for a consumer-paced vsync source. Set once before streaming.
+  void SetOnSlotFree(std::function<void()> cb) {
+    on_slot_free_ = std::move(cb);
+  }
+
+  // When an external pacer governs the frame rate (a consumer-paced vsync
+  // source that only delivers a baton when a slot is free), disable the
+  // packer's own wall-clock push-rate cap so the two do not fight -- the pacer
+  // alone limits the rate and the ring never overflows.
+  void SetExternalPacing(bool on) { external_pacing_ = on; }
+
  private:
   static constexpr uint32_t kRingSize = 4;
 
@@ -107,6 +124,8 @@ class Nv12GlPacker {
   GLuint vbo_{0};
   GLuint vao_{0};
   uint64_t last_push_us_{0};  // last submitted frame, for the push-rate cap
+  std::function<void()> on_slot_free_;  // credit callback (consumer-paced)
+  bool external_pacing_{false};         // pacer governs the rate; skip the cap
   GLint u_src_{-1};
   GLint u_w_{-1};
   GLint u_h_{-1};

--- a/shell/vsync/consumer_paced_vsync.cc
+++ b/shell/vsync/consumer_paced_vsync.cc
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vsync/consumer_paced_vsync.h"
+
+#include <chrono>
+#include <ctime>
+
+#include "asio/bind_executor.hpp"
+#include "asio/post.hpp"
+
+#include "logging/logging.h"
+#include "task_runner.h"
+
+namespace ivi {
+
+namespace {
+uint64_t MonotonicNs() {
+  timespec ts{};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1'000'000'000ULL +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+}  // namespace
+
+ConsumerPacedVsyncSource::ConsumerPacedVsyncSource(IVsyncProvider& provider,
+                                                   uint32_t min_period_ns,
+                                                   uint32_t pipeline_depth)
+    : provider_(provider),
+      min_period_ns_(min_period_ns),
+      pipeline_depth_(pipeline_depth == 0 ? 1 : pipeline_depth) {}
+
+ConsumerPacedVsyncSource::~ConsumerPacedVsyncSource() {
+  Stop();
+}
+
+void ConsumerPacedVsyncSource::Start(FLUTTER_API_SYMBOL(FlutterEngine) engine,
+                                     TaskRunner* runner) {
+  if (running_.load() || runner == nullptr ||
+      runner->GetIoContext() == nullptr) {
+    return;
+  }
+  runner_ = runner;
+  credits_ = static_cast<int>(pipeline_depth_);  // all slots free at bring-up
+  last_deliver_ns_ = 0;
+  ceiling_armed_ = false;
+  timer_ = std::make_unique<asio::steady_timer>(*runner_->GetIoContext());
+  // Batons must always park (this source, not an inline drain, decides timing).
+  provider_.SetSourcePending(true);
+  provider_.SetPeriodNs(min_period_ns_ != 0 ? min_period_ns_ : 16'666'667u);
+  provider_.SetEngine(engine, runner_);
+  running_.store(true, std::memory_order_release);
+  ihs::log::info("[ConsumerPacedVsync] paced vsync: depth={} ceiling={}",
+                 pipeline_depth_,
+                 min_period_ns_ != 0
+                     ? std::to_string(1'000'000'000u / min_period_ns_) + "fps"
+                     : std::string("none"));
+}
+
+void ConsumerPacedVsyncSource::SubmitBaton(FLUTTER_API_SYMBOL(FlutterEngine)
+                                               engine,
+                                           intptr_t baton) {
+  // Park the baton (SetSourcePending(true) keeps SubmitBaton from draining it
+  // inline), then try to deliver on the strand under the credit + rate rules.
+  provider_.SubmitBaton(engine, baton);
+  if (!running_.load(std::memory_order_acquire)) {
+    return;
+  }
+  asio::post(*runner_->GetStrandContext(), [this]() { TryDeliver(); });
+}
+
+void ConsumerPacedVsyncSource::AddCredit() {
+  if (!running_.load(std::memory_order_acquire)) {
+    return;
+  }
+  asio::post(*runner_->GetStrandContext(), [this]() {
+    if (credits_ < static_cast<int>(pipeline_depth_)) {
+      ++credits_;
+    }
+    TryDeliver();
+  });
+}
+
+void ConsumerPacedVsyncSource::TryDeliver() {
+  if (!running_.load(std::memory_order_acquire)) {
+    return;
+  }
+  // Nothing to do unless a slot is free AND the engine has parked a baton.
+  if (credits_ <= 0 || !provider_.HasParkedBaton()) {
+    return;
+  }
+  const uint64_t now = MonotonicNs();
+  if (min_period_ns_ != 0 && last_deliver_ns_ != 0) {
+    const uint64_t elapsed = now - last_deliver_ns_;
+    if (elapsed < min_period_ns_) {
+      ArmCeiling(min_period_ns_ - elapsed);  // rate ceiling: deliver later
+      return;
+    }
+  }
+  if (provider_.DeliverParkedBaton()) {
+    --credits_;  // this frame commits one pipeline slot
+    last_deliver_ns_ = now;
+  }
+}
+
+void ConsumerPacedVsyncSource::ArmCeiling(uint64_t ns) {
+  if (ceiling_armed_) {
+    return;  // a wait is already pending; its handler will re-check
+  }
+  ceiling_armed_ = true;
+  timer_->expires_after(std::chrono::nanoseconds(ns));
+  timer_->async_wait(asio::bind_executor(
+      *runner_->GetStrandContext(), [this](const asio::error_code& ec) {
+        ceiling_armed_ = false;
+        if (ec || !running_.load(std::memory_order_acquire)) {
+          return;  // cancelled (teardown) or io_context stopped
+        }
+        TryDeliver();
+      }));
+}
+
+void ConsumerPacedVsyncSource::Stop() {
+  if (running_.exchange(false, std::memory_order_acq_rel) &&
+      runner_ != nullptr && runner_->GetStrandContext() != nullptr) {
+    asio::post(*runner_->GetStrandContext(), [this]() {
+      if (timer_ != nullptr) {
+        timer_->cancel();
+      }
+    });
+  }
+  provider_.Stop();
+}
+
+}  // namespace ivi

--- a/shell/vsync/consumer_paced_vsync.cc
+++ b/shell/vsync/consumer_paced_vsync.cc
@@ -98,8 +98,9 @@ void ConsumerPacedVsyncSource::TryDeliver() {
   if (!running_.load(std::memory_order_acquire)) {
     return;
   }
-  // Nothing to do unless a slot is free AND the engine has parked a baton.
-  if (credits_ <= 0 || !provider_.HasParkedBaton()) {
+  // Nothing to do unless the engine has parked a baton and -- when credit-gated
+  // -- a slot is free. Free-run ignores credits and paces on the ceiling alone.
+  if (!provider_.HasParkedBaton() || (!free_run_ && credits_ <= 0)) {
     return;
   }
   const uint64_t now = MonotonicNs();
@@ -111,9 +112,26 @@ void ConsumerPacedVsyncSource::TryDeliver() {
     }
   }
   if (provider_.DeliverParkedBaton()) {
-    --credits_;  // this frame commits one pipeline slot
+    if (!free_run_) {
+      --credits_;  // this frame commits one pipeline slot
+    }
     last_deliver_ns_ = now;
   }
+}
+
+void ConsumerPacedVsyncSource::SetFreeRun(bool free_run) {
+  if (!running_.load(std::memory_order_acquire)) {
+    return;
+  }
+  asio::post(*runner_->GetStrandContext(), [this, free_run]() {
+    free_run_ = free_run;
+    if (!free_run) {
+      // Re-attach: assume the consumer re-established the pool -> all slots
+      // free.
+      credits_ = static_cast<int>(pipeline_depth_);
+    }
+    TryDeliver();  // kick: a baton may be parked and newly deliverable
+  });
 }
 
 void ConsumerPacedVsyncSource::ArmCeiling(uint64_t ns) {

--- a/shell/vsync/consumer_paced_vsync.h
+++ b/shell/vsync/consumer_paced_vsync.h
@@ -81,6 +81,14 @@ class ConsumerPacedVsyncSource {
   // any thread (a synchronous encoder's call site or an async release cb).
   void AddCredit();
 
+  // Free-run mode: pace on the ceiling ALONE, ignoring credits, for when no
+  // consumer is attached (a detached export pool, or a consumer that hitched --
+  // a watchdog flips this on until FRAME_RELEASE edges resume). Turning it back
+  // off resets the credit count to the full pipeline depth (the consumer is
+  // assumed to have re-established the pool). Credit-gated is the default; the
+  // encode path never calls this. Safe from any thread.
+  void SetFreeRun(bool free_run);
+
   // Stop pacing, cancel the ceiling timer, and drop any parked baton.
   void Stop();
 
@@ -100,6 +108,7 @@ class ConsumerPacedVsyncSource {
   int credits_{0};
   uint64_t last_deliver_ns_{0};
   bool ceiling_armed_{false};
+  bool free_run_{false};  // pace on the ceiling alone, ignoring credits
 };
 
 }  // namespace ivi

--- a/shell/vsync/consumer_paced_vsync.h
+++ b/shell/vsync/consumer_paced_vsync.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_VSYNC_CONSUMER_PACED_VSYNC_H_
+#define SHELL_VSYNC_CONSUMER_PACED_VSYNC_H_
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+#include <shell/platform/embedder/embedder.h>
+
+#include "asio/steady_timer.hpp"
+
+#include "vsync/ivsync_provider.h"
+
+class TaskRunner;
+
+namespace ivi {
+
+// Drives Flutter's vsync from DOWNSTREAM CONSUMER COMPLETION instead of a wall
+// clock. The engine is handed the next vsync baton only when the consumer
+// signals a free frame slot (a "credit"), so an engine that renders into a
+// bounded pipeline (a swap chain / encode ring) naturally slows to the
+// consumer's real drain rate -- true backpressure -- and stops entirely when
+// the consumer stalls, instead of rendering frames that are dropped.
+//
+// A CREDIT is one free slot in the producer's pipeline. Delivering a baton
+// commits a slot (the frame it triggers will fill one), so a credit is consumed
+// per delivered baton and returned when the consumer releases a slot. Start
+// with `pipeline_depth` credits (all slots free); in-flight frames never exceed
+// it.
+//
+// An optional MIN PERIOD caps the delivery rate so a fast or idle consumer
+// (credits always available) cannot free-run the engine faster than the target
+// frame rate. min_period_ns == 0 is pure backpressure (no ceiling).
+//
+// Backend-agnostic: it only needs an IVsyncProvider (the baton machinery) and a
+// TaskRunner (whose strand every OnVsync must marshal onto). The headless-EGL
+// GLES encoder drives it today; a Vulkan encoder can drive the same object
+// unchanged -- credits are a pipeline concept, not a renderer one.
+//
+// Threading: SubmitBaton()/AddCredit() may be called from any thread; each hops
+// to the runner's strand, where all scheduling state lives (no locks). Delivery
+// (FlutterEngineOnVsync) therefore always happens on the platform runner, which
+// Flutter requires.
+class ConsumerPacedVsyncSource {
+ public:
+  // `provider` is the baton machinery (owned by the backend, outlives this).
+  // `min_period_ns` is the rate ceiling (0 = none). `pipeline_depth` is the
+  // number of pipeline slots (the initial and maximum credit count).
+  ConsumerPacedVsyncSource(IVsyncProvider& provider,
+                           uint32_t min_period_ns,
+                           uint32_t pipeline_depth);
+  ~ConsumerPacedVsyncSource();
+
+  ConsumerPacedVsyncSource(const ConsumerPacedVsyncSource&) = delete;
+  ConsumerPacedVsyncSource& operator=(const ConsumerPacedVsyncSource&) = delete;
+
+  // Wire the engine + platform runner and begin pacing. The runner must expose
+  // a strand + io_context (TaskRunner::GetStrandContext/GetIoContext).
+  void Start(FLUTTER_API_SYMBOL(FlutterEngine) engine, TaskRunner* runner);
+
+  // The engine's vsync_callback trampoline hands the parked baton here.
+  void SubmitBaton(FLUTTER_API_SYMBOL(FlutterEngine) engine, intptr_t baton);
+
+  // The consumer finished with one frame slot -> return one credit. Safe from
+  // any thread (a synchronous encoder's call site or an async release cb).
+  void AddCredit();
+
+  // Stop pacing, cancel the ceiling timer, and drop any parked baton.
+  void Stop();
+
+ private:
+  void TryDeliver();             // strand only
+  void ArmCeiling(uint64_t ns);  // strand only
+
+  IVsyncProvider& provider_;
+  const uint32_t min_period_ns_;
+  const uint32_t pipeline_depth_;
+
+  TaskRunner* runner_{nullptr};
+  std::unique_ptr<asio::steady_timer> timer_;
+  std::atomic<bool> running_{false};
+
+  // Strand-only scheduling state (no lock: every mutator runs on the strand).
+  int credits_{0};
+  uint64_t last_deliver_ns_{0};
+  bool ceiling_armed_{false};
+};
+
+}  // namespace ivi
+
+#endif  // SHELL_VSYNC_CONSUMER_PACED_VSYNC_H_

--- a/shell/vsync/ivsync_provider.h
+++ b/shell/vsync/ivsync_provider.h
@@ -143,6 +143,15 @@ class IVsyncProvider {
     return last_frame_start_ns_.load(std::memory_order_acquire);
   }
 
+  /// True when a baton is parked awaiting delivery (i.e. the engine has asked
+  /// for a vsync that has not yet been handed back). Lets a scheduling owner
+  /// (e.g. a consumer-paced source) decide whether there is anything to deliver
+  /// before consuming a credit / arming a rate-ceiling timer, without taking
+  /// the baton.
+  [[nodiscard]] bool HasParkedBaton() const {
+    return vsync_baton_.load(std::memory_order_acquire) != 0;
+  }
+
  private:
   // Marshal one OnVsync onto the runner's strand. No-op when the runner is not
   // wired (the caller must leave the baton parked in that case).


### PR DESCRIPTION
## Problem

The headless encode backend paces the Flutter engine with a **free-running timer** at the target frame rate, independent of whether the encode ring can take another frame. Combined with `Nv12GlPacker`'s own push-rate cap, the pipeline is **double-gated**: the two limiters drift out of phase and drop frames, so the delivered rate sags below target.

## Change

Add **`ConsumerPacedVsyncSource`** (`shell/vsync/consumer_paced_vsync.{h,cc}`): a backend-agnostic vsync source that hands the engine the next baton only when the encode ring **frees a slot (a credit)**, with the frame rate as a **ceiling**. Backpressure, not a fixed clock.

- Wraps the existing `IVsyncProvider` baton machinery (adds `HasParkedBaton()` to peek without consuming) and runs entirely on the platform task-runner strand — `FlutterEngineOnVsync` stays where Flutter requires it.
- `Nv12GlPacker` reports a freed slot via `SetOnSlotFree`, and under `SetExternalPacing(true)` drops its own rate cap so the two no longer fight. A frame dropped on a full ring **returns its credit** (`on_slot_free` on the drop path), so the credit accounting cannot leak and stall.
- `HeadlessEglBackend` gains the paced path behind **`IVI_HEADLESS_PACED=1`**; the default remains the timer, and the non-paced path is byte-for-byte unchanged (callbacks are only wired when paced).

Backend-agnostic by design: credits are a pipeline concept, so a future Vulkan encode backend drives the same object — with the credit becoming a real `VkSemaphore`/`sync_file` fence instead of a software credit.

## Validation (Raspberry Pi 4, 1920x720, `IVI_ENC_MAX_FPS=30`, WebRTC send)

| Path | Frames / ~12 s | Effective rate | Background | Stall |
|---|---|---|---|---|
| `IVI_HEADLESS_PACED=1` | ~360 | **~30 fps** (ceiling) | correct | none |
| timer (default) | ~240 | ~20 fps | correct | none |

No deadlock across a sustained stream (proves the credit accounting), and the paced path holds the full 30 fps target — it renders exactly when a slot is free instead of losing frames to the redundant cap.