### PR TITLE
headless-vulkan: export ihs_vk_export_get_api for an in-process bridge

### DIFF
--- a/shared/include/ihs/vk_export.h
+++ b/shared/include/ihs/vk_export.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The CANONICAL, shell-side definition of the in-process C ABI the
+// ivi-homescreen headless-vulkan backend exposes to a bridge plugin loaded into
+// the same process. ivi-homescreen owns this header and exports exactly one
+// symbol, `ihs_vk_export_get_api`, at default visibility; the bridge vendors a
+// byte-identical copy and resolves the symbol with dlsym(RTLD_DEFAULT) without
+// ever linking the shell. Because the seam is in-process there is no IPC and no
+// fd passing here -- raw fds/handles cross by value; the bridge is what
+// marshals them out over the ihs-vk-export wire protocol (see wire_protocol.h).
+//
+// Versioned by a single get-api call: `ihs_vk_export_get_api(version)` returns
+// a struct-of-function-pointers for the requested major version or NULL. Adding
+// a method means a new struct + version, never reordering V1.
+//
+// This header intentionally mirrors the headless-vulkan backend's exported
+// state (ExportedImage / device_uuid) so the bridge can be written and tested
+// against it before the shell symbol exists.
+
+#ifndef IHS_VK_EXPORT_H_
+#define IHS_VK_EXPORT_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define IHS_VK_EXPORT_API_VERSION 1
+#define IHS_VK_EXPORT_MAX_SLOTS 8
+#define IHS_VK_EXPORT_MAX_PLANES 4
+
+// Handle type actually used by the pool (matches VkExternalMemoryHandleType).
+enum {
+  IHS_VK_HANDLE_OPAQUE_FD = 1,  // same-device OPAQUE_FD (portable floor)
+  IHS_VK_HANDLE_DMA_BUF = 2,    // dma-buf + DRM format modifier
+};
+
+// Pool-wide capabilities the bridge advertises to a consumer at HELLO/CAPS.
+typedef struct IhsVkExportCaps {
+  uint32_t api_version;
+  uint32_t handle_type;  // one of IHS_VK_HANDLE_*
+  uint32_t vk_format;    // VkFormat of every pool image
+  uint32_t drm_fourcc;   // DRM fourcc (dmabuf); 0 if opaque
+  uint32_t width;
+  uint32_t height;
+  uint32_t slot_count;     // pool images in the current table
+  uint32_t export_active;  // 0 if the backend has no exportable pool
+  uint8_t device_uuid[16];
+} IhsVkExportCaps;
+
+// One pool image. fds are OWNED BY THE CALLER: get_image_table() fills them
+// with dup()s the bridge must close. A slot with no export leaves fds == -1.
+typedef struct IhsVkExportImage {
+  int32_t memory_fd;         // dup of the image's exported memory fd
+  int32_t render_done_fd;    // dup of the render_done semaphore fd
+  int32_t consumer_done_fd;  // dup of the consumer_done semaphore fd
+  uint64_t alloc_size;
+  uint64_t drm_modifier;                            // dmabuf; 0 if opaque
+  uint64_t plane_offset[IHS_VK_EXPORT_MAX_PLANES];  // dmabuf
+  uint64_t plane_pitch[IHS_VK_EXPORT_MAX_PLANES];   // dmabuf
+  uint32_t width;
+  uint32_t height;
+  uint32_t vk_format;
+  uint32_t drm_fourcc;
+  uint32_t memory_type_index;
+  uint32_t handle_type;  // IHS_VK_HANDLE_*
+  uint32_t plane_count;
+} IhsVkExportImage;
+
+typedef struct IhsVkExportImageTable {
+  uint32_t generation;  // bumps on every pool rebuild (resize)
+  uint32_t slot_count;
+  IhsVkExportImage images[IHS_VK_EXPORT_MAX_SLOTS];
+} IhsVkExportImageTable;
+
+// Fired on the raster thread the instant the backend presents a frame into
+// `slot`; the bridge must only enqueue to its own ring here (socket writes
+// happen on the bridge IO thread). Not called concurrently with itself.
+typedef void (*IhsVkFrameListener)(uint32_t slot,
+                                   uint32_t frame_seq,
+                                   void* user);
+
+// Pacing source for the backend's vsync (see the consumer-paced vsync source).
+enum {
+  IHS_VK_PACE_FREE_RUN = 0,         // ceiling-only; no consumer attached
+  IHS_VK_PACE_CONSUMER_DRIVEN = 1,  // release_frame() edges drive the cadence
+};
+
+typedef struct IhsPointerEvent {
+  uint32_t phase;  // add/down/move/up/remove
+  float x, y;      // logical pixels
+  uint32_t buttons;
+  uint32_t device_id;
+} IhsPointerEvent;
+
+// V1 function table. All entry points are safe to call from the bridge IO
+// thread unless noted; set_frame_listener's callback fires on the raster
+// thread.
+typedef struct IhsVkExportApiV1 {
+  // Pool capabilities (device UUID, handle type, format, extent, slot count).
+  IhsVkExportCaps (*get_caps)(void);
+  // Fill `out` with the current pool: descriptors + dup'd fds the caller owns.
+  // Returns 0 on success, non-zero if there is no exportable pool.
+  int (*get_image_table)(IhsVkExportImageTable* out);
+  // Register the per-present callback (raster thread). cb == NULL clears it.
+  void (*set_frame_listener)(IhsVkFrameListener cb, void* user);
+  // The consumer released `slot` -- the pacing edge for consumer-driven vsync.
+  void (*release_frame)(uint32_t slot);
+  // Choose consumer-driven vs free-run pacing (IHS_VK_PACE_*).
+  void (*set_pace_source)(uint32_t src);
+  // Inject a pointer event through the engine's normal input path (thread-safe,
+  // marshaled to the platform task runner).
+  void (*inject_pointer)(const IhsPointerEvent* ev);
+  // Rebuild the pool at a new extent (resize). Returns 0 on success.
+  int (*rebuild_pool)(uint32_t width, uint32_t height);
+} IhsVkExportApiV1;
+
+// The one exported shell symbol. Returns the table for `requested_version`
+// (currently only IHS_VK_EXPORT_API_VERSION), or NULL if the running backend is
+// not headless-vulkan or the version is unsupported.
+const IhsVkExportApiV1* ihs_vk_export_get_api(uint32_t requested_version);
+
+// Convenience typedef for the dlsym'd pointer.
+typedef const IhsVkExportApiV1* (*IhsVkExportGetApiFn)(uint32_t);
+#define IHS_VK_EXPORT_GET_API_SYMBOL "ihs_vk_export_get_api"
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IHS_VK_EXPORT_H_

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -276,9 +276,19 @@ if (BUILD_BACKEND_HEADLESS_VULKAN)
     # Vulkan SDK in the system/sysroot.
     target_sources(${PROJECT_NAME} PRIVATE
             backend/headless_vulkan/headless_vulkan.cc
+            # In-process C ABI (ihs/vk_export.h): registry + the one exported
+            # `ihs_vk_export_get_api` symbol an in-process bridge dlsym's.
+            backend/headless_vulkan/vk_export_api.cc
             display/software_display.cc
     )
     target_link_libraries(${PROJECT_NAME} PRIVATE vulkan_headers)
+    # Put ONLY `ihs_vk_export_get_api` in the executable's dynamic symbol table
+    # (the bridge resolves it via dlsym(RTLD_DEFAULT)). Avoids blanket -rdynamic
+    # so no other internal symbol is exported; the shell sets no global
+    # -fvisibility=hidden, so the default-visibility attribute plus this keeps
+    # exactly one dynamic export.
+    target_link_options(${PROJECT_NAME} PRIVATE
+            -Wl,--export-dynamic-symbol=ihs_vk_export_get_api)
 endif ()
 
 # Shared libinput keyboard core (xkb translation + key-repeat) used by every

--- a/shell/backend/headless_vulkan/headless_vulkan.cc
+++ b/shell/backend/headless_vulkan/headless_vulkan.cc
@@ -37,10 +37,15 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 #include <string>
 #include <vector>
 
+#include "asio/post.hpp"
+
+#include "backend/headless_vulkan/vk_export_api.h"
 #include "engine.h"
+#include "libflutter_engine.h"
 #include "logging/logging.h"
 #include "shell/platform/homescreen/flutter_desktop_engine_state.h"
 #include "task_runner.h"
@@ -290,9 +295,18 @@ HeadlessVulkanBackend::HeadlessVulkanBackend(const uint32_t width,
     ihs::log::error("[HeadlessVulkan] Vulkan init failed; backend inert");
     Teardown();
   }
+
+  // Publish this backend to the exported `ihs_vk_export_get_api` seam so an
+  // in-process bridge plugin can resolve the pool. Done last so a fully
+  // constructed backend is what the ABI hands out (an inert backend still
+  // registers; export_active reports the truth).
+  ihs::RegisterVkExportBackend(this);
 }
 
 HeadlessVulkanBackend::~HeadlessVulkanBackend() {
+  // Withdraw from the exported ABI before tearing down so no bridge call lands
+  // on a half-destroyed backend.
+  ihs::UnregisterVkExportBackend(this);
   Teardown();
 }
 
@@ -1062,6 +1076,155 @@ void HeadlessVulkanBackend::Teardown() {
   }
 }
 
+// ── In-process C ABI (ihs/vk_export.h) ───────────────────────────────────────
+
+void HeadlessVulkanBackend::FillExportCaps(IhsVkExportCaps* out) const {
+  if (out == nullptr) {
+    return;
+  }
+  std::memset(out, 0, sizeof(*out));
+  out->api_version = IHS_VK_EXPORT_API_VERSION;
+  out->width = width_;
+  out->height = height_;
+  out->slot_count = kImageCount;
+  out->vk_format = static_cast<uint32_t>(image_format_);
+  out->export_active = export_enabled() ? 1u : 0u;
+  std::memcpy(out->device_uuid, device_uuid_.data(), device_uuid_.size());
+  out->handle_type = active_export_mode_ == ExportMode::kDmaBuf
+                         ? IHS_VK_HANDLE_DMA_BUF
+                         : (active_export_mode_ == ExportMode::kOpaqueFd
+                                ? IHS_VK_HANDLE_OPAQUE_FD
+                                : 0u);
+  // DRM fourcc is meaningful only for the dma-buf pool; opaque/none leave 0.
+  out->drm_fourcc = exported_images_[0].drm_fourcc;
+}
+
+int HeadlessVulkanBackend::FillImageTable(IhsVkExportImageTable* out) const {
+  if (out == nullptr) {
+    return -1;
+  }
+  if (!export_enabled()) {
+    return -1;
+  }
+  std::memset(out, 0, sizeof(*out));
+  out->generation = generation_;
+  out->slot_count = kImageCount;
+
+  // dup() the source fds so the caller owns/closes independent handles; -1 in
+  // means -1 out (no export for that fd).
+  auto dup_fd = [](int fd) -> int32_t { return fd >= 0 ? ::dup(fd) : -1; };
+
+  for (uint32_t i = 0; i < kImageCount; ++i) {
+    const ExportedImage& e = exported_images_[i];
+    IhsVkExportImage& o = out->images[i];
+    o.memory_fd = dup_fd(e.fd);
+    o.render_done_fd = dup_fd(e.render_done_fd);
+    o.consumer_done_fd = dup_fd(e.consumer_done_fd);
+    o.alloc_size = e.alloc_size;
+    o.drm_modifier = e.drm_modifier;
+    for (uint32_t p = 0; p < IHS_VK_EXPORT_MAX_PLANES; ++p) {
+      o.plane_offset[p] = e.plane_offset[p];
+      o.plane_pitch[p] = e.plane_pitch[p];
+    }
+    o.width = e.width;
+    o.height = e.height;
+    o.vk_format = e.vk_format;
+    o.drm_fourcc = e.drm_fourcc;
+    o.memory_type_index = e.memory_type_index;
+    // ExportedImage::handle_type holds a VkExternalMemoryHandleTypeFlagBits;
+    // translate it to the ABI's IHS_VK_HANDLE_* space.
+    o.handle_type =
+        e.handle_type == static_cast<uint32_t>(
+                             VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT)
+            ? IHS_VK_HANDLE_DMA_BUF
+            : (e.handle_type ==
+                       static_cast<uint32_t>(
+                           VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT)
+                   ? IHS_VK_HANDLE_OPAQUE_FD
+                   : 0u);
+    o.plane_count = e.plane_count;
+  }
+  return 0;
+}
+
+void HeadlessVulkanBackend::SetExportFrameListener(IhsVkFrameListener cb,
+                                                   void* user) {
+  std::scoped_lock lock(frame_listener_mutex_);
+  frame_listener_ = cb;
+  frame_listener_user_ = user;
+}
+
+void HeadlessVulkanBackend::OnConsumerReleaseFrame(uint32_t /* slot */) {
+  // The pacing edge: crediting the pacer lets the next baton flow. The slot is
+  // unused today (the ring is strictly ordered) but kept for a future
+  // out-of-order release.
+  if (pacer_) {
+    pacer_->AddCredit();
+  }
+}
+
+void HeadlessVulkanBackend::SetExportPaceSource(uint32_t src) {
+  if (pacer_) {
+    pacer_->SetFreeRun(src == IHS_VK_PACE_FREE_RUN);
+  }
+}
+
+void HeadlessVulkanBackend::InjectPointer(const IhsPointerEvent& ev) {
+  if (engine_handle_ == nullptr || platform_task_runner_ == nullptr ||
+      platform_task_runner_->GetStrandContext() == nullptr) {
+    return;
+  }
+  // Map the ABI phase (0..4) to the embedder's pointer phase.
+  FlutterPointerPhase phase;
+  switch (ev.phase) {
+    case 0:
+      phase = kAdd;
+      break;
+    case 1:
+      phase = kDown;
+      break;
+    case 2:
+      phase = kMove;
+      break;
+    case 3:
+      phase = kUp;
+      break;
+    case 4:
+      phase = kRemove;
+      break;
+    default:
+      return;  // unknown phase; drop rather than fabricate one
+  }
+
+  // Marshal onto the platform strand so SendPointerEvent runs on the same
+  // thread the engine services input from (the bridge calls this from its IO
+  // thread). Capture the POD event by value.
+  auto engine = engine_handle_;
+  asio::post(*platform_task_runner_->GetStrandContext(), [engine, phase, ev]() {
+    FlutterPointerEvent e{};
+    e.struct_size = sizeof(FlutterPointerEvent);
+    e.phase = phase;
+    e.timestamp =
+        static_cast<size_t>(LibFlutterEngine->GetCurrentTime() / 1000);
+    e.x = ev.x;
+    e.y = ev.y;
+    e.device = static_cast<int32_t>(ev.device_id);
+    e.device_kind = kFlutterPointerDeviceKindMouse;
+    e.buttons = ev.buttons;
+    LibFlutterEngine->SendPointerEvent(engine, &e, 1);
+  });
+}
+
+int HeadlessVulkanBackend::RebuildExportPool(uint32_t width, uint32_t height) {
+  // Not supported yet: a real rebuild must tear down and recreate the image
+  // pool AND the per-frame semaphores under raster-thread quiescence, then bump
+  // generation_ so a consumer re-imports. Deferred to a later step.
+  ihs::log::warn(
+      "[HeadlessVulkan] RebuildExportPool({}x{}) not supported yet; ignoring",
+      width, height);
+  return -1;
+}
+
 // ── Renderer config ──────────────────────────────────────────────────────────
 
 FlutterRendererConfig HeadlessVulkanBackend::GetRenderConfig() {
@@ -1154,6 +1317,22 @@ bool HeadlessVulkanBackend::PresentCallback(
     backend->LoopbackSelfConsume(k);
   }
   backend->current_image_ = (k + 1) % kImageCount;
+
+  // Notify the export bridge that image k was just presented. Fired outside any
+  // GL/Vulkan critical section (after the semaphore loopback and index
+  // advance), on the raster thread. Read the listener under the mutex so a
+  // concurrent SetExportFrameListener from the bridge thread can't tear the
+  // {cb,user} pair.
+  IhsVkFrameListener cb = nullptr;
+  void* user = nullptr;
+  {
+    std::scoped_lock lock(backend->frame_listener_mutex_);
+    cb = backend->frame_listener_;
+    user = backend->frame_listener_user_;
+  }
+  if (cb != nullptr) {
+    cb(k, backend->frame_seq_++, user);
+  }
   return true;
 }
 

--- a/shell/backend/headless_vulkan/headless_vulkan.h
+++ b/shell/backend/headless_vulkan/headless_vulkan.h
@@ -20,11 +20,13 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include <vulkan/vulkan.h>
 
 #include "backend/backend.h"
+#include "ihs/vk_export.h"
 #include "vsync/consumer_paced_vsync.h"
 #include "vsync/ivsync_provider.h"
 
@@ -135,6 +137,31 @@ class HeadlessVulkanBackend final : public Backend {
   [[nodiscard]] const std::array<uint8_t, VK_UUID_SIZE>& device_uuid() const {
     return device_uuid_;
   }
+
+  // ── In-process C ABI (ihs/vk_export.h) ─────────────────────────────────────
+  // Backing for the exported `ihs_vk_export_get_api` seam (see
+  // vk_export_api.cc). Each is safe to call from the bridge IO thread unless
+  // noted; the frame listener fires on the raster thread.
+
+  // Fill @p out with pool-wide capabilities (extent, format, handle type,
+  // device UUID, slot count). Never fails; export_active reflects the pool.
+  void FillExportCaps(IhsVkExportCaps* out) const;
+  // Fill @p out with the current pool descriptors, DUP'ing the three fds per
+  // slot (the caller owns/closes the dups). Returns non-zero (leaving @p out
+  // zeroed) when there is no exportable pool.
+  int FillImageTable(IhsVkExportImageTable* out) const;
+  // Register the per-present frame listener (fires on the raster thread; cb ==
+  // nullptr clears it). Stored under a mutex.
+  void SetExportFrameListener(IhsVkFrameListener cb, void* user);
+  // The consumer released @p slot -- the pacing edge for consumer-driven vsync.
+  void OnConsumerReleaseFrame(uint32_t slot);
+  // Select consumer-driven vs free-run pacing (IHS_VK_PACE_*).
+  void SetExportPaceSource(uint32_t src);
+  // Inject a pointer event through the engine's normal input path; marshaled to
+  // the platform task runner.
+  void InjectPointer(const IhsPointerEvent& ev);
+  // Rebuild the pool at a new extent. NOT SUPPORTED yet: logs and returns -1.
+  int RebuildExportPool(uint32_t width, uint32_t height);
 
  private:
   // Bring-up. Each logs and returns false on failure; a failed InitVulkan
@@ -249,4 +276,15 @@ class HeadlessVulkanBackend final : public Backend {
   TaskRunner* platform_task_runner_{nullptr};
   std::atomic<bool> vsync_running_{false};
   std::unique_ptr<ivi::ConsumerPacedVsyncSource> pacer_;
+
+  // Exported-pool bookkeeping for the ihs/vk_export.h C ABI. generation_ bumps
+  // on every pool rebuild (0 until RebuildExportPool is implemented) and rides
+  // the image table so a consumer detects a stale pool. frame_seq_ counts
+  // presents delivered to the listener. The listener {cb,user} is set from the
+  // bridge thread and read on the raster thread, so it is mutex-guarded.
+  uint32_t generation_{0};
+  uint32_t frame_seq_{0};
+  mutable std::mutex frame_listener_mutex_;
+  IhsVkFrameListener frame_listener_{nullptr};
+  void* frame_listener_user_{nullptr};
 };

--- a/shell/backend/headless_vulkan/vk_export_api.cc
+++ b/shell/backend/headless_vulkan/vk_export_api.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/headless_vulkan/vk_export_api.h"
+
+#include <atomic>
+#include <cstring>
+
+#include "backend/headless_vulkan/headless_vulkan.h"
+#include "ihs/vk_export.h"
+
+namespace {
+
+// The single active backend the exported ABI delegates to. Set by the backend
+// constructor, cleared by its destructor. Atomic because the bridge calls the
+// ABI from its own IO thread while the shell threads construct/destroy it.
+std::atomic<HeadlessVulkanBackend*> g_backend{nullptr};
+
+// ── C ABI entry points ───────────────────────────────────────────────────────
+// Each loads g_backend and delegates, returning a safe default when no
+// headless-vulkan backend is active.
+
+IhsVkExportCaps ApiGetCaps() {
+  IhsVkExportCaps caps{};
+  if (auto* b = g_backend.load(std::memory_order_acquire)) {
+    b->FillExportCaps(&caps);
+  } else {
+    caps.api_version = IHS_VK_EXPORT_API_VERSION;
+    caps.export_active = 0;
+  }
+  return caps;
+}
+
+int ApiGetImageTable(IhsVkExportImageTable* out) {
+  if (out == nullptr) {
+    return -1;
+  }
+  if (auto* b = g_backend.load(std::memory_order_acquire)) {
+    return b->FillImageTable(out);
+  }
+  std::memset(out, 0, sizeof(*out));
+  return -1;
+}
+
+void ApiSetFrameListener(IhsVkFrameListener cb, void* user) {
+  if (auto* b = g_backend.load(std::memory_order_acquire)) {
+    b->SetExportFrameListener(cb, user);
+  }
+}
+
+void ApiReleaseFrame(uint32_t slot) {
+  if (auto* b = g_backend.load(std::memory_order_acquire)) {
+    b->OnConsumerReleaseFrame(slot);
+  }
+}
+
+void ApiSetPaceSource(uint32_t src) {
+  if (auto* b = g_backend.load(std::memory_order_acquire)) {
+    b->SetExportPaceSource(src);
+  }
+}
+
+void ApiInjectPointer(const IhsPointerEvent* ev) {
+  if (ev == nullptr) {
+    return;
+  }
+  if (auto* b = g_backend.load(std::memory_order_acquire)) {
+    b->InjectPointer(*ev);
+  }
+}
+
+int ApiRebuildPool(uint32_t width, uint32_t height) {
+  if (auto* b = g_backend.load(std::memory_order_acquire)) {
+    return b->RebuildExportPool(width, height);
+  }
+  return -1;
+}
+
+const IhsVkExportApiV1 kApi = {
+    ApiGetCaps,       ApiGetImageTable, ApiSetFrameListener, ApiReleaseFrame,
+    ApiSetPaceSource, ApiInjectPointer, ApiRebuildPool,
+};
+
+}  // namespace
+
+namespace ihs {
+
+void RegisterVkExportBackend(HeadlessVulkanBackend* b) {
+  g_backend.store(b, std::memory_order_release);
+}
+
+void UnregisterVkExportBackend(HeadlessVulkanBackend* b) {
+  // Only clear the slot if it still points at this backend; a stale destructor
+  // must not clobber a newer registration.
+  HeadlessVulkanBackend* expected = b;
+  g_backend.compare_exchange_strong(expected, nullptr,
+                                    std::memory_order_acq_rel);
+}
+
+}  // namespace ihs
+
+// The one exported shell symbol. Default visibility + `used` so it survives
+// into the executable's dynamic symbol table (the CMake target also passes
+// --export-dynamic-symbol=ihs_vk_export_get_api). Returns NULL when no
+// headless-vulkan backend is active or the requested version is unsupported.
+extern "C" __attribute__((visibility("default"), used)) const IhsVkExportApiV1*
+ihs_vk_export_get_api(uint32_t requested_version) {
+  if (requested_version != IHS_VK_EXPORT_API_VERSION) {
+    return nullptr;
+  }
+  return g_backend.load(std::memory_order_acquire) ? &kApi : nullptr;
+}

--- a/shell/backend/headless_vulkan/vk_export_api.h
+++ b/shell/backend/headless_vulkan/vk_export_api.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Registry backing the one exported shell symbol `ihs_vk_export_get_api`
+// (defined in vk_export_api.cc). The active HeadlessVulkanBackend registers
+// itself here at construction and unregisters at destruction; the C ABI entry
+// points load the registered backend and delegate to it. When no
+// headless-vulkan backend is active the symbol returns NULL, so a non-headless
+// host is inert.
+
+class HeadlessVulkanBackend;
+
+namespace ihs {
+
+// Publish/withdraw the active backend for the exported C ABI. Register replaces
+// the current pointer; Unregister only clears it when it still equals @p b, so
+// a stale destructor never clobbers a newer backend.
+void RegisterVkExportBackend(HeadlessVulkanBackend* b);
+void UnregisterVkExportBackend(HeadlessVulkanBackend* b);
+
+}  // namespace ihs


### PR DESCRIPTION
Closes the produce side of the headless-vulkan sharing path: one dlsym'd C symbol hands the backend's exported image pool and per-frame semaphores to an in-process plugin, so a bridge process can forward the rendered frames to another renderer (CARLA/Unreal) without the shell knowing anything about the
consumer.

## What

- `shared/include/ihs/vk_export.h` — the canonical, versioned C ABI: a function table (`get_caps`, `get_image_table`, `set_frame_listener`, `release_frame`,
  `set_pace_source`, `inject_pointer`, `rebuild_pool`) reached through `ihs_vk_export_get_api(version)`.
- `HeadlessVulkanBackend` gains the matching methods:
  - `get_image_table` `dup()`s the pool's memory and render_done/consumer_done fds for the caller to own.
  - the frame listener fires from `PresentCallback` (raster thread, under a mutex) so every present reaches the bridge.
  - `release_frame` and `set_pace_source` drive the consumer-paced vsync — a release is a pacing credit, and the source flips to free-run when no consumer is attached.
  - `inject_pointer` marshals a `FlutterPointerEvent` onto the platform strand.
  - `rebuild_pool` is a stub (returns -1) until pool resize is implemented.
- A process-global atomic registry publishes the live backend (set at the end of construction, cleared at the start of destruction) so the free C functions reach it, returning `NULL` when no headless-vulkan backend is active — an ordinary host that loads a bridge plugin stays inert.
- The single symbol is placed in the executable's dynamic table with `-Wl,--export-dynamic-symbol` (no blanket `-rdynamic`).

All of it is gated behind `BUILD_BACKEND_HEADLESS_VULKAN`.

## Validation

Verified on a Raspberry Pi 4 (V3D, v3dv): with dma-buf export active, the exported ABI reports the real device (dmabuf, ABGR8888, the V3D deviceUUID) and hands out dup'd memory + semaphore fds for all three pool slots with the correct size and DRM modifier.