### PR TITLE
Cancel the pending Wayland read when the reactor is already stopped

### DIFF
--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -1031,14 +1031,22 @@ void Display::ArmWaylandRead() {
   while (wl_display_prepare_read(m_display) != 0) {
     wl_display_dispatch_pending(m_display);
   }
+  read_armed_ = true;
   wl_display_flush(m_display);
 
   wl_fd_->async_wait(asio::posix::stream_descriptor::wait_read,
                      [this](const std::error_code& ec) {
+                       const bool was_armed = read_armed_;
+                       read_armed_ = false;
                        if (ec) {
                          // Cancelled (teardown) — undo the pending
-                         // prepare_read.
-                         wl_display_cancel_read(m_display);
+                         // prepare_read, unless ReleaseWaylandFd already did.
+                         // Only one of the two may: libwayland counts readers,
+                         // and cancelling twice would drop the count below what
+                         // is outstanding.
+                         if (was_armed) {
+                           wl_display_cancel_read(m_display);
+                         }
                          return;
                        }
                        wl_display_read_events(m_display);
@@ -1096,6 +1104,19 @@ void Display::ReleaseWaylandFd() {
   wl_fd_->cancel(ec);
   wl_fd_->release();  // detach without closing libwayland's display fd
   wl_fd_.reset();
+  // cancel() only queues the handler with operation_aborted, and the reactor
+  // has already been stopped by the time this runs — so the cancel_read in
+  // ArmWaylandRead's handler never executes and the prepare_read it left
+  // outstanding would stay outstanding for the life of the process. libwayland
+  // then blocks any other thread that tries to read: wl_display_read_events
+  // waits for a reader that will never read. Mesa's Wayland WSI does exactly
+  // that inside vkDestroySwapchainKHR (wl_display_roundtrip_queue), which runs
+  // later in this same teardown, so leaving it armed hangs the process on exit
+  // instead of letting it quit.
+  if (read_armed_) {
+    read_armed_ = false;
+    wl_display_cancel_read(m_display);
+  }
 }
 
 void Display::StartEvents() {

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -430,6 +430,12 @@ class Display : public IDisplay,
   // repeat timerfd. Both fds are owned elsewhere (libwayland / the handler), so
   // these must release() — never close() — them on teardown.
   std::optional<asio::posix::stream_descriptor> wl_fd_;
+  // A wl_display_prepare_read is outstanding, waiting on wl_fd_. Tracked so
+  // teardown can undo it, because the handler that would is only reached while
+  // the reactor still runs. Not synchronized, and does not need to be: the
+  // reactor is a single io_context run on the thread that also tears the
+  // display down.
+  bool read_armed_{false};
   std::optional<asio::posix::stream_descriptor> repeat_fd_;
 
   std::shared_ptr<Engine> m_flutter_engine;


### PR DESCRIPTION
## The hang

Exiting on `wayland-vulkan` never completed. The process stopped rendering on SIGTERM and then sat in `~WaylandVulkanBackend` indefinitely, requiring SIGKILL. Every capture showed the same stack:

```
~WaylandVulkanBackend -> vkDestroySwapchainKHR
  -> wsi_wl_swapchain_chain_free -> wl_display_roundtrip_queue
  -> wl_display_dispatch_queue -> wl_display_read_events
  -> pthread_cond_wait
```

## Why

`Display::ArmWaylandRead()` leaves a `wl_display_prepare_read` outstanding and parks on the display fd. The `wl_display_cancel_read` that would undo it lives inside the `async_wait` handler.

Shutdown stops the reactor first — `primary_ioc_.stop()` in `App::Run` — and only then runs `~App`, which calls `Display::StopEvents()` -> `ReleaseWaylandFd()`. asio's `cancel()` does not run the handler inline; it queues it with `operation_aborted`, on an io_context that has already stopped and whose descriptor is released and destroyed immediately after. The handler never runs, so the read stays armed for the life of the process.

libwayland then has a reader that will never read, and any other reader waits on it. Mesa's Wayland WSI does a roundtrip inside `vkDestroySwapchainKHR`, later in that same teardown, so it waits forever.

## The fix

Track whether a read is armed, and undo it in `ReleaseWaylandFd()`, where the handler cannot. The handler only cancels a read it still owns, so whichever of the two runs first, libwayland's reader count is decremented exactly once — that guard matters if `StopEvents()` is ever called with the reactor still running, where both paths would otherwise cancel the same read.

## Verification

Reproduced the mechanism in isolation first: a `wl_display_prepare_read` with no matching `read_events` or `cancel_read` makes `wl_display_roundtrip` on another thread never return; without it the roundtrip returns immediately.

Then A/B from the same build tree, x86_64 under Mutter, four platform views, `wayland-vulkan` with `BUILD_COMPOSITOR` and `BUILD_HUD`:

| | SIGTERM to exit |
|---|---|
| without this change | never completes (SIGKILL, stack above) |
| with this change | 0.25 s |

Re-verified after clang-format on the exact committed tree: 3348 frames, no errors, 0.25 s exit.
