### PR TITLE
platform-views: dispatch renegotiate through the listener table

### DIFF
--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -803,6 +803,13 @@ void ListenerRejectGesture(int32_t /* id */, void* data) {
   }
 }
 
+void ListenerRenegotiate(int32_t /* id */, void* data) {
+  auto* view = static_cast<IhsPluginView*>(data);
+  if (view->callbacks.renegotiate != nullptr) {
+    view->callbacks.renegotiate(view->plugin_user_data);
+  }
+}
+
 void ListenerDispose(bool /*hybrid*/, void* data) {
   static_cast<IhsPluginView*>(data)->DisposePlugin();
 }
@@ -815,6 +822,7 @@ const platform_view_listener kListener = {
     /* dispose */ ListenerDispose,
     /* accept_gesture */ ListenerAcceptGesture,
     /* reject_gesture */ ListenerRejectGesture,
+    /* renegotiate */ ListenerRenegotiate,
 };
 
 // --- IhsPvHost implementation -----------------------------------------------

--- a/shell/platform/homescreen/platform_views/platform_view_listener.h
+++ b/shell/platform/homescreen/platform_views/platform_view_listener.h
@@ -46,6 +46,14 @@ struct platform_view_listener {
   /// two a host cannot implement.
   void (*accept_gesture)(int32_t id, void* data);
   void (*reject_gesture)(int32_t id, void* data);
+  /// The grant this view was given is no longer valid -- its output changed
+  /// mode, went away, or the plane backing it was taken -- so whatever the
+  /// view negotiated has to be negotiated again or dropped to the floor.
+  ///
+  /// Delivered per view rather than broadcast: only the views bound to the
+  /// output that changed are told, so a second display coming and going does
+  /// not disturb the first.
+  void (*renegotiate)(int32_t id, void* data);
 };
 
 typedef void (*PlatformViewAddListener)(void* context,

--- a/shell/platform/homescreen/platform_views/platform_view_registry.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_registry.cc
@@ -213,6 +213,37 @@ void PlatformViewRegistry::RejectGesture(int32_t id) {
   }
 }
 
+bool PlatformViewRegistry::Renegotiate(const int32_t id) {
+  const platform_view_listener* listener = nullptr;
+  void* context = nullptr;
+  if (!LookupListener(id, &listener, &context) ||
+      listener->renegotiate == nullptr) {
+    return false;
+  }
+  listener->renegotiate(id, context);
+  return true;
+}
+
+std::vector<int32_t> PlatformViewRegistry::InstanceIds() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<int32_t> ids;
+  ids.reserve(instances_.size());
+  for (const auto& [id, instance] : instances_) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+void PlatformViewRegistry::RenegotiateAll() {
+  // Snapshot the ids, then dispatch outside the lock: a plugin's renegotiate
+  // re-runs ihs_pv_negotiate, which comes back through the registry, so
+  // holding the lock across the callback would deadlock -- the same reason
+  // LookupListener copies the table out rather than dispatching under it.
+  for (const int32_t id : InstanceIds()) {
+    (void)Renegotiate(id);
+  }
+}
+
 void PlatformViewRegistry::UnregisterCompositorSurface(int32_t id) const {
 #if BUILD_COMPOSITOR
   if (engine_state_ != nullptr && engine_state_->view_controller != nullptr &&

--- a/shell/platform/homescreen/platform_views/platform_view_registry.h
+++ b/shell/platform/homescreen/platform_views/platform_view_registry.h
@@ -115,6 +115,19 @@ class PlatformViewRegistry {
   void AcceptGesture(int32_t id);
   void RejectGesture(int32_t id);
 
+  // Tell one view its grant is stale. Returns false when no instance holds
+  // @p id, or when the view registered no renegotiate callback -- the caller
+  // uses that to tell "nothing to notify" from "notified".
+  bool Renegotiate(int32_t id);
+
+  // Tell every live view. The output layer calls this for the views bound to
+  // an output that changed; a caller with no per-view mapping (a single-output
+  // system) can use it directly.
+  void RenegotiateAll();
+
+  // Ids of the live instances, so a caller can decide which to notify.
+  [[nodiscard]] std::vector<int32_t> InstanceIds() const;
+
  private:
   struct Instance {
     const platform_view_listener* listener{nullptr};

--- a/test/unit_test/platform_view_registry-test/test_case_platform_view_registry.cc
+++ b/test/unit_test/platform_view_registry-test/test_case_platform_view_registry.cc
@@ -21,6 +21,9 @@
 
 #include <memory>
 
+#include <algorithm>
+#include <vector>
+
 #include "gtest/gtest.h"
 #include "platform/homescreen/platform_views/platform_view.h"
 #include "platform/homescreen/platform_views/platform_view_listener.h"
@@ -36,6 +39,7 @@ struct Probe {
   double last_h = 0;
   int accept = 0;
   int reject = 0;
+  int renegotiate = 0;
   int32_t last_gesture_id = -1;
   void* last_gesture_data = nullptr;
 };
@@ -58,6 +62,13 @@ void ProbeAcceptGesture(int32_t id, void* data) {
   p->last_gesture_data = data;
 }
 
+void ProbeRenegotiate(int32_t id, void* data) {
+  auto* p = static_cast<Probe*>(data);
+  ++p->renegotiate;
+  p->last_gesture_id = id;
+  p->last_gesture_data = data;
+}
+
 void ProbeRejectGesture(int32_t id, void* data) {
   auto* p = static_cast<Probe*>(data);
   ++p->reject;
@@ -73,6 +84,7 @@ constexpr platform_view_listener kListener = {
     ProbeDispose,        // dispose
     ProbeAcceptGesture,  // accept_gesture
     ProbeRejectGesture,  // reject_gesture
+    ProbeRenegotiate,    // renegotiate
 };
 
 // A factory-created instance that flips a flag when destroyed, so the test can
@@ -155,6 +167,39 @@ TEST(PlatformViewRegistry, GestureArbitrationCarriesListenerContext) {
   EXPECT_TRUE(registry.Dispose(7, false));
   registry.AcceptGesture(7);
   EXPECT_EQ(probe.accept, 1);
+}
+
+// Renegotiation is per view: the output layer notifies only the views bound to
+// the output that changed, so the registry must be able to address one, and to
+// report whether anyone was listening.
+TEST(PlatformViewRegistry, RenegotiateAddressesOneView) {
+  PlatformViewRegistry registry(nullptr);
+  Probe a;
+  Probe b;
+  registry.RegisterListener(1, &kListener, &a);
+  registry.RegisterListener(2, &kListener, &b);
+
+  EXPECT_TRUE(registry.Renegotiate(1));
+  EXPECT_EQ(a.renegotiate, 1);
+  EXPECT_EQ(b.renegotiate, 0);  // the other output's view is undisturbed
+  EXPECT_EQ(a.last_gesture_data, &a);
+
+  // An id nobody holds reports that, rather than pretending it notified.
+  EXPECT_FALSE(registry.Renegotiate(42));
+
+  registry.RenegotiateAll();
+  EXPECT_EQ(a.renegotiate, 2);
+  EXPECT_EQ(b.renegotiate, 1);
+
+  auto ids = registry.InstanceIds();
+  std::sort(ids.begin(), ids.end());
+  EXPECT_EQ(ids, (std::vector<int32_t>{1, 2}));
+
+  // A disposed view is not notified again.
+  EXPECT_TRUE(registry.Dispose(1, false));
+  registry.RenegotiateAll();
+  EXPECT_EQ(a.renegotiate, 2);
+  EXPECT_EQ(b.renegotiate, 2);
 }
 
 TEST(PlatformViewRegistry, RepeatedRegistrationReplacesInPlace) {


### PR DESCRIPTION
First piece of the renegotiation path. **Stacked on #398** (same struct, same pattern) — review that one first; this diff is against it.

## Why this first

`IhsPvCallbacks::renegotiate` is documented in the plugin ABI, implemented by plugins (`shadertoy_view` handles it by re-running `ihs_pv_negotiate` and rebuilding its ring), and has never been reachable. `platform_view_listener` carries every other lifecycle event — resize, touch, dispose, the gesture pair — but not this one. So the registry had no way to say it and the host had nothing to forward.

Every design for the output-change path needs this same mechanism, so it is worth landing on its own rather than buried in the larger change.

## What it adds

- `platform_view_listener::renegotiate`, alongside the others.
- `PlatformViewRegistry::Renegotiate(id)` — notifies one view, reports whether anyone was listening.
- `PlatformViewRegistry::RenegotiateAll()` and `InstanceIds()` — the former for a single-output caller with no mapping to consult, the latter so a caller that does have one can decide for itself.
- The `ihs_pv` host trampoline forwarding to the plugin callback.

Per view, not broadcast, because that is the requirement: an output changing mode should disturb the views bound to *that* output and no others.

## Locking

The dispatch snapshots ids and calls outside the lock. A plugin's `renegotiate` re-runs `ihs_pv_negotiate`, which re-enters the registry — holding the lock across the callback would deadlock. That is the same reason `LookupListener` copies the table out rather than dispatching under it.

## What this does not do

Nothing fires it yet. The trigger needs three things that do not exist:

1. a view remembering which output it resolved to (`OutputManager::ResolveForView` is a static helper whose result is used at startup and discarded, and `FlutterView` keeps no output identity);
2. something implementing `IOutputListener` — the interface has zero implementations and `SetOutputListener` has zero call sites;
3. on DRM, a udev monitor, since `DrmOutputProvider::SupportsHotplug()` returns false and no change is ever detected.

Those are the next commits.

## Tests

Registry suite, 6/6:

```
[  PASSED  ] 6 tests.
```

New case covers: one view notified without disturbing the other, an unknown id reported rather than silently ignored, the all-views form, and a disposed view no longer notified.
