### PR TITLE
headless-vulkan: make the render-target pool exportable

### DIFF
--- a/shell/backend/headless_vulkan/headless_vulkan.cc
+++ b/shell/backend/headless_vulkan/headless_vulkan.cc
@@ -33,6 +33,8 @@
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
+#include <unistd.h>
+
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -42,6 +44,14 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #include "logging/logging.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #include "task_runner.h"
+
+// DRM fourcc / modifier constants for the dmabuf export path. Defined locally
+// (mirroring how drm_kms_vulkan sources these from <drm_fourcc.h>) so the
+// headless_vulkan CMake block keeps its single vulkan_headers dependency and
+// never pulls in libdrm — the only two values this backend needs.
+#ifndef DRM_FORMAT_MOD_LINEAR
+#define DRM_FORMAT_MOD_LINEAR 0ULL
+#endif
 
 namespace {
 
@@ -100,6 +110,126 @@ size_t ParseHexUuid(const char* s, std::array<uint8_t, VK_UUID_SIZE>& out) {
   return bytes;
 }
 
+// Usage the engine composites the render targets with — kept identical between
+// the plain and exportable pools so a consumer recreates a matching image.
+constexpr VkImageUsageFlags kRenderTargetUsage =
+    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+    VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
+// DRM fourcc for VK_FORMAT_R8G8B8A8_UNORM. DRM fourccs name the byte order in
+// memory (R,G,B,A ascending) which reversed is ABGR — DRM_FORMAT_ABGR8888,
+// fourcc_code('A','B','G','R'). Built locally to avoid a libdrm dependency.
+constexpr uint32_t FourCC(char a, char b, char c, char d) {
+  return static_cast<uint32_t>(static_cast<uint8_t>(a)) |
+         (static_cast<uint32_t>(static_cast<uint8_t>(b)) << 8) |
+         (static_cast<uint32_t>(static_cast<uint8_t>(c)) << 16) |
+         (static_cast<uint32_t>(static_cast<uint8_t>(d)) << 24);
+}
+constexpr uint32_t kDrmFormatAbgr8888 = FourCC('A', 'B', 'G', 'R');
+
+// True if the device can EXPORT @p handle for an image of this
+// format/usage/tiling (and, for the DRM-modifier path, this modifier). Uses the
+// vkGetPhysicalDeviceImageFormatProperties2 external-image query and checks
+// VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT — the robustness gate before any
+// exportable VkImage is created.
+bool ExternalHandleExportable(VkPhysicalDevice phys,
+                              VkFormat fmt,
+                              VkImageUsageFlags usage,
+                              VkImageTiling tiling,
+                              VkExternalMemoryHandleTypeFlagBits handle,
+                              uint64_t modifier,
+                              bool has_modifier) {
+  VkPhysicalDeviceImageDrmFormatModifierInfoEXT dm{};
+  dm.sType =
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT;
+  dm.drmFormatModifier = modifier;
+  dm.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+  VkPhysicalDeviceExternalImageFormatInfo ext{};
+  ext.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+  ext.handleType = handle;
+  if (has_modifier) {
+    ext.pNext = &dm;
+  }
+
+  VkPhysicalDeviceImageFormatInfo2 ifi{};
+  ifi.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+  ifi.pNext = &ext;
+  ifi.format = fmt;
+  ifi.type = VK_IMAGE_TYPE_2D;
+  ifi.tiling = tiling;
+  ifi.usage = usage;
+  ifi.flags = 0;
+
+  VkExternalImageFormatProperties efp{};
+  efp.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+  VkImageFormatProperties2 p2{};
+  p2.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+  p2.pNext = &efp;
+
+  if (d().vkGetPhysicalDeviceImageFormatProperties2(phys, &ifi, &p2) !=
+      VK_SUCCESS) {
+    return false;
+  }
+  return (efp.externalMemoryProperties.externalMemoryFeatures &
+          VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT) != 0;
+}
+
+// Plane count the driver uses for @p modifier with @p fmt (adapted from
+// drm_kms_vulkan's PlaneCountForModifier — the 2-call format-properties2
+// pattern).
+uint32_t PlaneCountForModifier(VkPhysicalDevice phys,
+                               VkFormat fmt,
+                               uint64_t modifier) {
+  VkDrmFormatModifierPropertiesListEXT list{};
+  list.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+  VkFormatProperties2 fp{};
+  fp.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+  fp.pNext = &list;
+  d().vkGetPhysicalDeviceFormatProperties2(phys, fmt, &fp);
+  std::vector<VkDrmFormatModifierPropertiesEXT> mods(
+      list.drmFormatModifierCount);
+  list.pDrmFormatModifierProperties = mods.data();
+  d().vkGetPhysicalDeviceFormatProperties2(phys, fmt, &fp);
+  for (const auto& m : mods) {
+    if (m.drmFormatModifier == modifier) {
+      return m.drmFormatModifierPlaneCount;
+    }
+  }
+  return 0;
+}
+
+// The DRM modifiers the device can EXPORT as a dma-buf for @p fmt with this
+// usage. Enumerates every modifier the format advertises, then keeps only those
+// that pass the exportable query above (which also validates the usage for the
+// DRM-modifier tiling). The image is created constrained to this list and the
+// driver picks the concrete modifier, read back after bind.
+std::vector<uint64_t> ExportableModifiers(VkPhysicalDevice phys,
+                                          VkFormat fmt,
+                                          VkImageUsageFlags usage) {
+  VkDrmFormatModifierPropertiesListEXT list{};
+  list.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+  VkFormatProperties2 fp{};
+  fp.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+  fp.pNext = &list;
+  d().vkGetPhysicalDeviceFormatProperties2(phys, fmt, &fp);
+  std::vector<VkDrmFormatModifierPropertiesEXT> mods(
+      list.drmFormatModifierCount);
+  list.pDrmFormatModifierProperties = mods.data();
+  d().vkGetPhysicalDeviceFormatProperties2(phys, fmt, &fp);
+
+  std::vector<uint64_t> out;
+  for (const auto& m : mods) {
+    if (ExternalHandleExportable(phys, fmt, usage,
+                                 VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT,
+                                 VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
+                                 m.drmFormatModifier, /*has_modifier=*/true)) {
+      out.push_back(m.drmFormatModifier);
+    }
+  }
+  return out;
+}
+
 }  // namespace
 
 HeadlessVulkanBackend::HeadlessVulkanBackend(const uint32_t width,
@@ -125,6 +255,24 @@ HeadlessVulkanBackend::HeadlessVulkanBackend(const uint32_t width,
           "[HeadlessVulkan] IVI_VK_DEVICE_UUID '{}' is not 16 hex bytes; "
           "ignoring",
           uuid);
+    }
+  }
+
+  // IVI_VK_EXPORT_MODE (opt-in): make the render-target pool exportable as
+  // external-memory dma-bufs ("dmabuf") or opaque fds ("opaque"). Unset leaves
+  // the current non-exportable pool, so the default boot needs no
+  // export-capable device.
+  if (const char* mode = std::getenv("IVI_VK_EXPORT_MODE");
+      mode != nullptr && mode[0] != '\0') {
+    if (std::strcmp(mode, "opaque") == 0) {
+      export_mode_ = ExportMode::kOpaqueFd;
+    } else if (std::strcmp(mode, "dmabuf") == 0) {
+      export_mode_ = ExportMode::kDmaBuf;
+    } else {
+      ihs::log::warn(
+          "[HeadlessVulkan] IVI_VK_EXPORT_MODE '{}' unknown (want "
+          "opaque|dmabuf); export disabled",
+          mode);
     }
   }
 
@@ -277,10 +425,17 @@ bool HeadlessVulkanBackend::CreateLogicalDevice() {
     d().vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
                                              &ext_count, avail.data());
   }
-  for (const char* opt : {VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
-                          VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
-                          VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
-                          VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME}) {
+  for (const char* opt :
+       {VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+        // dma-buf export path (opt-in via IVI_VK_EXPORT_MODE=dmabuf): the
+        // DRM-format-modifier tiling + dma-buf handle type. Enabled when
+        // present so the export preflight can succeed; harmless otherwise.
+        VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
+        VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME,
+        VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME}) {
     if (HasExt(avail, opt)) {
       enabled_device_extensions_.push_back(opt);
     }
@@ -311,92 +466,359 @@ bool HeadlessVulkanBackend::CreateLogicalDevice() {
   return true;
 }
 
-bool HeadlessVulkanBackend::CreateRenderTargets() {
+uint32_t HeadlessVulkanBackend::FindDeviceLocalMemoryType(
+    const uint32_t type_bits) const {
   VkPhysicalDeviceMemoryProperties mem_props{};
   d().vkGetPhysicalDeviceMemoryProperties(physical_device_, &mem_props);
+  for (uint32_t i = 0; i < mem_props.memoryTypeCount; ++i) {
+    if ((type_bits & (1u << i)) != 0 &&
+        (mem_props.memoryTypes[i].propertyFlags &
+         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0) {
+      return i;
+    }
+  }
+  return UINT32_MAX;
+}
 
-  auto find_device_local = [&](const uint32_t type_bits) -> uint32_t {
-    for (uint32_t i = 0; i < mem_props.memoryTypeCount; ++i) {
-      if ((type_bits & (1u << i)) != 0 &&
-          (mem_props.memoryTypes[i].propertyFlags &
-           VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0) {
-        return i;
+bool HeadlessVulkanBackend::CreateRenderTargets() {
+  // Decide the effective export mode. When export is requested, preflight the
+  // device: the needed extensions must be enabled and the device must advertise
+  // EXPORTABLE for the requested handle type / tiling. If anything is missing,
+  // warn and fall through to the plain (non-exportable) pool so the backend
+  // still boots and paces — export is never allowed to hard-fail bring-up.
+  active_export_mode_ = ExportMode::kNone;
+  std::vector<uint64_t> allowed_modifiers;
+
+  if (export_mode_ != ExportMode::kNone) {
+    auto ext_enabled = [&](const char* name) {
+      for (const char* e : enabled_device_extensions_) {
+        if (std::strcmp(e, name) == 0) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (export_mode_ == ExportMode::kOpaqueFd) {
+      if (!ext_enabled(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) ||
+          !ext_enabled(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME)) {
+        ihs::log::warn(
+            "[HeadlessVulkan] opaque-fd export requested but "
+            "VK_KHR_external_memory[_fd] absent; using non-exportable pool");
+      } else if (!ExternalHandleExportable(
+                     physical_device_, image_format_, kRenderTargetUsage,
+                     VK_IMAGE_TILING_OPTIMAL,
+                     VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT,
+                     /*modifier=*/0, /*has_modifier=*/false)) {
+        ihs::log::warn(
+            "[HeadlessVulkan] device does not advertise OPAQUE_FD export for "
+            "this format/usage; using non-exportable pool");
+      } else {
+        active_export_mode_ = ExportMode::kOpaqueFd;
+      }
+    } else {  // kDmaBuf
+      if (!ext_enabled(VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME) ||
+          !ext_enabled(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME) ||
+          !ext_enabled(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME)) {
+        ihs::log::warn(
+            "[HeadlessVulkan] dmabuf export requested but "
+            "VK_EXT_external_memory_dma_buf / "
+            "VK_EXT_image_drm_format_modifier / VK_KHR_external_memory_fd "
+            "absent; using non-exportable pool");
+      } else {
+        allowed_modifiers = ExportableModifiers(physical_device_, image_format_,
+                                                kRenderTargetUsage);
+        if (allowed_modifiers.empty()) {
+          ihs::log::warn(
+              "[HeadlessVulkan] no DRM modifier for this format/usage is "
+              "dma-buf exportable; using non-exportable pool");
+        } else {
+          active_export_mode_ = ExportMode::kDmaBuf;
+        }
       }
     }
-    return UINT32_MAX;
-  };
+  }
 
-  for (uint32_t i = 0; i < kImageCount; ++i) {
-    VkImageCreateInfo ici{};
-    ici.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    ici.imageType = VK_IMAGE_TYPE_2D;
-    ici.format = image_format_;
-    ici.extent = {width_, height_, 1};
-    ici.mipLevels = 1;
-    ici.arrayLayers = 1;
-    ici.samples = VK_SAMPLE_COUNT_1_BIT;
-    ici.tiling = VK_IMAGE_TILING_OPTIMAL;
-    ici.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-                VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-    if (d().vkCreateImage(device_, &ici, nullptr, &images_[i]) != VK_SUCCESS) {
-      ihs::log::error("[HeadlessVulkan] vkCreateImage {} failed", i);
-      return false;
+  if (active_export_mode_ != ExportMode::kNone) {
+    if (CreateExportablePool(allowed_modifiers)) {
+      ihs::log::info(
+          "[HeadlessVulkan] export pool active: mode={} images={} {}x{}",
+          active_export_mode_ == ExportMode::kDmaBuf ? "dmabuf" : "opaque",
+          kImageCount, width_, height_);
+      return true;
     }
+    // Exportable creation failed after a passing preflight (driver-specific);
+    // tear down any partial pool and fall back to the plain path.
+    ihs::log::warn(
+        "[HeadlessVulkan] exportable pool creation failed; falling back to "
+        "non-exportable pool");
+    DestroyRenderTargets();
+    active_export_mode_ = ExportMode::kNone;
+  }
 
-    VkMemoryRequirements req{};
-    d().vkGetImageMemoryRequirements(device_, images_[i], &req);
-    const uint32_t type_index = find_device_local(req.memoryTypeBits);
-    if (type_index == UINT32_MAX) {
-      ihs::log::error("[HeadlessVulkan] no DEVICE_LOCAL memory type for image");
-      return false;
-    }
-
-    // Dedicated allocation per image — one image per allocation is fine for the
-    // small ring and keeps the future export path (one dma-buf per image)
-    // simple.
-    VkMemoryDedicatedAllocateInfo dedicated{};
-    dedicated.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
-    dedicated.image = images_[i];
-    VkMemoryAllocateInfo alloc{};
-    alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    alloc.pNext = &dedicated;
-    alloc.allocationSize = req.size;
-    alloc.memoryTypeIndex = type_index;
-
-    if (d().vkAllocateMemory(device_, &alloc, nullptr, &image_memory_[i]) !=
-        VK_SUCCESS) {
-      ihs::log::error("[HeadlessVulkan] vkAllocateMemory {} failed", i);
-      return false;
-    }
-    if (d().vkBindImageMemory(device_, images_[i], image_memory_[i], 0) !=
-        VK_SUCCESS) {
-      ihs::log::error("[HeadlessVulkan] vkBindImageMemory {} failed", i);
-      return false;
-    }
+  if (!CreatePlainPool()) {
+    return false;
   }
   ihs::log::info("[HeadlessVulkan] {} render targets ready {}x{}", kImageCount,
                  width_, height_);
   return true;
 }
 
+bool HeadlessVulkanBackend::CreatePlainPool() {
+  for (uint32_t i = 0; i < kImageCount; ++i) {
+    if (!CreatePlainImage(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool HeadlessVulkanBackend::CreatePlainImage(const uint32_t i) {
+  VkImageCreateInfo ici{};
+  ici.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  ici.imageType = VK_IMAGE_TYPE_2D;
+  ici.format = image_format_;
+  ici.extent = {width_, height_, 1};
+  ici.mipLevels = 1;
+  ici.arrayLayers = 1;
+  ici.samples = VK_SAMPLE_COUNT_1_BIT;
+  ici.tiling = VK_IMAGE_TILING_OPTIMAL;
+  ici.usage = kRenderTargetUsage;
+  ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  if (d().vkCreateImage(device_, &ici, nullptr, &images_[i]) != VK_SUCCESS) {
+    ihs::log::error("[HeadlessVulkan] vkCreateImage {} failed", i);
+    return false;
+  }
+
+  VkMemoryRequirements req{};
+  d().vkGetImageMemoryRequirements(device_, images_[i], &req);
+  const uint32_t type_index = FindDeviceLocalMemoryType(req.memoryTypeBits);
+  if (type_index == UINT32_MAX) {
+    ihs::log::error("[HeadlessVulkan] no DEVICE_LOCAL memory type for image");
+    return false;
+  }
+
+  // Dedicated allocation per image — one image per allocation is fine for the
+  // small ring and keeps the export path (one dma-buf per image) simple.
+  VkMemoryDedicatedAllocateInfo dedicated{};
+  dedicated.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+  dedicated.image = images_[i];
+  VkMemoryAllocateInfo alloc{};
+  alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  alloc.pNext = &dedicated;
+  alloc.allocationSize = req.size;
+  alloc.memoryTypeIndex = type_index;
+
+  if (d().vkAllocateMemory(device_, &alloc, nullptr, &image_memory_[i]) !=
+      VK_SUCCESS) {
+    ihs::log::error("[HeadlessVulkan] vkAllocateMemory {} failed", i);
+    return false;
+  }
+  if (d().vkBindImageMemory(device_, images_[i], image_memory_[i], 0) !=
+      VK_SUCCESS) {
+    ihs::log::error("[HeadlessVulkan] vkBindImageMemory {} failed", i);
+    return false;
+  }
+  return true;
+}
+
+bool HeadlessVulkanBackend::CreateExportablePool(
+    const std::vector<uint64_t>& allowed_modifiers) {
+  for (uint32_t i = 0; i < kImageCount; ++i) {
+    if (!CreateExportableImage(i, allowed_modifiers)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool HeadlessVulkanBackend::CreateExportableImage(
+    const uint32_t i,
+    const std::vector<uint64_t>& allowed_modifiers) {
+  const bool dmabuf = active_export_mode_ == ExportMode::kDmaBuf;
+  const VkExternalMemoryHandleTypeFlagBits handle_type =
+      dmabuf ? VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT
+             : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+  // Constrain the dma-buf image to the negotiated modifier set (driver picks
+  // one, read back after bind). Unused for opaque-fd, which keeps OPTIMAL.
+  VkImageDrmFormatModifierListCreateInfoEXT mod_list{};
+  mod_list.sType =
+      VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT;
+  mod_list.drmFormatModifierCount =
+      static_cast<uint32_t>(allowed_modifiers.size());
+  mod_list.pDrmFormatModifiers = allowed_modifiers.data();
+
+  VkExternalMemoryImageCreateInfo ext{};
+  ext.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+  ext.handleTypes = handle_type;
+  if (dmabuf) {
+    ext.pNext = &mod_list;
+  }
+
+  VkImageCreateInfo ici{};
+  ici.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  ici.pNext = &ext;
+  ici.imageType = VK_IMAGE_TYPE_2D;
+  ici.format = image_format_;
+  ici.extent = {width_, height_, 1};
+  ici.mipLevels = 1;
+  ici.arrayLayers = 1;
+  ici.samples = VK_SAMPLE_COUNT_1_BIT;
+  ici.tiling = dmabuf ? VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT
+                      : VK_IMAGE_TILING_OPTIMAL;
+  ici.usage = kRenderTargetUsage;
+  ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  if (d().vkCreateImage(device_, &ici, nullptr, &images_[i]) != VK_SUCCESS) {
+    ihs::log::error("[HeadlessVulkan] exportable vkCreateImage {} failed", i);
+    return false;
+  }
+
+  VkMemoryRequirements req{};
+  d().vkGetImageMemoryRequirements(device_, images_[i], &req);
+  const uint32_t type_index = FindDeviceLocalMemoryType(req.memoryTypeBits);
+  if (type_index == UINT32_MAX) {
+    ihs::log::error("[HeadlessVulkan] no DEVICE_LOCAL memory type for image");
+    return false;
+  }
+
+  // Dedicated + exportable allocation: chain the export handle-type info
+  // alongside the dedicated-alloc info the plain pool already uses.
+  VkMemoryDedicatedAllocateInfo dedicated{};
+  dedicated.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+  dedicated.image = images_[i];
+  VkExportMemoryAllocateInfo emai{};
+  emai.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
+  emai.handleTypes = handle_type;
+  emai.pNext = &dedicated;
+  VkMemoryAllocateInfo alloc{};
+  alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  alloc.pNext = &emai;
+  alloc.allocationSize = req.size;
+  alloc.memoryTypeIndex = type_index;
+
+  if (d().vkAllocateMemory(device_, &alloc, nullptr, &image_memory_[i]) !=
+      VK_SUCCESS) {
+    ihs::log::error("[HeadlessVulkan] exportable vkAllocateMemory {} failed",
+                    i);
+    return false;
+  }
+  if (d().vkBindImageMemory(device_, images_[i], image_memory_[i], 0) !=
+      VK_SUCCESS) {
+    ihs::log::error("[HeadlessVulkan] exportable vkBindImageMemory {} failed",
+                    i);
+    return false;
+  }
+
+  ExportedImage& e = exported_images_[i];
+  e.alloc_size = req.size;
+  e.memory_type_index = type_index;
+  e.width = width_;
+  e.height = height_;
+  e.vk_format = static_cast<uint32_t>(image_format_);
+  e.handle_type = static_cast<uint32_t>(handle_type);
+  e.plane_count = 1;
+
+  if (dmabuf) {
+    // The concrete modifier the driver chose, plus per-plane offset/pitch a
+    // consumer needs to import (aspect VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT).
+    VkImageDrmFormatModifierPropertiesEXT mp{};
+    mp.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT;
+    if (d().vkGetImageDrmFormatModifierPropertiesEXT(device_, images_[i],
+                                                     &mp) != VK_SUCCESS) {
+      ihs::log::error(
+          "[HeadlessVulkan] vkGetImageDrmFormatModifierPropertiesEXT {} failed",
+          i);
+      return false;
+    }
+    e.drm_modifier = mp.drmFormatModifier;
+    e.drm_fourcc = kDrmFormatAbgr8888;
+
+    uint32_t plane_count =
+        PlaneCountForModifier(physical_device_, image_format_, e.drm_modifier);
+    if (plane_count < 1 || plane_count > 4) {
+      ihs::log::error(
+          "[HeadlessVulkan] unexpected plane count {} for chosen modifier",
+          plane_count);
+      return false;
+    }
+    e.plane_count = plane_count;
+
+    static constexpr std::array<VkImageAspectFlagBits, 4> kMemPlane = {
+        VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT,
+        VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT,
+        VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT,
+        VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT,
+    };
+    for (uint32_t p = 0; p < plane_count; ++p) {
+      VkImageSubresource sub{};
+      sub.aspectMask = kMemPlane[p];
+      VkSubresourceLayout sl{};
+      d().vkGetImageSubresourceLayout(device_, images_[i], &sub, &sl);
+      e.plane_offset[p] = sl.offset;
+      e.plane_pitch[p] = sl.rowPitch;
+    }
+  }
+
+  // Export the fd last, once the image + memory are fully described.
+  VkMemoryGetFdInfoKHR gfi{};
+  gfi.sType = VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR;
+  gfi.memory = image_memory_[i];
+  gfi.handleType = handle_type;
+  if (d().vkGetMemoryFdKHR(device_, &gfi, &e.fd) != VK_SUCCESS) {
+    ihs::log::error("[HeadlessVulkan] vkGetMemoryFdKHR {} failed", i);
+    return false;
+  }
+
+  if (dmabuf) {
+    ihs::log::info(
+        "[HeadlessVulkan] exported image {}: fd={} size={} fourcc=0x{:08x} "
+        "modifier=0x{:016x} planes={}",
+        i, e.fd, e.alloc_size, e.drm_fourcc, e.drm_modifier, e.plane_count);
+  } else {
+    ihs::log::info(
+        "[HeadlessVulkan] exported image {}: fd={} size={} memtype={} "
+        "(opaque-fd)",
+        i, e.fd, e.alloc_size, e.memory_type_index);
+  }
+  return true;
+}
+
+void HeadlessVulkanBackend::DestroyRenderTargets() {
+  for (uint32_t i = 0; i < kImageCount; ++i) {
+    if (images_[i] != VK_NULL_HANDLE) {
+      d().vkDestroyImage(device_, images_[i], nullptr);
+      images_[i] = VK_NULL_HANDLE;
+    }
+    if (image_memory_[i] != VK_NULL_HANDLE) {
+      d().vkFreeMemory(device_, image_memory_[i], nullptr);
+      image_memory_[i] = VK_NULL_HANDLE;
+    }
+    if (exported_images_[i].fd >= 0) {
+      ::close(exported_images_[i].fd);
+    }
+    exported_images_[i] = ExportedImage{};
+  }
+}
+
 void HeadlessVulkanBackend::Teardown() {
   if (device_ != VK_NULL_HANDLE) {
     d().vkDeviceWaitIdle(device_);
-    for (uint32_t i = 0; i < kImageCount; ++i) {
-      if (images_[i] != VK_NULL_HANDLE) {
-        d().vkDestroyImage(device_, images_[i], nullptr);
-        images_[i] = VK_NULL_HANDLE;
-      }
-      if (image_memory_[i] != VK_NULL_HANDLE) {
-        d().vkFreeMemory(device_, image_memory_[i], nullptr);
-        image_memory_[i] = VK_NULL_HANDLE;
-      }
-    }
+    DestroyRenderTargets();
     d().vkDestroyDevice(device_, nullptr);
     device_ = VK_NULL_HANDLE;
+  } else {
+    // Device already gone (or never created): still close any exported fds.
+    for (uint32_t i = 0; i < kImageCount; ++i) {
+      if (exported_images_[i].fd >= 0) {
+        ::close(exported_images_[i].fd);
+        exported_images_[i].fd = -1;
+      }
+    }
   }
   if (instance_ != VK_NULL_HANDLE) {
     d().vkDestroyInstance(instance_, nullptr);

--- a/shell/backend/headless_vulkan/headless_vulkan.h
+++ b/shell/backend/headless_vulkan/headless_vulkan.h
@@ -53,6 +53,31 @@ class HeadlessVulkanBackend final : public Backend {
   HeadlessVulkanBackend(const HeadlessVulkanBackend&) = delete;
   HeadlessVulkanBackend& operator=(const HeadlessVulkanBackend&) = delete;
 
+  // Requested external-memory export mode for the render-target pool, from
+  // IVI_VK_EXPORT_MODE (unset => kNone: current non-exportable behavior).
+  // Opaque fd is the portable, same-device floor (OPTIMAL tiling); dmabuf
+  // exports a DRM-format-modifier image a cross-process/cross-API consumer can
+  // import.
+  enum class ExportMode { kNone, kOpaqueFd, kDmaBuf };
+
+  // Everything a future handshake needs to re-import one pool image in another
+  // process/API. Populated only for the exported images; a plain (non-exported)
+  // pool leaves fd == -1 / handle_type == 0. POD by design.
+  struct ExportedImage {
+    int fd = -1;  // owned by the backend; -1 if not exported
+    uint64_t alloc_size = 0;
+    uint32_t memory_type_index = 0;
+    uint32_t drm_fourcc = 0;    // dmabuf only
+    uint64_t drm_modifier = 0;  // dmabuf only (DRM_FORMAT_MOD_*)
+    uint32_t plane_count = 1;
+    uint64_t plane_offset[4] = {0};
+    uint64_t plane_pitch[4] = {0};
+    uint32_t width = 0, height = 0;
+    uint32_t vk_format = 0;  // VkFormat
+    uint32_t handle_type =
+        0;  // VkExternalMemoryHandleTypeFlagBits used (0=none)
+  };
+
   // ── Backend interface ──────────────────────────────────────────────────────
   // No display surface and no platform-view compositing in WS-1, so the
   // size/surface/texture entry points are trivial stubs that satisfy the vtable
@@ -87,6 +112,22 @@ class HeadlessVulkanBackend final : public Backend {
   [[nodiscard]] uint32_t width() const { return width_; }
   [[nodiscard]] uint32_t height() const { return height_; }
 
+  // Export accessors for a future cross-process handshake. Nothing consumes
+  // these yet — they describe the pool the handshake would advertise. When
+  // export is disabled or fell back, export_enabled() is false and every
+  // ExportedImage has fd == -1.
+  [[nodiscard]] const std::array<ExportedImage, 3>& exported_images() const {
+    return exported_images_;
+  }
+  [[nodiscard]] bool export_enabled() const {
+    return active_export_mode_ != ExportMode::kNone;
+  }
+  // The selected device's 16-byte Vulkan deviceUUID; a HELLO handshake names
+  // the exact GPU an opaque-fd import must match.
+  [[nodiscard]] const std::array<uint8_t, VK_UUID_SIZE>& device_uuid() const {
+    return device_uuid_;
+  }
+
  private:
   // Bring-up. Each logs and returns false on failure; a failed InitVulkan
   // leaves the backend inert (GetRenderConfig hands the engine null handles,
@@ -96,6 +137,19 @@ class HeadlessVulkanBackend final : public Backend {
   bool SelectPhysicalDevice();
   bool CreateLogicalDevice();
   bool CreateRenderTargets();
+  // Pool creators used by CreateRenderTargets. CreateExportablePool honors
+  // active_export_mode_ (opaque-fd or dmabuf) and, on any failure, lets the
+  // caller fall back to CreatePlainPool (the original non-exportable path) so
+  // the backend always boots and paces.
+  bool CreatePlainPool();
+  bool CreateExportablePool(const std::vector<uint64_t>& allowed_modifiers);
+  bool CreatePlainImage(uint32_t index);
+  bool CreateExportableImage(uint32_t index,
+                             const std::vector<uint64_t>& allowed_modifiers);
+  [[nodiscard]] uint32_t FindDeviceLocalMemoryType(uint32_t type_bits) const;
+  // Destroy the images/memory and close any exported fds. Shared by the
+  // export→plain fallback and Teardown.
+  void DestroyRenderTargets();
   void Teardown();
 
   // Root-surface renderer callbacks (user_data == the FlutterDesktopEngineState
@@ -142,6 +196,13 @@ class HeadlessVulkanBackend final : public Backend {
   std::array<VkImage, kImageCount> images_{};
   std::array<VkDeviceMemory, kImageCount> image_memory_{};
   uint32_t current_image_{0};
+
+  // Export state. export_mode_ is the mode requested via IVI_VK_EXPORT_MODE;
+  // active_export_mode_ is what actually took (kNone after a fallback). The
+  // per-image handles/layout a future handshake reads live in exported_images_.
+  ExportMode export_mode_{ExportMode::kNone};
+  ExportMode active_export_mode_{ExportMode::kNone};
+  std::array<ExportedImage, kImageCount> exported_images_{};
 
   // Synthetic-vsync pacing. vsync_ holds the baton machinery; the pacer drives
   // it, run in free-run (ceiling-only) mode since WS-1 has no consumer.


### PR DESCRIPTION
Makes the headless Vulkan backend's render-target pool exportable as external-memory handles — the foundation for a future cross-process handoff. The images the engine composites into become shareable fds.

## Behavior
- **Opt-in** via `IVI_VK_EXPORT_MODE=opaque|dmabuf`. **Unset = today's non-exportable pool, unchanged** — the default boot needs no export-capable device.
- **opaque-fd** (OPTIMAL tiling): the portable, same-device floor. `VkExternalMemoryImageCreateInfo{OPAQUE_FD}` + `VkExportMemoryAllocateInfo{OPAQUE_FD}` → `vkGetMemoryFdKHR`.
- **dmabuf** (`VK_EXT_image_drm_format_modifier` + `VK_EXT_external_memory_dma_buf`, adapted from `drm_kms_vulkan/vulkan_backing_store.cc`): negotiates the modifier set, reads back the driver-chosen modifier + per-plane offset/pitch.

## Robustness
Before creating exportable images, a preflight checks the needed device extensions are enabled and that `vkGetPhysicalDeviceImageFormatProperties2` advertises `EXPORTABLE` for the requested handle/tiling (per-modifier for dmabuf). On any miss — or if exportable creation fails after a passing preflight — it logs and **falls back to the plain non-exportable pool**, so export never hard-fails bring-up. Exported fds are closed on teardown (both the device-present and device-already-gone paths).

## Accessors (for a future handshake; nothing consumes them yet)
A per-image `ExportedImage` record `{fd, alloc_size, drm_fourcc, drm_modifier, per-plane offset/pitch, extent, vk_format, handle_type}` plus `exported_images()`, `export_enabled()`, and `device_uuid()`.

The `get_next_image`/`present` render path and the vsync are unchanged; no CMake/dependency changes (the DRM fourcc/modifier constants are defined locally, keeping the single `vulkan_headers` dep).

## Validation (Raspberry Pi 4, V3D / v3dv)
| Mode | Result |
|---|---|
| `dmabuf` | 3 fds exported, size 5,529,600 (1920×720×4), fourcc `ABGR8888`, real V3D modifier, planes=1 → engine renders into the **modifier-tiled** images, **30 fps** |
| `opaque` | 3 opaque fds exported → **30 fps** (v3dv supports the OPAQUE_FD floor too) |
| default | non-exportable pool, unchanged, 30 fps |

Both export modes produce real handles and the engine renders + paces correctly into the exportable images; no crashes or validation errors. (opaque-fd is the CARLA/desktop floor; dma-buf additionally serves KMS/GStreamer consumers.)