### PR TITLE
backend: drop an internal planning label from headless_vulkan comments

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -198,14 +198,14 @@ option(BUILD_BACKEND_HEADLESS_EGL
         OFF)
 
 #
-# Headless Vulkan backend (WS-1): boots the Flutter Vulkan renderer with no
+# Headless Vulkan backend: boots the Flutter Vulkan renderer with no
 # display / Wayland / scanout and paces clear-color frames at IVI_HEADLESS_FPS.
-# A stub for a later dma-buf-export + external-semaphore + socket workstream;
+# A foundation for a later dma-buf-export + external-semaphore + socket path;
 # needs only the vendored Vulkan headers at build time (vulkan.hpp dlopens
 # libvulkan at runtime).
 #
 option(BUILD_BACKEND_HEADLESS_VULKAN
-        "Build the headless Vulkan backend (Vulkan render, no display; WS-1 stub)"
+        "Build the headless Vulkan backend (Vulkan render, no display)"
         OFF)
 
 # Shared encoder dependencies. Both the software encoder sink

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -269,7 +269,7 @@ if (BUILD_BACKEND_HEADLESS_EGL)
 endif ()
 
 if (BUILD_BACKEND_HEADLESS_VULKAN)
-    # WS-1 stub: Vulkan render with no display / Wayland / scanout, paced at
+    # Vulkan render with no display / Wayland / scanout, paced at
     # IVI_HEADLESS_FPS. Reuses SoftwareDisplay (a no-op IDisplay). No EGL/GLES:
     # Vulkan is resolved at runtime via vulkan.hpp's dynamic loader; only the
     # vendored headers (vulkan_headers) are needed at build time — never a

--- a/shell/backend/headless_vulkan/headless_vulkan.cc
+++ b/shell/backend/headless_vulkan/headless_vulkan.cc
@@ -268,7 +268,7 @@ bool HeadlessVulkanBackend::SelectPhysicalDevice() {
 
 bool HeadlessVulkanBackend::CreateLogicalDevice() {
   // Enable the external-memory / external-semaphore device extensions when the
-  // device advertises them. Harmless in WS-1; a later export path needs them.
+  // device advertises them. Harmless now; a later export path needs them.
   uint32_t ext_count = 0;
   d().vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
                                            &ext_count, nullptr);
@@ -431,7 +431,7 @@ FlutterRendererConfig HeadlessVulkanBackend::GetRenderConfig() {
 }
 
 FlutterCompositor HeadlessVulkanBackend::GetCompositorConfig() {
-  // Single-surface rendering: no platform-view layer compositing in WS-1.
+  // Single-surface rendering: no platform-view layer compositing yet.
   FlutterCompositor compositor{};
   compositor.struct_size = sizeof(FlutterCompositor);
   return compositor;
@@ -477,7 +477,7 @@ FlutterVulkanImage HeadlessVulkanBackend::GetNextImageCallback(
 bool HeadlessVulkanBackend::PresentCallback(
     void* user_data,
     const FlutterVulkanImage* /* image */) {
-  // WS-1 does nothing with the composited frame — the pacer drives cadence.
+  // Nothing consumes the composited frame yet — the pacer drives cadence.
   // Advance the round-robin index so the next frame targets a different image.
   auto* backend = BackendOf(user_data);
   backend->current_image_ = (backend->current_image_ + 1) % kImageCount;
@@ -526,7 +526,7 @@ void HeadlessVulkanBackend::StartVsyncIfReady() {
     return;
   }
   vsync_running_.store(true, std::memory_order_release);
-  // Free-run (ceiling-only) pacing: WS-1 has no consumer to gate on, so the
+  // Free-run (ceiling-only) pacing: there is no consumer to gate on, so the
   // pacer delivers a baton on the vsync_period_ns_ ceiling alone. The pipeline
   // depth matches the render-target ring.
   pacer_ = std::make_unique<ivi::ConsumerPacedVsyncSource>(
@@ -556,7 +556,7 @@ void HeadlessVulkanBackend::Resize(size_t /*index*/,
   if (w == width_ && h == height_) {
     return;
   }
-  // Geometry changes are not supported in WS-1 (the render-target ring would
+  // Geometry changes are not supported yet (the render-target ring would
   // need re-allocation). Log and keep the initial size.
   ihs::log::warn("[HeadlessVulkan] resize to {}x{} ignored (fixed at {}x{})", w,
                  h, width_, height_);

--- a/shell/backend/headless_vulkan/headless_vulkan.h
+++ b/shell/backend/headless_vulkan/headless_vulkan.h
@@ -31,18 +31,18 @@
 class Engine;
 class TaskRunner;
 
-// Headless Vulkan backend (WS-1 stub): boots the Flutter Vulkan renderer with
+// Headless Vulkan backend (initial): boots the Flutter Vulkan renderer with
 // no display, no Wayland, no scanout, and paces clear-color frames at a target
 // frame rate. It brings up a minimal Vulkan device (instance + physical-device
 // select + one graphics queue) and hands the engine a small ring of
 // render-target VkImages it composites into; the frames go nowhere yet.
 //
-// The device is set up so a LATER workstream can export those images as
+// The device is set up so a later change can export those images as
 // dma-bufs and hand them across an external-semaphore-synchronized socket to a
 // consumer: the external-memory / external-semaphore DEVICE extensions are
 // enabled here when the device advertises them (harmless now), and the selected
 // device's 16-byte deviceUUID is retained so a future HELLO handshake can name
-// the exact GPU. WS-1 itself does none of that — PresentCallback only advances
+// the exact GPU. None of that happens yet — PresentCallback only advances
 // the round-robin index, and the ConsumerPacedVsyncSource runs free (no
 // consumer) so the engine renders at the IVI_HEADLESS_FPS ceiling.
 class HeadlessVulkanBackend final : public Backend {
@@ -54,7 +54,7 @@ class HeadlessVulkanBackend final : public Backend {
   HeadlessVulkanBackend& operator=(const HeadlessVulkanBackend&) = delete;
 
   // ── Backend interface ──────────────────────────────────────────────────────
-  // No display surface and no platform-view compositing in WS-1, so the
+  // No display surface and no platform-view compositing here, so the
   // size/surface/texture entry points are trivial stubs that satisfy the vtable
   // and the FlutterView call sites; the engine drives the renderer callbacks
   // (GetRenderConfig) directly.
@@ -78,7 +78,7 @@ class HeadlessVulkanBackend final : public Backend {
 
   // Synthetic vsync: without a display there is no vblank, so pace the engine
   // to IVI_HEADLESS_FPS via a ConsumerPacedVsyncSource run in free-run mode (no
-  // consumer attached in WS-1). fps <= 0 leaves Flutter's wall-clock scheduler.
+  // consumer attached). fps <= 0 leaves Flutter's wall-clock scheduler.
   [[nodiscard]] VsyncCallback GetVsyncCallback() const override;
   void SetEngineHandle(FLUTTER_API_SYMBOL(FlutterEngine) engine) override;
   void SetPlatformTaskRunner(TaskRunner* runner) override;
@@ -144,7 +144,7 @@ class HeadlessVulkanBackend final : public Backend {
   uint32_t current_image_{0};
 
   // Synthetic-vsync pacing. vsync_ holds the baton machinery; the pacer drives
-  // it, run in free-run (ceiling-only) mode since WS-1 has no consumer.
+  // it, run in free-run (ceiling-only) mode since there is no consumer.
   ivi::IVsyncProvider vsync_;
   FLUTTER_API_SYMBOL(FlutterEngine) engine_handle_ { nullptr };
   TaskRunner* platform_task_runner_{nullptr};


### PR DESCRIPTION
Follow-up cleanup to the headless Vulkan backend. Its comments and the `BUILD_BACKEND_HEADLESS_VULKAN` option help string carried an internal planning label that is not defined anywhere in the tree, so it read as a dangling reference to a document that does not exist here.

Reword those comments (and the option help string) to plainly describe what the backend does and does not do yet — e.g. "does nothing with the composited frame" instead of the label, "a later export path" instead of naming a workstream.

Comment and help text only across `headless_vulkan.{h,cc}`, `cmake/options.cmake`, and `shell/CMakeLists.txt`; no behavior change (symmetric diff, clang-format clean).