### PR TITLE
headless-vulkan: full bridge-loaded export path with a Vulkan test consumer

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -279,9 +279,12 @@ if (BUILD_BACKEND_HEADLESS_VULKAN)
             # In-process C ABI (ihs/vk_export.h): registry + the one exported
             # `ihs_vk_export_get_api` symbol an in-process bridge dlsym's.
             backend/headless_vulkan/vk_export_api.cc
+            # Env-gated loader (IVI_VK_BRIDGE_SO) that dlopen's an in-process
+            # bridge plugin and drives its create/start/stop/destroy lifecycle.
+            vk_export_bridge_loader.cc
             display/software_display.cc
     )
-    target_link_libraries(${PROJECT_NAME} PRIVATE vulkan_headers)
+    target_link_libraries(${PROJECT_NAME} PRIVATE vulkan_headers ${CMAKE_DL_LIBS})
     # Put ONLY `ihs_vk_export_get_api` in the executable's dynamic symbol table
     # (the bridge resolves it via dlsym(RTLD_DEFAULT)). Avoids blanket -rdynamic
     # so no other internal symbol is exported; the shell sets no global
@@ -457,6 +460,25 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN OR BUILD_DRM_KMS_VULKAN_PROBE)
             ${CMAKE_SOURCE_DIR}/third_party/Vulkan-Headers/include
     )
     target_link_libraries(drm_kms_vulkan_probe PRIVATE ${CMAKE_DL_LIBS} PkgConfig::DRM)
+endif ()
+
+# Standalone same-device consumer for the ihs-vk-export path: connects to the
+# bridge's SEQPACKET socket, imports the headless-vulkan backend's exported pool
+# (dma-buf + semaphore fds), and per presented frame waits render_done, copies
+# the image out and checksums it, signals consumer_done, and sends a
+# FrameRelease (driving the backend's consumer-paced vsync). Like the backend it
+# resolves Vulkan through vulkan.hpp's dynamic loader (dlopens libvulkan at
+# runtime), so only the vendored headers + libdl are needed at build time.
+if (BUILD_BACKEND_HEADLESS_VULKAN)
+    add_executable(ihs_vk_export_consumer
+            backend/headless_vulkan/export_consumer/export_consumer_main.cc
+            backend/headless_vulkan/export_consumer/vk_consumer.cc
+            backend/headless_vulkan/export_consumer/wire_client.cc
+    )
+    # Self-contained: wire_protocol.h (the shell copy of the wire contract) and
+    # the two local headers are all same-directory includes; no extra -I needed.
+    target_link_libraries(ihs_vk_export_consumer PRIVATE
+            vulkan_headers ${CMAKE_DL_LIBS})
 endif ()
 
 # Attach the IHS logging surface (logging.h shim + logger.hpp over ihs_shared).

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -15,6 +15,9 @@
 
 #include "app.h"
 #include "logging/logging.h"
+#if BUILD_BACKEND_HEADLESS_VULKAN
+#include "vk_export_bridge_loader.h"
+#endif
 
 #include <algorithm>
 #include <csignal>
@@ -214,10 +217,24 @@ App::App(const std::vector<Configuration::Config>& configs) {
     display->StartEvents();
   }
 
+#if BUILD_BACKEND_HEADLESS_VULKAN
+  // Bring up the in-process ihs-vk-export bridge last: the headless-vulkan
+  // backend registered its export API during display/view construction above,
+  // so the module's dlsym(RTLD_DEFAULT) now resolves to a live backend. Inert
+  // unless IVI_VK_BRIDGE_SO is set.
+  vk_export_bridge_ = std::make_unique<ihs::VkExportBridgeLoader>();
+#endif
+
   IHS_DEBUG("-App::App");
 }
 
 App::~App() {
+#if BUILD_BACKEND_HEADLESS_VULKAN
+  // Stop and unload the bridge before anything else: this clears the backend's
+  // raster-thread frame listener and joins the module's IO thread while the
+  // backend (owned by the views/displays below) is still alive.
+  vk_export_bridge_.reset();
+#endif
   for (const auto& display : m_displays) {
     display->StopEvents();
   }

--- a/shell/app.h
+++ b/shell/app.h
@@ -32,6 +32,10 @@ class IDisplay;
 
 class WaylandWindow;
 
+namespace ihs {
+class VkExportBridgeLoader;
+}  // namespace ihs
+
 class App final {
  public:
   explicit App(const std::vector<Configuration::Config>& configs);
@@ -96,4 +100,13 @@ class App final {
   asio::io_context primary_ioc_;
   asio::executor_work_guard<asio::io_context::executor_type> primary_work_{
       asio::make_work_guard(primary_ioc_)};
+
+#if BUILD_BACKEND_HEADLESS_VULKAN
+  // Optional in-process ihs-vk-export bridge (enabled by IVI_VK_BRIDGE_SO).
+  // Constructed at the end of the App ctor — after the headless-vulkan backend
+  // has registered its export API — and reset at the start of ~App so the
+  // module's raster-thread frame listener is cleared and its IO thread joined
+  // while the backend is still alive. Inert unless the env var is set.
+  std::unique_ptr<ihs::VkExportBridgeLoader> vk_export_bridge_;
+#endif
 };

--- a/shell/backend/headless_vulkan/export_consumer/export_consumer_main.cc
+++ b/shell/backend/headless_vulkan/export_consumer/export_consumer_main.cc
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standalone same-device test consumer for the ihs-vk-export path. It connects
+// to the ihs_carla_bridge's Unix SEQPACKET socket, imports the headless-vulkan
+// backend's exported image pool, and for each presented frame waits
+// render_done, copies the image to a host buffer and checksums it (proving
+// zero-copy content correctness), signals consumer_done and sends a
+// FrameRelease -- which drives the backend's consumer-paced vsync.
+//
+// Env:
+//   IHS_VK_CONSUMER_SOCKET  socket path (else $XDG_RUNTIME_DIR/<leaf>, else
+//                           /tmp/<leaf>)
+//   IHS_VK_CONSUMER_FRAMES  stop after this many consumed frames (default 120)
+//
+// Exit code: 0 on a clean run (frame budget reached, or a Bye/SIGINT), non-zero
+// on any protocol, import, or Vulkan failure.
+
+#include <poll.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "vk_consumer.h"
+#include "wire_client.h"
+#include "wire_protocol.h"
+
+namespace {
+
+volatile sig_atomic_t g_stop = 0;
+
+void OnSigint(int /*sig*/) {
+  g_stop = 1;
+}
+
+void LogErr(const char* msg) {
+  std::fprintf(stderr, "[ihs-vk-consumer] ERROR: %s\n", msg);
+}
+
+std::string ResolveSocketPath() {
+  if (const char* env = std::getenv("IHS_VK_CONSUMER_SOCKET");
+      env != nullptr && env[0] != '\0') {
+    return env;
+  }
+  if (const char* xdg = std::getenv("XDG_RUNTIME_DIR");
+      xdg != nullptr && xdg[0] != '\0') {
+    return std::string(xdg) + "/" + ihs_vke::kDefaultSocketLeaf;
+  }
+  return std::string("/tmp/") + ihs_vke::kDefaultSocketLeaf;
+}
+
+uint32_t ResolveFrameBudget() {
+  if (const char* env = std::getenv("IHS_VK_CONSUMER_FRAMES");
+      env != nullptr && env[0] != '\0') {
+    const long n = std::strtol(env, nullptr, 10);
+    if (n > 0) {
+      return static_cast<uint32_t>(n);
+    }
+  }
+  return 120;
+}
+
+void ToHex(const uint8_t* uuid, char out[33]) {
+  static const char* kHex = "0123456789abcdef";
+  for (int i = 0; i < 16; ++i) {
+    out[2 * i] = kHex[(uuid[i] >> 4) & 0xf];
+    out[2 * i + 1] = kHex[uuid[i] & 0xf];
+  }
+  out[32] = '\0';
+}
+
+// Send Hello: the fixed struct followed by the consumer name in one payload.
+bool SendHello(int sock, const uint8_t* device_uuid) {
+  static constexpr char kName[] = "ihs-vk-export-consumer";
+  const uint32_t name_len = static_cast<uint32_t>(std::strlen(kName));
+
+  std::vector<uint8_t> buf(sizeof(ihs_vke::Hello) + name_len);
+  ihs_vke::Hello hello{};
+  hello.protocol_version = ihs_vke::kProtocolVersion;
+  hello.consumer_name_len = name_len;
+  std::memcpy(hello.device_uuid, device_uuid, 16);
+  std::memcpy(buf.data(), &hello, sizeof(hello));
+  std::memcpy(buf.data() + sizeof(hello), kName, name_len);
+
+  return ihs_vke_consumer::SendFramed(sock, ihs_vke::MsgType::kHello,
+                                      buf.data(), buf.size(), nullptr, 0);
+}
+
+}  // namespace
+
+int main() {
+  // Best-effort clean shutdown on Ctrl-C: the poll loop observes g_stop.
+  struct sigaction sa{};
+  sa.sa_handler = OnSigint;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;  // no SA_RESTART, so poll() returns EINTR promptly
+  sigaction(SIGINT, &sa, nullptr);
+  sigaction(SIGTERM, &sa, nullptr);
+
+  const std::string socket_path = ResolveSocketPath();
+  const uint32_t frame_budget = ResolveFrameBudget();
+
+  ihs_vke_consumer::VkConsumer consumer;
+  if (!consumer.InitVulkan()) {
+    LogErr("Vulkan initialization failed");
+    return 1;
+  }
+  char uuid_hex[33];
+  ToHex(consumer.device_uuid(), uuid_hex);
+  std::fprintf(stderr, "[ihs-vk-consumer] deviceUUID=%s socket=%s frames=%u\n",
+               uuid_hex, socket_path.c_str(), frame_budget);
+
+  const int sock = ihs_vke_consumer::ConnectSeqpacket(socket_path.c_str());
+  if (sock < 0) {
+    std::fprintf(stderr, "[ihs-vk-consumer] ERROR: connect(%s) failed: %s\n",
+                 socket_path.c_str(), std::strerror(errno));
+    return 1;
+  }
+
+  if (!SendHello(sock, consumer.device_uuid())) {
+    LogErr("failed to send Hello");
+    ::close(sock);
+    return 1;
+  }
+
+  int exit_code = 0;
+  bool table_loaded = false;
+  bool caps_ok = false;
+  uint32_t consumed = 0;
+  bool running = true;
+
+  while (running && !g_stop && consumed < frame_budget) {
+    pollfd pfd{};
+    pfd.fd = sock;
+    pfd.events = POLLIN;
+    const int pr = ::poll(&pfd, 1, /*timeout_ms=*/200);
+    if (pr < 0) {
+      if (errno == EINTR) {
+        continue;  // signal -> re-check g_stop
+      }
+      LogErr("poll failed");
+      exit_code = 1;
+      break;
+    }
+    if (pr == 0) {
+      continue;  // timeout -> re-check loop conditions
+    }
+    if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+      std::fprintf(stderr, "[ihs-vk-consumer] socket hung up\n");
+      break;
+    }
+
+    ihs_vke_consumer::RecvMsg m = ihs_vke_consumer::RecvFramed(sock);
+    if (m.closed) {
+      std::fprintf(stderr, "[ihs-vk-consumer] peer closed the connection\n");
+      break;
+    }
+    if (!m.ok) {
+      LogErr(m.truncated ? "oversized/truncated datagram (protocol error)"
+                         : "recv failed");
+      exit_code = 1;
+      break;
+    }
+
+    switch (m.type) {
+      case ihs_vke::MsgType::kCaps: {
+        if (m.payload.size() < sizeof(ihs_vke::Caps)) {
+          LogErr("Caps payload too small");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        ihs_vke::Caps caps{};
+        std::memcpy(&caps, m.payload.data(), sizeof(caps));
+        if (caps.protocol_version != ihs_vke::kProtocolVersion) {
+          std::fprintf(stderr,
+                       "[ihs-vk-consumer] ERROR: caps protocol_version %u != "
+                       "%u\n",
+                       caps.protocol_version, ihs_vke::kProtocolVersion);
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        const bool has_usable =
+            (caps.handle_types &
+             (ihs_vke::kHandleDmaBuf | ihs_vke::kHandleOpaqueFd)) != 0;
+        if (!has_usable) {
+          LogErr("caps offer no importable handle type");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        char caps_uuid[33];
+        ToHex(caps.device_uuid, caps_uuid);
+        std::fprintf(stderr,
+                     "[ihs-vk-consumer] caps: format=%u fourcc=0x%08x "
+                     "extent=%ux%u slots=%u handle_types=0x%x flags=0x%x "
+                     "deviceUUID=%s\n",
+                     caps.vk_format, caps.drm_fourcc, caps.width, caps.height,
+                     caps.slot_count, caps.handle_types, caps.flags, caps_uuid);
+        if (std::memcmp(caps.device_uuid, consumer.device_uuid(), 16) != 0) {
+          std::fprintf(stderr,
+                       "[ihs-vk-consumer] WARNING: caps deviceUUID does not "
+                       "match this device; same-device import may fail\n");
+        }
+        caps_ok = true;
+        break;
+      }
+
+      case ihs_vke::MsgType::kImageTable: {
+        if (!caps_ok) {
+          LogErr("ImageTable arrived before a valid Caps");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        if (m.payload.size() < sizeof(ihs_vke::ImageTableHeader)) {
+          LogErr("ImageTable header too small");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        ihs_vke::ImageTableHeader hdr{};
+        std::memcpy(&hdr, m.payload.data(), sizeof(hdr));
+        const size_t expected =
+            sizeof(hdr) +
+            static_cast<size_t>(hdr.slot_count) * sizeof(ihs_vke::ImageDesc);
+        if (hdr.slot_count == 0 || hdr.slot_count > ihs_vke::kMaxSlots ||
+            m.payload.size() < expected ||
+            m.fds.size() != ihs_vke::ImageTableFdCount(hdr.slot_count)) {
+          LogErr("ImageTable shape mismatch (payload/fd count)");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        std::vector<ihs_vke::ImageDesc> descs(hdr.slot_count);
+        std::memcpy(
+            descs.data(), m.payload.data() + sizeof(hdr),
+            static_cast<size_t>(hdr.slot_count) * sizeof(ihs_vke::ImageDesc));
+
+        // Take ownership of the fds out of the RecvMsg so CloseFds cannot
+        // double-close them; ImportImageTable now owns every fd (imports or
+        // closes each).
+        std::vector<int> fds = std::move(m.fds);
+        m.fds.clear();
+
+        if (!consumer.ImportImageTable(hdr.generation, descs[0].width,
+                                       descs[0].height, descs[0].handle_type,
+                                       descs, fds)) {
+          LogErr("image table import failed");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        table_loaded = true;
+        break;
+      }
+
+      case ihs_vke::MsgType::kFramePresent: {
+        if (m.payload.size() < sizeof(ihs_vke::FramePresent)) {
+          LogErr("FramePresent payload too small");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        ihs_vke::FramePresent fp{};
+        std::memcpy(&fp, m.payload.data(), sizeof(fp));
+        if (!table_loaded || fp.generation != consumer.generation()) {
+          // Stale generation (e.g. a present that predates our table): skip it
+          // rather than wait a semaphore for a slot we have not imported.
+          std::fprintf(stderr,
+                       "[ihs-vk-consumer] skipping present seq=%u slot=%u "
+                       "(generation %u != %u)\n",
+                       fp.frame_seq, fp.slot, fp.generation,
+                       consumer.generation());
+          break;
+        }
+
+        ihs_vke_consumer::FrameStats stats{};
+        if (!consumer.ConsumePresent(fp.slot, fp.frame_seq, &stats)) {
+          LogErr("ConsumePresent failed");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        std::fprintf(stderr,
+                     "[ihs-vk-consumer] frame seq=%u slot=%u crc=0x%016lx "
+                     "px[0]=0x%08x px[center]=0x%08x\n",
+                     stats.frame_seq, stats.slot,
+                     static_cast<unsigned long>(stats.crc), stats.px_first,
+                     stats.px_center);
+
+        // The CPU-side pacing edge the backend's vsync consumes.
+        ihs_vke::FrameRelease rel{fp.slot, consumer.generation()};
+        if (!ihs_vke_consumer::SendPod(sock, ihs_vke::MsgType::kFrameRelease,
+                                       rel)) {
+          LogErr("failed to send FrameRelease");
+          exit_code = 1;
+          running = false;
+          break;
+        }
+        ++consumed;
+        break;
+      }
+
+      case ihs_vke::MsgType::kBye: {
+        uint32_t reason = 0;
+        if (m.payload.size() >= sizeof(ihs_vke::Bye)) {
+          ihs_vke::Bye bye{};
+          std::memcpy(&bye, m.payload.data(), sizeof(bye));
+          reason = bye.reason;
+        }
+        std::fprintf(stderr, "[ihs-vk-consumer] received Bye (reason=%u)\n",
+                     reason);
+        running = false;
+        break;
+      }
+
+      default:
+        // kInputPointer / kInputKey / kResize are consumer->bridge or reserved;
+        // ignore anything unexpected from the bridge.
+        break;
+    }
+
+    ihs_vke_consumer::CloseFds(m);  // no-op when ownership was moved out
+  }
+
+  // Best-effort farewell so the bridge sees an orderly close.
+  ihs_vke::Bye bye{static_cast<uint32_t>(ihs_vke::ByeReason::kNormal)};
+  ihs_vke_consumer::SendPod(sock, ihs_vke::MsgType::kBye, bye);
+
+  consumer.Teardown();
+  ::close(sock);
+
+  std::fprintf(stderr,
+               "[ihs-vk-consumer] done: consumed %u frame(s), exit=%d\n",
+               consumed, exit_code);
+  return exit_code;
+}

--- a/shell/backend/headless_vulkan/export_consumer/vk_consumer.cc
+++ b/shell/backend/headless_vulkan/export_consumer/vk_consumer.cc
@@ -1,0 +1,796 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Use vulkan.hpp's dynamic dispatch loader, matching the shell's Vulkan
+// backends. The loader dlopens libvulkan at runtime, so this binary needs no
+// Vulkan link library -- only the vendored headers at build time. This is the
+// one translation unit that includes vulkan.hpp, so it owns the dispatcher's
+// single storage definition.
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+#include <vulkan/vulkan.hpp>
+
+VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+
+#include "vk_consumer.h"
+
+#include <unistd.h>
+
+#include <array>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <exception>
+
+namespace ihs_vke_consumer {
+
+namespace {
+
+// Accessor for the dynamic dispatcher, matching headless_vulkan.cc's idiom.
+const auto& d() {
+  return vk::detail::defaultDispatchLoaderDynamic;
+}
+
+void LogErr(const char* fmt, ...) {
+  std::fputs("[ihs-vk-consumer] ERROR: ", stderr);
+  va_list ap;
+  va_start(ap, fmt);
+  std::vfprintf(stderr, fmt, ap);
+  va_end(ap);
+  std::fputc('\n', stderr);
+}
+
+void LogInfo(const char* fmt, ...) {
+  std::fputs("[ihs-vk-consumer] ", stderr);
+  va_list ap;
+  va_start(ap, fmt);
+  std::vfprintf(stderr, fmt, ap);
+  va_end(ap);
+  std::fputc('\n', stderr);
+}
+
+bool HasExt(const std::vector<VkExtensionProperties>& exts, const char* name) {
+  for (const auto& e : exts) {
+    if (std::strcmp(e.extensionName, name) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// The usage the exported pool images are created with (see
+// headless_vulkan.cc's kRenderTargetUsage). Recreating the imported image with
+// the same usage keeps its memory requirements compatible with the exporter's,
+// which the opaque-fd import in particular relies on, and keeps a chosen DRM
+// modifier valid for the dma-buf import.
+constexpr VkImageUsageFlags kImportUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                                           VK_IMAGE_USAGE_SAMPLED_BIT |
+                                           VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
+}  // namespace
+
+VkConsumer::~VkConsumer() {
+  Teardown();
+}
+
+bool VkConsumer::InitVulkan() {
+  try {
+    VULKAN_HPP_DEFAULT_DISPATCHER.init();
+  } catch (const std::exception& e) {
+    LogErr("Vulkan loader not present: %s", e.what());
+    return false;
+  }
+  if (d().vkCreateInstance == nullptr) {
+    LogErr("vkCreateInstance unresolved");
+    return false;
+  }
+  return CreateInstance() && SelectPhysicalDevice() && CreateLogicalDevice() &&
+         CreateCommandPool();
+}
+
+bool VkConsumer::CreateInstance() {
+  VkApplicationInfo app{};
+  app.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+  app.pApplicationName = "ihs-vk-export-consumer";
+  app.apiVersion = VK_API_VERSION_1_1;
+
+  // These are core in 1.1; enable them only when the loader still advertises
+  // them as instance extensions so vkCreateInstance never fails on a driver
+  // that folded them into core.
+  uint32_t ext_count = 0;
+  d().vkEnumerateInstanceExtensionProperties(nullptr, &ext_count, nullptr);
+  std::vector<VkExtensionProperties> avail(ext_count);
+  if (ext_count > 0) {
+    d().vkEnumerateInstanceExtensionProperties(nullptr, &ext_count,
+                                               avail.data());
+  }
+  for (const char* opt :
+       {VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+        VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME}) {
+    if (HasExt(avail, opt)) {
+      enabled_instance_extensions_.push_back(opt);
+    }
+  }
+
+  VkInstanceCreateInfo info{};
+  info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+  info.pApplicationInfo = &app;
+  info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_instance_extensions_.size());
+  info.ppEnabledExtensionNames = enabled_instance_extensions_.data();
+
+  if (d().vkCreateInstance(&info, nullptr, &instance_) != VK_SUCCESS) {
+    LogErr("vkCreateInstance failed");
+    return false;
+  }
+  VULKAN_HPP_DEFAULT_DISPATCHER.init(vk::Instance(instance_));
+  return true;
+}
+
+bool VkConsumer::SelectPhysicalDevice() {
+  uint32_t count = 0;
+  d().vkEnumeratePhysicalDevices(instance_, &count, nullptr);
+  if (count == 0) {
+    LogErr("no Vulkan physical devices");
+    return false;
+  }
+  std::vector<VkPhysicalDevice> devices(count);
+  d().vkEnumeratePhysicalDevices(instance_, &count, devices.data());
+
+  // Single-GPU target (Raspberry Pi V3D): take physical device 0.
+  physical_device_ = devices[0];
+
+  VkPhysicalDeviceProperties props{};
+  d().vkGetPhysicalDeviceProperties(physical_device_, &props);
+  if (props.apiVersion < VK_API_VERSION_1_1) {
+    LogErr("physical device 0 (%s) exposes Vulkan < 1.1", props.deviceName);
+    return false;
+  }
+
+  VkPhysicalDeviceIDProperties id{};
+  id.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+  VkPhysicalDeviceProperties2 p2{};
+  p2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+  p2.pNext = &id;
+  d().vkGetPhysicalDeviceProperties2(physical_device_, &p2);
+  std::memcpy(device_uuid_, id.deviceUUID, VK_UUID_SIZE);
+
+  uint32_t qf_count = 0;
+  d().vkGetPhysicalDeviceQueueFamilyProperties(physical_device_, &qf_count,
+                                               nullptr);
+  std::vector<VkQueueFamilyProperties> qfs(qf_count);
+  if (qf_count > 0) {
+    d().vkGetPhysicalDeviceQueueFamilyProperties(physical_device_, &qf_count,
+                                                 qfs.data());
+  }
+  for (uint32_t i = 0; i < qfs.size(); ++i) {
+    // A graphics queue also supports transfer + the queue-family-ownership
+    // barriers this consumer issues.
+    if (qfs[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+      queue_family_ = i;
+      break;
+    }
+  }
+  if (queue_family_ == UINT32_MAX) {
+    LogErr("physical device 0 (%s) has no graphics queue", props.deviceName);
+    return false;
+  }
+
+  LogInfo("selected physical device 0: '%s'", props.deviceName);
+  return true;
+}
+
+bool VkConsumer::CreateLogicalDevice() {
+  uint32_t ext_count = 0;
+  d().vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
+                                           &ext_count, nullptr);
+  std::vector<VkExtensionProperties> avail(ext_count);
+  if (ext_count > 0) {
+    d().vkEnumerateDeviceExtensionProperties(physical_device_, nullptr,
+                                             &ext_count, avail.data());
+  }
+
+  // The import path needs all of these; a missing one is a hard failure so the
+  // reason is clear rather than surfacing later as a failed import.
+  static constexpr std::array<const char*, 7> kRequired = {
+      VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
+      VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
+      VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME,
+      VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME,
+  };
+  for (const char* req : kRequired) {
+    if (!HasExt(avail, req)) {
+      LogErr("device is missing required extension %s", req);
+      return false;
+    }
+    enabled_device_extensions_.push_back(req);
+  }
+
+  constexpr float priority = 1.0f;
+  VkDeviceQueueCreateInfo queue_info{};
+  queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  queue_info.queueFamilyIndex = queue_family_;
+  queue_info.queueCount = 1;
+  queue_info.pQueuePriorities = &priority;
+
+  VkDeviceCreateInfo device_info{};
+  device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  device_info.queueCreateInfoCount = 1;
+  device_info.pQueueCreateInfos = &queue_info;
+  device_info.enabledExtensionCount =
+      static_cast<uint32_t>(enabled_device_extensions_.size());
+  device_info.ppEnabledExtensionNames = enabled_device_extensions_.data();
+
+  if (d().vkCreateDevice(physical_device_, &device_info, nullptr, &device_) !=
+      VK_SUCCESS) {
+    LogErr("vkCreateDevice failed");
+    return false;
+  }
+  VULKAN_HPP_DEFAULT_DISPATCHER.init(vk::Device(device_));
+  d().vkGetDeviceQueue(device_, queue_family_, 0, &queue_);
+  return true;
+}
+
+bool VkConsumer::CreateCommandPool() {
+  VkCommandPoolCreateInfo cpi{};
+  cpi.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+  cpi.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+  cpi.queueFamilyIndex = queue_family_;
+  if (d().vkCreateCommandPool(device_, &cpi, nullptr, &command_pool_) !=
+      VK_SUCCESS) {
+    LogErr("vkCreateCommandPool failed");
+    return false;
+  }
+  return true;
+}
+
+uint32_t VkConsumer::FindHostVisibleMemoryType(uint32_t type_bits,
+                                               bool* coherent) const {
+  VkPhysicalDeviceMemoryProperties mem{};
+  d().vkGetPhysicalDeviceMemoryProperties(physical_device_, &mem);
+  // Prefer a coherent host-visible type (no explicit invalidate needed), but
+  // accept a non-coherent one and invalidate before reading.
+  uint32_t fallback = UINT32_MAX;
+  for (uint32_t i = 0; i < mem.memoryTypeCount; ++i) {
+    if ((type_bits & (1u << i)) == 0) {
+      continue;
+    }
+    const VkMemoryPropertyFlags f = mem.memoryTypes[i].propertyFlags;
+    if ((f & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0) {
+      continue;
+    }
+    if (f & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) {
+      *coherent = true;
+      return i;
+    }
+    if (fallback == UINT32_MAX) {
+      fallback = i;
+    }
+  }
+  *coherent = false;
+  return fallback;
+}
+
+bool VkConsumer::CreateReadbackBuffer(uint32_t width, uint32_t height) {
+  const VkDeviceSize needed = static_cast<VkDeviceSize>(width) * height * 4;
+  if (readback_buffer_ != VK_NULL_HANDLE && readback_size_ >= needed) {
+    return true;  // an existing buffer is large enough
+  }
+  // Drop any prior (too-small) buffer.
+  if (readback_memory_ != VK_NULL_HANDLE) {
+    d().vkUnmapMemory(device_, readback_memory_);
+    d().vkFreeMemory(device_, readback_memory_, nullptr);
+    readback_memory_ = VK_NULL_HANDLE;
+    readback_mapped_ = nullptr;
+  }
+  if (readback_buffer_ != VK_NULL_HANDLE) {
+    d().vkDestroyBuffer(device_, readback_buffer_, nullptr);
+    readback_buffer_ = VK_NULL_HANDLE;
+  }
+  readback_size_ = 0;
+
+  VkBufferCreateInfo bci{};
+  bci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+  bci.size = needed;
+  bci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+  bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  if (d().vkCreateBuffer(device_, &bci, nullptr, &readback_buffer_) !=
+      VK_SUCCESS) {
+    LogErr("vkCreateBuffer (readback) failed");
+    return false;
+  }
+
+  VkMemoryRequirements req{};
+  d().vkGetBufferMemoryRequirements(device_, readback_buffer_, &req);
+  const uint32_t mt =
+      FindHostVisibleMemoryType(req.memoryTypeBits, &readback_coherent_);
+  if (mt == UINT32_MAX) {
+    LogErr("no host-visible memory type for readback buffer");
+    return false;
+  }
+
+  VkMemoryAllocateInfo mai{};
+  mai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  mai.allocationSize = req.size;
+  mai.memoryTypeIndex = mt;
+  if (d().vkAllocateMemory(device_, &mai, nullptr, &readback_memory_) !=
+      VK_SUCCESS) {
+    LogErr("vkAllocateMemory (readback) failed");
+    return false;
+  }
+  if (d().vkBindBufferMemory(device_, readback_buffer_, readback_memory_, 0) !=
+      VK_SUCCESS) {
+    LogErr("vkBindBufferMemory (readback) failed");
+    return false;
+  }
+  if (d().vkMapMemory(device_, readback_memory_, 0, VK_WHOLE_SIZE, 0,
+                      &readback_mapped_) != VK_SUCCESS) {
+    LogErr("vkMapMemory (readback) failed");
+    return false;
+  }
+  readback_size_ = req.size;
+  return true;
+}
+
+bool VkConsumer::ImportSlotImage(const ihs_vke::ImageDesc& desc,
+                                 uint32_t slot,
+                                 int mem_fd) {
+  const bool dmabuf = handle_type_ == ihs_vke::kHandleDmaBuf;
+  const VkExternalMemoryHandleTypeFlagBits handle =
+      dmabuf ? VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT
+             : VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+  const auto format = static_cast<VkFormat>(desc.vk_format);
+
+  // Explicit per-plane layout for the dma-buf import: the exporter published
+  // the modifier and each plane's offset/pitch; reconstruct the same tiling so
+  // the imported image aliases the exact bytes the backend rendered.
+  std::array<VkSubresourceLayout, ihs_vke::kMaxPlanes> plane_layouts{};
+  const uint32_t plane_count = dmabuf ? desc.plane_count : 1u;
+  for (uint32_t p = 0; p < plane_count && p < ihs_vke::kMaxPlanes; ++p) {
+    plane_layouts[p].offset = desc.plane_offset[p];
+    plane_layouts[p].rowPitch = desc.plane_pitch[p];
+  }
+  VkImageDrmFormatModifierExplicitCreateInfoEXT mod{};
+  mod.sType =
+      VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT;
+  mod.drmFormatModifier = desc.drm_modifier;
+  mod.drmFormatModifierPlaneCount = plane_count;
+  mod.pPlaneLayouts = plane_layouts.data();
+
+  VkExternalMemoryImageCreateInfo ext{};
+  ext.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+  ext.handleTypes = handle;
+  if (dmabuf) {
+    ext.pNext = &mod;
+  }
+
+  VkImageCreateInfo ici{};
+  ici.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  ici.pNext = &ext;
+  ici.imageType = VK_IMAGE_TYPE_2D;
+  ici.format = format;
+  ici.extent = {desc.width, desc.height, 1};
+  ici.mipLevels = 1;
+  ici.arrayLayers = 1;
+  ici.samples = VK_SAMPLE_COUNT_1_BIT;
+  ici.tiling = dmabuf ? VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT
+                      : VK_IMAGE_TILING_OPTIMAL;
+  ici.usage = kImportUsage;
+  ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  if (d().vkCreateImage(device_, &ici, nullptr, &images_[slot]) != VK_SUCCESS) {
+    LogErr("slot %u: vkCreateImage failed", slot);
+    return false;
+  }
+
+  VkMemoryRequirements req{};
+  d().vkGetImageMemoryRequirements(device_, images_[slot], &req);
+
+  // Memory type: for a dma-buf, intersect the image's requirement with the
+  // fd's compatible types; for an opaque fd, reuse the exporter's published
+  // memory_type_index (opaque memory must import onto the same type).
+  uint32_t mt = UINT32_MAX;
+  if (dmabuf) {
+    VkMemoryFdPropertiesKHR fdp{};
+    fdp.sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR;
+    if (d().vkGetMemoryFdPropertiesKHR(device_, handle, mem_fd, &fdp) !=
+        VK_SUCCESS) {
+      LogErr("slot %u: vkGetMemoryFdPropertiesKHR failed", slot);
+      return false;
+    }
+    const uint32_t allowed = req.memoryTypeBits & fdp.memoryTypeBits;
+    for (uint32_t i = 0; i < 32; ++i) {
+      if (allowed & (1u << i)) {
+        mt = i;
+        break;
+      }
+    }
+  } else {
+    mt = desc.memory_type_index;
+  }
+  if (mt == UINT32_MAX) {
+    LogErr("slot %u: no compatible memory type for import", slot);
+    return false;
+  }
+
+  // A dma-buf-backed image requires a dedicated allocation on most drivers;
+  // the exporter also allocated the backing memory dedicated per image.
+  VkMemoryDedicatedAllocateInfo dedicated{};
+  dedicated.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+  dedicated.image = images_[slot];
+  VkImportMemoryFdInfoKHR import_fd{};
+  import_fd.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR;
+  import_fd.pNext = &dedicated;
+  import_fd.handleType = handle;
+  import_fd.fd = mem_fd;
+  VkMemoryAllocateInfo mai{};
+  mai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  mai.pNext = &import_fd;
+  mai.allocationSize = req.size;
+  mai.memoryTypeIndex = mt;
+
+  // On success Vulkan owns the imported fd; on failure it stays with the caller
+  // (ImportImageTable closes it).
+  if (d().vkAllocateMemory(device_, &mai, nullptr, &image_memory_[slot]) !=
+      VK_SUCCESS) {
+    LogErr("slot %u: vkAllocateMemory (import) failed", slot);
+    return false;
+  }
+  if (d().vkBindImageMemory(device_, images_[slot], image_memory_[slot], 0) !=
+      VK_SUCCESS) {
+    LogErr("slot %u: vkBindImageMemory failed", slot);
+    return false;
+  }
+  return true;
+}
+
+bool VkConsumer::ImportSlotSemaphore(int fd, VkSemaphore* out) {
+  VkSemaphoreCreateInfo sci{};
+  sci.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;  // binary
+  if (d().vkCreateSemaphore(device_, &sci, nullptr, out) != VK_SUCCESS) {
+    LogErr("vkCreateSemaphore (import target) failed");
+    return false;
+  }
+  // Permanent OPAQUE_FD import: the imported semaphore shares the exporter's
+  // payload, so a signal on the backend side satisfies a wait here (and vice
+  // versa) across every frame. Vulkan owns the fd on success.
+  VkImportSemaphoreFdInfoKHR ifi{};
+  ifi.sType = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR;
+  ifi.semaphore = *out;
+  ifi.flags = 0;  // permanent
+  ifi.handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+  ifi.fd = fd;
+  if (d().vkImportSemaphoreFdKHR(device_, &ifi) != VK_SUCCESS) {
+    LogErr("vkImportSemaphoreFdKHR (OPAQUE_FD) failed");
+    return false;
+  }
+  return true;
+}
+
+bool VkConsumer::ImportImageTable(uint32_t generation,
+                                  uint32_t width,
+                                  uint32_t height,
+                                  uint32_t handle_type,
+                                  const std::vector<ihs_vke::ImageDesc>& descs,
+                                  std::vector<int>& fds) {
+  const uint32_t slots = static_cast<uint32_t>(descs.size());
+  if (slots == 0 || slots > ihs_vke::kMaxSlots ||
+      fds.size() != ihs_vke::ImageTableFdCount(slots)) {
+    LogErr("image table shape invalid (slots=%u fds=%zu)", slots, fds.size());
+    return false;
+  }
+  if (handle_type != ihs_vke::kHandleDmaBuf &&
+      handle_type != ihs_vke::kHandleOpaqueFd) {
+    LogErr("unsupported handle type 0x%x", handle_type);
+    return false;
+  }
+
+  // Idle and drop any previous table before importing the new one.
+  if (device_ != VK_NULL_HANDLE) {
+    d().vkDeviceWaitIdle(device_);
+  }
+  DestroySlots();
+
+  handle_type_ = handle_type;
+  width_ = width;
+  height_ = height;
+  generation_ = generation;
+  slot_count_ = slots;
+
+  images_.assign(slots, VK_NULL_HANDLE);
+  image_memory_.assign(slots, VK_NULL_HANDLE);
+  render_done_.assign(slots, VK_NULL_HANDLE);
+  consumer_done_.assign(slots, VK_NULL_HANDLE);
+  cmd_.assign(slots, VK_NULL_HANDLE);
+  fence_.assign(slots, VK_NULL_HANDLE);
+
+  // Ownership discipline: mark each fd -1 as it is consumed (imported); any fd
+  // still set at the end of a failed import is closed by the cleanup below.
+  auto take = [&](size_t idx) -> int {
+    const int fd = fds[idx];
+    fds[idx] = -1;
+    return fd;
+  };
+  auto fail = [&]() -> bool {
+    for (int& fd : fds) {
+      if (fd >= 0) {
+        ::close(fd);
+        fd = -1;
+      }
+    }
+    if (device_ != VK_NULL_HANDLE) {
+      d().vkDeviceWaitIdle(device_);
+    }
+    DestroySlots();
+    slot_count_ = 0;
+    return false;
+  };
+
+  if (!CreateReadbackBuffer(width, height)) {
+    return fail();
+  }
+
+  VkCommandBufferAllocateInfo cbai{};
+  cbai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+  cbai.commandPool = command_pool_;
+  cbai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+  cbai.commandBufferCount = 1;
+
+  for (uint32_t s = 0; s < slots; ++s) {
+    const int mem_fd = take(3u * s + 0);
+    const int render_done_fd = take(3u * s + 1);
+    const int consumer_done_fd = take(3u * s + 2);
+    if (mem_fd < 0 || render_done_fd < 0 || consumer_done_fd < 0) {
+      LogErr("slot %u: missing fd(s) in image table", s);
+      // Close whichever of this slot's fds we did receive.
+      if (mem_fd >= 0) {
+        ::close(mem_fd);
+      }
+      if (render_done_fd >= 0) {
+        ::close(render_done_fd);
+      }
+      if (consumer_done_fd >= 0) {
+        ::close(consumer_done_fd);
+      }
+      return fail();
+    }
+
+    if (!ImportSlotImage(descs[s], s, mem_fd)) {
+      ::close(mem_fd);  // allocate failed before taking ownership
+      ::close(render_done_fd);
+      ::close(consumer_done_fd);
+      return fail();
+    }
+    // ImportSlotImage's vkAllocateMemory consumed mem_fd on success.
+    if (!ImportSlotSemaphore(render_done_fd, &render_done_[s])) {
+      ::close(render_done_fd);
+      ::close(consumer_done_fd);
+      return fail();
+    }
+    if (!ImportSlotSemaphore(consumer_done_fd, &consumer_done_[s])) {
+      ::close(consumer_done_fd);
+      return fail();
+    }
+
+    if (d().vkAllocateCommandBuffers(device_, &cbai, &cmd_[s]) != VK_SUCCESS) {
+      LogErr("slot %u: vkAllocateCommandBuffers failed", s);
+      return fail();
+    }
+    VkFenceCreateInfo fci{};
+    fci.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;  // unsignaled
+    if (d().vkCreateFence(device_, &fci, nullptr, &fence_[s]) != VK_SUCCESS) {
+      LogErr("slot %u: vkCreateFence failed", s);
+      return fail();
+    }
+  }
+
+  LogInfo("imported image table: generation=%u slots=%u %ux%u handle=%s",
+          generation_, slot_count_, width_, height_,
+          handle_type_ == ihs_vke::kHandleDmaBuf ? "dmabuf" : "opaque-fd");
+  return true;
+}
+
+bool VkConsumer::ConsumePresent(uint32_t slot,
+                                uint32_t frame_seq,
+                                FrameStats* out) {
+  if (slot >= slot_count_ || images_[slot] == VK_NULL_HANDLE) {
+    LogErr("present for invalid slot %u (slot_count=%u)", slot, slot_count_);
+    return false;
+  }
+
+  VkCommandBuffer cmd = cmd_[slot];
+  VkCommandBufferBeginInfo bi{};
+  bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+  bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+  if (d().vkBeginCommandBuffer(cmd, &bi) != VK_SUCCESS) {
+    LogErr("slot %u: vkBeginCommandBuffer failed", slot);
+    return false;
+  }
+
+  const VkImageSubresourceRange color_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0,
+                                            1};
+
+  // Acquire the image from the foreign producer queue (the backend rendered it
+  // and does not do a matching Vulkan queue-family release, so FOREIGN_EXT
+  // models the external producer). oldLayout UNDEFINED is used because we only
+  // copy the pixels out: for the dma-buf path the DRM modifier pins the memory
+  // layout so the content survives the transition, and render_done gates the
+  // read either way. (See the note in the file/report about the opaque-fd
+  // path, where OPTIMAL tiling is not modifier-pinned.)
+  VkImageMemoryBarrier acquire{};
+  acquire.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  acquire.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  acquire.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  acquire.srcQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT;
+  acquire.dstQueueFamilyIndex = queue_family_;
+  acquire.srcAccessMask = 0;
+  acquire.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+  acquire.image = images_[slot];
+  acquire.subresourceRange = color_range;
+  d().vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                           nullptr, 1, &acquire);
+
+  VkBufferImageCopy region{};
+  region.bufferOffset = 0;
+  region.bufferRowLength = 0;    // tightly packed to width
+  region.bufferImageHeight = 0;  // tightly packed to height
+  region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+  region.imageOffset = {0, 0, 0};
+  region.imageExtent = {width_, height_, 1};
+  d().vkCmdCopyImageToBuffer(cmd, images_[slot],
+                             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                             readback_buffer_, 1, &region);
+
+  // Release the image back to the foreign producer queue so the backend can
+  // re-render this slot after it observes consumer_done.
+  VkImageMemoryBarrier release{};
+  release.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  release.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+  release.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+  release.srcQueueFamilyIndex = queue_family_;
+  release.dstQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT;
+  release.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+  release.dstAccessMask = 0;
+  release.image = images_[slot];
+  release.subresourceRange = color_range;
+  d().vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr,
+                           0, nullptr, 1, &release);
+
+  if (d().vkEndCommandBuffer(cmd) != VK_SUCCESS) {
+    LogErr("slot %u: vkEndCommandBuffer failed", slot);
+    return false;
+  }
+
+  // Exactly one wait on render_done[slot] and one signal of consumer_done[slot]
+  // per present, keeping the binary-semaphore pairing with the backend strict.
+  const VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+  VkSubmitInfo si{};
+  si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+  si.waitSemaphoreCount = 1;
+  si.pWaitSemaphores = &render_done_[slot];
+  si.pWaitDstStageMask = &wait_stage;
+  si.commandBufferCount = 1;
+  si.pCommandBuffers = &cmd;
+  si.signalSemaphoreCount = 1;
+  si.pSignalSemaphores = &consumer_done_[slot];
+  if (d().vkQueueSubmit(queue_, 1, &si, fence_[slot]) != VK_SUCCESS) {
+    LogErr("slot %u: vkQueueSubmit failed", slot);
+    return false;
+  }
+  if (d().vkWaitForFences(device_, 1, &fence_[slot], VK_TRUE, UINT64_MAX) !=
+      VK_SUCCESS) {
+    LogErr("slot %u: vkWaitForFences failed", slot);
+    return false;
+  }
+  d().vkResetFences(device_, 1, &fence_[slot]);
+
+  if (!readback_coherent_) {
+    VkMappedMemoryRange range{};
+    range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+    range.memory = readback_memory_;
+    range.offset = 0;
+    range.size = VK_WHOLE_SIZE;
+    d().vkInvalidateMappedMemoryRanges(device_, 1, &range);
+  }
+
+  // FNV-1a over the copied pixels: proves the shared memory carries the
+  // backend's rendered frame and that it changes frame to frame.
+  const auto* bytes = static_cast<const uint8_t*>(readback_mapped_);
+  const size_t n = static_cast<size_t>(width_) * height_ * 4;
+  uint64_t crc = 1469598103934665603ULL;  // FNV offset basis
+  for (size_t i = 0; i < n; ++i) {
+    crc ^= bytes[i];
+    crc *= 1099511628211ULL;  // FNV prime
+  }
+
+  const auto* px = reinterpret_cast<const uint32_t*>(bytes);
+  const size_t center =
+      (static_cast<size_t>(height_ / 2) * width_) + width_ / 2;
+
+  if (out != nullptr) {
+    out->slot = slot;
+    out->frame_seq = frame_seq;
+    out->crc = crc;
+    out->px_first = px[0];
+    out->px_center = center < (n / 4) ? px[center] : 0;
+  }
+  return true;
+}
+
+void VkConsumer::DestroySlots() {
+  for (size_t i = 0; i < slot_count_; ++i) {
+    if (i < fence_.size() && fence_[i] != VK_NULL_HANDLE) {
+      d().vkDestroyFence(device_, fence_[i], nullptr);
+    }
+    if (i < cmd_.size() && cmd_[i] != VK_NULL_HANDLE) {
+      d().vkFreeCommandBuffers(device_, command_pool_, 1, &cmd_[i]);
+    }
+    if (i < render_done_.size() && render_done_[i] != VK_NULL_HANDLE) {
+      d().vkDestroySemaphore(device_, render_done_[i], nullptr);
+    }
+    if (i < consumer_done_.size() && consumer_done_[i] != VK_NULL_HANDLE) {
+      d().vkDestroySemaphore(device_, consumer_done_[i], nullptr);
+    }
+    if (i < images_.size() && images_[i] != VK_NULL_HANDLE) {
+      d().vkDestroyImage(device_, images_[i], nullptr);
+    }
+    if (i < image_memory_.size() && image_memory_[i] != VK_NULL_HANDLE) {
+      d().vkFreeMemory(device_, image_memory_[i],
+                       nullptr);  // closes imported fd
+    }
+  }
+  images_.clear();
+  image_memory_.clear();
+  render_done_.clear();
+  consumer_done_.clear();
+  cmd_.clear();
+  fence_.clear();
+}
+
+void VkConsumer::Teardown() {
+  if (device_ != VK_NULL_HANDLE) {
+    d().vkDeviceWaitIdle(device_);
+    DestroySlots();
+    slot_count_ = 0;
+    if (readback_memory_ != VK_NULL_HANDLE) {
+      d().vkUnmapMemory(device_, readback_memory_);
+      d().vkFreeMemory(device_, readback_memory_, nullptr);
+      readback_memory_ = VK_NULL_HANDLE;
+      readback_mapped_ = nullptr;
+    }
+    if (readback_buffer_ != VK_NULL_HANDLE) {
+      d().vkDestroyBuffer(device_, readback_buffer_, nullptr);
+      readback_buffer_ = VK_NULL_HANDLE;
+    }
+    if (command_pool_ != VK_NULL_HANDLE) {
+      d().vkDestroyCommandPool(device_, command_pool_, nullptr);
+      command_pool_ = VK_NULL_HANDLE;
+    }
+    d().vkDestroyDevice(device_, nullptr);
+    device_ = VK_NULL_HANDLE;
+  }
+  if (instance_ != VK_NULL_HANDLE) {
+    d().vkDestroyInstance(instance_, nullptr);
+    instance_ = VK_NULL_HANDLE;
+  }
+}
+
+}  // namespace ihs_vke_consumer

--- a/shell/backend/headless_vulkan/export_consumer/vk_consumer.h
+++ b/shell/backend/headless_vulkan/export_consumer/vk_consumer.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The same-device import half of the ihs-vk-export path: it imports the
+// headless-vulkan backend's exported image pool (dma-buf or opaque-fd memory
+// plus the render_done/consumer_done binary semaphores) into its own VkDevice,
+// then per presented frame waits render_done, copies the image out to a host
+// buffer and checksums it (proving the shared memory carries the rendered
+// pixels), and signals consumer_done. It is import-symmetric to the backend's
+// export code in headless_vulkan.cc.
+//
+// This header exposes only C Vulkan handles so the vulkan.hpp dynamic
+// dispatcher stays confined to the implementation translation unit.
+
+#ifndef SHELL_BACKEND_HEADLESS_VULKAN_EXPORT_CONSUMER_VK_CONSUMER_H_
+#define SHELL_BACKEND_HEADLESS_VULKAN_EXPORT_CONSUMER_VK_CONSUMER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include <vulkan/vulkan.h>
+
+#include "wire_protocol.h"
+
+namespace ihs_vke_consumer {
+
+// What ConsumePresent reports about a single frame: a checksum over the whole
+// copied-out image plus two sampled pixels, enough to confirm content and to
+// see it change frame to frame.
+struct FrameStats {
+  uint32_t slot = 0;
+  uint32_t frame_seq = 0;
+  uint64_t crc = 0;        // FNV-1a over width*height*4 bytes
+  uint32_t px_first = 0;   // pixel (0,0), packed as read from memory
+  uint32_t px_center = 0;  // pixel (width/2, height/2)
+};
+
+class VkConsumer {
+ public:
+  VkConsumer() = default;
+  ~VkConsumer();
+
+  VkConsumer(const VkConsumer&) = delete;
+  VkConsumer& operator=(const VkConsumer&) = delete;
+
+  // Bring up the loader, a VK_API_VERSION_1_1 instance and a single-GPU device
+  // (physical device 0) with the external-memory / external-semaphore / dma-buf
+  // extensions enabled, and read the device's VkPhysicalDeviceIDProperties
+  // deviceUUID. Returns false (with a logged reason) on any failure.
+  bool InitVulkan();
+
+  // The selected device's UUID (16 bytes), for the Hello handshake and the
+  // caps deviceUUID comparison. Valid after InitVulkan.
+  const uint8_t* device_uuid() const { return device_uuid_; }
+
+  // Import an image table. `descs` holds slot_count descriptors; `fds` holds
+  // 3*slot_count descriptors in slot order [mem_0, render_done_0,
+  // consumer_done_0, mem_1, ...]. On success the consumer takes ownership of
+  // every fd (each is imported into Vulkan, which owns it thereafter) and any
+  // previous table is torn down first. On failure every not-yet-consumed fd in
+  // `fds` is closed. Returns false on any Vulkan error.
+  bool ImportImageTable(uint32_t generation,
+                        uint32_t width,
+                        uint32_t height,
+                        uint32_t handle_type,  // ihs_vke::HandleTypeBits bit
+                        const std::vector<ihs_vke::ImageDesc>& descs,
+                        std::vector<int>& fds);
+
+  uint32_t generation() const { return generation_; }
+  uint32_t slot_count() const { return slot_count_; }
+
+  // Process one presented frame in `slot`: submit a copy-out that waits
+  // render_done[slot] exactly once (binary), acquires the image from the
+  // foreign producer queue, copies the whole image into the readback buffer,
+  // releases it back, and signals consumer_done[slot] exactly once; then
+  // CPU-wait the per-slot fence and checksum the pixels into `out`. Returns
+  // false on any Vulkan error. The caller sends the FrameRelease pacing edge
+  // after this returns.
+  bool ConsumePresent(uint32_t slot, uint32_t frame_seq, FrameStats* out);
+
+  // Destroy every Vulkan object and close every owned fd. Idempotent.
+  void Teardown();
+
+ private:
+  bool CreateInstance();
+  bool SelectPhysicalDevice();  // physical device 0
+  bool CreateLogicalDevice();
+  bool CreateCommandPool();
+  bool CreateReadbackBuffer(uint32_t width, uint32_t height);
+  void DestroySlots();
+  uint32_t FindHostVisibleMemoryType(uint32_t type_bits, bool* coherent) const;
+
+  bool ImportSlotImage(const ihs_vke::ImageDesc& desc,
+                       uint32_t slot,
+                       int mem_fd);
+  bool ImportSlotSemaphore(int fd, VkSemaphore* out);
+
+  VkInstance instance_ = VK_NULL_HANDLE;
+  VkPhysicalDevice physical_device_ = VK_NULL_HANDLE;
+  VkDevice device_ = VK_NULL_HANDLE;
+  uint32_t queue_family_ = UINT32_MAX;
+  VkQueue queue_ = VK_NULL_HANDLE;
+  uint8_t device_uuid_[VK_UUID_SIZE] = {};
+
+  std::vector<const char*> enabled_instance_extensions_;
+  std::vector<const char*> enabled_device_extensions_;
+
+  VkCommandPool command_pool_ = VK_NULL_HANDLE;
+
+  // One host-visible readback buffer, reused across slots (each present is
+  // fenced to completion before the next, so a single buffer never overlaps).
+  VkBuffer readback_buffer_ = VK_NULL_HANDLE;
+  VkDeviceMemory readback_memory_ = VK_NULL_HANDLE;
+  void* readback_mapped_ = nullptr;
+  VkDeviceSize readback_size_ = 0;
+  bool readback_coherent_ = false;
+
+  // Per-slot imported resources (sized to slot_count_).
+  std::vector<VkImage> images_;
+  std::vector<VkDeviceMemory> image_memory_;
+  std::vector<VkSemaphore> render_done_;
+  std::vector<VkSemaphore> consumer_done_;
+  std::vector<VkCommandBuffer> cmd_;
+  std::vector<VkFence> fence_;
+
+  uint32_t generation_ = 0;
+  uint32_t slot_count_ = 0;
+  uint32_t width_ = 0;
+  uint32_t height_ = 0;
+  uint32_t handle_type_ = 0;  // ihs_vke::HandleTypeBits bit for the pool
+};
+
+}  // namespace ihs_vke_consumer
+
+#endif  // SHELL_BACKEND_HEADLESS_VULKAN_EXPORT_CONSUMER_VK_CONSUMER_H_

--- a/shell/backend/headless_vulkan/export_consumer/wire_client.cc
+++ b/shell/backend/headless_vulkan/export_consumer/wire_client.cc
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wire_client.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+
+namespace ihs_vke_consumer {
+
+namespace {
+// The most fds any one message carries (a full-pool image table): three per
+// slot -- memory, render_done, consumer_done.
+constexpr size_t kMaxFds = 3 * ihs_vke::kMaxSlots;
+
+// Largest payload the protocol defines (an image table for a full pool), plus
+// slack for a Hello name. Sizes the receive buffer; a larger datagram is a
+// protocol error (reported as truncated).
+constexpr size_t kMaxPayloadBytes =
+    sizeof(ihs_vke::ImageTableHeader) +
+    ihs_vke::kMaxSlots * sizeof(ihs_vke::ImageDesc) + 256;
+
+ssize_t RetryingSendmsg(int sock, const msghdr* msg) {
+  ssize_t n;
+  do {
+    n = ::sendmsg(sock, msg, MSG_NOSIGNAL);
+  } while (n < 0 && errno == EINTR);
+  return n;
+}
+
+ssize_t RetryingRecvmsg(int sock, msghdr* msg) {
+  ssize_t n;
+  do {
+    n = ::recvmsg(sock, msg, MSG_CMSG_CLOEXEC);
+  } while (n < 0 && errno == EINTR);
+  return n;
+}
+}  // namespace
+
+int ConnectSeqpacket(const char* path) {
+  if (path == nullptr) {
+    errno = EINVAL;
+    return -1;
+  }
+  sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  if (std::strlen(path) >= sizeof(addr.sun_path)) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  std::strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+
+  const int sock = ::socket(AF_UNIX, SOCK_SEQPACKET | SOCK_CLOEXEC, 0);
+  if (sock < 0) {
+    return -1;
+  }
+  if (::connect(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+    const int saved = errno;
+    ::close(sock);
+    errno = saved;
+    return -1;
+  }
+  return sock;
+}
+
+bool SendFramed(int sock,
+                ihs_vke::MsgType type,
+                const void* payload,
+                size_t payload_len,
+                const int* fds,
+                size_t nfds) {
+  if (nfds > kMaxFds || (payload_len != 0 && payload == nullptr)) {
+    return false;
+  }
+  ihs_vke::MsgHeader hdr{static_cast<uint32_t>(type),
+                         static_cast<uint32_t>(payload_len)};
+
+  iovec iov[2];
+  iov[0].iov_base = &hdr;
+  iov[0].iov_len = sizeof(hdr);
+  iov[1].iov_base = const_cast<void*>(payload);
+  iov[1].iov_len = payload_len;
+
+  msghdr msg{};
+  msg.msg_iov = iov;
+  msg.msg_iovlen = payload_len != 0 ? 2 : 1;
+
+  // Ancillary SCM_RIGHTS block for the fds (only when there are any).
+  alignas(cmsghdr) char cbuf[CMSG_SPACE(sizeof(int) * kMaxFds)];
+  if (nfds > 0) {
+    std::memset(cbuf, 0, sizeof(cbuf));
+    msg.msg_control = cbuf;
+    msg.msg_controllen = CMSG_SPACE(sizeof(int) * nfds);
+    cmsghdr* cm = CMSG_FIRSTHDR(&msg);
+    cm->cmsg_level = SOL_SOCKET;
+    cm->cmsg_type = SCM_RIGHTS;
+    cm->cmsg_len = CMSG_LEN(sizeof(int) * nfds);
+    std::memcpy(CMSG_DATA(cm), fds, sizeof(int) * nfds);
+    msg.msg_controllen = cm->cmsg_len;  // exact length the kernel expects
+  }
+
+  const ssize_t sent = RetryingSendmsg(sock, &msg);
+  // SEQPACKET delivers the whole datagram or nothing; a short count is an
+  // error.
+  return sent == static_cast<ssize_t>(sizeof(hdr) + payload_len);
+}
+
+RecvMsg RecvFramed(int sock) {
+  RecvMsg out;
+
+  ihs_vke::MsgHeader hdr{};
+  std::vector<uint8_t> buf(kMaxPayloadBytes);
+  iovec iov[2];
+  iov[0].iov_base = &hdr;
+  iov[0].iov_len = sizeof(hdr);
+  iov[1].iov_base = buf.data();
+  iov[1].iov_len = buf.size();
+
+  alignas(cmsghdr) char cbuf[CMSG_SPACE(sizeof(int) * kMaxFds)];
+  msghdr msg{};
+  msg.msg_iov = iov;
+  msg.msg_iovlen = 2;
+  msg.msg_control = cbuf;
+  msg.msg_controllen = sizeof(cbuf);
+
+  const ssize_t n = RetryingRecvmsg(sock, &msg);
+  if (n == 0) {
+    out.closed = true;  // orderly peer shutdown
+    return out;
+  }
+  if (n < 0) {
+    return out;  // ok=false; errno holds the reason
+  }
+
+  // Collect any fds first so every error path can close them.
+  for (cmsghdr* cm = CMSG_FIRSTHDR(&msg); cm != nullptr;
+       cm = CMSG_NXTHDR(&msg, cm)) {
+    if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_RIGHTS) {
+      const size_t bytes = cm->cmsg_len - CMSG_LEN(0);
+      const size_t count = bytes / sizeof(int);
+      const int* fds = reinterpret_cast<const int*>(CMSG_DATA(cm));
+      for (size_t i = 0; i < count; ++i) {
+        out.fds.push_back(fds[i]);
+      }
+    }
+  }
+
+  // A truncated payload or dropped fds means the sender exceeded our limits --
+  // treat as a protocol error and discard (closing any fds we did receive).
+  if ((msg.msg_flags & (MSG_TRUNC | MSG_CTRUNC)) != 0 ||
+      n < static_cast<ssize_t>(sizeof(hdr)) ||
+      hdr.len != static_cast<uint32_t>(n) - sizeof(hdr)) {
+    out.truncated = true;
+    CloseFds(out);
+    return out;
+  }
+
+  out.type = static_cast<ihs_vke::MsgType>(hdr.type);
+  out.payload.assign(buf.begin(), buf.begin() + hdr.len);
+  out.ok = true;
+  return out;
+}
+
+void CloseFds(RecvMsg& m) {
+  for (int fd : m.fds) {
+    if (fd >= 0) {
+      ::close(fd);
+    }
+  }
+  m.fds.clear();
+}
+
+}  // namespace ihs_vke_consumer

--- a/shell/backend/headless_vulkan/export_consumer/wire_client.h
+++ b/shell/backend/headless_vulkan/export_consumer/wire_client.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Minimal, self-contained SEQPACKET framing for the ihs-vk-export test
+// consumer (the client half of wire_protocol.h). One message is one datagram:
+// an 8-byte MsgHeader { type, len } followed by `len` payload bytes, with any
+// file descriptors carried as ancillary SCM_RIGHTS data on the same datagram.
+// The consumer only needs to send Hello / FrameRelease / Bye and to receive
+// Caps / ImageTable / FramePresent / Bye, so this is intentionally smaller than
+// the bridge's transport -- it lives entirely inside the consumer.
+
+#ifndef SHELL_BACKEND_HEADLESS_VULKAN_EXPORT_CONSUMER_WIRE_CLIENT_H_
+#define SHELL_BACKEND_HEADLESS_VULKAN_EXPORT_CONSUMER_WIRE_CLIENT_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "wire_protocol.h"
+
+namespace ihs_vke_consumer {
+
+// Connect an AF_UNIX SOCK_SEQPACKET client socket to `path`. Returns the
+// connected fd (CLOEXEC) or -1 on failure (errno set).
+int ConnectSeqpacket(const char* path);
+
+// Send one framed message: header{type,len} + payload, with `nfds` descriptors
+// as SCM_RIGHTS. Returns true iff the whole datagram was sent. Does not take
+// ownership of the fds (the caller keeps and closes its own copies).
+bool SendFramed(int sock,
+                ihs_vke::MsgType type,
+                const void* payload,
+                size_t payload_len,
+                const int* fds,
+                size_t nfds);
+
+// Convenience: send a POD payload with no fds.
+template <typename T>
+inline bool SendPod(int sock, ihs_vke::MsgType type, const T& payload) {
+  return SendFramed(sock, type, &payload, sizeof(T), nullptr, 0);
+}
+
+// One received datagram. Any fds are dup()-owned by this struct; close each
+// when done (CloseFds, or transfer ownership out).
+struct RecvMsg {
+  ihs_vke::MsgType type{};
+  std::vector<uint8_t> payload;
+  std::vector<int> fds;
+  bool ok = false;         // a well-formed message was received
+  bool closed = false;     // the peer closed the connection (ok == false)
+  bool truncated = false;  // payload or fds did not fit (protocol error)
+};
+
+// Receive exactly one datagram. Never blocks past one message. On a clean peer
+// close returns { ok=false, closed=true }. On a short/oversized datagram
+// returns { ok=false, truncated=true } and closes any fds it did receive. Uses
+// MSG_CMSG_CLOEXEC so received fds are not leaked across an exec.
+RecvMsg RecvFramed(int sock);
+
+// Close every fd still held by a RecvMsg (helper for error/drop paths).
+void CloseFds(RecvMsg& m);
+
+}  // namespace ihs_vke_consumer
+
+#endif  // SHELL_BACKEND_HEADLESS_VULKAN_EXPORT_CONSUMER_WIRE_CLIENT_H_

--- a/shell/backend/headless_vulkan/export_consumer/wire_protocol.h
+++ b/shell/backend/headless_vulkan/export_consumer/wire_protocol.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ihs-vk-export wire protocol, version 1 -- the contract between the bridge
+// (server) and a CARLA/Unreal consumer (client) over a Unix SEQPACKET socket.
+//
+// Framing: every message is one seqpacket datagram = a fixed little-endian
+// header { u32 type; u32 len } immediately followed by `len` payload bytes.
+// File descriptors (memory + semaphore fds) never appear in the payload; they
+// ride the SAME datagram as ancillary SCM_RIGHTS data, in the well-defined
+// order documented per message. The receiver dup()s and owns every fd it gets.
+//
+// Endianness/ABI: fields are little-endian and the payload structs are shared
+// verbatim by both ends (same header, same arch). Every struct is padding-free
+// by construction (fields ordered widest-first) and guarded with a
+// static_assert on its size so an accidental layout change is caught at compile
+// time.
+//
+// Roles: the bridge is the server (it owns the exported image pool and drives
+// presentation); the consumer connects, matches the advertised deviceUUID, and
+// imports the pool. Directions below are B=bridge, C=consumer.
+
+#ifndef IHS_CARLA_BRIDGE_WIRE_PROTOCOL_H_
+#define IHS_CARLA_BRIDGE_WIRE_PROTOCOL_H_
+
+#include <cstdint>
+
+namespace ihs_vke {
+
+inline constexpr uint32_t kProtocolVersion = 1;
+inline constexpr uint32_t kMaxSlots =
+    8;  // pool images per session (pool is small)
+inline constexpr uint32_t kMaxPlanes = 4;  // DRM planes per dmabuf image
+inline constexpr uint32_t kConsumerNameMax = 64;
+
+// Default socket path (the deployment may override). $XDG_RUNTIME_DIR is
+// resolved at runtime; this is the leaf name.
+inline constexpr char kDefaultSocketLeaf[] = "ihs-vk-export.sock";
+
+enum class MsgType : uint32_t {
+  kHello = 1,       // C->B: version, consumer name, consumer deviceUUID
+  kCaps = 2,        // B->C: version, deviceUUID, offered handle types, format,
+                    //       extent, pool size, capability flags
+  kImageTable = 3,  // B->C: per-slot descriptors + fds (mem,render_done,
+                    //       consumer_done) via SCM_RIGHTS; carries a generation
+  kFramePresent = 4,  // B->C: slot index + frame sequence + damage rect (info)
+  kFrameRelease = 5,  // C->B: slot index (consumer_done was signaled GPU-side;
+                      //       this is the CPU-side pacing edge)
+  kInputPointer = 6,  // C->B: pointer phase, x, y (logical px), buttons, device
+  kInputKey = 7,      // C->B: reserved for v1 (unimplemented)
+  kResize = 8,        // C->B: new extent -> pool rebuild + new kImageTable
+  kBye = 9,           // either: reason code
+};
+
+// Handle-type bits a session can carry (mirror VkExternalMemoryHandleType).
+enum HandleTypeBits : uint32_t {
+  kHandleOpaqueFd = 1u << 0,  // same-device OPAQUE_FD (the portable floor)
+  kHandleDmaBuf = 1u << 1,    // dma-buf with a DRM format modifier
+};
+
+// Capability flags (Caps.flags).
+enum CapsFlagBits : uint32_t {
+  kCapsTimelineSemaphores = 1u << 0,  // timeline sems available (else binary)
+};
+
+// ---- Fixed message header (precedes every payload) --------------------------
+struct MsgHeader {
+  uint32_t type;  // MsgType
+  uint32_t len;   // payload byte count following this header
+};
+static_assert(sizeof(MsgHeader) == 8, "MsgHeader must be 8 bytes");
+
+// ---- Payloads ---------------------------------------------------------------
+
+// C->B. The consumer announces itself and the GPU it will import onto; the
+// bridge must have selected the SAME physical device (deviceUUID match) for an
+// OPAQUE_FD import to be valid.
+struct Hello {
+  uint32_t protocol_version;
+  uint32_t consumer_name_len;  // bytes of name that follow the struct (<= max)
+  uint8_t device_uuid[16];     // VkPhysicalDeviceIDProperties.deviceUUID
+  // followed by consumer_name_len bytes of UTF-8 name (not NUL-terminated)
+};
+static_assert(sizeof(Hello) == 24, "Hello layout");
+
+// B->C. What the pool advertises. handle_types is a HandleTypeBits mask; the
+// consumer picks one it can import and expects the following kImageTable to use
+// it. extent + slot_count + vk_format describe the pool shape up front.
+struct Caps {
+  uint32_t protocol_version;
+  uint32_t handle_types;  // HandleTypeBits mask offered
+  uint32_t vk_format;     // VkFormat of every pool image
+  uint32_t drm_fourcc;    // DRM fourcc (dmabuf); 0 if opaque-only
+  uint32_t width;
+  uint32_t height;
+  uint32_t slot_count;  // pool images (<= kMaxSlots)
+  uint32_t flags;       // CapsFlagBits
+  uint8_t device_uuid[16];
+};
+static_assert(sizeof(Caps) == 48, "Caps layout");
+
+// One pool image in a kImageTable. The three fds for this slot -- memory,
+// render_done semaphore, consumer_done semaphore -- travel as SCM_RIGHTS in the
+// same datagram; see kImageTable's fd order below.
+struct ImageDesc {
+  uint64_t alloc_size;                // total device memory bytes
+  uint64_t drm_modifier;              // dmabuf DRM_FORMAT_MOD_*; 0 if opaque
+  uint64_t plane_offset[kMaxPlanes];  // dmabuf per-plane byte offset
+  uint64_t plane_pitch[kMaxPlanes];   // dmabuf per-plane row stride
+  uint32_t width;
+  uint32_t height;
+  uint32_t vk_format;          // VkFormat
+  uint32_t drm_fourcc;         // dmabuf; 0 if opaque
+  uint32_t memory_type_index;  // for an opaque-fd import
+  uint32_t handle_type;        // HandleTypeBits (single bit) used for this pool
+  uint32_t plane_count;        // dmabuf plane count (1 for opaque)
+  uint32_t reserved;           // pad to 8-byte multiple; must be 0
+};
+static_assert(sizeof(ImageDesc) == 16 + 2 * 8 * kMaxPlanes + 32,
+              "ImageDesc layout");
+
+// B->C header for kImageTable. Followed by `slot_count` ImageDesc records.
+// SCM_RIGHTS fds accompany the datagram in slot order, three per slot:
+//   [ mem_0, render_done_0, consumer_done_0, mem_1, render_done_1, ... ]
+// i.e. 3 * slot_count fds. `generation` bumps on every rebuild (see kResize);
+// the consumer must drop a stale-generation table.
+struct ImageTableHeader {
+  uint32_t generation;
+  uint32_t slot_count;
+  // followed by slot_count ImageDesc records
+};
+static_assert(sizeof(ImageTableHeader) == 8, "ImageTableHeader layout");
+
+// B->C. A frame was presented into `slot`. damage_* is informational (whole
+// image is valid); the consumer waits the slot's render_done semaphore GPU-side
+// before sampling.
+struct FramePresent {
+  uint32_t slot;
+  uint32_t frame_seq;
+  uint32_t generation;  // must match the current kImageTable
+  int32_t damage_x, damage_y, damage_w, damage_h;
+};
+static_assert(sizeof(FramePresent) == 28, "FramePresent layout");
+
+// C->B. The consumer released `slot` (its consumer_done semaphore was signaled
+// GPU-side). This is the CPU-side pacing edge the backend's vsync consumes.
+struct FrameRelease {
+  uint32_t slot;
+  uint32_t generation;
+};
+static_assert(sizeof(FrameRelease) == 8, "FrameRelease layout");
+
+enum class PointerPhase : uint32_t {
+  kAdd = 0,
+  kDown = 1,
+  kMove = 2,
+  kUp = 3,
+  kRemove = 4,
+};
+
+// C->B. Pointer input in the bridge's logical pixel space; the shell injects it
+// through the engine's normal pointer path (hit-testing/hover/a11y correct).
+struct InputPointer {
+  uint32_t phase;    // PointerPhase
+  float x, y;        // logical pixels
+  uint32_t buttons;  // button bitmask
+  uint32_t device_id;
+};
+static_assert(sizeof(InputPointer) == 20, "InputPointer layout");
+
+// C->B. New extent; the bridge rebuilds the pool and sends a fresh kImageTable
+// with an incremented generation.
+struct Resize {
+  uint32_t width;
+  uint32_t height;
+};
+static_assert(sizeof(Resize) == 8, "Resize layout");
+
+enum class ByeReason : uint32_t {
+  kNormal = 0,
+  kProtocolError = 1,
+  kDeviceMismatch = 2,  // consumer could not match the advertised deviceUUID
+  kUnsupported = 3,     // no mutually supported handle type
+  kInternalError = 4,
+};
+
+// Either direction. Best-effort last message before closing.
+struct Bye {
+  uint32_t reason;  // ByeReason
+};
+static_assert(sizeof(Bye) == 4, "Bye layout");
+
+// Number of SCM_RIGHTS fds a kImageTable carries for `slot_count` slots.
+inline constexpr uint32_t ImageTableFdCount(uint32_t slot_count) {
+  return 3u * slot_count;  // mem + render_done + consumer_done per slot
+}
+
+}  // namespace ihs_vke
+
+#endif  // IHS_CARLA_BRIDGE_WIRE_PROTOCOL_H_

--- a/shell/backend/headless_vulkan/headless_vulkan.cc
+++ b/shell/backend/headless_vulkan/headless_vulkan.cc
@@ -879,13 +879,30 @@ void HeadlessVulkanBackend::CreateExportSemaphores() {
     return;
   }
 
-  // Per image: create the two OPAQUE_FD-exportable binary semaphores and export
-  // one persistent fd each. On any failure, roll back and skip the whole
-  // feature — the image export still stands.
-  auto rollback = [&]() {
+  // Create the exportable semaphores, export their fds, and pre-signal each
+  // consumer_done. On any failure roll back and skip the whole feature — the
+  // image export still stands.
+  if (!InstallExportSemaphores()) {
     DestroyExportSemaphores();
     semaphores_active_ = false;
-  };
+    return;
+  }
+
+  semaphores_active_ = true;
+  ihs::log::info(
+      "[HeadlessVulkan] per-frame sync semaphores active (images={}, "
+      "loopback={})",
+      kImageCount, loopback_ ? "on" : "off");
+}
+
+bool HeadlessVulkanBackend::InstallExportSemaphores() {
+  // Create the two OPAQUE_FD-exportable binary semaphores per image and export
+  // one persistent fd each (recorded in exported_images_ under export_fd_mutex_
+  // so a concurrent FillImageTable never dups a torn fd). Each consumer_done
+  // starts SIGNALED so the first GetNextImage wait passes (the image is
+  // "free"). Assumes render_done_/consumer_done_ are currently null — initial
+  // bring-up, or after RebaselineSemaphores destroyed them.
+  std::scoped_lock lock(export_fd_mutex_);
   for (uint32_t i = 0; i < kImageCount; ++i) {
     VkExportSemaphoreCreateInfo exp{};
     exp.sType = VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO;
@@ -901,8 +918,7 @@ void HeadlessVulkanBackend::CreateExportSemaphores() {
           "[HeadlessVulkan] vkCreateSemaphore {} failed; disabling "
           "per-frame sync",
           i);
-      rollback();
-      return;
+      return false;
     }
 
     const auto export_fd = [&](VkSemaphore sem, int* out) -> bool {
@@ -919,8 +935,7 @@ void HeadlessVulkanBackend::CreateExportSemaphores() {
           "[HeadlessVulkan] vkGetSemaphoreFdKHR {} failed; disabling per-frame "
           "sync",
           i);
-      rollback();
-      return;
+      return false;
     }
     ihs::log::info(
         "[HeadlessVulkan] image {} sync semaphores: render_done_fd={} "
@@ -942,16 +957,55 @@ void HeadlessVulkanBackend::CreateExportSemaphores() {
           "per-frame sync",
           i);
       d().vkQueueWaitIdle(graphics_queue_);
-      rollback();
-      return;
+      return false;
     }
   }
+  return true;
+}
 
-  semaphores_active_ = true;
-  ihs::log::info(
-      "[HeadlessVulkan] per-frame sync semaphores active (images={}, "
-      "loopback={})",
-      kImageCount, loopback_ ? "on" : "off");
+void HeadlessVulkanBackend::RebaselineSemaphores() {
+  // Between consumer sessions, recreate the binary semaphores so the next
+  // consumer starts from a clean baseline (render_done unsignaled,
+  // consumer_done signaled) with fresh export fds. Binary semaphores cannot be
+  // reset in place, and a detached consumer may have left either one signaled —
+  // reusing them would risk a double-signal. Runs on the raster thread while
+  // dormant (no in-flight per-frame sync submits), so a full queue idle is
+  // safe; the sync command pool + fence are kept, only the semaphores are
+  // cycled.
+  if (!semaphores_active_) {
+    return;
+  }
+  d().vkQueueWaitIdle(graphics_queue_);
+  {
+    std::scoped_lock lock(export_fd_mutex_);
+    for (uint32_t i = 0; i < kImageCount; ++i) {
+      if (render_done_[i] != VK_NULL_HANDLE) {
+        d().vkDestroySemaphore(device_, render_done_[i], nullptr);
+        render_done_[i] = VK_NULL_HANDLE;
+      }
+      if (consumer_done_[i] != VK_NULL_HANDLE) {
+        d().vkDestroySemaphore(device_, consumer_done_[i], nullptr);
+        consumer_done_[i] = VK_NULL_HANDLE;
+      }
+      if (exported_images_[i].render_done_fd >= 0) {
+        ::close(exported_images_[i].render_done_fd);
+        exported_images_[i].render_done_fd = -1;
+      }
+      if (exported_images_[i].consumer_done_fd >= 0) {
+        ::close(exported_images_[i].consumer_done_fd);
+        exported_images_[i].consumer_done_fd = -1;
+      }
+    }
+  }
+  if (!InstallExportSemaphores()) {
+    ihs::log::warn(
+        "[HeadlessVulkan] semaphore rebaseline failed; per-frame sync "
+        "disabled");
+    DestroyExportSemaphores();
+    semaphores_active_ = false;
+    return;
+  }
+  ihs::log::info("[HeadlessVulkan] semaphores rebaselined for next consumer");
 }
 
 void HeadlessVulkanBackend::DestroyExportSemaphores() {
@@ -1110,6 +1164,19 @@ int HeadlessVulkanBackend::FillImageTable(IhsVkExportImageTable* out) const {
   out->generation = generation_;
   out->slot_count = kImageCount;
 
+  // If a prior consumer just detached, wait briefly for the raster thread to
+  // reinstall fresh semaphores (RebaselineSemaphores) so the fds exported here
+  // carry a clean binary state rather than the previous session's leftovers.
+  // The raster thread ticks well within this bound at the pacing rate; the cap
+  // keeps a stalled raster from hanging a handshake.
+  for (int spin = 0;
+       spin < 200 && sync_rebaseline_pending_.load(std::memory_order_acquire);
+       ++spin) {
+    ::usleep(1000);  // 1 ms
+  }
+  // Serialize the fd reads against RebaselineSemaphores' rewrite.
+  std::scoped_lock lock(export_fd_mutex_);
+
   // dup() the source fds so the caller owns/closes independent handles; -1 in
   // means -1 out (no export for that fd).
   auto dup_fd = [](int fd) -> int32_t { return fd >= 0 ? ::dup(fd) : -1; };
@@ -1164,6 +1231,18 @@ void HeadlessVulkanBackend::OnConsumerReleaseFrame(uint32_t /* slot */) {
 }
 
 void HeadlessVulkanBackend::SetExportPaceSource(uint32_t src) {
+  // A consumer-driven pace source means a real external consumer is attached
+  // and will signal consumer_done / wait render_done, so the per-frame GPU
+  // handshake can run (see GetNextImageCallback / PresentCallback). Free-run
+  // means no consumer, so it must stay dormant.
+  const bool now_active = src == IHS_VK_PACE_CONSUMER_DRIVEN;
+  const bool was_active =
+      export_consumer_active_.exchange(now_active, std::memory_order_acq_rel);
+  if (was_active && !now_active) {
+    // The consumer detached: ask the raster thread to recreate the semaphores
+    // before the next consumer imports them (see GetNextImageCallback).
+    sync_rebaseline_pending_.store(true, std::memory_order_release);
+  }
   if (pacer_) {
     pacer_->SetFreeRun(src == IHS_VK_PACE_FREE_RUN);
   }
@@ -1287,10 +1366,32 @@ FlutterVulkanImage HeadlessVulkanBackend::GetNextImageCallback(
     void* user_data,
     const FlutterFrameInfo* /* frame_info */) {
   auto* backend = BackendOf(user_data);
-  // Loopback only: block until the (stand-in) consumer released this image, so
-  // the engine never re-renders an image a consumer is still reading. Without
-  // loopback the binary consumer_done has no signaler and this would deadlock —
-  // so the per-frame ops stay dormant and the fds are merely exported.
+  // A consumer detached since the last frame: recreate the semaphores now,
+  // while dormant, so the next consumer imports a clean baseline. Done here (a
+  // raster- thread frame boundary with no in-flight sync submits) rather than
+  // from the bridge thread, which must never touch the graphics queue.
+  if (backend->sync_rebaseline_pending_.load(std::memory_order_acquire) &&
+      backend->semaphores_active_ && !backend->loopback_ &&
+      !backend->export_consumer_active_.load(std::memory_order_acquire)) {
+    backend->RebaselineSemaphores();
+    backend->sync_rebaseline_pending_.store(false, std::memory_order_release);
+  }
+
+  // Latch this frame's sync state once and reuse it in PresentCallback, so a
+  // mid-frame attach/detach can never split a frame's render_done signal from
+  // the listener notification it must back. The handshake runs when the
+  // semaphores exist and either the loopback stand-in or a real consumer is
+  // attached; with neither, the ops stay dormant and the fds are merely
+  // exported.
+  backend->frame_sync_active_ =
+      backend->semaphores_active_ &&
+      (backend->loopback_ ||
+       backend->export_consumer_active_.load(std::memory_order_acquire));
+  // consumer_done is only CPU-waited for the loopback stand-in, which always
+  // signals it. A real consumer's backpressure is the credit/FrameRelease edge
+  // (sent after it finishes reading the slot), so the backend must not block on
+  // consumer_done here — a consumer that vanishes mid-frame would otherwise
+  // wedge the raster thread on a signal that never comes.
   if (backend->loopback_ && backend->semaphores_active_) {
     backend->WaitConsumerDone(backend->current_image_);
   }
@@ -1309,12 +1410,16 @@ bool HeadlessVulkanBackend::PresentCallback(
   // Advance the round-robin index so the next frame targets a different image.
   auto* backend = BackendOf(user_data);
   const uint32_t k = backend->current_image_;  // index the engine just rendered
-  if (backend->loopback_ && backend->semaphores_active_) {
+  // frame_sync_active_ was latched for this frame in GetNextImageCallback.
+  if (backend->frame_sync_active_) {
     // Signal render_done[k] after the engine's render submits (same queue,
-    // ordered), then have the loopback consumer immediately drain it and signal
-    // consumer_done[k] so image k is free for its next GetNextImage.
+    // ordered) so the consumer may sample image k. In loopback the stand-in
+    // consumer immediately drains it and signals consumer_done[k]; a real
+    // consumer waits render_done[k] and signals consumer_done[k] itself.
     backend->SignalRenderDone(k);
-    backend->LoopbackSelfConsume(k);
+    if (backend->loopback_) {
+      backend->LoopbackSelfConsume(k);
+    }
   }
   backend->current_image_ = (k + 1) % kImageCount;
 
@@ -1330,7 +1435,11 @@ bool HeadlessVulkanBackend::PresentCallback(
     cb = backend->frame_listener_;
     user = backend->frame_listener_user_;
   }
-  if (cb != nullptr) {
+  // Only advertise the frame when its render_done[k] was signaled this frame
+  // (frame_sync_active_): a consumer waits render_done[k] before sampling, so a
+  // FramePresent without the matching signal would hang it. Dormant frames (no
+  // consumer) simply are not advertised; the server drops them anyway.
+  if (cb != nullptr && backend->frame_sync_active_) {
     cb(k, backend->frame_seq_++, user);
   }
   return true;

--- a/shell/backend/headless_vulkan/headless_vulkan.h
+++ b/shell/backend/headless_vulkan/headless_vulkan.h
@@ -189,6 +189,18 @@ class HeadlessVulkanBackend final : public Backend {
   // Best-effort — logs and skips (leaving the fds -1) if the device cannot
   // export an OPAQUE_FD semaphore; never fails bring-up.
   void CreateExportSemaphores();
+  // Create the two exportable binary semaphores per image, export a persistent
+  // fd for each (into exported_images_, under export_fd_mutex_), and pre-signal
+  // every consumer_done. Returns false on any failure (the caller rolls back).
+  // Shared by CreateExportSemaphores (initial) and RebaselineSemaphores (per
+  // reconnect); assumes the sync command pool + fence already exist.
+  bool InstallExportSemaphores();
+  // Recreate the per-frame semaphores from scratch between consumer sessions.
+  // Binary semaphores cannot be reset in place, and a detaching consumer leaves
+  // render_done/consumer_done in an arbitrary signaled state; recreating gives
+  // each new consumer a clean baseline (render_done unsignaled, consumer_done
+  // signaled) and fresh export fds. Runs on the raster thread while dormant.
+  void RebaselineSemaphores();
   // Destroy the semaphores, close their fds, and destroy the sync command
   // pool + fence. Called by DestroyRenderTargets.
   void DestroyExportSemaphores();
@@ -264,10 +276,30 @@ class HeadlessVulkanBackend final : public Backend {
   // that stands in for the future socket consumer to validate the round-trip.
   bool loopback_{false};
   bool semaphores_active_{false};
+  // A real external consumer is attached and driving the pacing (set when the
+  // bridge selects consumer-driven pacing, cleared on free-run). Together with
+  // loopback_ it decides whether the per-frame render_done/consumer_done
+  // handshake runs: with neither, the binary consumer_done has no signaler, so
+  // the ops stay dormant and the fds are merely exported. Set from the bridge
+  // thread, read on the raster thread.
+  std::atomic<bool> export_consumer_active_{false};
+  // Latched once per frame in GetNextImage and reused in PresentCallback so a
+  // mid-frame attach/detach can never split a frame's wait from its signal
+  // (which would leave a binary semaphore double-signaled). Raster-thread only.
+  bool frame_sync_active_{false};
+  // Set when a consumer detaches; the raster thread recreates the semaphores at
+  // the next dormant frame so the following consumer starts from a clean
+  // baseline. Read on the raster thread and in FillImageTable (bridge thread).
+  std::atomic<bool> sync_rebaseline_pending_{false};
   std::array<VkSemaphore, kImageCount> render_done_{};
   std::array<VkSemaphore, kImageCount> consumer_done_{};
   VkCommandPool sync_command_pool_{VK_NULL_HANDLE};
   VkFence consumer_wait_fence_{VK_NULL_HANDLE};
+  // Guards the exported semaphore fds in exported_images_ between the raster
+  // thread (RebaselineSemaphores rewrites them) and the bridge thread
+  // (FillImageTable dups them). mutable so the const FillImageTable can lock
+  // it.
+  mutable std::mutex export_fd_mutex_;
 
   // Synthetic-vsync pacing. vsync_ holds the baton machinery; the pacer drives
   // it, run in free-run (ceiling-only) mode since there is no consumer.

--- a/shell/vk_export_bridge_loader.cc
+++ b/shell/vk_export_bridge_loader.cc
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vk_export_bridge_loader.h"
+
+#include <dlfcn.h>
+
+#include <cstdlib>
+
+#include "logging/logging.h"
+
+namespace ihs {
+
+namespace {
+
+// Resolve the bridge socket path: an explicit override, else the well-known
+// leaf under $XDG_RUNTIME_DIR, else a /tmp fallback for bare environments.
+std::string ResolveSocketPath() {
+  if (const char* s = std::getenv("IVI_VK_BRIDGE_SOCKET"); s != nullptr && *s) {
+    return s;
+  }
+  if (const char* xdg = std::getenv("XDG_RUNTIME_DIR");
+      xdg != nullptr && *xdg) {
+    return std::string(xdg) + "/ihs-vk-export.sock";
+  }
+  return "/tmp/ihs-vk-export.sock";
+}
+
+}  // namespace
+
+VkExportBridgeLoader::VkExportBridgeLoader() {
+  const char* module = std::getenv("IVI_VK_BRIDGE_SO");
+  if (module == nullptr || *module == '\0') {
+    return;  // not configured; stay inert.
+  }
+
+  dl_ = ::dlopen(module, RTLD_NOW | RTLD_LOCAL);
+  if (dl_ == nullptr) {
+    ihs::log::error("[VkExportBridge] dlopen('{}') failed: {}", module,
+                    ::dlerror());
+    return;
+  }
+
+  create_ = reinterpret_cast<CreateFn>(::dlsym(dl_, "ihs_carla_bridge_create"));
+  start_ = reinterpret_cast<StartFn>(::dlsym(dl_, "ihs_carla_bridge_start"));
+  stop_ = reinterpret_cast<StopFn>(::dlsym(dl_, "ihs_carla_bridge_stop"));
+  destroy_ =
+      reinterpret_cast<DestroyFn>(::dlsym(dl_, "ihs_carla_bridge_destroy"));
+  if (create_ == nullptr || start_ == nullptr || stop_ == nullptr ||
+      destroy_ == nullptr) {
+    ihs::log::error("[VkExportBridge] '{}' missing ihs_carla_bridge_* symbols",
+                    module);
+    ::dlclose(dl_);
+    dl_ = nullptr;
+    return;
+  }
+
+  const std::string socket_path = ResolveSocketPath();
+  bridge_ = create_(socket_path.c_str());
+  if (bridge_ == nullptr) {
+    ihs::log::error("[VkExportBridge] create('{}') returned null", socket_path);
+    ::dlclose(dl_);
+    dl_ = nullptr;
+    return;
+  }
+
+  if (start_(bridge_) != 0) {
+    // The most common cause is that the active backend is not headless-vulkan
+    // (or export is not enabled), so the module resolved no export API.
+    ihs::log::error(
+        "[VkExportBridge] start failed; no headless-vulkan export active");
+    destroy_(bridge_);
+    bridge_ = nullptr;
+    ::dlclose(dl_);
+    dl_ = nullptr;
+    return;
+  }
+
+  ihs::log::info("[VkExportBridge] bridge started on '{}' (module '{}')",
+                 socket_path, module);
+}
+
+VkExportBridgeLoader::~VkExportBridgeLoader() {
+  if (bridge_ != nullptr) {
+    stop_(bridge_);
+    destroy_(bridge_);
+    bridge_ = nullptr;
+  }
+  if (dl_ != nullptr) {
+    ::dlclose(dl_);
+    dl_ = nullptr;
+  }
+}
+
+}  // namespace ihs

--- a/shell/vk_export_bridge_loader.h
+++ b/shell/vk_export_bridge_loader.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace ihs {
+
+// Env-gated loader for an in-process ihs-vk-export bridge plugin. When
+// IVI_VK_BRIDGE_SO names a shared module, this dlopen's it and drives its four
+// C ABI entry points (create -> start ... stop -> destroy) so the module can
+// forward the headless-vulkan backend's exported image pool to another process.
+//
+// The bridge resolves the shell's single exported `ihs_vk_export_get_api`
+// symbol itself via dlsym(RTLD_DEFAULT), so this loader only has to bring the
+// module in and manage its lifetime; it never touches the export API directly.
+// The App owns one of these: it must be constructed AFTER the headless-vulkan
+// backend has registered itself (so the export API resolves to a live backend)
+// and destroyed BEFORE the backend, so the module's frame listener is cleared
+// and its IO thread joined while the backend is still alive.
+//
+// Unless IVI_VK_BRIDGE_SO is set the loader is completely inert. Any failure
+// (missing module, unresolved symbols, no active export) is logged and left
+// non-fatal: an ordinary shell run is unaffected.
+class VkExportBridgeLoader {
+ public:
+  VkExportBridgeLoader();
+  ~VkExportBridgeLoader();
+
+  VkExportBridgeLoader(const VkExportBridgeLoader&) = delete;
+  VkExportBridgeLoader& operator=(const VkExportBridgeLoader&) = delete;
+
+  // True once the module is loaded and its bridge instance started.
+  [[nodiscard]] bool active() const { return bridge_ != nullptr; }
+
+ private:
+  using CreateFn = void* (*)(const char*);
+  using StartFn = int (*)(void*);
+  using StopFn = void (*)(void*);
+  using DestroyFn = void (*)(void*);
+
+  void* dl_ = nullptr;      // dlopen handle for the module
+  void* bridge_ = nullptr;  // opaque IhsCarlaBridge* the module returned
+  CreateFn create_ = nullptr;
+  StartFn start_ = nullptr;
+  StopFn stop_ = nullptr;
+  DestroyFn destroy_ = nullptr;
+};
+
+}  // namespace ihs


### PR DESCRIPTION
Completes the headless-vulkan zero-copy sharing path end-to-end: the shell loads an in-process bridge, and a same-device Vulkan consumer imports the exported dma-buf pool + per-frame semaphores, reads the rendered frames, and drives the
backend's consumer-paced vsync. This replaces the loopback self-test with a real external consumer.

## Commits

1. **Sync a real export consumer and rebaseline across sessions** — the `render_done`/`consumer_done` handshake previously ran only for the loopback stand-in (gated on `loopback_`), so a real consumer received a `FramePresent`
   but blocked forever on a `render_done` the backend never signaled. This wires the handshake for a real consumer via a per-frame latched flag, drops the blocking `consumer_done` wait for real consumers (backpressure is the credit/`FrameRelease` edge, so a vanished consumer can't wedge the raster thread), and recreates the binary semaphores between sessions (they can't be reset in place) so each reconnecting consumer imports a clean baseline.
2. **In-process bridge loader and a Vulkan export test consumer** — an env-gated `App` loader (`IVI_VK_BRIDGE_SO`) that dlopens the bridge and drives its four C ABI entry points, plus a standalone `ihs_vk_export_consumer` binary that imports the pool (vulkan.hpp dynamic loader), checksums each frame to prove zero-copy content correctness, and releases it. Both gated behind `BUILD_BACKEND_HEADLESS_VULKAN`.

## Validation (Raspberry Pi 4, V3D)

- The shell loads the bridge in-process (`[VkExportBridge] bridge started …`).
- The consumer selects the V3D device, matches the exporter's `deviceUUID`, and imports the dma-buf pool + semaphores.
- Dozens of frames flow round-robin across the 3 slots; the consumer reads real, spatially-varying pixels (`px[0] != px[center]`) — zero-copy content proven.
- Repeated connect/disconnect/reconnect each logs a clean semaphore rebaseline and delivers frames without stalling.

## Notes

The consumer treats `FrameRelease` as "finished reading the slot" (it CPU-waits its readback before releasing), which is the contract the backend's credit-based backpressure relies on. Pool-resize (`rebuild_pool`) remains a stub.