### PR TITLE
platform-views: report the scanned-out KMS plane through the DRM_PLANE grant

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -1129,6 +1129,10 @@ bool DrmCompositor::PresentViaGlFallback(const FlutterLayer** layers,
         }
       }
       if (surface_sp) {
+        // GL-composited this present: no plane. Report 0 so the DRM_PLANE grant
+        // accessor reflects the fallback rather than a stale plane id (which
+        // would read as the zero-GPU path still being honored).
+        surface_sp->SetScanoutPlane(0);
         surface_sp->OnPresent(layer);
         if (const auto tex = surface_sp->GetGlTextureName(); tex != 0) {
           const auto sw = surface_sp->GetGlTextureWidth();
@@ -2922,6 +2926,23 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
     return PresentViaGlFallback(layers, layer_count);
   }
   scene_ebusy_streak_ = 0;  // a clean commit clears the transient-EBUSY streak
+
+  // Report each platform view's scanout plane back through its surface (feeds
+  // the DRM_PLANE grant accessor, ihs_pv_grant_drm_plane_id). commit() ran
+  // record_placement above, so last_assigned_plane_id() is this frame's. Every
+  // layer is on a plane here -- the test() check above routes to GL fallback if
+  // any layer would be composited -- so PVs get their non-zero plane id; the
+  // fallback path reports 0 for them.
+  for (const auto& fl : frame_layers) {
+    if (fl.pv_tag == nullptr || !fl.pv_surface) {
+      continue;
+    }
+    uint32_t plane_id = 0;
+    if (const auto* layer = scene_->find_by_identity_tag(fl.pv_tag)) {
+      plane_id = layer->last_assigned_plane_id().value_or(0);
+    }
+    fl.pv_surface->SetScanoutPlane(plane_id);
+  }
 
   if (blocking_modeset) {
     // A blocking ALLOW_MODESET commit landed (first commit, or a plane-topology

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -155,7 +155,11 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
 
   // Negotiated grant, cached from the host's grant() for the accessors.
   uint32_t granted_kind{IHS_PV_KIND_NONE};
-  uint32_t drm_plane_id{0};
+  // The KMS plane this view was scanned out on at the last present, or 0 when
+  // it was GL-composited (no plane) that present. Written on the compositor
+  // thread via SetScanoutPlane, read on the platform thread via the DRM_PLANE
+  // accessor, so it is atomic. Feeds ihs_pv_grant_drm_plane_id.
+  std::atomic<uint32_t> drm_plane_id{0};
   int shm_fd{-1};
   size_t shm_stride{0};
 
@@ -283,6 +287,13 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     return id_;
   }
   void OnResize(int32_t, int32_t) override {}
+
+  // The compositor reports the KMS plane this view scanned out on this present
+  // (0 == GL-composited). Stored for the DRM_PLANE grant accessor. Compositor
+  // thread; the field is atomic.
+  void SetScanoutPlane(uint32_t plane_id) override {
+    drm_plane_id.store(plane_id, std::memory_order_relaxed);
+  }
 
 #if IVI_HAVE_VULKAN
   // The compositor samples the most recently submitted buffer. Null until the
@@ -989,7 +1000,15 @@ void HostRevoke(void* /*user_data*/, IhsPlatformView* view) {
 }
 
 uint32_t HostGrantDrmPlaneId(void* /*user_data*/, IhsPlatformView* view) {
-  return reinterpret_cast<IhsPluginView*>(view)->drm_plane_id;
+  auto* v = reinterpret_cast<IhsPluginView*>(view);
+  // Per the ABI, the accessor is 0 unless the current grant is DRM_PLANE.
+  // Otherwise it is the plane the compositor scanned this view out on at the
+  // last present -- and 0 while the view is GL-composited (no plane), so a
+  // direct-scanout producer sees when its zero-GPU path is not being honored.
+  if (v->granted_kind != IHS_PV_KIND_DRM_PLANE) {
+    return 0;
+  }
+  return v->drm_plane_id.load(std::memory_order_relaxed);
 }
 
 int HostGrantShmFd(void* /*user_data*/,

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -314,4 +314,18 @@ class ICompositorSurface {
    * per-buffer releases).
    */
   virtual void OnScanoutRelease(uint32_t /*buffer_id*/) {}
+
+  /**
+   * @brief Report which KMS plane the surface's frame was scanned out on this
+   * present, or 0 when it was GL-composited (no plane) this present.
+   *
+   * The DRM scene path calls this once per present after the atomic commit,
+   * with the plane object id the allocator placed this surface on (or 0 on a
+   * GL-composite fallback). It feeds the @c DRM_PLANE grant accessor
+   * (@c ihs_pv_grant_drm_plane_id), so a direct-scanout producer can tell
+   * whether its zero-GPU path is actually being honored frame to frame. Called
+   * on the compositor thread; an implementation must be thread-safe. The
+   * default ignores it.
+   */
+  virtual void SetScanoutPlane(uint32_t /*plane_id*/) {}
 };


### PR DESCRIPTION
## What

`ihs_pv_grant_drm_plane_id(view)` now returns the KMS plane the platform view was scanned out on at the last present, or **0** when it was GL-composited that present — so a `DRM_PLANE`-granted producer can tell, frame to frame, whether its zero-GPU direct-scanout path is actually being honored.

Previously the accessor always returned 0: `HostGrant` recorded the grant kind but never a plane, because planes are assigned **per frame** by the drm-cxx allocator (a view can move planes or fall to composition), not reserved at grant
time.

## How

- New `ICompositorSurface::SetScanoutPlane(uint32_t)` hook (default no-op).
- The DRM scene compositor calls it per platform view after the atomic commit with the layer's `last_assigned_plane_id()` — every layer is on a plane on that path, since the `test()` gate routes to GL fallback if any layer would be composited — and the **GL-fallback path reports 0**.
- `IhsPluginView` stores it in a `std::atomic<uint32_t>` (written on the compositor thread, read on the platform thread); `HostGrantDrmPlaneId` is gated on `granted_kind == DRM_PLANE` per the ABI.

## Validation

HW-validated on **Raspberry Pi 4 (vc4)**: a box view granted `DRM_PLANE` (`granted_kind=2`) reads back the same plane the compositor assigned it — e.g. `drm_plane_id=195`, matching the compositor's `SetScanoutPlane(195)` — and `0` on the presents it is GL-composited. Exercised by the `LP_PV_DRM_PLANE` mode in toyota-connected/ivi-homescreen-plugins (companion PR).
