### PR TITLE
headless-vulkan: implement rebuild_pool for consumer-driven resize

### DIFF
--- a/shell/backend/headless_vulkan/export_consumer/export_consumer_main.cc
+++ b/shell/backend/headless_vulkan/export_consumer/export_consumer_main.cc
@@ -80,6 +80,28 @@ uint32_t ResolveFrameBudget() {
   return 120;
 }
 
+// Optional resize request: IHS_VK_CONSUMER_RESIZE="WxH" makes the consumer send
+// one Resize after a few frames, exercising the backend's rebuild_pool. Returns
+// {0,0} when unset/invalid.
+ihs_vke::Resize ResolveResize() {
+  ihs_vke::Resize r{0, 0};
+  const char* env = std::getenv("IHS_VK_CONSUMER_RESIZE");
+  if (env == nullptr || env[0] == '\0') {
+    return r;
+  }
+  char* end = nullptr;
+  const long w = std::strtol(env, &end, 10);
+  long h = 0;
+  if (end != nullptr && (*end == 'x' || *end == 'X')) {
+    h = std::strtol(end + 1, nullptr, 10);
+  }
+  if (w > 0 && h > 0) {
+    r.width = static_cast<uint32_t>(w);
+    r.height = static_cast<uint32_t>(h);
+  }
+  return r;
+}
+
 void ToHex(const uint8_t* uuid, char out[33]) {
   static const char* kHex = "0123456789abcdef";
   for (int i = 0; i < 16; ++i) {
@@ -119,6 +141,8 @@ int main() {
 
   const std::string socket_path = ResolveSocketPath();
   const uint32_t frame_budget = ResolveFrameBudget();
+  const ihs_vke::Resize resize = ResolveResize();
+  bool resize_sent = false;
 
   ihs_vke_consumer::VkConsumer consumer;
   if (!consumer.InitVulkan()) {
@@ -320,6 +344,21 @@ int main() {
           break;
         }
         ++consumed;
+
+        // Optionally request a resize partway through; the bridge rebuilds the
+        // pool and sends a fresh ImageTable, which the kImageTable case
+        // re-imports at the new extent.
+        if (resize.width != 0 && !resize_sent && consumed >= 8) {
+          if (ihs_vke_consumer::SendPod(sock, ihs_vke::MsgType::kResize,
+                                        resize)) {
+            std::fprintf(stderr,
+                         "[ihs-vk-consumer] requested resize to %ux%u\n",
+                         resize.width, resize.height);
+            resize_sent = true;
+          } else {
+            LogErr("failed to send Resize");
+          }
+        }
         break;
       }
 

--- a/shell/backend/headless_vulkan/headless_vulkan.cc
+++ b/shell/backend/headless_vulkan/headless_vulkan.cc
@@ -1164,13 +1164,15 @@ int HeadlessVulkanBackend::FillImageTable(IhsVkExportImageTable* out) const {
   out->generation = generation_;
   out->slot_count = kImageCount;
 
-  // If a prior consumer just detached, wait briefly for the raster thread to
-  // reinstall fresh semaphores (RebaselineSemaphores) so the fds exported here
-  // carry a clean binary state rather than the previous session's leftovers.
-  // The raster thread ticks well within this bound at the pacing rate; the cap
-  // keeps a stalled raster from hanging a handshake.
+  // Wait briefly for the raster thread to finish any pending semaphore
+  // rebaseline (a prior consumer detached) or pool resize, so the fds exported
+  // here are the current generation with a clean binary state rather than
+  // leftovers. The raster thread ticks well within this bound at the pacing
+  // rate; the cap keeps a stalled raster from hanging a handshake.
   for (int spin = 0;
-       spin < 200 && sync_rebaseline_pending_.load(std::memory_order_acquire);
+       spin < 400 &&
+       (sync_rebaseline_pending_.load(std::memory_order_acquire) ||
+        resize_pending_.load(std::memory_order_acquire));
        ++spin) {
     ::usleep(1000);  // 1 ms
   }
@@ -1294,14 +1296,111 @@ void HeadlessVulkanBackend::InjectPointer(const IhsPointerEvent& ev) {
   });
 }
 
+void HeadlessVulkanBackend::SendWindowMetrics(uint32_t width, uint32_t height) {
+  if (engine_handle_ == nullptr) {
+    return;
+  }
+  FlutterWindowMetricsEvent metrics{};
+  metrics.struct_size = sizeof(FlutterWindowMetricsEvent);
+  metrics.width = width;
+  metrics.height = height;
+  // Headless has no display scale: logical == physical pixels (pixel_ratio 1).
+  metrics.pixel_ratio = 1.0;
+  metrics.display_id = 0;
+  metrics.view_id = 0;
+  LibFlutterEngine->SendWindowMetricsEvent(engine_handle_, &metrics);
+}
+
+void HeadlessVulkanBackend::PerformResize() {
+  uint32_t w = 0;
+  uint32_t h = 0;
+  {
+    std::lock_guard<std::mutex> lk(resize_mutex_);
+    w = resize_width_;
+    h = resize_height_;
+  }
+
+  // No in-flight per-frame sync submits here (we are at a GetNextImage boundary
+  // before this frame's render), so a full device idle makes destroying and
+  // recreating the pool + semaphores safe. The consumer's imported dma-bufs
+  // keep their own fd references, so freeing our side does not pull the memory
+  // out from under a consumer that has not yet dropped the old generation.
+  d().vkDeviceWaitIdle(device_);
+  const uint32_t old_w = width_;
+  const uint32_t old_h = height_;
+  DestroyRenderTargets();
+  width_ = w;
+  height_ = h;
+  const bool ok = CreateRenderTargets();
+  if (ok) {
+    ++generation_;
+    current_image_ = 0;
+    // CreateRenderTargets reinstalled fresh semaphores, so any earlier
+    // rebaseline request is now satisfied.
+    sync_rebaseline_pending_.store(false, std::memory_order_release);
+    ihs::log::info(
+        "[HeadlessVulkan] pool rebuilt {}x{} -> {}x{} (generation {})", old_w,
+        old_h, w, h, generation_);
+  } else {
+    ihs::log::error("[HeadlessVulkan] pool rebuild to {}x{} failed", w, h);
+  }
+
+  // Restore pacing: a real consumer resumes consumer-driven (credits reset to
+  // the pipeline depth); otherwise stay free-run.
+  if (pacer_ != nullptr) {
+    pacer_->SetFreeRun(
+        !export_consumer_active_.load(std::memory_order_acquire));
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(resize_mutex_);
+    resize_result_ = ok ? 0 : -1;
+    resize_done_ = true;
+  }
+  resize_pending_.store(false, std::memory_order_release);
+  resize_cv_.notify_all();
+}
+
 int HeadlessVulkanBackend::RebuildExportPool(uint32_t width, uint32_t height) {
-  // Not supported yet: a real rebuild must tear down and recreate the image
-  // pool AND the per-frame semaphores under raster-thread quiescence, then bump
-  // generation_ so a consumer re-imports. Deferred to a later step.
-  ihs::log::warn(
-      "[HeadlessVulkan] RebuildExportPool({}x{}) not supported yet; ignoring",
-      width, height);
-  return -1;
+  if (!export_enabled() || width == 0 || height == 0) {
+    return -1;
+  }
+  if (width == width_ && height == height_) {
+    return 0;  // already at this extent
+  }
+  if (engine_handle_ == nullptr ||
+      !vsync_running_.load(std::memory_order_acquire)) {
+    return -1;  // no running engine to drive a frame through the rebuild
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(resize_mutex_);
+    resize_width_ = width;
+    resize_height_ = height;
+    resize_done_ = false;
+    resize_result_ = -1;
+  }
+  resize_pending_.store(true, std::memory_order_release);
+
+  // Force frames so the raster thread reaches GetNextImage and performs the
+  // rebuild even if consumer pacing is currently credit-starved; PerformResize
+  // restores the pacing mode. Then push the new metrics so the rebuilt frame
+  // lays out at the new size.
+  if (pacer_ != nullptr) {
+    pacer_->SetFreeRun(true);
+  }
+  SendWindowMetrics(width, height);
+
+  std::unique_lock<std::mutex> lk(resize_mutex_);
+  const bool done = resize_cv_.wait_for(lk, std::chrono::seconds(2),
+                                        [this] { return resize_done_; });
+  if (!done) {
+    resize_pending_.store(false, std::memory_order_release);
+    ihs::log::warn("[HeadlessVulkan] RebuildExportPool({}x{}) timed out", width,
+                   height);
+    return -1;
+  }
+  return resize_result_;
 }
 
 // ── Renderer config ──────────────────────────────────────────────────────────
@@ -1366,6 +1465,13 @@ FlutterVulkanImage HeadlessVulkanBackend::GetNextImageCallback(
     void* user_data,
     const FlutterFrameInfo* /* frame_info */) {
   auto* backend = BackendOf(user_data);
+  // A consumer requested a resize: rebuild the pool at the new extent now, at
+  // this frame boundary, so the image returned below (and the render into it)
+  // is the new size. Runs before the rebaseline check — a rebuild reinstalls
+  // the semaphores itself.
+  if (backend->resize_pending_.load(std::memory_order_acquire)) {
+    backend->PerformResize();
+  }
   // A consumer detached since the last frame: recreate the semaphores now,
   // while dormant, so the next consumer imports a clean baseline. Done here (a
   // raster- thread frame boundary with no in-flight sync submits) rather than

--- a/shell/backend/headless_vulkan/headless_vulkan.h
+++ b/shell/backend/headless_vulkan/headless_vulkan.h
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -160,7 +161,11 @@ class HeadlessVulkanBackend final : public Backend {
   // Inject a pointer event through the engine's normal input path; marshaled to
   // the platform task runner.
   void InjectPointer(const IhsPointerEvent& ev);
-  // Rebuild the pool at a new extent. NOT SUPPORTED yet: logs and returns -1.
+  // Rebuild the exported pool at a new extent (consumer-driven resize). Blocks
+  // until the raster thread recreates the images + semaphores at the new size,
+  // bumps generation_, and the engine is told to relayout. Returns 0 on
+  // success, -1 if export is off, the size is unchanged/invalid, or it timed
+  // out. Called from the bridge IO thread.
   int RebuildExportPool(uint32_t width, uint32_t height);
 
  private:
@@ -214,6 +219,14 @@ class HeadlessVulkanBackend final : public Backend {
   // export→plain fallback and Teardown.
   void DestroyRenderTargets();
   void Teardown();
+
+  // Perform a pending pool resize on the raster thread at a GetNextImage frame
+  // boundary: wait the device idle, recreate the render targets + semaphores at
+  // resize_{width,height}_, bump generation_, and unblock RebuildExportPool.
+  void PerformResize();
+  // Push a new viewport size to the engine so it relayouts at the new extent.
+  // The engine metrics API is thread-safe; called from the bridge IO thread.
+  void SendWindowMetrics(uint32_t width, uint32_t height);
 
   // Root-surface renderer callbacks (user_data == the FlutterDesktopEngineState
   // handed to FlutterEngineRun; recovered via BackendOf).
@@ -300,6 +313,20 @@ class HeadlessVulkanBackend final : public Backend {
   // (FillImageTable dups them). mutable so the const FillImageTable can lock
   // it.
   mutable std::mutex export_fd_mutex_;
+
+  // Consumer-driven pool resize. RebuildExportPool (bridge IO thread) stashes
+  // the requested extent, sets resize_pending_, and blocks on resize_cv_ until
+  // the raster thread's next GetNextImage runs PerformResize and reports the
+  // outcome. FillImageTable also waits out a pending resize so it exports the
+  // rebuilt fds. Sizes/flags under resize_mutex_; resize_pending_ is the
+  // raster-thread trigger.
+  std::atomic<bool> resize_pending_{false};
+  std::mutex resize_mutex_;
+  std::condition_variable resize_cv_;
+  uint32_t resize_width_{0};   // guarded by resize_mutex_
+  uint32_t resize_height_{0};  // guarded by resize_mutex_
+  bool resize_done_{false};    // guarded by resize_mutex_
+  int resize_result_{-1};      // guarded by resize_mutex_
 
   // Synthetic-vsync pacing. vsync_ holds the baton machinery; the pacer drives
   // it, run in free-run (ceiling-only) mode since there is no consumer.


### PR DESCRIPTION
Implements the last stub in the headless-vulkan export ABI: `rebuild_pool`, a live resize of the exported render-target pool at a consumer-requested extent.

## How

The bridge calls `rebuild_pool` on its IO thread (from a wire `Resize`), but the pool's Vulkan objects belong to the raster thread, so the work is marshaled there:

- `RebuildExportPool` stashes the extent, sets `resize_pending_`, forces the
  pacer to free-run (so a credit-starved consumer pipeline still yields a frame),
  pushes new window metrics to the engine, and blocks on a condition variable.
- The next `GetNextImageCallback` runs `PerformResize` at that frame boundary:
  device idle, destroy + recreate the render targets and per-frame semaphores at
  the new size (reusing `CreateRenderTargets`), bump `generation_`, reset the
  round-robin index, restore pacing, wake the caller.
- The engine, having received the new metrics, renders the next frame at the new
  extent into the fresh pool; the bridge resends the image table so the consumer
  re-imports. `FillImageTable` waits out a pending resize so it exports the rebuilt fds.

Destroying our images mid-session is safe: a consumer still holding the old generation keeps its own dma-buf fd references alive.

The test consumer gains `IHS_VK_CONSUMER_RESIZE=WxH` to request one resize partway through a run.

## Validation (Raspberry Pi 4, V3D)

A consumer imports the pool at 1920×720, requests 1280×600, the shell logs `pool rebuilt 1920x720 -> 1280x600 (generation 1)`, and the consumer re-imports at 1280×600 and keeps reading frames across the rebuild — 24 frames, 24 distinct checksums, no stall.

## Note

Headless has no display scale, so the new metrics use `pixel_ratio = 1.0` (logical == physical px), matching the initial bring-up.