### PR TITLE
Destroy the App before stopping the logging subsystem

### DIFF
--- a/shell/main.cc
+++ b/shell/main.cc
@@ -308,21 +308,29 @@ int main(const int argc, char** argv) {
     return active.list_modes(list_modes_dev) == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
   }
 
-  // Construct the App. It populates the runtime backend registry and resolves
-  // the active backend from its configs on first display creation, so it is
-  // self-contained (e.g. the app unit test constructs App without main()).
-  App app(configs);
+  // Scoped so ~App runs before logging is stopped below. Shutdown is where a
+  // backend reports what the session did -- the motion-to-photon and vsync
+  // summaries, the DRM CRTC restore, the VT keyboard mode being handed back --
+  // and all of it is emitted from destructors. Left to run at `return`, after
+  // ihs_log_stop(), every one of those lines is written to a logging system
+  // that has already gone away, and the operator sees a log that simply stops.
+  {
+    // Construct the App. It populates the runtime backend registry and resolves
+    // the active backend from its configs on first display creation, so it is
+    // self-contained (e.g. the app unit test constructs App without main()).
+    App app(configs);
 
-  // Construct the waker (publishing its eventfd) before installing the
-  // signal handlers, so HandleShutdownSignal's async-signal-safe wake always
-  // has a valid fd to write to.
-  (void)MainLoopWaker::instance();
-  InstallShutdownHandlers();
+    // Construct the waker (publishing its eventfd) before installing the
+    // signal handlers, so HandleShutdownSignal's async-signal-safe wake always
+    // has a valid fd to write to.
+    (void)MainLoopWaker::instance();
+    InstallShutdownHandlers();
 
-  // Run the application: the shared reactor drives every backend on this (main)
-  // thread and blocks until the shutdown signal stops the io_context.
-  const int ret = app.Run();
-  (void)ret;
+    // Run the application: the shared reactor drives every backend on this
+    // (main) thread and blocks until the shutdown signal stops the io_context.
+    const int ret = app.Run();
+    (void)ret;
+  }
 
   IHS_LOGGING_FLUSH();
   IHS_LOGGING_STOP();


### PR DESCRIPTION
## What I went looking for, and what it turned out to be

The task was "the DRM backend has no motion-to-photon session summary, unlike Wayland". That was wrong on both counts, and my own doing — I had grepped the earlier run for `session summary|m2p`, while the line actually reads `motion->photon session`, matching neither.

`DrmBackend` does log one (`drm_backend.cc:1425`), `InitMotionToPhoton()` is called (`:369`), and the flag was set. The summary was never printed because **it was emitted after the logging system was stopped**.

`main()` calls `IHS_LOGGING_FLUSH()` / `IHS_LOGGING_STOP()` immediately after `app.Run()` returns — but `app` is a local, so `~App` and every backend, display and profiler destructor beneath it run at `return`, after those calls. Their records go into a stopped ring and are dropped.

## What that costs

Precisely the diagnostics a shutdown is worth having: the motion-to-photon and vsync session summaries, the DRM CRTC restore, the VT keyboard mode being handed back. `HandleShutdownSignal`'s own comment promises the last two happen "when the loop falls through and the App / backend destructors run" — they do run, but silently.

It is not DRM-specific. Every backend logs from destructors, so Wayland and software lose their teardown the same way.

## The change

Scope the `App` so it is destroyed while the sink is still there. Two braces and a comment.

## Verification

Raspberry Pi 4, `drm-kms-egl`, `IVI_VSYNC_PROFILE=1 IVI_M2P_PROFILE=1`, SIGTERM to exit.

**Before** — teardown ran (~750 ms measured between the signal and exit) and printed nothing; the log ends on an application line from twelve seconds earlier.

**After** — same command, same panel:

```
[DrmVsync] session summary: frames=56 fps=17.39 mean_interval=57504us max_interval=149820us discarded=0 stalls=0
[DrmVsync] session buckets: 60Hz=1 (1.8%) 30Hz=0 (0.0%) 20Hz=38 (69.1%) slow=12 (21.8%) idle=4 (7.3%)
[drm] motion->photon session (frame-accurate, 132 samples): mean=61.2ms p50=42.5ms p95=200.5ms p99=200.5ms max=310.7ms
[drm] motion->photon session (floor, 132 samples): mean=43.0ms p50=35.5ms p95=112.5ms p99=200.5ms max=257.5ms
[0x7fa20a9020] Platform ~Task Runner
```

`clang-format` reported no changes, so the binary measured is the committed source.

One thing worth knowing when reproducing: the vsync and m2p summaries are both gated on having samples, so an idle session with no input prints neither. The `~Task Runner` line is the reliable marker that teardown logging reached the sink at all.
