### PR TITLE
platform-views: give the gesture callbacks their listener context

### DIFF
--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -761,9 +761,15 @@ uint32_t IhsPluginView::GetGlTextureName() const {
 
 // platform_view_listener trampolines: the registry drives these with the
 // listener context (the IhsPluginView*), which we forward into the plugin's
-// IhsPvCallbacks. accept_gesture/reject_gesture take a bare id (no context), so
-// they cannot reach the view here and are left null — gesture-arena arbitration
-// for ihs_pv views is a follow-up.
+// IhsPvCallbacks.
+//
+// accept_gesture/reject_gesture are wired for completeness rather than because
+// anything calls them. Flutter emits acceptGesture/rejectGesture only from
+// DarwinPlatformViewController; the PlatformViewLink/PlatformViewSurface path
+// an ihs_pv view is built from settles the gesture arena inside the render
+// object, flushing or dropping the cached pointer events without a platform
+// message. So a plugin's callbacks stay unreached on Linux until something
+// drives that channel — the host side is simply no longer the reason why.
 void ListenerResize(double width, double height, void* data) {
   auto* view = static_cast<IhsPluginView*>(data);
   if (view->callbacks.resize != nullptr) {
@@ -783,6 +789,20 @@ void ListenerOnTouch(int32_t action,
   }
 }
 
+void ListenerAcceptGesture(int32_t /* id */, void* data) {
+  auto* view = static_cast<IhsPluginView*>(data);
+  if (view->callbacks.accept_gesture != nullptr) {
+    view->callbacks.accept_gesture(view->plugin_user_data);
+  }
+}
+
+void ListenerRejectGesture(int32_t /* id */, void* data) {
+  auto* view = static_cast<IhsPluginView*>(data);
+  if (view->callbacks.reject_gesture != nullptr) {
+    view->callbacks.reject_gesture(view->plugin_user_data);
+  }
+}
+
 void ListenerDispose(bool /*hybrid*/, void* data) {
   static_cast<IhsPluginView*>(data)->DisposePlugin();
 }
@@ -793,8 +813,8 @@ const platform_view_listener kListener = {
     /* set_offset */ nullptr,
     /* on_touch */ ListenerOnTouch,
     /* dispose */ ListenerDispose,
-    /* accept_gesture */ nullptr,
-    /* reject_gesture */ nullptr,
+    /* accept_gesture */ ListenerAcceptGesture,
+    /* reject_gesture */ ListenerRejectGesture,
 };
 
 // --- IhsPvHost implementation -----------------------------------------------

--- a/shell/platform/homescreen/platform_views/platform_view_listener.h
+++ b/shell/platform/homescreen/platform_views/platform_view_listener.h
@@ -32,16 +32,20 @@ struct platform_view_listener {
                    const double* pointer_data,
                    void* data);
   void (*dispose)(bool hybrid, void* data);
-  /// When a touch sequence is happening on the embedded UIView all touch events
-  /// are delayed. Calling this method releases the delayed events to the
-  /// embedded UIView and makes it consume any following touch events for the
-  /// pointers involved in the active gesture.
-  void (*accept_gesture)(int32_t id);
-  /// When a touch sequence is happening on the embedded UIView all touch events
-  /// are delayed. Calling this method drops the buffered touch events and
-  /// prevents any future touch events for the pointers that are part of the
-  /// active touch sequence from arriving to the embedded view.
-  void (*reject_gesture)(int32_t id);
+  /// Gesture-arena arbitration for a sequence already delivered to the view:
+  /// accept releases the delayed touches to it and lets it consume the rest of
+  /// the sequence, reject drops them and sends it nothing further for those
+  /// pointers.
+  ///
+  /// These are an iOS concept ("the embedded UIView" of the original docs) and
+  /// nothing on Linux drives them today: Flutter sends acceptGesture /
+  /// rejectGesture from DarwinPlatformViewController alone, while the
+  /// PlatformViewSurface path used here settles the arena inside the render
+  /// object without a platform message. They take @p data like every other
+  /// entry so a host can reach the view they concern, rather than being the
+  /// two a host cannot implement.
+  void (*accept_gesture)(int32_t id, void* data);
+  void (*reject_gesture)(int32_t id, void* data);
 };
 
 typedef void (*PlatformViewAddListener)(void* context,

--- a/shell/platform/homescreen/platform_views/platform_view_registry.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_registry.cc
@@ -200,7 +200,7 @@ void PlatformViewRegistry::AcceptGesture(int32_t id) {
   void* context = nullptr;
   if (LookupListener(id, &listener, &context) &&
       listener->accept_gesture != nullptr) {
-    listener->accept_gesture(id);
+    listener->accept_gesture(id, context);
   }
 }
 
@@ -209,7 +209,7 @@ void PlatformViewRegistry::RejectGesture(int32_t id) {
   void* context = nullptr;
   if (LookupListener(id, &listener, &context) &&
       listener->reject_gesture != nullptr) {
-    listener->reject_gesture(id);
+    listener->reject_gesture(id, context);
   }
 }
 

--- a/test/unit_test/platform_view_registry-test/test_case_platform_view_registry.cc
+++ b/test/unit_test/platform_view_registry-test/test_case_platform_view_registry.cc
@@ -34,6 +34,10 @@ struct Probe {
   int dispose = 0;
   double last_w = 0;
   double last_h = 0;
+  int accept = 0;
+  int reject = 0;
+  int32_t last_gesture_id = -1;
+  void* last_gesture_data = nullptr;
 };
 
 void ProbeResize(double w, double h, void* data) {
@@ -47,18 +51,35 @@ void ProbeDispose(bool /* hybrid */, void* data) {
   ++static_cast<Probe*>(data)->dispose;
 }
 
+void ProbeAcceptGesture(int32_t id, void* data) {
+  auto* p = static_cast<Probe*>(data);
+  ++p->accept;
+  p->last_gesture_id = id;
+  p->last_gesture_data = data;
+}
+
+void ProbeRejectGesture(int32_t id, void* data) {
+  auto* p = static_cast<Probe*>(data);
+  ++p->reject;
+  p->last_gesture_id = id;
+  p->last_gesture_data = data;
+}
+
 constexpr platform_view_listener kListener = {
-    ProbeResize,   // resize
-    nullptr,       // set_direction
-    nullptr,       // set_offset
-    nullptr,       // on_touch
-    ProbeDispose,  // dispose
-    nullptr,       // accept_gesture
-    nullptr,       // reject_gesture
+    ProbeResize,         // resize
+    nullptr,             // set_direction
+    nullptr,             // set_offset
+    nullptr,             // on_touch
+    ProbeDispose,        // dispose
+    ProbeAcceptGesture,  // accept_gesture
+    ProbeRejectGesture,  // reject_gesture
 };
 
 // A factory-created instance that flips a flag when destroyed, so the test can
 // prove the registry owns and releases it on dispose.
+//
+// (kListener above now fills accept_gesture/reject_gesture; the arbitration
+// test below is what those are for.)
 class FakeView : public PlatformView {
  public:
   FakeView(const PlatformViewRegistry::CreateRequest& r, bool* destroyed)
@@ -105,6 +126,37 @@ TEST(PlatformViewRegistry, LegacyListenerLifecycle) {
 // replaced in place, so the id stays live and dispatch reaches the listener.
 // (The old toggle erased the entry, which CreateViaFactory then resurrected
 // with a null listener -> a later Resize dereferenced it and crashed.)
+// The gesture callbacks are handed the listener's context, so a host can reach
+// the view a decision concerns. Before they took a bare id, which is why the
+// ihs_pv host could not implement them at all.
+TEST(PlatformViewRegistry, GestureArbitrationCarriesListenerContext) {
+  PlatformViewRegistry registry(nullptr);
+  Probe probe;
+  registry.RegisterListener(7, &kListener, &probe);
+
+  registry.AcceptGesture(7);
+  EXPECT_EQ(probe.accept, 1);
+  EXPECT_EQ(probe.reject, 0);
+  EXPECT_EQ(probe.last_gesture_id, 7);
+  EXPECT_EQ(probe.last_gesture_data, &probe);
+
+  registry.RejectGesture(7);
+  EXPECT_EQ(probe.reject, 1);
+  EXPECT_EQ(probe.last_gesture_id, 7);
+  EXPECT_EQ(probe.last_gesture_data, &probe);
+
+  // An id with no listener is a no-op, not a crash.
+  registry.AcceptGesture(99);
+  registry.RejectGesture(99);
+  EXPECT_EQ(probe.accept, 1);
+  EXPECT_EQ(probe.reject, 1);
+
+  // After dispose the listener is gone and arbitration stops reaching it.
+  EXPECT_TRUE(registry.Dispose(7, false));
+  registry.AcceptGesture(7);
+  EXPECT_EQ(probe.accept, 1);
+}
+
 TEST(PlatformViewRegistry, RepeatedRegistrationReplacesInPlace) {
   PlatformViewRegistry registry(nullptr);
   Probe probe;


### PR DESCRIPTION
## The asymmetry

`accept_gesture` and `reject_gesture` take a bare `int32_t id`; every other entry in `platform_view_listener` takes a trailing `void* data`. `PlatformViewRegistry` already resolves the listener's context for them and then discards it:

```cpp
void PlatformViewRegistry::AcceptGesture(int32_t id) {
  const platform_view_listener* listener = nullptr;
  void* context = nullptr;                       // resolved…
  if (LookupListener(id, &listener, &context) && listener->accept_gesture) {
    listener->accept_gesture(id);                // …and dropped
  }
}
```

That is why the `ihs_pv` host left both null, with a comment calling arbitration "a follow-up": its trampolines recover the `IhsPluginView*` from `data`, and these two had none to recover.

## The change

Pass the context, and wire the host's trampolines.

Nothing outside this repo has to change. Every implementor of the struct sets these two to `nullptr` — the two in-tree (`kListener` in the host, the registry unit test) and every one in the plugin repos that carry their own copy of the header (`fluorite`, `ivi-homescreen-plugins`, `plugins-ahmed`: `layer_playground_view`, `webview_flutter_view`, `nav_render_view`, `filament_view`, `fluorite_core`). A function pointer is a function pointer, so the struct layout is unchanged for anything already built, and a null member is never invoked.

## What it does not do

It does not make the callbacks fire. Flutter sends `acceptGesture`/`rejectGesture` from `DarwinPlatformViewController` alone; the `PlatformViewLink`/`PlatformViewSurface` path an `ihs_pv` view is built from settles the gesture arena inside the render object — flushing or dropping the cached pointer events — without a platform message. A plugin's callbacks therefore stay unreached on Linux. The host side is simply no longer the reason why, and the struct's docs now say that instead of describing "the embedded UIView" they were copied from.

## Tests

New case in the registry suite — arbitration reaches the callback with the id **and** the listener's own context, an unknown id is a no-op rather than a crash, and dispose stops delivery:

```
[==========] 5 tests from 1 test suite ran.
[  PASSED  ] 5 tests.
```

Note the unrelated `text_input-test` target does not link in this tree (`undefined reference to glTexParameteri` in `flutter_desktop_texture_registrar.cc`), which is pre-existing and untouched here.
