### PR TITLE
logging: say when a record was truncated

### DIFF
--- a/shared/src/logging/thread_ring.cpp
+++ b/shared/src/logging/thread_ring.cpp
@@ -2,6 +2,7 @@
 #include "thread_ring.hpp"
 
 #include <algorithm>
+#include <cstdio>
 #include <cstring>
 #include <ctime>
 
@@ -44,6 +45,30 @@ bool ThreadRing::push(std::uint32_t ctx_index,
     std::memcpy(slot.text, text, copy_len);
   }
   slot.text[copy_len] = '\0';
+  // A clipped record has to say so. Records are capped at
+  // IHS_LOG_TEXT_CAPACITY, and a line cut at that boundary reads as a
+  // complete one -- while the tail is exactly where a structured payload (a
+  // JSON summary, the end of a stack frame) keeps what the reader came for.
+  // Stamping the overflow count over the last few characters costs one more
+  // character of message than a bare ellipsis and answers "how much did I
+  // lose". Only on the truncating branch, which is rare by construction.
+  if (len > copy_len) {
+    // Wide enough for the longest "...+%zu" a 64-bit size_t can produce (4 +
+    // 20 digits + NUL), so the marker itself is never the thing that gets
+    // truncated.
+    char mark[32];
+    const int n = std::snprintf(mark, sizeof(mark), "...+%zu", len - copy_len);
+    // snprintf returns the length it WOULD have written, so n >= sizeof(mark)
+    // means the marker was itself truncated -- copying n bytes would then run
+    // past what was written and drop mark's NUL into the middle of the text.
+    // Unreachable with the buffer above; checked because the alternative is a
+    // corrupt record if either size ever changes.
+    if (n > 0 && static_cast<std::size_t>(n) < sizeof(mark) &&
+        static_cast<std::size_t>(n) <= copy_len) {
+      std::memcpy(slot.text + copy_len - static_cast<std::size_t>(n), mark,
+                  static_cast<std::size_t>(n));
+    }
+  }
   slot.text_len = static_cast<std::uint16_t>(copy_len);
 
   head_.store(head + 1, std::memory_order_release);


### PR DESCRIPTION
## The problem

Log records are capped at `IHS_LOG_TEXT_CAPACITY` (240). `ThreadRing::push` clamps to that and copies, silently — so a clipped line reads as a complete one.

That matters because the tail is where structured payloads keep the part the reader came for. Concretely: `multi_touch_test` prints its results as one JSON line from Dart. It arrives through `Engine::onLogMessageCallback`, which formats `"{}: {}"` with tag `flutter` (9 chars), leaving 230 for the message — and the JSON is longer, so every run silently dropped the five `c1`..`c5` verdict flags at the end. The line looked complete. I only noticed because I went looking for flags that were never there.

## The change

Stamp the overflow count over the last characters of a record that did not fit:

```
before: ...ABCDEFGHIJKLMNOPQRSTUVWX
after:  ...ABCDEFGHIJKLMNOPQRST...+160
```

`"...+160"` costs one more character of message than a bare ellipsis and answers "how much did I lose", which is what decides whether to go looking for the rest.

It runs only on the truncating branch, which is rare by construction, and `push` is the single choke point every producer funnels through — `emit_raw`, `emit_fmt`, and the `ihs_log` C ABI alike — so one place covers all of them.

## Why not just raise the cap

`IHS_LOG_TEXT_CAPACITY` is public ABI in `shared/include/ihs/logging.h`, documented as the truncation limit, and every producer sizes a stack buffer from it. It also sets `sizeof(RingSlot)` against `static_assert(sizeof(RingSlot) % 64 == 0)` — 20 bytes of header plus 240 of text pads to 320, five cache lines. Raising it is an ABI change plus a ring-memory increase, and it would only move the boundary rather than remove it. A record that announces its own truncation is useful at any cap.

## Verification

x86_64, a probe linking `libihs_shared` and emitting a 399-character record, A/B against the same build with the patch stashed:

| | tail of the emitted line |
| --- | --- |
| without | `…MNOPQRSTUVWXYZABCDE` — ends mid-content, no marker |
| with | `…MNOPQRSTUVWX...+160` |

399 − 239 = 160, so the count is right. A short record is byte-identical either way. Re-ran the probe after `clang-format`, which reflowed one line, so the measurement describes the committed source.
