### PR TITLE
drm: give every contact in a touch frame one timestamp

### DIFF
--- a/shell/input/drm_seat.cc
+++ b/shell/input/drm_seat.cc
@@ -1171,12 +1171,14 @@ void DrmSeat::FlushTouchBatch() const {
   if (touch_batch_.empty() || touch_batch_region_ == nullptr) {
     touch_batch_.clear();
     touch_batch_region_ = nullptr;
+    touch_batch_ts_ = 0;
     return;
   }
   DispatchToRegion(*touch_batch_region_, touch_batch_.data(),
                    touch_batch_.size());
   touch_batch_.clear();
   touch_batch_region_ = nullptr;
+  touch_batch_ts_ = 0;
 }
 
 void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
@@ -1275,7 +1277,6 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
   FlutterPointerEvent pe{};
   pe.struct_size = sizeof(FlutterPointerEvent);
   pe.phase = phase;
-  pe.timestamp = FlutterTimestampMicros();
   pe.x = fx;
   pe.y = fy;
   pe.device = ev.slot;
@@ -1288,6 +1289,18 @@ void DrmSeat::HandleTouch(const drm::input::TouchEvent& ev) const {
     FlushTouchBatch();
   }
   touch_batch_region_ = region;
+  // One stamp for the whole frame. The contacts of a touch frame are one
+  // hardware scan and are logically simultaneous, so stamping each as it is
+  // walked hands the engine ten fingers whose times differ by however long
+  // that walk took -- and the engine's pointer resampler then interpolates
+  // that skew between fingers which in fact moved together. Latched from the
+  // first contact of the batch, the same way the Wayland path latches
+  // frame_time_us. Must come after the region flush above, so a batch that
+  // just went out does not leave its stamp behind for the next one.
+  if (touch_batch_.empty()) {
+    touch_batch_ts_ = FlutterTimestampMicros();
+  }
+  pe.timestamp = touch_batch_ts_;
   touch_batch_.push_back(pe);
 
   // Backstops: cancel ends the session with no guaranteed trailing frame

--- a/shell/input/drm_seat.h
+++ b/shell/input/drm_seat.h
@@ -276,6 +276,9 @@ class DrmSeat final : public ISeat {
   // 2500/s. Touched only from the seat dispatch thread.
   mutable std::vector<FlutterPointerEvent> touch_batch_;
   mutable const ViewRegion* touch_batch_region_ = nullptr;
+  // The stamp shared by every contact in the open batch, latched from the
+  // first one. See HandleTouch.
+  mutable size_t touch_batch_ts_ = 0;
   void FlushTouchBatch() const;
 
   // Caller-supplied hook for libinput's privileged device opens. Empty


### PR DESCRIPTION
## The defect

The contacts of a touch frame are one hardware scan and are logically simultaneous, but `DrmSeat::HandleTouch` stamped each contact with its own `FlutterTimestampMicros()` call as it walked them into the batch. Ten fingers that moved together reached the engine with ten different microsecond stamps, and the engine's pointer resampler interpolates that skew as though the fingers had moved at slightly different times.

The transport batching was already correct — one `SendPointerEvent` per frame — so only the stamp was wrong.

`Engine::CoalesceTouchFrame` makes exactly this point in its own comment, and the Wayland path already does it, latching `frame_time_us` from the first contact that carried one. The DRM path does not go through `CoalesceTouchFrame`, so it never picked that up. The DRM **pointer** path was unaffected — it already computes one `ts` and applies it across the events it sends — so this was touch-specific.

## The fix

Latch one stamp from the first contact of the batch, give it to every contact, and clear it when the batch flushes. The latch is taken *after* the region-straddle flush, so a batch that has just gone out cannot leave its stamp behind for the next one.

## Verification

Raspberry Pi 4 driving the official 800x480 DSI panel (`ft5x06`, confirmed 10 slots via `EVIOCGABS(ABS_MT_SLOT)`) on `drm-kms-egl`, using `test/integration/multi_touch_test` with its uinput injector for a synchronized ten-finger drag. Same base commit, same panel, same injector run:

| | before | after |
| --- | --- | --- |
| mean contacts per frame | 1.31 | **8.73** |
| largest frame | 3 | **10** |
| C4 verdict (threshold 6.0) | fail | **pass** |

C1 concurrency and C2 phase legality were already passing and are unchanged: ten simultaneous contacts with ten distinct ids, zero legality violations across ~10 000 move groups.

Hand-driven touch cannot decide this check, which is worth noting for anyone re-running it: the `ft5x06` only reports slots whose position changed in a scan, so held-still fingers emit nothing and the mean stays near 1 even on a correct embedder. The injector, which moves all ten slots every scan, is what makes C4 meaningful.

`clang-tidy` and `clang-format` were run after the change, and the resulting binary's `.text` is byte-identical to the one measured on the hardware above.

## Not addressed here

C3 (churn, ≥24 distinct ids) reports 10 on this backend and is unchanged. `pe.device = ev.slot`, and libinput slots are bounded 0–9 and reused, so the Flutter device id cannot reach 24 even though the injector drove kernel tracking ids to 40. That check targets an unbounded compositor touch id, which this backend does not have; it needs a backend-scoped note in the test README rather than a code change.
