### PR TITLE
headless-vulkan: per-frame export semaphores (render_done / consumer_done)

### DIFF
--- a/shell/backend/headless_vulkan/headless_vulkan.cc
+++ b/shell/backend/headless_vulkan/headless_vulkan.cc
@@ -276,6 +276,16 @@ HeadlessVulkanBackend::HeadlessVulkanBackend(const uint32_t width,
     }
   }
 
+  // IVI_VK_EXPORT_LOOPBACK (opt-in): run an in-process stand-in consumer that
+  // signals consumer_done as soon as render_done fires, validating the
+  // per-frame semaphore round-trip without a real socket consumer. Without it
+  // the exported semaphore fds stay dormant (no one would signal consumer_done,
+  // so driving the per-frame wait would deadlock).
+  if (const char* lb = std::getenv("IVI_VK_EXPORT_LOOPBACK");
+      lb != nullptr && lb[0] != '\0' && std::strcmp(lb, "0") != 0) {
+    loopback_ = true;
+  }
+
   if (!InitVulkan()) {
     ihs::log::error("[HeadlessVulkan] Vulkan init failed; backend inert");
     Teardown();
@@ -545,6 +555,8 @@ bool HeadlessVulkanBackend::CreateRenderTargets() {
           "[HeadlessVulkan] export pool active: mode={} images={} {}x{}",
           active_export_mode_ == ExportMode::kDmaBuf ? "dmabuf" : "opaque",
           kImageCount, width_, height_);
+      // Best-effort per-frame sync semaphores on top of the exported images.
+      CreateExportSemaphores();
       return true;
     }
     // Exportable creation failed after a passing preflight (driver-specific);
@@ -788,7 +800,220 @@ bool HeadlessVulkanBackend::CreateExportableImage(
   return true;
 }
 
+void HeadlessVulkanBackend::CreateExportSemaphores() {
+  // Only meaningful when the image pool exported; require the
+  // external-semaphore device extensions the same way CreateRenderTargets gates
+  // the image export.
+  auto ext_enabled = [&](const char* name) {
+    for (const char* e : enabled_device_extensions_) {
+      if (std::strcmp(e, name) == 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+  if (!ext_enabled(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) ||
+      !ext_enabled(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME)) {
+    ihs::log::warn(
+        "[HeadlessVulkan] VK_KHR_external_semaphore[_fd] absent; per-frame "
+        "sync "
+        "semaphores disabled (image export still active)");
+    return;
+  }
+
+  // Preflight: the device must advertise OPAQUE_FD semaphore export.
+  VkPhysicalDeviceExternalSemaphoreInfo esi{};
+  esi.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO;
+  esi.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+  VkExternalSemaphoreProperties esp{};
+  esp.sType = VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES;
+  d().vkGetPhysicalDeviceExternalSemaphoreProperties(physical_device_, &esi,
+                                                     &esp);
+  if ((esp.externalSemaphoreFeatures &
+       VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT) == 0) {
+    ihs::log::warn(
+        "[HeadlessVulkan] device does not advertise EXPORTABLE OPAQUE_FD "
+        "semaphores; per-frame sync semaphores disabled");
+    return;
+  }
+
+  // Command pool + reusable fence for the CPU-side consumer_done wait. The
+  // empty signal/self-consume submits carry no command buffers, so the pool is
+  // used only to satisfy the fence-backed wait submit; still, keep it around.
+  VkCommandPoolCreateInfo cpi{};
+  cpi.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+  cpi.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+  cpi.queueFamilyIndex = graphics_queue_family_;
+  if (d().vkCreateCommandPool(device_, &cpi, nullptr, &sync_command_pool_) !=
+      VK_SUCCESS) {
+    ihs::log::warn(
+        "[HeadlessVulkan] sync command pool creation failed; per-frame sync "
+        "semaphores disabled");
+    sync_command_pool_ = VK_NULL_HANDLE;
+    return;
+  }
+  VkFenceCreateInfo fci{};
+  fci.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;  // unsignaled
+  if (d().vkCreateFence(device_, &fci, nullptr, &consumer_wait_fence_) !=
+      VK_SUCCESS) {
+    ihs::log::warn(
+        "[HeadlessVulkan] sync fence creation failed; per-frame sync "
+        "semaphores disabled");
+    d().vkDestroyCommandPool(device_, sync_command_pool_, nullptr);
+    sync_command_pool_ = VK_NULL_HANDLE;
+    consumer_wait_fence_ = VK_NULL_HANDLE;
+    return;
+  }
+
+  // Per image: create the two OPAQUE_FD-exportable binary semaphores and export
+  // one persistent fd each. On any failure, roll back and skip the whole
+  // feature — the image export still stands.
+  auto rollback = [&]() {
+    DestroyExportSemaphores();
+    semaphores_active_ = false;
+  };
+  for (uint32_t i = 0; i < kImageCount; ++i) {
+    VkExportSemaphoreCreateInfo exp{};
+    exp.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO;
+    exp.handleTypes = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+    VkSemaphoreCreateInfo sci{};
+    sci.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+    sci.pNext = &exp;
+    if (d().vkCreateSemaphore(device_, &sci, nullptr, &render_done_[i]) !=
+            VK_SUCCESS ||
+        d().vkCreateSemaphore(device_, &sci, nullptr, &consumer_done_[i]) !=
+            VK_SUCCESS) {
+      ihs::log::warn(
+          "[HeadlessVulkan] vkCreateSemaphore {} failed; disabling "
+          "per-frame sync",
+          i);
+      rollback();
+      return;
+    }
+
+    const auto export_fd = [&](VkSemaphore sem, int* out) -> bool {
+      VkSemaphoreGetFdInfoKHR gfi{};
+      gfi.sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR;
+      gfi.semaphore = sem;
+      gfi.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+      return d().vkGetSemaphoreFdKHR(device_, &gfi, out) == VK_SUCCESS;
+    };
+    ExportedImage& e = exported_images_[i];
+    if (!export_fd(render_done_[i], &e.render_done_fd) ||
+        !export_fd(consumer_done_[i], &e.consumer_done_fd)) {
+      ihs::log::warn(
+          "[HeadlessVulkan] vkGetSemaphoreFdKHR {} failed; disabling per-frame "
+          "sync",
+          i);
+      rollback();
+      return;
+    }
+    ihs::log::info(
+        "[HeadlessVulkan] image {} sync semaphores: render_done_fd={} "
+        "consumer_done_fd={}",
+        i, e.render_done_fd, e.consumer_done_fd);
+  }
+
+  // Initialize each consumer_done to SIGNALED so the first GetNextImage wait
+  // passes (the image starts "free"). One empty signal-only submit per image.
+  for (uint32_t i = 0; i < kImageCount; ++i) {
+    VkSubmitInfo si{};
+    si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    si.signalSemaphoreCount = 1;
+    si.pSignalSemaphores = &consumer_done_[i];
+    if (d().vkQueueSubmit(graphics_queue_, 1, &si, VK_NULL_HANDLE) !=
+        VK_SUCCESS) {
+      ihs::log::warn(
+          "[HeadlessVulkan] initial consumer_done signal {} failed; disabling "
+          "per-frame sync",
+          i);
+      d().vkQueueWaitIdle(graphics_queue_);
+      rollback();
+      return;
+    }
+  }
+
+  semaphores_active_ = true;
+  ihs::log::info(
+      "[HeadlessVulkan] per-frame sync semaphores active (images={}, "
+      "loopback={})",
+      kImageCount, loopback_ ? "on" : "off");
+}
+
+void HeadlessVulkanBackend::DestroyExportSemaphores() {
+  for (uint32_t i = 0; i < kImageCount; ++i) {
+    if (render_done_[i] != VK_NULL_HANDLE) {
+      d().vkDestroySemaphore(device_, render_done_[i], nullptr);
+      render_done_[i] = VK_NULL_HANDLE;
+    }
+    if (consumer_done_[i] != VK_NULL_HANDLE) {
+      d().vkDestroySemaphore(device_, consumer_done_[i], nullptr);
+      consumer_done_[i] = VK_NULL_HANDLE;
+    }
+    if (exported_images_[i].render_done_fd >= 0) {
+      ::close(exported_images_[i].render_done_fd);
+      exported_images_[i].render_done_fd = -1;
+    }
+    if (exported_images_[i].consumer_done_fd >= 0) {
+      ::close(exported_images_[i].consumer_done_fd);
+      exported_images_[i].consumer_done_fd = -1;
+    }
+  }
+  if (consumer_wait_fence_ != VK_NULL_HANDLE) {
+    d().vkDestroyFence(device_, consumer_wait_fence_, nullptr);
+    consumer_wait_fence_ = VK_NULL_HANDLE;
+  }
+  if (sync_command_pool_ != VK_NULL_HANDLE) {
+    d().vkDestroyCommandPool(device_, sync_command_pool_, nullptr);
+    sync_command_pool_ = VK_NULL_HANDLE;
+  }
+  semaphores_active_ = false;
+}
+
+void HeadlessVulkanBackend::WaitConsumerDone(const uint32_t k) {
+  // CPU-wait consumer_done[k]: an empty wait-only submit (fence-backed) that
+  // unsignals the binary semaphore and confirms the consumer released image k.
+  VkPipelineStageFlags stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+  VkSubmitInfo si{};
+  si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+  si.waitSemaphoreCount = 1;
+  si.pWaitSemaphores = &consumer_done_[k];
+  si.pWaitDstStageMask = &stage;
+  if (d().vkQueueSubmit(graphics_queue_, 1, &si, consumer_wait_fence_) !=
+      VK_SUCCESS) {
+    return;
+  }
+  d().vkWaitForFences(device_, 1, &consumer_wait_fence_, VK_TRUE, UINT64_MAX);
+  d().vkResetFences(device_, 1, &consumer_wait_fence_);
+}
+
+void HeadlessVulkanBackend::SignalRenderDone(const uint32_t k) {
+  // Signal render_done[k]: empty signal-only submit. Same-queue ordering means
+  // it signals after the engine's render submits for image k complete.
+  VkSubmitInfo si{};
+  si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+  si.signalSemaphoreCount = 1;
+  si.pSignalSemaphores = &render_done_[k];
+  d().vkQueueSubmit(graphics_queue_, 1, &si, VK_NULL_HANDLE);
+}
+
+void HeadlessVulkanBackend::LoopbackSelfConsume(const uint32_t k) {
+  // Stand-in consumer: wait render_done[k] (unsignal) and signal
+  // consumer_done[k] in one empty submit, so the next GetNextImage for image k
+  // finds it free.
+  VkPipelineStageFlags stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+  VkSubmitInfo si{};
+  si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+  si.waitSemaphoreCount = 1;
+  si.pWaitSemaphores = &render_done_[k];
+  si.pWaitDstStageMask = &stage;
+  si.signalSemaphoreCount = 1;
+  si.pSignalSemaphores = &consumer_done_[k];
+  d().vkQueueSubmit(graphics_queue_, 1, &si, VK_NULL_HANDLE);
+}
+
 void HeadlessVulkanBackend::DestroyRenderTargets() {
+  DestroyExportSemaphores();
   for (uint32_t i = 0; i < kImageCount; ++i) {
     if (images_[i] != VK_NULL_HANDLE) {
       d().vkDestroyImage(device_, images_[i], nullptr);
@@ -812,11 +1037,22 @@ void HeadlessVulkanBackend::Teardown() {
     d().vkDestroyDevice(device_, nullptr);
     device_ = VK_NULL_HANDLE;
   } else {
-    // Device already gone (or never created): still close any exported fds.
+    // Device already gone (or never created): still close any exported fds
+    // (image memory + the per-frame sync semaphores). The
+    // VkSemaphore/pool/fence handles die with the device; only the fds are ours
+    // to close.
     for (uint32_t i = 0; i < kImageCount; ++i) {
       if (exported_images_[i].fd >= 0) {
         ::close(exported_images_[i].fd);
         exported_images_[i].fd = -1;
+      }
+      if (exported_images_[i].render_done_fd >= 0) {
+        ::close(exported_images_[i].render_done_fd);
+        exported_images_[i].render_done_fd = -1;
+      }
+      if (exported_images_[i].consumer_done_fd >= 0) {
+        ::close(exported_images_[i].consumer_done_fd);
+        exported_images_[i].consumer_done_fd = -1;
       }
     }
   }
@@ -888,6 +1124,13 @@ FlutterVulkanImage HeadlessVulkanBackend::GetNextImageCallback(
     void* user_data,
     const FlutterFrameInfo* /* frame_info */) {
   auto* backend = BackendOf(user_data);
+  // Loopback only: block until the (stand-in) consumer released this image, so
+  // the engine never re-renders an image a consumer is still reading. Without
+  // loopback the binary consumer_done has no signaler and this would deadlock —
+  // so the per-frame ops stay dormant and the fds are merely exported.
+  if (backend->loopback_ && backend->semaphores_active_) {
+    backend->WaitConsumerDone(backend->current_image_);
+  }
   return {
       .struct_size = sizeof(FlutterVulkanImage),
       .image =
@@ -902,7 +1145,15 @@ bool HeadlessVulkanBackend::PresentCallback(
   // WS-1 does nothing with the composited frame — the pacer drives cadence.
   // Advance the round-robin index so the next frame targets a different image.
   auto* backend = BackendOf(user_data);
-  backend->current_image_ = (backend->current_image_ + 1) % kImageCount;
+  const uint32_t k = backend->current_image_;  // index the engine just rendered
+  if (backend->loopback_ && backend->semaphores_active_) {
+    // Signal render_done[k] after the engine's render submits (same queue,
+    // ordered), then have the loopback consumer immediately drain it and signal
+    // consumer_done[k] so image k is free for its next GetNextImage.
+    backend->SignalRenderDone(k);
+    backend->LoopbackSelfConsume(k);
+  }
+  backend->current_image_ = (k + 1) % kImageCount;
   return true;
 }
 

--- a/shell/backend/headless_vulkan/headless_vulkan.h
+++ b/shell/backend/headless_vulkan/headless_vulkan.h
@@ -65,6 +65,14 @@ class HeadlessVulkanBackend final : public Backend {
   // pool leaves fd == -1 / handle_type == 0. POD by design.
   struct ExportedImage {
     int fd = -1;  // owned by the backend; -1 if not exported
+    // Per-frame cross-process GPU sync (OPAQUE_FD exports of binary
+    // VkSemaphores; -1 unless the semaphore machinery came up). render_done:
+    // the backend signals it once image i is rendered, a consumer waits on it.
+    // consumer_done: a consumer signals it when done reading image i, the
+    // backend waits before re-rendering. Both are persistent OPAQUE_FD handles
+    // a consumer imports once and shares the binary state with the backend.
+    int render_done_fd = -1;
+    int consumer_done_fd = -1;
     uint64_t alloc_size = 0;
     uint32_t memory_type_index = 0;
     uint32_t drm_fourcc = 0;    // dmabuf only
@@ -147,6 +155,22 @@ class HeadlessVulkanBackend final : public Backend {
   bool CreateExportableImage(uint32_t index,
                              const std::vector<uint64_t>& allowed_modifiers);
   [[nodiscard]] uint32_t FindDeviceLocalMemoryType(uint32_t type_bits) const;
+  // Per-frame cross-process GPU sync. Called after the exportable image pool is
+  // built (export active only): creates a pair of OPAQUE_FD-exportable binary
+  // semaphores per image (render_done / consumer_done), exports their fds, and
+  // pre-signals each consumer_done so the first GetNextImage wait passes.
+  // Best-effort — logs and skips (leaving the fds -1) if the device cannot
+  // export an OPAQUE_FD semaphore; never fails bring-up.
+  void CreateExportSemaphores();
+  // Destroy the semaphores, close their fds, and destroy the sync command
+  // pool + fence. Called by DestroyRenderTargets.
+  void DestroyExportSemaphores();
+  // The per-frame loopback round-trip (active only when loopback_ &&
+  // semaphores_active_), all on graphics_queue_ from the raster thread.
+  void WaitConsumerDone(uint32_t k);  // GetNextImage: CPU-wait consumer_done[k]
+  void SignalRenderDone(uint32_t k);  // Present: signal render_done[k]
+  void LoopbackSelfConsume(
+      uint32_t k);  // Present: wait render / signal consumer
   // Destroy the images/memory and close any exported fds. Shared by the
   // export→plain fallback and Teardown.
   void DestroyRenderTargets();
@@ -203,6 +227,20 @@ class HeadlessVulkanBackend final : public Backend {
   ExportMode export_mode_{ExportMode::kNone};
   ExportMode active_export_mode_{ExportMode::kNone};
   std::array<ExportedImage, kImageCount> exported_images_{};
+
+  // Per-frame cross-process sync semaphores. render_done_[i] /
+  // consumer_done_[i] are binary VkSemaphores exported as OPAQUE_FD (fds stored
+  // in exported_images_[i]); semaphores_active_ gates every per-frame op. The
+  // sync command pool + reusable fence back the CPU-side consumer_done wait; no
+  // command buffers are recorded — the empty submits only carry wait/signal
+  // semaphores. IVI_VK_EXPORT_LOOPBACK=1 enables an in-process self-consumer
+  // that stands in for the future socket consumer to validate the round-trip.
+  bool loopback_{false};
+  bool semaphores_active_{false};
+  std::array<VkSemaphore, kImageCount> render_done_{};
+  std::array<VkSemaphore, kImageCount> consumer_done_{};
+  VkCommandPool sync_command_pool_{VK_NULL_HANDLE};
+  VkFence consumer_wait_fence_{VK_NULL_HANDLE};
 
   // Synthetic-vsync pacing. vsync_ holds the baton machinery; the pacer drives
   // it, run in free-run (ceiling-only) mode since WS-1 has no consumer.


### PR DESCRIPTION
> Stacked on #383 (the exportable image pool) — the semaphore fds live alongside each `ExportedImage`. Base retargets to `v2.0` once #383 merges.

Adds the cross-process GPU sync a consumer needs: per pool image a **`render_done`** and a **`consumer_done`** binary semaphore, exported as **OPAQUE_FD**.

- **`render_done`** — signaled once the engine finishes rendering into an image (an empty queue submit at present; same-queue ordering makes it signal *after* the render). A consumer waits on it before sampling.
- **`consumer_done`** — signaled by a consumer when it releases the image; the backend waits on it in `get_next_image` before re-rendering that image.

Created only when image export is active and the device advertises `VK_KHR_external_semaphore_fd` + OPAQUE_FD exportability (`vkGetPhysicalDeviceExternalSemaphoreProperties`); the two fds join the per-image `ExportedImage` record. Any miss leaves the fds `-1` with the image export intact — semaphores never hard-fail bring-up.

## Loopback self-test
The per-frame acquire/signal round-trip runs only under **`IVI_VK_EXPORT_LOOPBACK=1`** — an in-process stand-in consumer (waits `render_done`, re-signals `consumer_done`) that lets the binary-semaphore cycle be exercised before a real consumer exists. Without it the semaphores are exported but **dormant** and the default path is unchanged (a `consumer_done` no one signals would otherwise deadlock the acquire wait).

The cycle — `consumer_done` starts signaled → acquire waits it → render → present signals `render_done` → consumer drains it and re-signals `consumer_done` — alternates each semaphore exactly once per lap (no double-signal, every wait has a prior signaler). All submits run on the graphics queue from the raster thread, in step with the engine's own submits.

## Validation (Raspberry Pi 4, V3D / v3dv)
| Config | Result |
|---|---|
| dmabuf + loopback | 6 semaphore fds exported; full round-trip **270 frames @ ~30 fps**, no stall/validation error |
| dmabuf, no loopback | semaphores exported dormant, ~30 fps (default unchanged) |
| opaque + loopback | OPAQUE_FD round-trip also ~30 fps (the CARLA floor) |

Semaphore teardown (destroy + close fds + fence + command pool) is guarded and runs after `vkDeviceWaitIdle`, including the device-already-gone path and the export→plain fallback where no semaphores were created.