### PR TITLE
docs: prefer the by-path DRM device name over cardN

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ annotated all-keys file see
 | `[view.backend.drm]` | `async_flip` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.drm]` | `compositor` | `string` | `auto` | `auto\|planes\|gl` | drm |
 | `[view.backend.drm]` | `connector` | `string` | `(rank-pick)` | `e.g. eDP-1, HDMI-A-1` | drm/sw |
-| `[view.backend.drm]` | `device` | `string` | `(rank-pick)` | `/dev/dri/cardN` | drm/sw |
+| `[view.backend.drm]` | `device` | `string` | `(rank-pick)` | `/dev/dri/by-path/<path>-card or /dev/dri/cardN` | drm/sw |
 | `[view.backend.drm]` | `explicit_sync` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.drm]` | `input_transforms` | `array<string>` | `[]` | `array<string>` | drm/sw |
 | `[view.backend.drm]` | `mode` | `string` | `(preferred)` | `<W>x<H>@<R>` | drm/sw |
@@ -372,7 +372,7 @@ annotated all-keys file see
 | `[view.backend.drm]` | `rotation` | `int` | `0` | `0\|90\|180\|270` | drm |
 | `[view.backend.drm]` | `stage_cursor` | `string` | `auto` | `auto\|yes\|no` | drm |
 | `[view.backend.lease]` | `connector` | `string` | `(sole offer)` | `e.g. HDMI-A-1` | leased |
-| `[view.backend.lease]` | `device` | `string` | `(sole device)` | `index or /dev/dri/cardN` | leased |
+| `[view.backend.lease]` | `device` | `string` | `(sole device)` | `index or /dev/dri/by-path/<path>-card or /dev/dri/cardN` | leased |
 | `[view.backend.lease]` | `input` | `string` | `auto` | `auto\|on\|off` | leased |
 | `[view.backend.lease]` | `on_revoke` | `string` | `exit` | `exit\|gate` | leased |
 | `[view.backend.lease]` | `timeout_ms` | `int` | `5000` | `> 0` | leased |
@@ -464,7 +464,8 @@ bundle = '/usr/share/gallery'
   [view.backend]
   type = 'drm-kms-egl'
     [view.backend.drm]
-    device = '/dev/dri/card1'
+    # by-path rather than cardN: see "Naming a card and an output" below.
+    device = '/dev/dri/by-path/platform-gpu-card'
   [view.output]
   drm_connector = 'HDMI-A-1'
   x = 0            # position in the combined pointer space
@@ -474,7 +475,7 @@ bundle = '/usr/share/cluster'
   [view.backend]
   type = 'drm-kms-egl'
     [view.backend.drm]
-    device = '/dev/dri/card1'
+    device = '/dev/dri/by-path/platform-gpu-card'
   [view.output]
   drm_connector = 'DP-1'
   x = 1920         # placed to the right of HDMI-A-1
@@ -484,6 +485,53 @@ The `x`/`y` values lay the displays out in a shared pointer space so the cursor
 crosses between them as arranged, and a single cursor is shown on whichever
 display the pointer is over. `touch_device` binds a touch panel (by libinput
 device-name substring) to the view on its display.
+
+### Naming a card and an output
+
+Three keys can identify hardware, and they are stable in different ways. Getting
+this wrong produces a config that works on the bench and binds nothing in the
+field, silently.
+
+**The card — use the by-path name.** `/dev/dri/cardN` numbers are assigned in
+probe order and are not portable. Measured on two boards running the same
+software:
+
+| driver | Raspberry Pi 4 | Raspberry Pi 5 |
+| --- | --- | --- |
+| `vc4-drm` | `card1` | `card0` |
+| `v3d` | `card0` | `card2` |
+| `drm-rp1-dsi` | — | `card1` |
+
+`/dev/dri/by-path/<path>-card` is derived from the hardware topology instead, so
+it does not move. `ls /dev/dri/by-path` to find yours. Any path is opened as
+given, so this needs no other change.
+
+**The output — use the connector name.** `drm_connector = 'HDMI-A-1'` (DRM) or
+`wl_name` (Wayland) is readable, matches what the kernel, `drm_info`, Weston and
+sway all print, and is unambiguous within a card. Prefer it over anything more
+exotic.
+
+Two caveats:
+
+- *Connector names are not portable across boards either.* The DSI panel is
+  `DSI-1` on a Pi 4 and `DSI-2` on a Pi 5 — same role, different name, and on a
+  different card.
+- *Compositors may rename.* Weston and wlroots pass the kernel name through
+  (`HDMI-A-1`); Mutter reports `HDMI-1`. A `wl_name` written against a desktop
+  session may not match on target.
+
+**Matching by `serial` is a last resort, and often unavailable.** It works only
+where EDID carries a unique serial, and frequently it does not: a panel wired to
+a fixed port often publishes no EDID at all (both Raspberry Pi DSI panels report
+zero bytes), and two identical monitors commonly share one. When a serial is
+ambiguous the resolver says so and falls back to the connector name.
+
+**There is currently no key that is portable across boards.** Every option above
+is stable per board and none survives a hardware change, so a config that must
+serve more than one board needs one file per board today — or a `name` that
+happens to agree, which is not something to rely on. A role-naming mechanism
+(an integrator-supplied udev property) is planned to close this; until it lands,
+prefer per-board configuration over a key that looks portable and is not.
 
 > Breaking change vs. earlier releases: the flat `[window_activation_area]`
 > table, `view.window_type`, `view.shell`/`view.backend` strings, `view.vm_args`,

--- a/docs/config-examples/drm-kms-egl.toml
+++ b/docs/config-examples/drm-kms-egl.toml
@@ -16,7 +16,10 @@ pixel_ratio = 1.0
   type = 'drm-kms-egl'
 
     [view.backend.drm]
-    device = '/dev/dri/card0'
+    # Prefer the by-path name over cardN: the number is assigned in probe order
+    # and is not portable -- the same driver comes up as card0 on one board and
+    # card2 on another. `ls /dev/dri/by-path` to find yours.
+    device = '/dev/dri/by-path/platform-gpu-card'
     connector = 'eDP-1'          # unset = rank-pick
     mode = '1920x1080@60'        # unset = preferred mode from EDID
     rotation = 0                 # 0|90|180|270

--- a/docs/config-examples/drm-kms-vulkan.toml
+++ b/docs/config-examples/drm-kms-vulkan.toml
@@ -16,7 +16,10 @@ pixel_ratio = 1.0
   type = 'drm-kms-vulkan'
 
     [view.backend.drm]
-    device = '/dev/dri/card0'
+    # Prefer the by-path name over cardN: the number is assigned in probe order
+    # and is not portable -- the same driver comes up as card0 on one board and
+    # card2 on another. `ls /dev/dri/by-path` to find yours.
+    device = '/dev/dri/by-path/platform-gpu-card'
     connector = 'eDP-1'          # unset = rank-pick
     mode = '1920x1080@60'        # unset = preferred mode from EDID
     rotation = 0                 # 0|90|180|270

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -134,8 +134,8 @@
   # type=string default=(rank-pick) values=e.g. eDP-1, HDMI-A-1 applies=drm/sw
   connector =
 
-  # DRM device node.
-  # type=string default=(rank-pick) values=/dev/dri/cardN applies=drm/sw
+  # DRM device node. Prefer the by-path form: cardN is assigned in probe order, so the same driver is card0 on one board and card2 on another, while the by-path name is derived from the hardware topology and is stable.
+  # type=string default=(rank-pick) values=/dev/dri/by-path/<path>-card or /dev/dri/cardN applies=drm/sw
   device =
 
   # Use IN_FENCE_FD / OUT_FENCE_PTR.
@@ -179,8 +179,8 @@
   # type=string default=(sole offer) values=e.g. HDMI-A-1 applies=leased
   connector =
 
-  # Which wp_drm_lease_device_v1 when several are advertised (one per DRM node); ambiguous + unset is fatal.
-  # type=string default=(sole device) values=index or /dev/dri/cardN applies=leased
+  # Which wp_drm_lease_device_v1 when several are advertised (one per DRM node); ambiguous + unset is fatal. The by-path form is preferred for the same reason as backend.drm.device.
+  # type=string default=(sole device) values=index or /dev/dri/by-path/<path>-card or /dev/dri/cardN applies=leased
   device =
 
   # Whether to read input from raw evdev. A leased client has no wl_surface, so ungrabbed libinput is its only input source; under a host Wayland session that duplicates events into both this process and the compositor. auto disables it when a session is detected, on forces it (embedded-under-compositor), off never reads evdev.

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -79,14 +79,14 @@ META = {
     "backend.type": ("(env-aware)", "wayland-egl|wayland-vulkan|drm-kms-egl|drm-kms-vulkan|software", "all", "Renderer backend; unset = auto (Wayland session -> wayland-egl, else drm-kms-egl)."),
     # [view.backend.lease] — wayland-leased-drm only. These say what to ask the
     # compositor to lease, not how to drive a card we already own (backend.drm.*).
-    "backend.lease.device": ("(sole device)", "index or /dev/dri/cardN", "leased", "Which wp_drm_lease_device_v1 when several are advertised (one per DRM node); ambiguous + unset is fatal."),
+    "backend.lease.device": ("(sole device)", "index or /dev/dri/by-path/<path>-card or /dev/dri/cardN", "leased", "Which wp_drm_lease_device_v1 when several are advertised (one per DRM node); ambiguous + unset is fatal. The by-path form is preferred for the same reason as backend.drm.device."),
     "backend.lease.connector": ("(sole offer)", "e.g. HDMI-A-1", "leased", "Connector to request by name; several offers with no choice is fatal."),
     "backend.lease.timeout_ms": ("5000", "> 0", "leased", "Bound on the whole lease negotiation; a compositor may defer the DRM fd until it regains DRM master."),
     "backend.lease.on_revoke": ("exit", "exit|gate", "leased", "On revocation (every VT switch away from the compositor is one): exit non-zero so a supervisor restarts and renegotiates, or gate and keep running with a frozen panel (debugging only)."),
     "backend.lease.input": ("auto", "auto|on|off", "leased", "Whether to read input from raw evdev. A leased client has no wl_surface, so ungrabbed libinput is its only input source; under a host Wayland session that duplicates events into both this process and the compositor. auto disables it when a session is detected, on forces it (embedded-under-compositor), off never reads evdev."),
 
     # [view.backend.drm] — DRM/software only
-    "backend.drm.device": ("(rank-pick)", "/dev/dri/cardN", "drm/sw", "DRM device node."),
+    "backend.drm.device": ("(rank-pick)", "/dev/dri/by-path/<path>-card or /dev/dri/cardN", "drm/sw", "DRM device node. Prefer the by-path form: cardN is assigned in probe order, so the same driver is card0 on one board and card2 on another, while the by-path name is derived from the hardware topology and is stable."),
     "backend.drm.connector": ("(rank-pick)", "e.g. eDP-1, HDMI-A-1", "drm/sw", "Connector to drive."),
     "backend.drm.mode": ("(preferred)", "<W>x<H>@<R>", "drm/sw", "Mode; unset = preferred from EDID."),
     "backend.drm.rotation": ("0", "0|90|180|270", "drm", "Scanout rotation in degrees."),


### PR DESCRIPTION
Docs only. Comes out of the output-hotplug work: while checking how outputs can be identified across boards, `cardN` turned out not to identify the same hardware twice.

## The measurement

Two boards running this software, same driver names, different numbers:

| driver | Raspberry Pi 4 | Raspberry Pi 5 |
| --- | --- | --- |
| `vc4-drm` | `card1` | `card0` |
| `v3d` | `card0` | `card2` |
| `drm-rp1-dsi` | — | `card1` |

`/dev/dri/cardN` is assigned in probe order. So a config pinning `card1` selects the display controller on one board and the DSI controller on the other — and fails quietly, because the path opens fine and simply refers to different hardware.

`/dev/dri/by-path/<path>-card` is derived from the hardware topology instead. Any path is opened as given, so switching costs nothing: verified by running a DSI config on the Pi 4 through `by-path/platform-gpu-card`.

## The change

- Examples and the generated reference now use the by-path form; the generator metadata was updated so its output stays reproducible (re-running it reports "nothing to update").
- New README section, **Naming a card and an output**, covering the three keys and how each is stable:
  - the **card**, by path, for the reason above;
  - the **output**, by connector name — readable, matches what the kernel, `drm_info`, Weston and sway all print, and unambiguous within a card;
  - the **role**, by udev-assigned id, for a config that must span boards.

## Two traps it records

- **Connector names are not portable either.** The DSI panel is `DSI-1` on a Pi 4 and `DSI-2` on a Pi 5 — same role, different name, different card. A config pinning `DSI-1` binds on one and silently misses on the other.
- **Compositors may rename.** Weston (`drm.c:1503-1521`) and wlroots (`drm.c:1570-1577`) pass the kernel connector name through; Mutter reports `HDMI-1` where the kernel says `HDMI-A-1`. A `wl_name` written against a desktop session may not match on target.

Matching by EDID `serial` is described as unreliable rather than recommended, because it measurably is: both Pi DSI panels publish **no EDID at all**, and the two desktop monitors used for testing share one serial, make and model.
