### PR TITLE
[ci] Bumped outdated actions

### DIFF
--- a/.github/actions/setup-libdisplay-info/action.yml
+++ b/.github/actions/setup-libdisplay-info/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Restore cached libdisplay-info
       if: steps.probe.outputs.from-source == 'true'
       id: cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ${{ steps.probe.outputs.prefix }}
         key: libdisplay-info-${{ inputs.pin-version }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/ihs-logging-compat-matrix.yml
+++ b/.github/workflows/ihs-logging-compat-matrix.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Ensure toolchain
         run: |
@@ -115,7 +115,7 @@ jobs:
           apt-get install -y --no-install-recommends git ninja-build
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build + run compat_smoke
         run: |
@@ -148,7 +148,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Ensure toolchain
         run: |

--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload baseline artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ihs-shared-abi
           path: shared/abi/libihs_shared.so.abi

--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -38,7 +38,7 @@ jobs:
         enable_dlt: [ON, OFF]
     name: "consumer-smoke DLT=${{ matrix.enable_dlt }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install toolchain
         run: |
@@ -98,7 +98,7 @@ jobs:
     if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Fetch fmt submodule (raw-fmt reference)
         run: git submodule update --init --depth 1 third_party/fmt
@@ -127,7 +127,7 @@ jobs:
     if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install toolchain + libabigail
         run: |
@@ -190,7 +190,7 @@ jobs:
               || github.event_name == 'push') }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install toolchain + dlt-daemon
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/oss-codeql.yml
+++ b/.github/workflows/oss-codeql.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 

--- a/.github/workflows/oss-integration.yaml
+++ b/.github/workflows/oss-integration.yaml
@@ -25,7 +25,7 @@ jobs:
       # sentry-native augment + crashpad_handler into a per-workspace overlay,
       # so no setup-workspace is needed.
       - name: Checkout ivi-homescreen (PR)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout ivi-homescreen (PR)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -399,7 +399,7 @@ jobs:
         run: genhtml -o lcovHtml -s --legend --branch-coverage coverage.info
 
       - name: Upload coverage HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-test-coverage-html
           path: ${{github.workspace}}/build/unit-tests/lcovHtml/

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -202,7 +202,7 @@ jobs:
       # so this needs no setup-workspace / pinned checkout — it compiles exactly
       # the code under review.
       - name: Checkout ivi-homescreen (PR)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install build deps
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout ivi-homescreen (PR)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Install build deps
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -78,7 +78,7 @@ jobs:
       # store/ only — not all of ~/.cache/emb — to skip the multi-GB image/CAS
       # downloads and stay under the repo cache limit.
       - name: Cache emb store (extracted sysroot + toolchain)
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/emb/store
           key: emb-store-${{ matrix.pios }}-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml', 'emb_cli/boards/raspberry-pi.emb.yaml') }}
@@ -100,7 +100,7 @@ jobs:
       # cannot restore into root-owned /usr/local/bin. Install from the cached
       # dir into /usr/local/bin (where the publish step's oras is on PATH).
       - name: Cache oras binary
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/oras-bin
           key: oras-${{ env.ORAS_VERSION }}-linux-amd64
@@ -187,7 +187,7 @@ jobs:
       # OCI cache in the Build step (EMB_CACHE_REGISTRY), so the resolve is a
       # cache hit. Root in-container; the image ships curl.
       - name: Cache oras binary
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: /usr/local/bin/oras
           key: oras-${{ env.ORAS_VERSION }}-linux-amd64

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -57,7 +57,7 @@ jobs:
     name: publish-${{ matrix.pios }}
     steps:
       - name: Checkout ivi-homescreen
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           path: ivi-homescreen
           submodules: recursive
@@ -157,13 +157,13 @@ jobs:
     name: build-${{ matrix.board }}-${{ matrix.pios }}-${{ matrix.backend }}
     steps:
       - name: Checkout ivi-homescreen
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           path: ivi-homescreen
           submodules: recursive
 
       - name: Checkout ivi-homescreen-plugins (sibling)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: toyota-connected/ivi-homescreen-plugins
           path: ivi-homescreen-plugins

--- a/.github/workflows/stargate-ivi-homescreen.yml
+++ b/.github/workflows/stargate-ivi-homescreen.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/wiz.yml
+++ b/.github/workflows/wiz.yml
@@ -17,7 +17,7 @@ jobs:
       composefiles: ${{ steps.set-matrix.outputs.composefiles }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: find-docker-files
         id: set-matrix
         run: |
@@ -72,7 +72,7 @@ jobs:
           password: ${{ secrets.STARGATE_ARTIFACTORY_TOKEN }}
           append: true
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: docker compose local build
         id: compose
         run: |
@@ -109,7 +109,7 @@ jobs:
         dockerfile: ${{ fromJson(needs.set-matrix.outputs.dockerfiles) }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Wiz IaC Scan
         uses: sg-innersource/wizcli-wrapper@v1
         with:
@@ -121,7 +121,7 @@ jobs:
     runs-on: [sg-jpe-x64-ubuntu-22.04-2core]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Wiz IaC Scan
         uses: sg-innersource/wizcli-wrapper@v1
         with:


### PR DESCRIPTION
_Originally posted by @jwinarske in https://github.com/toyota-connected/ivi-homescreen/pull/323#pullrequestreview-4831262430_

> As a follow up we should fix all of these occurrences: "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/"

