### PR TITLE
drm_kms_egl: release a platform-view buffer only after its flip completes

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -279,6 +279,9 @@ DrmCompositor::DrmCompositor(DrmBackend* backend, DrmOutputContext out)
 
 DrmCompositor::~DrmCompositor() {
   (void)WaitForPendingFlip();
+  // The final flip is done, so anything held for its post-flip release is now
+  // off the plane -- return it so producers aren't left blocked on a ring slot.
+  DrainDeferredScanoutReleases();
 
   if (texture_blit_fbo_ != 0) {
     glDeleteFramebuffers(1, &texture_blit_fbo_);
@@ -310,6 +313,21 @@ DrmCompositor::~DrmCompositor() {
   if (bg_store_valid_) {
     DestroyGbmStore(bg_store_);
     bg_store_valid_ = false;
+  }
+}
+
+void DrmCompositor::DrainDeferredScanoutReleases() {
+  // Take the batch under the lock, then fire the callbacks without it: they run
+  // producer code (an eventfd signal) and must not re-enter under our mutex.
+  std::vector<DeferredScanoutRelease> ready;
+  {
+    const std::scoped_lock lock(deferred_releases_mu_);
+    ready.swap(deferred_releases_);
+  }
+  for (const DeferredScanoutRelease& r : ready) {
+    if (r.surface) {
+      r.surface->OnScanoutRelease(r.buffer_id);
+    }
   }
 }
 
@@ -2379,6 +2397,12 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   }
   const uint64_t t1 = profile ? NsNow() : 0;
 
+  // The previous frame's flip has now completed, so every platform-view buffer
+  // displaced up to and including that frame is off the plane -- return them to
+  // their producers here, one present after drm-cxx signalled the release. See
+  // deferred_releases_.
+  DrainDeferredScanoutReleases();
+
   // Walk the FlutterLayer[] in z-order (Flutter's convention: layer 0
   // is bottom). Sync scene_'s layer set against the current frame: add
   // new, update geometry/zpos on existing, remove any scene layer whose
@@ -2707,12 +2731,20 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       // The retained surface shared_ptr keeps the view alive across a release
       // even if it is concurrently disposed.
       drm::scene::ExternalDmaBufPool::Options opts{};
-      opts.on_release = [surface = fl.pv_surface](
+      // Defer the release by one present: the buffer is displaced now but stays
+      // on the plane until this commit's flip completes, so returning it to the
+      // producer here would let it be overwritten under scanout. Hold it and
+      // fire OnScanoutRelease at the next present's top
+      // (post-WaitForPendingFlip), when the flip is done. See
+      // deferred_releases_.
+      opts.on_release = [this, surface = fl.pv_surface](
                             std::uintptr_t key,
                             std::optional<drm::sync::SyncFence>) {
-        if (surface) {
-          surface->OnScanoutRelease(static_cast<uint32_t>(key));
+        if (!surface) {
+          return;
         }
+        const std::scoped_lock lock(deferred_releases_mu_);
+        deferred_releases_.push_back({surface, static_cast<uint32_t>(key)});
       };
       auto pool = drm::scene::ExternalDmaBufPool::create(
           backend_->device(), db.width, db.height, db.fourcc, db.modifier,

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -282,6 +282,10 @@ class DrmCompositor : public IFlipSink {
 
   bool WaitForPendingFlip() const;
 
+  // Fire the platform-view scanout releases held since the last present, now
+  // that WaitForPendingFlip has confirmed their displacing flip completed.
+  void DrainDeferredScanoutReleases();
+
   // Post-first-commit sanity probe. Confirms the kernel actually honored
   // the modeset by reading CRTC.ACTIVE + primary plane.FB_ID via
   // drmModeObjectGetProperties, then samples vblank sequence across ~2
@@ -443,6 +447,25 @@ class DrmCompositor : public IFlipSink {
   // find_by_identity_tag / commit through this scene; CreateBackingStore
   // produces matching LayerBufferSource wrappers stashed in StoreBaton
   // until their first Present add_layer()s them in.
+  // Deferred platform-view scanout releases. drm-cxx fires a pool's on_release
+  // the moment a buffer is displaced (committed over), but the buffer is still
+  // scanned out until that commit's page flip completes -- so returning it to
+  // the producer immediately lets the producer (a decoder) overwrite a buffer
+  // the HVS is still reading, showing a later frame's pixels for one flip (a
+  // visible temporal jump on the direct-scanout path; the detile-copy path was
+  // insulated). Instead, hold each release here and fire it at the top of the
+  // next present, after WaitForPendingFlip has confirmed the displacing flip
+  // completed and the buffer is provably off the plane. The shared_ptr keeps
+  // the surface alive until then. Declared before scene_ so it outlives the
+  // pools whose callbacks append to it. Appended from the scene commit /
+  // teardown, drained on the present thread -- guarded by its mutex.
+  struct DeferredScanoutRelease {
+    std::shared_ptr<ICompositorSurface> surface;
+    std::uint32_t buffer_id;
+  };
+  std::mutex deferred_releases_mu_;
+  std::vector<DeferredScanoutRelease> deferred_releases_;
+
   std::unique_ptr<drm::scene::LayerScene> scene_;
 
   // Embedder-side mirror of the scene's live layer set, keyed by


### PR DESCRIPTION
## Summary
On the direct-scanout (zero-copy) platform-view path, a decoded frame could briefly show a *later* frame's pixels — a visible temporal jump. Root cause: drm-cxx fires a pool's `on_release` the moment a buffer is **displaced** (a new frame committed over it), but the buffer is still scanned out until that commit's **page flip completes**. The shell returned the buffer to the producer immediately (dropping the OUT_FENCE drm-cxx hands it), so the producer — a hardware decoder — could recycle and overwrite a buffer the HVS was still reading.

The detile-copy path (e.g. the Pi's SAND-tiled HEVC output, which must be copied to linear to be displayable) never showed this because the plane samples a stable copy, not the decoder's live buffer.

## Fix
Hold each platform-view scanout release and fire `OnScanoutRelease` at the **top of the next present**, after `WaitForPendingFlip()` has confirmed the displacing flip completed and the buffer is provably off the plane. This is a one-present deferral (well within pool headroom) that keeps the direct-scanout path fully **zero-copy** and glitch-free. The copy path is unaffected. The deferred set is also drained in the destructor so producers aren't left blocked on a ring slot.

## Test plan
On a Raspberry Pi 4 (KMS overlay plane, HDMI), an H.264 stream decoded on the stateful M2M decoder (`/dev/video10`, linear NV12) scanned out directly: the temporal jump was reproducible before this change and gone after, across repeated playbacks, with no copy in the path. HEVC (detile-copy) is unchanged.