### PR TITLE
Chunk the engine's log messages instead of truncating them

### DIFF
--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -16,8 +16,11 @@
 #include <pthread.h>
 #include <sched.h>
 #include <filesystem>
+#include <string_view>
 #include <utility>
 #include <vector>
+
+#include "logging/log_chunk.h"
 #include "logging/logging.h"
 #include "profiling/pv_latency.h"
 
@@ -870,7 +873,22 @@ void Engine::OnFlutterPlatformMessage(
 void Engine::onLogMessageCallback(const char* tag,
                                   const char* message,
                                   void* /* user_data */) {
-  ihs::log::info("{}: {}", tag, message);
+  // Chunk rather than let the record cap cut the line. Dart print() and
+  // debugPrint() arrive here whole, and what they carry -- a stack trace, an
+  // encoded summary -- is routinely longer than one record, with the part
+  // worth reading at the end. LoggingHandler already treats the
+  // flutter/logging channel this way; this is the other path Dart output
+  // takes.
+  //
+  // Every chunk repeats the tag, so the budget is the record minus "<tag>: ".
+  const std::string_view tag_text = tag != nullptr ? tag : "";
+  const std::size_t overhead = tag_text.size() + 2;  // ": "
+  const std::size_t budget = overhead + 1 < IHS_LOG_TEXT_CAPACITY
+                                 ? IHS_LOG_TEXT_CAPACITY - 1 - overhead
+                                 : 1;
+  ihs::log::emit_chunked(message, budget, [tag_text](std::string_view line) {
+    ihs::log::info("{}: {}", tag_text, line);
+  });
 
 #if ENABLE_DLT
   // Route the Flutter engine's message to the DLT bridge under a dedicated

--- a/shell/logging/log_chunk.h
+++ b/shell/logging/log_chunk.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020-2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_LOGGING_LOG_CHUNK_H_
+#define SHELL_LOGGING_LOG_CHUNK_H_
+
+#include <cstddef>
+#include <string_view>
+
+namespace ihs::log {
+
+/**
+ * @brief Split a message so no piece exceeds @p max bytes, emitting each.
+ *
+ * A single ihs log record is capped at IHS_LOG_TEXT_CAPACITY bytes, but Dart
+ * messages — exception stack traces, an encoded summary — routinely exceed
+ * that, and the tail is where a structured payload keeps what the reader came
+ * for. Breaking on newlines first keeps a stack frame per record; whatever is
+ * still over length is hard-split rather than dropped.
+ *
+ * @p max is the budget for the text handed to @p emit, so a caller that
+ * prefixes each record (with a tag, say) passes the record capacity minus that
+ * prefix. It is clamped to at least 1 so a pathological budget cannot spin.
+ *
+ * An empty message is emitted once, unchanged: a caller logging "" means to
+ * produce a line.
+ */
+template <class Emit>
+void emit_chunked(const char* message, std::size_t max, Emit emit) {
+  if (message == nullptr) {
+    return;
+  }
+  if (max == 0) {
+    max = 1;
+  }
+  std::string_view rest{message};
+  if (rest.empty()) {
+    emit(rest);
+    return;
+  }
+  while (!rest.empty()) {
+    std::size_t take = rest.size();
+    const std::size_t nl = rest.find('\n');
+    const bool at_newline = nl != std::string_view::npos && nl < take;
+    if (at_newline) {
+      take = nl;
+    }
+    if (take > max) {
+      take = max;
+      emit(rest.substr(0, take));
+      rest.remove_prefix(take);
+      continue;
+    }
+    emit(rest.substr(0, take));
+    rest.remove_prefix(at_newline ? take + 1 : take);  // consume the '\n' too
+  }
+}
+
+}  // namespace ihs::log
+
+#endif  // SHELL_LOGGING_LOG_CHUNK_H_

--- a/shell/platform/homescreen/logging_handler.cc
+++ b/shell/platform/homescreen/logging_handler.cc
@@ -18,6 +18,7 @@
 
 #include <flutter/standard_method_codec.h>
 
+#include "logging/log_chunk.h"
 #include "logging/logging.h"
 
 LoggingHandler::LoggingHandler(flutter::BinaryMessenger* messenger,
@@ -60,38 +61,6 @@ enum DartLogLevel {
   kLevelOff = 6,
 };
 
-// A single ihs log record is capped at IHS_LOG_TEXT_CAPACITY bytes, but Dart
-// messages — notably exception stack traces — routinely exceed that. Emit the
-// message in chunks so nothing is silently truncated: break on newlines first
-// (natural per stack frame), then hard-split any remaining over-length run.
-template <class Emit>
-void emit_chunked(const char* message, Emit emit) {
-  if (message == nullptr) {
-    return;
-  }
-  constexpr std::size_t kMax = IHS_LOG_TEXT_CAPACITY - 1;
-  std::string_view rest{message};
-  if (rest.empty()) {
-    emit(rest);
-    return;
-  }
-  while (!rest.empty()) {
-    std::size_t take = rest.size();
-    const std::size_t nl = rest.find('\n');
-    const bool at_newline = nl != std::string_view::npos && nl < take;
-    if (at_newline) {
-      take = nl;
-    }
-    if (take > kMax) {
-      take = kMax;
-      emit(rest.substr(0, take));
-      rest.remove_prefix(take);
-      continue;
-    }
-    emit(rest.substr(0, take));
-    rest.remove_prefix(at_newline ? take + 1 : take);  // consume the '\n' too
-  }
-}
 }  // namespace
 
 void LoggingHandler::OnLogMessage(int level,
@@ -124,5 +93,5 @@ void LoggingHandler::OnLogMessage(int level,
         break;
     }
   };
-  emit_chunked(message, emit);
+  ihs::log::emit_chunked(message, IHS_LOG_TEXT_CAPACITY - 1, emit);
 }


### PR DESCRIPTION
## The gap

Dart `print()` and `debugPrint()` reach the shell through `Engine::onLogMessageCallback`, which formatted `"{}: {}"` into a single record and let the remainder fall off. A record holds `IHS_LOG_TEXT_CAPACITY` bytes, so with the `flutter` tag anything past 230 bytes was lost — and a stack trace or an encoded summary keeps the part worth reading at the end.

The shell had already decided how this should behave. `LoggingHandler::OnLogMessage` splits long messages on newlines and hard-splits the remainder, under a comment saying it does so "so nothing is silently truncated". That treatment simply never reached the other path Dart output takes.

## The change

Lift the existing helper into `shell/logging/log_chunk.h`, give it an explicit budget so a caller that prefixes each record can subtract its prefix, and call it from both places. The engine callback repeats the tag on every chunk, so it passes the record capacity minus `"<tag>: "`.

No new policy, no new buffer, no cap change — the behavior the codebase already documented, applied to the path that was missing it.

## Verification

Raspberry Pi 4 on `drm-kms-egl`, using `multi_touch_test` with `SELFCHECK_AFTER_S` so the summary prints on a timer — no touch input needed. Its JSON payload is 301 bytes.

**Before** — the line stops at the cap, and the next line is the following summary. The remainder never existed:

```
[I] SHEL: flutter: MTT-SUMMARY: {"peak_simultaneous":10,"peak_distinct_ids":10,"di
[I] SHEL: flutter: MTT-SUMMARY: {"peak_simultaneous":10,"peak_distinct_ids":10,"di
```

**After** — same box, same app, the 230-byte line is followed by its own 71-byte continuation:

```
[I] SHEL: flutter: MTT-SUMMARY: {"peak_simultaneous":0,"peak_distinct_ids":0,"dist
[I] SHEL: flutter: egality":true,"c3_churn":false,"c4_frame_batch":false,"c5_cance
```

230 + 71 = 301, so nothing is dropped. Re-ran on the post-`clang-format` binary.

## Relationship to the other two

- #394 marks a clipped record with `...+<n>`. Still worth having as the backstop for producers that don't chunk, but after this change the Dart path no longer relies on it.
- #395 reorders that summary's fields so the verdict flags survive a clip. Independent of this, and still the right belt-and-braces for anything that reads a single line.

Raising `IHS_LOG_TEXT_CAPACITY` was considered and not done: the ring is pre-allocated per producer thread (256 slots inline, never freed), so a bigger cap is pure memory — 80 KiB per thread today, 96 KiB at a 304-byte cap — and any cap still has a cliff. Chunking removes the cliff for the path long lines actually come from. A configurable cap can follow separately if it earns its keep.
