### PR TITLE
test/multi_touch_test: keep the verdict flags out of the truncation

### DIFF
--- a/test/integration/multi_touch_test/README.md
+++ b/test/integration/multi_touch_test/README.md
@@ -29,9 +29,26 @@ arena — so the raw stream reaches the checks unmodified.
 | C4 | frame batch | contacts in one hardware scan arrive with one shared timestamp (the embedder stamps the batch once). Mean move-group size during the synchronized 10-finger drag must be ≥ `EXPECT_BATCH_MEAN` (6.0). An unbatched embedder stamps each contact separately → mean ≈ 1 |
 | C5 | cancel | after a compositor cancel, every down contact receives `PointerCancel` within 500 ms. Advisory until a cancel is observed (trigger one manually via a compositor system gesture) |
 
-`MTT-SUMMARY: {json}` is printed whenever all contacts lift.
+Whenever all contacts lift, two lines are printed:
+
+```
+MTT-CHECKS: c1=pass c2=pass c3=FAIL c4=pass c5=FAIL
+MTT-SUMMARY: {json}
+```
+
 `MULTI_TOUCH_TEST: PASS|FAIL` is printed by the Self-check button, or
 automatically with `--dart-define=SELFCHECK_AFTER_S=<seconds>`.
+
+Scrape `MTT-CHECKS`, not the JSON. The embedder caps a log record at
+`IHS_LOG_TEXT_CAPACITY` (240 bytes, less the `flutter: ` tag) and the encoded
+summary is longer than that, so it does not arrive as one line — the shell
+chunks it onto a continuation record. Nothing is lost, but a reader that
+matches a single line gets only the first piece.
+
+The summary puts the five verdict flags first, so that first piece carries
+them. `MTT-CHECKS` is better still: short enough to be safe by construction, it
+always lands whole on one line. Should a record ever be dropped rather than
+chunked, it ends in `...+<n>` giving the number of characters lost.
 
 ## Expected results
 

--- a/test/integration/multi_touch_test/lib/main.dart
+++ b/test/integration/multi_touch_test/lib/main.dart
@@ -39,10 +39,16 @@
 //                    after a cancel arrives for any device. Advisory unless
 //                    a cancel is actually observed.
 //
-// A summary JSON line prefixed "MTT-SUMMARY:" is printed whenever all
-// contacts lift, and "MULTI_TOUCH_TEST: PASS|FAIL" whenever the Self-check
-// button is tapped or SELFCHECK_AFTER_S (dart-define) elapses — CI runs
-// scrape either.
+// Two lines are printed whenever all contacts lift: "MTT-CHECKS:" with the
+// five verdicts, and a summary JSON line prefixed "MTT-SUMMARY:".
+// "MULTI_TOUCH_TEST: PASS|FAIL" follows whenever the Self-check button is
+// tapped or SELFCHECK_AFTER_S (dart-define) elapses.
+//
+// CI should scrape "MTT-CHECKS:" or "MULTI_TOUCH_TEST:", not the JSON: the
+// embedder caps a log record and the encoded summary is longer than the cap,
+// so it is chunked onto a continuation record rather than arriving as one
+// line. The summary orders the verdict flags first so the first piece carries
+// them, but only the short lines are safe by construction.
 //
 // Drive it with tools/inject_ten_finger.py (uinput, no hardware needed) or a
 // real 10-point panel.
@@ -267,7 +273,17 @@ class _TouchProbePageState extends State<TouchProbePage> {
   bool get _c4 => _groupCount > 0 && _meanBatch >= kExpectBatchMean;
   bool get _c5 => _cancelViolations == 0; // advisory if no cancel observed
 
+  // Verdict flags first, counters after. The embedder caps a log record at
+  // IHS_LOG_TEXT_CAPACITY and the encoded summary is longer than that, so
+  // whatever sits at the end of this map is what gets clipped on the way out.
+  // The flags are the part a reader cannot reconstruct; a missing counter is
+  // merely inconvenient.
   Map<String, dynamic> _summary() => <String, dynamic>{
+        'c1_concurrency': _c1,
+        'c2_legality': _c2,
+        'c3_churn': _c3,
+        'c4_frame_batch': _c4,
+        'c5_cancel': _c5,
         'peak_simultaneous': _peakSimultaneous,
         'peak_distinct_ids': _peakDistinctAtPeak,
         'distinct_ids_total': _everSeenIds.length,
@@ -277,14 +293,19 @@ class _TouchProbePageState extends State<TouchProbePage> {
         'largest_batch': _largestGroup,
         'cancel_observed': _cancelObserved,
         'cancel_violations': _cancelViolations,
-        'c1_concurrency': _c1,
-        'c2_legality': _c2,
-        'c3_churn': _c3,
-        'c4_frame_batch': _c4,
-        'c5_cancel': _c5,
       };
 
+  // The five checks on one short line, well under any record cap, so a scrape
+  // never has to parse a JSON line that may have been clipped.
+  String _checksLine() => 'MTT-CHECKS: '
+      'c1=${_c1 ? 'pass' : 'FAIL'} '
+      'c2=${_c2 ? 'pass' : 'FAIL'} '
+      'c3=${_c3 ? 'pass' : 'FAIL'} '
+      'c4=${_c4 ? 'pass' : 'FAIL'} '
+      'c5=${_c5 ? 'pass' : 'FAIL'}';
+
   void _printSummary() {
+    debugPrint(_checksLine());
     debugPrint('MTT-SUMMARY: ${jsonEncode(_summary())}');
   }
 


### PR DESCRIPTION
## The problem

The test prints its results as one JSON line from Dart. It reaches the log through `Engine::onLogMessageCallback`, which formats `"{}: {}"` with the tag `flutter` — 9 characters of a 239-character record — leaving 230 for the message.

The encoded summary is ~307 characters. So every run silently lost its tail, and the tail was `c1_concurrency` through `c5_cancel`: exactly the five verdict flags the test exists to report.

Measured on the Pi 4 DSI run, the line ended:

```
...,"cancel_violations":0,"c1_concurrency":tru
```

Nothing about it indicated the rest was missing. I only caught it while looking for flags that had never been printed.

## The change

**Order the flags first in `_summary()`.** The clip now lands in the counters — which a reader can live without — instead of the verdicts, which are the point. With the values from the last hardware run, all five flags survive and the cut falls mid-`mean_batch`.

**Print `MTT-CHECKS` as its own line**, 51 characters:

```
MTT-CHECKS: c1=pass c2=pass c3=FAIL c4=pass c5=FAIL
MTT-SUMMARY: {"c1_concurrency":true,...}
```

Short enough to be safe by construction rather than by arithmetic. CI should scrape that rather than parse a JSON line that may have been clipped. README updated to say so.

## Scope

The cap belongs to the embedder's log record, not to this test, so this change does not try to fix it here — it arranges for the test's output to survive it. #394 makes a clipped record announce itself (`...+<n>`), which is the complementary half: this PR stops the verdict being lost, that one stops any truncation being silent.
