### PR TITLE
display: read a connector's EDID into OutputInfo

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -319,6 +319,7 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
             backend/drm_kms_egl/gl_cursor.cc
             backend/gl_process_resolver.cc
             display/drm_display.cc
+            display/connector_edid.cc
             display/drm_output_provider.cc
             display/drm_device_resolver.cc
             display/drm_mode_list.cc
@@ -403,6 +404,7 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN)
             $<$<BOOL:${BUILD_COMPOSITOR}>:backend/wayland_vulkan/wl_layer_compositor.cc>
             backend/drm_kms_egl/driver_probe.cc
             display/drm_display.cc
+            display/connector_edid.cc
             display/drm_output_provider.cc
             display/drm_device_resolver.cc
             display/drm_mode_list.cc

--- a/shell/backend/drm_kms_egl/driver_probe.cc
+++ b/shell/backend/drm_kms_egl/driver_probe.cc
@@ -15,6 +15,7 @@
  */
 
 #include "backend/drm_kms_egl/driver_probe.h"
+#include "display/connector_edid.h"
 #include "logging/logging.h"
 
 #include <drm_fourcc.h>
@@ -31,8 +32,6 @@
 #include <utility>
 
 #include <drm-cxx/core/format.hpp>
-#include <drm-cxx/detail/span.hpp>
-#include <drm-cxx/display/edid.hpp>
 
 #include "logging.h"
 
@@ -227,49 +226,6 @@ bool HasAtomicCap(const int drm_fd) {
 bool HasAsyncFlipCap(const int drm_fd) {
   uint64_t cap = 0;
   return drmGetCap(drm_fd, DRM_CAP_ASYNC_PAGE_FLIP, &cap) == 0 && cap == 1;
-}
-
-// Fetch + parse the EDID blob on the given connector. Walks the
-// connector's properties to find one named "EDID", reads its blob, hands
-// the bytes to drm-cxx's libdisplay-info-backed parser. nullopt on any
-// failure (no EDID blob, bad bytes, libdisplay-info rejects it) — EDID
-// data is informational here, never load-bearing.
-std::optional<drm::display::ConnectorInfo> ProbeConnectorInfo(
-    const int drm_fd,
-    const uint32_t connector_id) {
-  drmModeObjectProperties* props = drmModeObjectGetProperties(
-      drm_fd, connector_id, DRM_MODE_OBJECT_CONNECTOR);
-  if (props == nullptr) {
-    return std::nullopt;
-  }
-  uint32_t edid_blob_id = 0;
-  for (uint32_t i = 0; i < props->count_props && edid_blob_id == 0; ++i) {
-    drmModePropertyRes* prop = drmModeGetProperty(drm_fd, props->props[i]);
-    if (prop != nullptr) {
-      if (std::string_view(prop->name) == "EDID") {
-        edid_blob_id = static_cast<uint32_t>(props->prop_values[i]);
-      }
-      drmModeFreeProperty(prop);
-    }
-  }
-  drmModeFreeObjectProperties(props);
-  if (edid_blob_id == 0) {
-    return std::nullopt;
-  }
-  drmModePropertyBlobRes* blob = drmModeGetPropertyBlob(drm_fd, edid_blob_id);
-  if (blob == nullptr || blob->data == nullptr || blob->length == 0) {
-    if (blob != nullptr) {
-      drmModeFreePropertyBlob(blob);
-    }
-    return std::nullopt;
-  }
-  auto parsed = drm::display::parse_edid(drm::span<const uint8_t>(
-      static_cast<const uint8_t*>(blob->data), blob->length));
-  drmModeFreePropertyBlob(blob);
-  if (!parsed) {
-    return std::nullopt;
-  }
-  return {std::move(*parsed)};
 }
 
 }  // namespace

--- a/shell/display/connector_edid.cc
+++ b/shell/display/connector_edid.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "display/connector_edid.h"
+
+#include <string_view>
+#include <utility>
+
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+#include <drm-cxx/detail/span.hpp>
+#include <drm-cxx/display/edid.hpp>
+
+namespace homescreen {
+
+std::optional<drm::display::ConnectorInfo> ProbeConnectorInfo(
+    const int drm_fd,
+    const uint32_t connector_id) {
+  drmModeObjectProperties* props = drmModeObjectGetProperties(
+      drm_fd, connector_id, DRM_MODE_OBJECT_CONNECTOR);
+  if (props == nullptr) {
+    return std::nullopt;
+  }
+  uint32_t edid_blob_id = 0;
+  for (uint32_t i = 0; i < props->count_props && edid_blob_id == 0; ++i) {
+    drmModePropertyRes* prop = drmModeGetProperty(drm_fd, props->props[i]);
+    if (prop != nullptr) {
+      if (std::string_view(prop->name) == "EDID") {
+        edid_blob_id = static_cast<uint32_t>(props->prop_values[i]);
+      }
+      drmModeFreeProperty(prop);
+    }
+  }
+  drmModeFreeObjectProperties(props);
+  if (edid_blob_id == 0) {
+    return std::nullopt;
+  }
+  drmModePropertyBlobRes* blob = drmModeGetPropertyBlob(drm_fd, edid_blob_id);
+  if (blob == nullptr || blob->data == nullptr || blob->length == 0) {
+    if (blob != nullptr) {
+      drmModeFreePropertyBlob(blob);
+    }
+    return std::nullopt;
+  }
+  auto parsed = drm::display::parse_edid(drm::span<const uint8_t>(
+      static_cast<const uint8_t*>(blob->data), blob->length));
+  drmModeFreePropertyBlob(blob);
+  if (!parsed) {
+    return std::nullopt;
+  }
+  return {std::move(*parsed)};
+}
+
+}  // namespace homescreen

--- a/shell/display/connector_edid.h
+++ b/shell/display/connector_edid.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020-2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_DISPLAY_CONNECTOR_EDID_H_
+#define SHELL_DISPLAY_CONNECTOR_EDID_H_
+
+#include <cstdint>
+#include <optional>
+
+#include <drm-cxx/display/connector_info.hpp>
+
+namespace homescreen {
+
+/**
+ * @brief Read and parse a connector's EDID.
+ *
+ * Fetches the connector's EDID property blob through @p drm_fd and parses it
+ * with drm-cxx (libdisplay-info underneath), yielding the monitor's make,
+ * model, serial and physical size.
+ *
+ * Shared rather than duplicated: the driver probe wants this to describe the
+ * panel it is about to drive, and the output provider wants it so a view can
+ * be matched to a monitor by serial rather than by port. Both need exactly the
+ * same blob from exactly the same property.
+ *
+ * @param[in] drm_fd       an open DRM device; may be a lease, which the kernel
+ *                         filters to the leased objects
+ * @param[in] connector_id KMS connector object id
+ * @return the parsed EDID, or nullopt when the connector exposes no EDID
+ *         property, the blob is empty, or it does not parse
+ *
+ * @note nullopt is ordinary, not an error. A disconnected port has no EDID,
+ *       and neither do many panels that are permanently wired to one -- DSI on
+ *       an embedded board is the common case, and low-cost panels that do carry
+ *       an EDID often omit the serial. Callers must treat every identity field
+ *       as optional and fall back to the connector name.
+ */
+[[nodiscard]] std::optional<drm::display::ConnectorInfo> ProbeConnectorInfo(
+    int drm_fd,
+    uint32_t connector_id);
+
+}  // namespace homescreen
+
+#endif  // SHELL_DISPLAY_CONNECTOR_EDID_H_

--- a/shell/display/drm_output_provider.cc
+++ b/shell/display/drm_output_provider.cc
@@ -16,6 +16,8 @@
 
 #include "display/drm_output_provider.h"
 
+#include "display/connector_edid.h"
+
 #include <algorithm>
 #include <utility>
 
@@ -67,9 +69,37 @@ std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
     info.connected = connector.connected;
     info.handle = connector.connector_id;
 
+    // Monitor identity from the connector's EDID. Without it OutputInfo::serial
+    // is always empty, so the edid_serial tier of ResolveOutput can never fire
+    // and a [view.output] serial= silently falls through to the connector name
+    // -- a documented match that could not work. A port with nothing attached,
+    // or a panel whose EDID does not parse, simply leaves these empty.
+    //
+    // Note the serial is only as unique as the panel maker chose to make it:
+    // two LG DQHD heads measured here report the same serial, the same model
+    // string and the same make, so a serial= match against them is ambiguous
+    // and ResolveOutput says so before falling through to the connector name.
+    if (const auto edid =
+            ProbeConnectorInfo(dev->fd(), connector.connector_id)) {
+      info.make = edid->make;
+      info.model = edid->model;
+      info.serial = edid->serial;
+      info.mm_width = edid->width_mm;
+      info.mm_height = edid->height_mm;
+    } else if (connector.connected) {
+      // Routine, not a fault: a panel wired to a fixed port -- DSI on an
+      // embedded board is the usual case -- often carries no EDID at all, and
+      // plenty that do carry one omit the serial. Such an output can only be
+      // identified by its connector name, so say so rather than leave someone
+      // wondering why a serial= match never binds.
+      ihs::log::debug(
+          "[DrmOutputProvider] '{}' reports no usable EDID; identity is the "
+          "connector name alone",
+          info.name);
+    }
+
     // Current extent + refresh come from the connector's preferred mode (the
-    // EDID-preferred entry, else the first advertised). EDID make/model/serial
-    // are not read here yet; name is the join key ResolveOutput uses.
+    // EDID-preferred entry, else the first advertised).
     const drm::ModeInfo* mode = nullptr;
     for (const auto& candidate : connector.modes) {
       if (candidate.preferred()) {


### PR DESCRIPTION
First step of the output-hotplug work. Self-contained: no behavior change beyond fields being populated, and it fixes a documented match that could never fire.

## The problem

`DrmOutputProvider::EnumerateOutputs` filled `name`, extent and refresh, and left `make` / `model` / `serial` / `mm_width` / `mm_height` at their defaults — with a comment saying EDID "is not read here yet".

That is not cosmetic. `OutputInfo::serial` was therefore *always* empty, so the `edid_serial` tier of `ResolveOutput` (`output.cc:29-48`) could never match in production. A config saying

```toml
[view.output]
serial = "..."
```

silently fell through to connector-name matching. The tier is documented in `docs/source/readme.md`, has unit coverage against synthetic data, and could not work on a real machine.

## The change

The parsing already existed — `driver_probe.cc` reads the connector's EDID property blob and hands it to `drm::display::parse_edid`, whose `ConnectorInfo` carries exactly the fields `OutputInfo` was missing. Lift that helper into `display/connector_edid.{h,cc}` so both callers share one copy, and populate the provider from it.

**No new dependency.** The helper needs libdrm and drm-cxx, both already linked wherever `drm_output_provider.cc` compiles. (The `wayland_leased_drm` block only adds `lease_client.cc`, so it is unaffected.)

## Verification

Built with `-DBUILD_BACKEND_DRM_KMS_EGL=ON`, and the new code path exercised directly against a card with two heads attached — which previously reported nothing:

```
HDMI-A-1   make=LG Electronics  model=LG HDR DQHD  serial=0x000A7BA0  300x340 mm
DP-1       make=LG Electronics  model=LG HDR DQHD  serial=0x000A7BA0  600x340 mm
```

Worth noting what that shows about serials: **both panels report the same one**, along with the same make and model. So EDID makes the tier *work* without making it *sufficient* to tell two identical monitors apart — `ResolveOutput` already warns and falls through when a serial is ambiguous, which is the correct outcome here. That is the evidence behind the follow-up step adding an integrator-supplied `output_id`.

## Next

`OutputInfo::output_id` from a udev property plus the Wayland-side identity fill; then the view binding, the `IOutputListener` implementation, park/resume, and the DRM hotplug bridge.
