### PR TITLE
logging: rejoin a split message so it prints as one line

### DIFF
--- a/shared/src/logging/bridge.cpp
+++ b/shared/src/logging/bridge.cpp
@@ -103,8 +103,44 @@ bool DltBridge::log(const ContextHandle& ctx,
     return false;
   }
   ThreadRing& ring = RingRegistry::thread_local_ring();
-  return ring.push(ctx.index(), static_cast<std::uint8_t>(level),
-                   message.data(), message.size());
+  const auto lvl = static_cast<std::uint8_t>(level);
+
+  // A message that fits is one slot, which is the common case and stays a
+  // single push.
+  constexpr std::size_t kFit = kSlotTextCapacity - 1;
+  if (message.size() <= kFit) {
+    return ring.push(ctx.index(), lvl, message.data(), message.size());
+  }
+
+  // Longer than a slot: split it here rather than let the slot clip it, and
+  // mark every piece but the last so the drain can put it back together. Doing
+  // this below the C ABI means a caller never has to know the slot size --
+  // ihs_log() takes a message of any length and nothing is lost.
+  //
+  // All or nothing. A run whose last piece failed to enqueue would leave the
+  // drain holding a partial with no terminator, and the next unrelated record
+  // on this ring would be appended to it and printed as though it belonged --
+  // one corrupt line, plus a lost one, from a transient full ring. So take the
+  // room up front; the consumer only ever frees more, so a count read here
+  // cannot shrink under us.
+  const std::size_t pieces = (message.size() + kFit - 1) / kFit;
+  if (ring.space() < pieces) {
+    // Not enough room for the whole message. Enqueue what one slot holds and
+    // let push() mark it clipped, which is exactly the behavior this path had
+    // before it learned to split.
+    return ring.push(ctx.index(), lvl, message.data(), message.size());
+  }
+  bool ok = true;
+  std::string_view rest = message;
+  while (!rest.empty()) {
+    const std::size_t take = rest.size() < kFit ? rest.size() : kFit;
+    const bool last = take == rest.size();
+    ok = ring.push(ctx.index(), lvl, rest.data(), take,
+                   last ? 0 : kFlagContinues) &&
+         ok;
+    rest.remove_prefix(take);
+  }
+  return ok;
 }
 
 }  // namespace ihs::dlt

--- a/shared/src/logging/dlt_sink.cpp
+++ b/shared/src/logging/dlt_sink.cpp
@@ -16,12 +16,45 @@
 
 #include "dlt_sink.hpp"
 
+#include <array>
+#include <cstdio>
+#include <cstring>
+
+#include "ring_slot.hpp"
+
 #include "libdlt_loader.hpp"
 
 namespace ihs::dlt {
 
 void DltSink::write(const LogRecord& record) noexcept {
-  loader_.emit(record.dlt_ctx, static_cast<int>(record.level), record.text);
+  // A record reaching a sink can now be longer than one ring slot: the drain
+  // rejoins a message that was split across slots, so a console or file sink
+  // prints it as one line. DLT does not get that. Its payload buffer is
+  // libdlt's, sized by DLT_USER_BUF_MAX_SIZE inside a library we dlopen and
+  // deliberately do not trust with its own bounds (see libdlt_loader's guard
+  // scratch), and until this rejoin every record handed to it was bounded by
+  // the slot. Clamping here keeps that bound exactly, so what DLT is asked to
+  // carry does not change.
+  if (record.text_len < kSlotTextCapacity) {
+    loader_.emit(record.dlt_ctx, static_cast<int>(record.level), record.text);
+    return;
+  }
+  // Say that it was clamped, the same way a record clipped on the way into a
+  // slot says so. Silently handing DLT a shortened line would leave its reader
+  // unable to tell one from a message that simply ended there.
+  std::array<char, kSlotTextCapacity> clamped{};
+  char mark[32];
+  const int marked = std::snprintf(mark, sizeof(mark), "...+%zu",
+                                   record.text_len - (clamped.size() - 1));
+  const std::size_t mark_len =
+      marked > 0 && static_cast<std::size_t>(marked) < sizeof(mark)
+          ? static_cast<std::size_t>(marked)
+          : 0;
+  const std::size_t take = clamped.size() - 1 - mark_len;
+  std::memcpy(clamped.data(), record.text, take);
+  std::memcpy(clamped.data() + take, mark, mark_len);
+  clamped[take + mark_len] = '\0';
+  loader_.emit(record.dlt_ctx, static_cast<int>(record.level), clamped.data());
 }
 
 }  // namespace ihs::dlt

--- a/shared/src/logging/ring_slot.hpp
+++ b/shared/src/logging/ring_slot.hpp
@@ -8,6 +8,13 @@ namespace ihs::dlt {
 
 inline constexpr std::size_t kSlotTextCapacity = 240;
 
+// RingSlot::flags. A message longer than a slot is pushed as several slots,
+// every one but the last carrying kFlagContinues; the drain rejoins them so a
+// sink is handed the whole message and emits one line with one prefix. Without
+// that a long line arrives split, each piece separately timestamped and
+// tagged, and a reader has to reassemble it by hand.
+inline constexpr std::uint8_t kFlagContinues = 0x1;
+
 // Fixed-size slot owned by the producer thread's SPSC ring. Cache-line aligned
 // to keep producer writes from false-sharing with consumer reads of adjacent
 // slots.
@@ -17,7 +24,7 @@ struct alignas(64) RingSlot {
   std::uint32_t sequence = 0;   // monotonically increasing per-ring
   std::uint16_t text_len = 0;
   std::uint8_t level = 0;  // ihs::dlt::LogLevel value
-  std::uint8_t reserved = 0;
+  std::uint8_t flags = 0;  // kFlagContinues
   char text[kSlotTextCapacity] = {};
 
   [[nodiscard]] const char* message() const noexcept { return text; }

--- a/shared/src/logging/thread_ring.cpp
+++ b/shared/src/logging/thread_ring.cpp
@@ -24,7 +24,8 @@ namespace ihs::dlt {
 bool ThreadRing::push(std::uint32_t ctx_index,
                       std::uint8_t level,
                       const char* text,
-                      std::size_t len) noexcept {
+                      std::size_t len,
+                      std::uint8_t flags) noexcept {
   const std::uint32_t head = head_.load(std::memory_order_relaxed);
   const std::uint32_t tail = tail_.load(std::memory_order_acquire);
 
@@ -36,6 +37,7 @@ bool ThreadRing::push(std::uint32_t ctx_index,
   RingSlot& slot = slots_[head & kMask];
   slot.ctx_index = ctx_index;
   slot.level = level;
+  slot.flags = flags;
   slot.sequence = head;
   slot.ts_ns = now_realtime_ns();
 

--- a/shared/src/logging/thread_ring.hpp
+++ b/shared/src/logging/thread_ring.hpp
@@ -6,6 +6,8 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <string_view>
 
 namespace ihs::dlt {
 
@@ -27,11 +29,67 @@ class ThreadRing {
   bool push(std::uint32_t ctx_index,
             std::uint8_t level,
             const char* text,
-            std::size_t len) noexcept;
+            std::size_t len,
+            std::uint8_t flags = 0) noexcept;
+
+  // Free slots, from the producer's side. Safe to act on: the consumer only
+  // ever frees more, so a count taken here cannot shrink before the producer
+  // uses it. Lets a caller splitting one message across slots check up front
+  // that the whole sequence fits, rather than discover halfway that it does
+  // not and leave an unterminated run behind.
+  [[nodiscard]] std::size_t space() const noexcept {
+    const std::uint32_t head = head_.load(std::memory_order_relaxed);
+    const std::uint32_t tail = tail_.load(std::memory_order_acquire);
+    const std::uint32_t used = head - tail;
+    return used >= kRingCapacity ? 0 : kRingCapacity - used;
+  }
 
   // Consumer side — called only from the worker thread.
   [[nodiscard]] const RingSlot* peek() const noexcept;
   void pop() noexcept;
+
+  // Reassembly buffer for a message split across slots. Consumer-side only:
+  // the worker owns it, so it needs no synchronization, and it lives here
+  // rather than in the worker because a drain can end mid-sequence and the
+  // partial has to survive until the next pass over this ring.
+  //
+  // Capped so a producer that never terminates a sequence cannot grow it
+  // without bound; past the cap the tail is dropped, which is the same outcome
+  // as the old per-slot clipping and strictly better than exhausting memory.
+  [[nodiscard]] const std::string& partial() const noexcept { return partial_; }
+
+  // The emit time of the piece that started the partial. A rejoined message
+  // belongs at the instant it was logged, not at the instant its last piece
+  // landed -- otherwise a long message sorts after short ones that were logged
+  // while it was still being written.
+  [[nodiscard]] std::uint64_t partial_ts_ns() const noexcept {
+    return partial_ts_ns_;
+  }
+  void begin_partial(std::uint64_t ts_ns) noexcept { partial_ts_ns_ = ts_ns; }
+  void append_partial(const char* text, std::size_t len) {
+    if (text == nullptr || dropped_partial_) {
+      return;
+    }
+    // Mark the clip where it happens rather than on a later call: the piece
+    // that overflows may be the last one, and then no later call comes. A
+    // reader cannot otherwise tell a complete message from one that hit the
+    // ceiling. push() marks its own clip the same way, for the message it is
+    // handed whole when a split would not fit the ring.
+    const std::size_t room =
+        kMaxText > partial_.size() ? kMaxText - partial_.size() : 0;
+    if (len <= room) {
+      partial_.append(text, len);
+      return;
+    }
+    partial_.append(text, room);
+    partial_.append(kCapMark);  // room was reserved for it; the cap holds
+    dropped_partial_ = true;
+  }
+  void clear_partial() noexcept {
+    partial_.clear();
+    dropped_partial_ = false;
+    partial_ts_ns_ = 0;
+  }
 
   [[nodiscard]] bool empty() const noexcept;
   [[nodiscard]] std::size_t pending() const noexcept;
@@ -58,6 +116,18 @@ class ThreadRing {
   // Registry linkage — touched only under RingRegistry's ownership.
   ThreadRing* next = nullptr;
 
+ private:
+  // kMaxPartial bounds the buffer; kMaxText is what a message may occupy in
+  // it, the difference reserved so the marker always fits without pushing the
+  // buffer past its own cap.
+  static constexpr std::string_view kCapMark = "...[log record capped]";
+  static constexpr std::size_t kMaxPartial = 64 * 1024;
+  static constexpr std::size_t kMaxText = kMaxPartial - kCapMark.size();
+  std::string partial_;
+  std::uint64_t partial_ts_ns_ = 0;  // emit time of the piece that started it
+  bool dropped_partial_ = false;     // cap hit; marker already appended
+
+ public:
  private:
   static constexpr std::uint32_t kMask = kRingCapacity - 1;
 

--- a/shared/src/logging/worker.cpp
+++ b/shared/src/logging/worker.cpp
@@ -16,8 +16,10 @@
 
 #include "worker.hpp"
 
+#include <string_view>
 #include "context_cache.hpp"
 #include "ring_registry.hpp"
+
 #include "ring_slot.hpp"
 #include "thread_ring.hpp"
 
@@ -122,17 +124,42 @@ std::size_t Worker::drain_all() {
        ring = ring->next) {
     while (const RingSlot* slot = ring->peek()) {
       if (ContextEntry* entry = cache_.at(slot->ctx_index)) {
+        // Rejoin a message that was split across slots. The pieces are
+        // consecutive in this ring -- one thread owns it, and the split loop
+        // pushes them back to back -- but a drain can land mid-sequence, so
+        // the partial lives on the ring across passes rather than in a local.
+        // A sink is only ever handed a whole message, so it keeps printing one
+        // prefix per line and needs to know nothing about any of this.
+        const bool continues = (slot->flags & kFlagContinues) != 0;
+        const bool joining = continues || !ring->partial().empty();
+        if (joining) {
+          if (ring->partial().empty()) {
+            ring->begin_partial(slot->ts_ns);
+          }
+          ring->append_partial(slot->text, slot->text_len);
+          if (continues) {
+            ring->pop();
+            ++drained;
+            continue;
+          }
+        }
+        const std::string_view whole =
+            joining ? std::string_view{ring->partial()}
+                    : std::string_view{slot->text, slot->text_len};
         const LogRecord record{
             entry->id.c_str(),
             &entry->dlt_ctx,
             static_cast<LogLevel>(slot->level),
-            slot->text,
-            slot->text_len,
-            slot->ts_ns,  // emit time, captured when the record was pushed
+            whole.data(),
+            whole.size(),
+            // A rejoined message is stamped when its first piece was pushed,
+            // so it sorts where it was logged rather than where it finished.
+            joining ? ring->partial_ts_ns() : slot->ts_ns,
         };
         for (const auto& sink : *sinks_) {
           sink->write(record);
         }
+        ring->clear_partial();
       }
       ring->pop();
       ++drained;

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -873,20 +873,12 @@ void Engine::OnFlutterPlatformMessage(
 void Engine::onLogMessageCallback(const char* tag,
                                   const char* message,
                                   void* /* user_data */) {
-  // Chunk rather than let the record cap cut the line. Dart print() and
-  // debugPrint() arrive here whole, and what they carry -- a stack trace, an
-  // encoded summary -- is routinely longer than one record, with the part
-  // worth reading at the end. LoggingHandler already treats the
-  // flutter/logging channel this way; this is the other path Dart output
-  // takes.
-  //
-  // Every chunk repeats the tag, so the budget is the record minus "<tag>: ".
+  // One record per line. Dart print() and debugPrint() arrive here whole, and
+  // a stack trace is several lines in one string; without this they run
+  // together into a single record. Over-length lines need no handling here --
+  // the logging library splits and the drain rejoins them.
   const std::string_view tag_text = tag != nullptr ? tag : "";
-  const std::size_t overhead = tag_text.size() + 2;  // ": "
-  const std::size_t budget = overhead + 1 < IHS_LOG_TEXT_CAPACITY
-                                 ? IHS_LOG_TEXT_CAPACITY - 1 - overhead
-                                 : 1;
-  ihs::log::emit_chunked(message, budget, [tag_text](std::string_view line) {
+  ihs::log::emit_chunked(message, [tag_text](std::string_view line) {
     ihs::log::info("{}: {}", tag_text, line);
   });
 

--- a/shell/logging/log_chunk.h
+++ b/shell/logging/log_chunk.h
@@ -23,28 +23,25 @@
 namespace ihs::log {
 
 /**
- * @brief Split a message so no piece exceeds @p max bytes, emitting each.
+ * @brief Emit a message one line at a time.
  *
- * A single ihs log record is capped at IHS_LOG_TEXT_CAPACITY bytes, but Dart
- * messages — exception stack traces, an encoded summary — routinely exceed
- * that, and the tail is where a structured payload keeps what the reader came
- * for. Breaking on newlines first keeps a stack frame per record; whatever is
- * still over length is hard-split rather than dropped.
+ * Dart messages — exception stack traces above all — arrive as several lines
+ * in one string, and a log record is a line. Splitting on newlines here keeps
+ * one stack frame per record instead of running them together.
  *
- * @p max is the budget for the text handed to @p emit, so a caller that
- * prefixes each record (with a tag, say) passes the record capacity minus that
- * prefix. It is clamped to at least 1 so a pathological budget cannot spin.
+ * Length is deliberately not this function's problem. A run with no newline to
+ * break on is emitted whole, however long: the logging library splits an
+ * over-length message across records itself and the drain rejoins them, so it
+ * reaches a sink intact. Cutting it here would hand the library several
+ * complete messages instead, and it would print as several stamped pieces.
  *
  * An empty message is emitted once, unchanged: a caller logging "" means to
  * produce a line.
  */
 template <class Emit>
-void emit_chunked(const char* message, std::size_t max, Emit emit) {
+void emit_chunked(const char* message, Emit emit) {
   if (message == nullptr) {
     return;
-  }
-  if (max == 0) {
-    max = 1;
   }
   std::string_view rest{message};
   if (rest.empty()) {
@@ -57,12 +54,6 @@ void emit_chunked(const char* message, std::size_t max, Emit emit) {
     const bool at_newline = nl != std::string_view::npos && nl < take;
     if (at_newline) {
       take = nl;
-    }
-    if (take > max) {
-      take = max;
-      emit(rest.substr(0, take));
-      rest.remove_prefix(take);
-      continue;
     }
     emit(rest.substr(0, take));
     rest.remove_prefix(at_newline ? take + 1 : take);  // consume the '\n' too

--- a/shell/logging/logging.h
+++ b/shell/logging/logging.h
@@ -37,6 +37,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -102,10 +104,27 @@ inline void emit_fmt(IhsLogLevel level,
   char buf[IHS_LOG_TEXT_CAPACITY];
   const auto result = fmt::format_to_n(buf, sizeof(buf) - 1, fmt_str,
                                        std::forward<Args>(args)...);
-  const std::size_t len = result.size < sizeof(buf)
-                              ? static_cast<std::size_t>(result.size)
-                              : sizeof(buf) - 1;
-  ihs_log(ctx.index(), static_cast<std::uint8_t>(level), buf, len);
+  if (result.size < sizeof(buf)) {
+    ihs_log(ctx.index(), static_cast<std::uint8_t>(level), buf,
+            static_cast<std::size_t>(result.size));
+    maybe_flush(level);
+    return;
+  }
+  // Too long for the stack buffer. Format it again into a growable one and
+  // hand the whole thing over: ihs_log splits an over-length message across
+  // records and the drain rejoins them, so the line survives -- but only if it
+  // arrives intact. Clipping it here would lose the tail before the library
+  // ever sees it, silently, unlike a record the library had to drop.
+  //
+  // The buffer is thread_local and kept, so a caller that logs long lines
+  // repeatedly allocates once rather than per call, and a caller that never
+  // does pays nothing.
+  static thread_local std::string overflow;
+  overflow.clear();
+  fmt::format_to(std::back_inserter(overflow), fmt_str,
+                 std::forward<Args>(args)...);
+  ihs_log(ctx.index(), static_cast<std::uint8_t>(level), overflow.data(),
+          overflow.size());
   maybe_flush(level);
 }
 

--- a/shell/platform/homescreen/logging_handler.cc
+++ b/shell/platform/homescreen/logging_handler.cc
@@ -93,5 +93,5 @@ void LoggingHandler::OnLogMessage(int level,
         break;
     }
   };
-  ihs::log::emit_chunked(message, IHS_LOG_TEXT_CAPACITY - 1, emit);
+  ihs::log::emit_chunked(message, emit);
 }

--- a/test/integration/multi_touch_test/README.md
+++ b/test/integration/multi_touch_test/README.md
@@ -39,16 +39,18 @@ MTT-SUMMARY: {json}
 `MULTI_TOUCH_TEST: PASS|FAIL` is printed by the Self-check button, or
 automatically with `--dart-define=SELFCHECK_AFTER_S=<seconds>`.
 
-Scrape `MTT-CHECKS`, not the JSON. The embedder caps a log record at
-`IHS_LOG_TEXT_CAPACITY` (240 bytes, less the `flutter: ` tag) and the encoded
-summary is longer than that, so it does not arrive as one line — the shell
-chunks it onto a continuation record. Nothing is lost, but a reader that
-matches a single line gets only the first piece.
+`MTT-SUMMARY` arrives whole, on one line, and parses. A log record is capped at
+`IHS_LOG_TEXT_CAPACITY` and the encoded summary is longer than that, but the
+logging library splits an over-length message across records and rejoins it
+before any sink sees it, so what lands in the log is a single line.
 
-The summary puts the five verdict flags first, so that first piece carries
-them. `MTT-CHECKS` is better still: short enough to be safe by construction, it
-always lands whole on one line. Should a record ever be dropped rather than
-chunked, it ends in `...+<n>` giving the number of characters lost.
+`MTT-CHECKS` remains the easier thing to scrape — the five verdicts, no JSON
+parser needed — and `MULTI_TOUCH_TEST: PASS|FAIL` easier still. The summary
+orders the verdict flags first, which no longer matters for surviving a cut and
+is simply a readable order.
+
+Verified on a Raspberry Pi 4 over `drm-kms-egl`: two summary lines from a touch
+session, both parsed by `json.load`, 14 keys each.
 
 ## Expected results
 

--- a/test/integration/multi_touch_test/lib/main.dart
+++ b/test/integration/multi_touch_test/lib/main.dart
@@ -44,11 +44,10 @@
 // "MULTI_TOUCH_TEST: PASS|FAIL" follows whenever the Self-check button is
 // tapped or SELFCHECK_AFTER_S (dart-define) elapses.
 //
-// CI should scrape "MTT-CHECKS:" or "MULTI_TOUCH_TEST:", not the JSON: the
-// embedder caps a log record and the encoded summary is longer than the cap,
-// so it is chunked onto a continuation record rather than arriving as one
-// line. The summary orders the verdict flags first so the first piece carries
-// them, but only the short lines are safe by construction.
+// The summary is longer than one log record, but the logging library splits
+// and rejoins it, so it arrives on one line and parses. CI can read the JSON,
+// or scrape "MTT-CHECKS:" / "MULTI_TOUCH_TEST:" and skip parsing entirely. The
+// verdict flags come first for readability, not to survive a cut.
 //
 // Drive it with tools/inject_ten_finger.py (uinput, no hardware needed) or a
 // real 10-point panel.


### PR DESCRIPTION
## The problem

A log record is one ring slot. A message longer than a slot arrived as several lines, each with its own timestamp and tag, and the reader had to put it back together. For a structured payload that means no single line is parseable:

```
[I] SHEL: flutter: MTT-SUMMARY: {"c1_concurrency":false,...,"move_groups":0,"mean_batc
[I] SHEL: flutter: h":0.0,"largest_batch":0,"cancel_observed":false,"cancel_violations":0}
```

Nothing is lost there — #396 saw to that — but neither line is JSON, and the split lands mid-token.

## The change

Split below the C ABI, rejoin at the drain, so the seam never reaches a sink.

- **`ihs_log()` takes a message of any length.** Longer than a slot, it is pushed as several slots with every piece but the last carrying `kFlagContinues`. The flag rides in the byte `RingSlot` already had spare, so slot size and its cache-line sizing are untouched.
- **The drain rejoins before writing.** A sink is handed the whole message and keeps printing one prefix per line, knowing nothing about any of this — so console, file, and any future sink benefit without changes. The partial lives on the ring rather than in a local, because a drain can end mid-sequence, and it is capped so a producer that never terminates a sequence cannot grow it without bound.
- **`emit_fmt` no longer clips at its stack buffer.** This was the one that actually bit: it formatted into `char[IHS_LOG_TEXT_CAPACITY]` and truncated *upstream* of everything above, so the tail was gone before the library saw it. Over length it now formats into a `thread_local` string, kept between calls, so a caller that logs long lines allocates once and one that never does pays nothing.

The shell's newline splitting stays — a stack trace should be one record per frame. Its hard-split of over-length runs is gone, since that hands the library several complete messages and defeats the rejoin.

## DLT is deliberately excluded

Its payload buffer belongs to a libdlt we `dlopen` and explicitly do not trust with its own bounds — `libdlt_loader` brackets it with sentinel guards and self-disables on overrun. Until this rejoin, every record handed to it was bounded by the slot; after it, a record could be up to the 64 KiB assembly cap. `DltSink` clamps to the old bound, so what DLT is asked to carry does not change.

## Verification

| | result |
| --- | --- |
| x86_64 probe, 399-byte record via the C ABI | one line, one prefix, 399 bytes |
| Pi 4, `drm-kms-egl`, `multi_touch_test` summary | one 301-byte line, `json.load` parses it, 14 keys |
| before, same box | 230 bytes + a continuation, neither piece valid JSON |

Also built with `ENABLE_DLT=ON` — a config none of the earlier logging changes were compiled against.

## Relationship to what has already landed

- #396 chunked in the shell so nothing was lost. This supersedes its hard-split half while keeping its newline half, and goes further: the pieces are now rejoined rather than left for the reader.
- #394's `...+<n>` marker stays meaningful for a record that is genuinely dropped — the assembly cap, or a ring overflow — rather than split.
