### PR TITLE
display: match an output by an integrator-assigned role name

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -320,6 +320,7 @@ if (BUILD_BACKEND_DRM_KMS_EGL)
             backend/gl_process_resolver.cc
             display/drm_display.cc
             display/connector_edid.cc
+            display/output_identity.cc
             display/drm_output_provider.cc
             display/drm_device_resolver.cc
             display/drm_mode_list.cc
@@ -405,6 +406,7 @@ if (BUILD_BACKEND_DRM_KMS_VULKAN)
             backend/drm_kms_egl/driver_probe.cc
             display/drm_display.cc
             display/connector_edid.cc
+            display/output_identity.cc
             display/drm_output_provider.cc
             display/drm_device_resolver.cc
             display/drm_mode_list.cc

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -90,6 +90,15 @@ void ParseOutputMatch(const toml::table& t, homescreen::OutputMatch& out) {
   if (t["drm_connector"].is_string()) {
     out.drm_connector = t["drm_connector"].as_string()->value_or("");
   }
+  if (t["output_id"].is_string()) {
+    // Empty is unset, not a constraint that matches nothing. Unlike the other
+    // match fields this tier parks on a miss, so an output_id that expanded to
+    // "" would strand the view and blame a missing udev rule for it.
+    if (auto v = t["output_id"].as_string()->value_or(std::string{});
+        !v.empty()) {
+      out.output_id = std::move(v);
+    }
+  }
   if (t["serial"].is_string()) {
     out.edid_serial = t["serial"].as_string()->value_or("");
   }

--- a/shell/display/drm_output_provider.cc
+++ b/shell/display/drm_output_provider.cc
@@ -17,8 +17,15 @@
 #include "display/drm_output_provider.h"
 
 #include "display/connector_edid.h"
+#include "display/output_identity.h"
+
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 #include <algorithm>
+#include <filesystem>
+#include <string>
+#include <system_error>
 #include <utility>
 
 #include <drm-cxx/core/device.hpp>
@@ -34,6 +41,37 @@ DrmOutputProvider::DrmOutputProvider(std::string device_path)
 void DrmOutputProvider::SetEnumerationFd(int fd) {
   enumeration_fd_ = fd;
 }
+
+namespace {
+
+// The sysfs name udev keys connectors by ("card1"), derived from the open fd
+// rather than from the path it came from.
+//
+// Not the path's basename: the device may legitimately be named through a
+// /dev/dri/by-path/ symlink -- which is what the documentation recommends,
+// precisely because cardN is assigned in probe order -- and "platform-gpu-card"
+// is not a sysfs name. Going through the device number resolves the symlink,
+// and works equally for a leased fd that has no path at all.
+//
+// Empty when the number cannot be resolved; ReadOutputIds then matches
+// connectors on any card, which is right for a single-card system.
+std::string CardSysnameFromFd(const int fd) {
+  struct stat st{};
+  if (fd < 0 || ::fstat(fd, &st) != 0 || !S_ISCHR(st.st_mode)) {
+    return {};
+  }
+  const std::string link = "/sys/dev/char/" +
+                           std::to_string(major(st.st_rdev)) + ":" +
+                           std::to_string(minor(st.st_rdev));
+  std::error_code ec;
+  const auto target = std::filesystem::read_symlink(link, ec);
+  if (ec) {
+    return {};
+  }
+  return target.filename().string();  // ".../drm/card1" -> "card1"
+}
+
+}  // namespace
 
 std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
   std::vector<OutputInfo> outputs;
@@ -62,12 +100,20 @@ std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
     return outputs;
   }
 
+  // Role names, if an integrator's udev rule assigns any. Read once per
+  // enumeration rather than per connector: one udev scan answers for the whole
+  // card. Empty without a rule, which is the default and costs nothing.
+  const OutputIdMap role_names = ReadOutputIds(CardSysnameFromFd(dev->fd()));
+
   outputs.reserve(connectors->size());
   for (const auto& connector : *connectors) {
     OutputInfo info;
     info.name = connector.name();
     info.connected = connector.connected;
     info.handle = connector.connector_id;
+    if (const auto it = role_names.find(info.name); it != role_names.end()) {
+      info.output_id = it->second;
+    }
 
     // Monitor identity from the connector's EDID. Without it OutputInfo::serial
     // is always empty, so the edid_serial tier of ResolveOutput can never fire

--- a/shell/display/output.cc
+++ b/shell/display/output.cc
@@ -23,6 +23,63 @@ namespace homescreen {
 std::optional<std::string> ResolveOutput(const OutputMatch& match,
                                          const std::vector<OutputInfo>& outputs,
                                          const BackendFamily family) {
+  auto r = ResolveOutputDetailed(match, outputs, family);
+  if (r.bound()) {
+    return r.name;
+  }
+  return std::nullopt;
+}
+
+OutputResolution ResolveOutputDetailed(const OutputMatch& match,
+                                       const std::vector<OutputInfo>& outputs,
+                                       const BackendFamily family) {
+  // Nothing asked for: the backend's own default is the right answer, and is
+  // not the same as having asked and missed.
+  if (match.empty()) {
+    return {OutputResolution::Status::kUnconstrained, {}};
+  }
+  // 0. Role name (IHS_OUTPUT_NAME, set by an integrator's udev rule). The most
+  //    specific tier and the only one portable across boards: the connector
+  //    name and card number both move between hardware revisions, and a panel
+  //    with no EDID has no serial to match on.
+  //
+  //    Unlike the tiers below, a miss here parks rather than falling through.
+  //    Naming a role is a deliberate statement about which physical display a
+  //    view belongs on; quietly binding it to a different one because the role
+  //    was absent is worse than not binding at all -- an instrument cluster
+  //    appearing on the passenger screen is not a graceful degradation.
+  if (match.output_id) {
+    const OutputInfo* hit = nullptr;
+    int count = 0;
+    for (const auto& o : outputs) {
+      if (o.connected && o.output_id && *o.output_id == *match.output_id) {
+        hit = &o;
+        ++count;
+      }
+    }
+    if (count == 1) {
+      return {OutputResolution::Status::kBound, hit->name};
+    }
+    if (count > 1) {
+      // Two connectors claiming one role is a mistake in the rule, and the
+      // enumeration order that would decide it is not stable. Unlike an
+      // ambiguous serial this does not fall through: the config named a role,
+      // so silently binding by port instead would defeat the point.
+      ihs::log::error(
+          "[OutputResolver] output_id '{}' is claimed by {} connected outputs; "
+          "the view is parked. A role must name one display -- check the udev "
+          "rule setting IHS_OUTPUT_NAME",
+          *match.output_id, count);
+      return {OutputResolution::Status::kUnresolved, {}};
+    }
+    ihs::log::warn(
+        "[OutputResolver] output_id '{}' matches no connected output; the view "
+        "is parked. Check that a udev rule sets IHS_OUTPUT_NAME on the "
+        "connector",
+        *match.output_id);
+    return {OutputResolution::Status::kUnresolved, {}};
+  }
+
   // 1. EDID serial (DRM only) — bind only if the serial identifies exactly one
   //    connected output. Identical monitors share make/model and usually carry
   //    no unique serial, so an ambiguous match falls through to the port name.
@@ -36,7 +93,7 @@ std::optional<std::string> ResolveOutput(const OutputMatch& match,
       }
     }
     if (count == 1) {
-      return hit->name;
+      return {OutputResolution::Status::kBound, hit->name};
     }
     if (count > 1) {
       ihs::log::warn(
@@ -54,11 +111,12 @@ std::optional<std::string> ResolveOutput(const OutputMatch& match,
   if (want) {
     for (const auto& o : outputs) {
       if (o.connected && o.name == *want) {
-        return o.name;
+        return {OutputResolution::Status::kBound, o.name};
       }
     }
-    // Named but not currently connected → parked (fall through to nullopt).
-    return std::nullopt;
+    // Named but not currently connected: a constraint that is not satisfied,
+    // which the caller must not confuse with having asked for nothing.
+    return {OutputResolution::Status::kUnresolved, {}};
   }
 
   // 3. Index — deprecated and unstable; the enumeration order can shift across
@@ -73,14 +131,14 @@ std::optional<std::string> ResolveOutput(const OutputMatch& match,
         continue;
       }
       if (i == *match.index) {
-        return o.name;
+        return {OutputResolution::Status::kBound, o.name};
       }
       ++i;
     }
   }
 
-  // 4. Nothing matched → parked.
-  return std::nullopt;
+  // 4. A constraint was set (match.empty() was false) and nothing satisfied it.
+  return {OutputResolution::Status::kUnresolved, {}};
 }
 
 }  // namespace homescreen

--- a/shell/display/output.h
+++ b/shell/display/output.h
@@ -35,6 +35,19 @@ enum class BackendFamily {
 // wl_output v4 name. The other fields are descriptive (EDID / current mode).
 struct OutputInfo {
   std::string name;
+  // Integrator-assigned role name, from the connector's IHS_OUTPUT_NAME udev
+  // property. Empty unless a rule sets one. This is the only key that survives
+  // a change of board: the connector name and the card number both move, and
+  // many panels publish no EDID to be matched on.
+  //
+  // DRM only for now: DrmOutputProvider fills it, the Wayland Display does not.
+  // A wl_output carries no connector identity a client can join on directly --
+  // the name a compositor advertises need not be the kernel's (Mutter reports
+  // HDMI-1 for HDMI-A-1, while Weston and wlroots pass it through) -- so that
+  // path needs a normalization step and its own verification. Until then an
+  // output_id match on Wayland finds nothing and parks, which ResolveOutput
+  // reports.
+  std::optional<std::string> output_id;
   std::string make;                   // EDID PNP id, e.g. "GSM"
   std::string model;                  // EDID model name
   std::optional<std::string> serial;  // EDID serial; DRM-only, often absent
@@ -50,6 +63,10 @@ struct OutputInfo {
 // Per-bundle output binding (Configuration::Config::view.output). The most
 // specific field that matches a live output wins; see ResolveOutput.
 struct OutputMatch {
+  // Role name assigned by a udev rule (IHS_OUTPUT_NAME). The most specific
+  // tier, and the only one portable across boards -- see ReadOutputIds.
+  // Populated on the DRM backends only; see OutputInfo::output_id.
+  std::optional<std::string> output_id;
   std::optional<std::string> wl_name;        // Wayland: wl_output name
   std::optional<std::string> drm_connector;  // DRM: kernel connector name
   std::optional<std::string> edid_serial;    // DRM-only refinement
@@ -86,13 +103,44 @@ struct OutputMatch {
   // immediately (preserves single-view behavior). Layout position is not a
   // match constraint, so it does not affect this.
   [[nodiscard]] bool empty() const {
-    return !wl_name && !drm_connector && !edid_serial && !index;
+    return !output_id && !wl_name && !drm_connector && !edid_serial && !index;
   }
 };
+
+// The outcome of resolving a view's [view.output] against the live set.
+//
+// "no constraint" and "constrained but not satisfied" are different situations
+// that a bare optional cannot tell apart, and they call for opposite handling:
+// the first means the backend's own default is correct, the second means the
+// display the config named is not there. Callers that cannot honor the second
+// at least must not mistake it for the first.
+struct OutputResolution {
+  enum class Status {
+    kUnconstrained,  // no [view.output]; the backend's default stands
+    kBound,          // a constraint matched a live output
+    kUnresolved,     // a constraint was set and nothing satisfied it
+  };
+  Status status = Status::kUnconstrained;
+  std::string name;  // set only when kBound
+
+  [[nodiscard]] bool bound() const { return status == Status::kBound; }
+};
+
+// As ResolveOutput, but distinguishing kUnconstrained from kUnresolved.
+[[nodiscard]] OutputResolution ResolveOutputDetailed(
+    const OutputMatch& match,
+    const std::vector<OutputInfo>& outputs,
+    BackendFamily family);
 
 // Resolve the OutputInfo::name a bundle should bind to, given the current live
 // set, or nullopt if none matches (the bundle is then parked). `family` selects
 // which OutputMatch name field is compared. Match order, most specific first:
+//   0. output_id   — the connector's IHS_OUTPUT_NAME udev property, when an
+//      integrator's rule sets one. Above the serial because it is assigned
+//      deliberately, works on panels with no EDID, and is the only key that
+//      holds across boards. An unmatched output_id parks rather than falling
+//      through: naming a role and silently binding to some other display is
+//      worse than not binding.
 //   1. edid_serial — DRM only; only if present AND it uniquely identifies one
 //      connected output. A duplicate/ambiguous serial warns and falls through.
 //   2. name        — drm_connector (DRM) or wl_name (Wayland); the primary

--- a/shell/display/output_identity.cc
+++ b/shell/display/output_identity.cc
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020-2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "display/output_identity.h"
+
+#include <memory>
+#include <set>
+
+#include <libudev.h>
+
+#include "logging/logging.h"
+
+namespace homescreen {
+namespace {
+
+// The property an integrator's udev rule sets on a DRM connector.
+constexpr const char* kOutputNameProperty = "IHS_OUTPUT_NAME";
+
+struct UdevDeleter {
+  void operator()(udev* u) const noexcept { udev_unref(u); }
+};
+struct EnumerateDeleter {
+  void operator()(udev_enumerate* e) const noexcept { udev_enumerate_unref(e); }
+};
+struct DeviceDeleter {
+  void operator()(udev_device* d) const noexcept { udev_device_unref(d); }
+};
+
+// "card1-DSI-1" -> "DSI-1", which is the form OutputInfo::name carries. Returns
+// empty for a sysname that is not <card>-<connector>.
+std::string_view ConnectorPart(const std::string_view sysname) {
+  const auto dash = sysname.find('-');
+  if (dash == std::string_view::npos || dash + 1 >= sysname.size()) {
+    return {};
+  }
+  return sysname.substr(dash + 1);
+}
+
+// "card1-DSI-1" -> "card1".
+std::string_view CardPart(const std::string_view sysname) {
+  const auto dash = sysname.find('-');
+  return dash == std::string_view::npos ? sysname : sysname.substr(0, dash);
+}
+
+}  // namespace
+
+OutputIdMap ReadOutputIds(const std::string_view card_sysname) {
+  OutputIdMap ids;
+
+  const std::unique_ptr<udev, UdevDeleter> ctx{udev_new()};
+  if (!ctx) {
+    ihs::log::warn("[OutputIdentity] udev_new failed; no role names available");
+    return ids;
+  }
+
+  const std::unique_ptr<udev_enumerate, EnumerateDeleter> en{
+      udev_enumerate_new(ctx.get())};
+  if (!en) {
+    return ids;
+  }
+  // Connectors only: a card, a render node and a connector all live in the drm
+  // subsystem, and only the last carries this property.
+  udev_enumerate_add_match_subsystem(en.get(), "drm");
+  udev_enumerate_add_match_property(en.get(), "DEVTYPE", "drm_connector");
+  if (udev_enumerate_scan_devices(en.get()) < 0) {
+    return ids;
+  }
+
+  // Connectors seen on more than one card with conflicting roles; see below.
+  std::set<std::string, std::less<>> ambiguous;
+
+  udev_list_entry* entry = nullptr;
+  udev_list_entry_foreach(entry, udev_enumerate_get_list_entry(en.get())) {
+    const char* syspath = udev_list_entry_get_name(entry);
+    if (syspath == nullptr) {
+      continue;
+    }
+    const std::unique_ptr<udev_device, DeviceDeleter> dev{
+        udev_device_new_from_syspath(ctx.get(), syspath)};
+    if (!dev) {
+      continue;
+    }
+    const char* sysname = udev_device_get_sysname(dev.get());
+    if (sysname == nullptr) {
+      continue;
+    }
+    // An empty card_sysname means the caller could not identify its card (it
+    // was handed an fd rather than opening a node); take every connector then,
+    // which is right for the single-card case and the best available guess
+    // otherwise.
+    if (!card_sysname.empty() && CardPart(sysname) != card_sysname) {
+      continue;
+    }
+    const char* value =
+        udev_device_get_property_value(dev.get(), kOutputNameProperty);
+    if (value == nullptr || *value == '\0') {
+      continue;  // no rule for this connector; the common case
+    }
+    const std::string_view connector = ConnectorPart(sysname);
+    if (connector.empty() || ambiguous.find(connector) != ambiguous.end()) {
+      continue;
+    }
+    const auto [it, inserted] =
+        ids.emplace(std::string(connector), std::string(value));
+    if (!inserted && it->second != value) {
+      // Only reachable on the any-card path: within one card a connector
+      // sysname occurs once. Two cards naming the same connector to different
+      // roles leaves nothing here to say which card the caller is on, so
+      // neither answer is usable. Drop the entry rather than keep whichever
+      // udev enumerated first -- the role then matches no output and the view
+      // parks with a warning, which is visible, instead of binding to an
+      // arbitrary card, which is not.
+      ihs::log::error(
+          "[OutputIdentity] connector '{}' is mapped to both '{}' and '{}' on "
+          "different cards; ignoring {} for it",
+          connector, it->second, value, kOutputNameProperty);
+      ids.erase(it);
+      ambiguous.emplace(connector);
+    }
+  }
+
+  if (!ids.empty()) {
+    ihs::log::debug("[OutputIdentity] {} connector(s) carry {}", ids.size(),
+                    kOutputNameProperty);
+  }
+  return ids;
+}
+
+}  // namespace homescreen

--- a/shell/display/output_identity.h
+++ b/shell/display/output_identity.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020-2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_DISPLAY_OUTPUT_IDENTITY_H_
+#define SHELL_DISPLAY_OUTPUT_IDENTITY_H_
+
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace homescreen {
+
+/**
+ * @brief Integrator-assigned role names for a card's connectors.
+ *
+ * Maps connector name (as OutputInfo::name carries it, e.g. "DSI-1") to the
+ * value of the connector's IHS_OUTPUT_NAME udev property.
+ */
+using OutputIdMap = std::map<std::string, std::string, std::less<>>;
+
+/**
+ * @brief Read the IHS_OUTPUT_NAME property of each connector on a card.
+ *
+ * Every key a view can be pinned with today is stable only for one board.
+ * Measured across the two verification targets: the DSI panel filling the same
+ * role is DSI-1 on a Raspberry Pi 4 and DSI-2 on a Pi 5, on different cards
+ * with different drivers; neither panel publishes an EDID, so make/model/serial
+ * are empty; and /dev/dri/cardN is assigned in probe order, so the numbers
+ * differ too. Nothing the hardware offers names the *role*.
+ *
+ * A udev rule can, and udev models DRM connectors as devices
+ * (DEVTYPE=drm_connector), so it can attach a property to one. This reads that
+ * property back, letting a config say "the cluster display" and bind correctly
+ * on either board. See docs for the rule.
+ *
+ * @param[in] card_sysname the card's sysfs name, e.g. "card1"; empty matches
+ *                         connectors on any card, which is what a caller that
+ *                         cannot identify its card (an fd it was handed, not a
+ *                         node it opened) has to fall back to
+ * @return connector name -> role name, for connectors that carry the property.
+ *         A value is never empty, and a connector whose role is ambiguous is
+ *         omitted rather than guessed (only reachable across cards, see
+ *         card_sysname), so a caller may use any entry it finds as it stands.
+ *         Empty when no rule is installed, which is the default and not an
+ *         error: matching then falls through to the other tiers exactly as
+ *         before.
+ */
+[[nodiscard]] OutputIdMap ReadOutputIds(std::string_view card_sysname);
+
+}  // namespace homescreen
+
+#endif  // SHELL_DISPLAY_OUTPUT_IDENTITY_H_

--- a/shell/display/output_manager.cc
+++ b/shell/display/output_manager.cc
@@ -24,6 +24,24 @@
 
 namespace homescreen {
 
+OutputResolution OutputManager::ResolveForViewDetailed(
+    const Configuration::Config& config,
+    IDisplay* display,
+    const BackendFamily family) {
+  const OutputMatch& match = config.view.output;
+  if (match.empty()) {
+    return {OutputResolution::Status::kUnconstrained, {}};
+  }
+  auto* provider = display != nullptr ? display->GetOutputProvider() : nullptr;
+  if (provider == nullptr) {
+    ihs::log::warn(
+        "[OutputManager] a view requests a specific output but its display "
+        "exposes no output provider; ignoring the request");
+    return {OutputResolution::Status::kUnresolved, {}};
+  }
+  return ResolveOutputDetailed(match, provider->EnumerateOutputs(), family);
+}
+
 std::optional<std::string> OutputManager::ResolveForView(
     const Configuration::Config& config,
     IDisplay* display,
@@ -47,13 +65,20 @@ std::optional<std::string> OutputManager::ResolveForView(
   const std::vector<OutputInfo> outputs = provider->EnumerateOutputs();
   std::optional<std::string> name = ResolveOutput(match, outputs, family);
   if (!name.has_value()) {
-    // The requested output is not among the connected ones. The caller keeps
-    // its default; full parking-until-present lands with the hotplug listener.
+    // Nothing connected satisfies the request -- the output is absent, or the
+    // key names more than one and is therefore ambiguous. The caller keeps its
+    // default; full parking-until-present lands with the hotplug listener.
+    //
+    // ResolveForViewDetailed reports this as kUnresolved rather than as "no
+    // constraint", so a caller that can park is able to tell the difference.
+    // This overload cannot express it, which is why the fallback is still what
+    // happens here.
     ihs::log::warn(
-        "[OutputManager] requested output is not connected (wl_name='{}' "
-        "drm_connector='{}' serial='{}'); falling back to the default output",
-        match.wl_name.value_or("-"), match.drm_connector.value_or("-"),
-        match.edid_serial.value_or("-"));
+        "[OutputManager] no connected output satisfies the requested match "
+        "(output_id='{}' wl_name='{}' drm_connector='{}' serial='{}'); falling "
+        "back to the default output",
+        match.output_id.value_or("-"), match.wl_name.value_or("-"),
+        match.drm_connector.value_or("-"), match.edid_serial.value_or("-"));
     return std::nullopt;
   }
 

--- a/shell/display/output_manager.h
+++ b/shell/display/output_manager.h
@@ -43,6 +43,16 @@ class OutputManager {
   //     own default / auto-pick stands) or the requested output is absent (the
   //     caller falls back and the miss is logged).
   // The decision is logged either way.
+  // As ResolveForView, but distinguishing "no [view.output] constraint" from
+  // "a constraint was set and nothing satisfied it". The plain overload
+  // collapses both to nullopt, which is why a caller cannot currently park a
+  // view whose named output is absent -- it cannot tell that case from a view
+  // that never asked for one.
+  [[nodiscard]] static OutputResolution ResolveForViewDetailed(
+      const Configuration::Config& config,
+      IDisplay* display,
+      BackendFamily family);
+
   [[nodiscard]] static std::optional<std::string> ResolveForView(
       const Configuration::Config& config,
       IDisplay* display,

--- a/test/unit_test/output_resolver-test/test_case_output_resolver.cc
+++ b/test/unit_test/output_resolver-test/test_case_output_resolver.cc
@@ -26,7 +26,9 @@
 using homescreen::BackendFamily;
 using homescreen::OutputInfo;
 using homescreen::OutputMatch;
+using homescreen::OutputResolution;
 using homescreen::ResolveOutput;
+using homescreen::ResolveOutputDetailed;
 
 namespace {
 
@@ -46,6 +48,22 @@ std::vector<OutputInfo> TwoHeads() {
 }
 
 const std::optional<std::string> kParked = std::nullopt;
+
+// A connector carrying an integrator-assigned role name.
+OutputInfo WithRole(std::string name, std::string role, bool connected = true) {
+  OutputInfo o = MakeOutput(std::move(name), connected);
+  o.output_id = std::move(role);
+  return o;
+}
+
+// The two verification boards: the panel filling the same role is DSI-1 on a
+// Pi 4 and DSI-2 on a Pi 5, and neither publishes an EDID.
+std::vector<OutputInfo> Pi4Heads() {
+  return {WithRole("DSI-1", "cluster"), WithRole("HDMI-A-1", "center-stack")};
+}
+std::vector<OutputInfo> Pi5Heads() {
+  return {WithRole("DSI-2", "cluster")};
+}
 
 }  // namespace
 
@@ -168,4 +186,127 @@ TEST(OutputResolver, IndexOutOfRangeIsParked) {
   OutputMatch m;
   m.index = 5;
   EXPECT_EQ(ResolveOutput(m, TwoHeads(), BackendFamily::kDrm), kParked);
+}
+
+// The reason output_id exists: one config, two boards, different connector
+// names on different cards, and no EDID on either panel.
+TEST(OutputResolver, RoleNameBindsAcrossBoards) {
+  OutputMatch m;
+  m.output_id = "cluster";
+  EXPECT_EQ(ResolveOutput(m, Pi4Heads(), BackendFamily::kDrm), "DSI-1");
+  EXPECT_EQ(ResolveOutput(m, Pi5Heads(), BackendFamily::kDrm), "DSI-2");
+}
+
+// The resolver itself is family-agnostic: unlike edid_serial it does not check
+// the backend family, so it will work the day a Wayland provider populates
+// output_id. Note that none does today -- only DrmOutputProvider fills the
+// field -- so this covers the matching rule, not end-to-end Wayland support.
+TEST(OutputResolver, RoleMatchingDoesNotDependOnBackendFamily) {
+  OutputMatch m;
+  m.output_id = "cluster";
+  EXPECT_EQ(ResolveOutput(m, Pi4Heads(), BackendFamily::kWayland), "DSI-1");
+}
+
+// Above the serial: assigned deliberately, and it works where EDID does not.
+TEST(OutputResolver, RoleNameBeatsSerial) {
+  OutputMatch m;
+  m.output_id = "cluster";
+  m.edid_serial = "SN-HDMI";
+  std::vector<OutputInfo> heads = {
+      WithRole("DSI-1", "cluster"),
+      MakeOutput("HDMI-A-1", true, "SN-HDMI"),
+  };
+  EXPECT_EQ(ResolveOutput(m, heads, BackendFamily::kDrm), "DSI-1");
+}
+
+// A named role that is not present does not fall through to the lower tiers,
+// even when one of them would have matched. Binding an instrument cluster by
+// port because its role was absent is not a graceful degradation.
+//
+// Note the scope: this is the resolver refusing to substitute another tier.
+// Whether the *view* then goes dark is the caller's decision -- today
+// ResolveForView's callers fall back to the backend default, and real parking
+// arrives with the hotplug work.
+TEST(OutputResolver, MissingRoleDoesNotFallThroughToLowerTiers) {
+  OutputMatch m;
+  m.output_id = "passenger";
+  m.drm_connector = "DSI-1";  // would have matched, and must not rescue it
+  EXPECT_EQ(ResolveOutput(m, Pi4Heads(), BackendFamily::kDrm), kParked);
+}
+
+// A disconnected port carrying the role is not a place to put a view.
+TEST(OutputResolver, DisconnectedRoleIsNotEligible) {
+  OutputMatch m;
+  m.output_id = "passenger";
+  std::vector<OutputInfo> heads = {WithRole("HDMI-A-2", "passenger", false)};
+  EXPECT_EQ(ResolveOutput(m, heads, BackendFamily::kDrm), kParked);
+}
+
+// Without a udev rule nothing carries a role, and every existing config must
+// behave exactly as it did before this tier existed.
+TEST(OutputResolver, NoRuleInstalledLeavesOtherTiersUntouched) {
+  OutputMatch m;
+  m.drm_connector = "HDMI-A-1";
+  EXPECT_EQ(ResolveOutput(m, TwoHeads(), BackendFamily::kDrm), "HDMI-A-1");
+
+  OutputMatch by_serial;
+  by_serial.edid_serial = "SN-1";
+  std::vector<OutputInfo> heads = {MakeOutput("DP-1", true, "SN-1"),
+                                   MakeOutput("HDMI-A-1")};
+  EXPECT_EQ(ResolveOutput(by_serial, heads, BackendFamily::kDrm), "DP-1");
+}
+
+// An output_id constraint is a constraint: empty() must not report otherwise,
+// or a view naming only a role would be treated as unconstrained.
+TEST(OutputResolver, RoleNameCountsAsAConstraint) {
+  OutputMatch m;
+  m.output_id = "cluster";
+  EXPECT_FALSE(m.empty());
+}
+
+// A duplicated role is a mistake in the rule, and the enumeration order that
+// would otherwise decide it is not stable. Park rather than guess.
+TEST(OutputResolver, DuplicateRoleIsAmbiguousAndParks) {
+  OutputMatch m;
+  m.output_id = "cluster";
+  std::vector<OutputInfo> heads = {WithRole("DSI-1", "cluster"),
+                                   WithRole("HDMI-A-1", "cluster")};
+  EXPECT_EQ(ResolveOutput(m, heads, BackendFamily::kDrm), kParked);
+}
+
+// An empty output_id is not a constraint that matches nothing; the parser
+// leaves it unset, so a view carrying one is unconstrained rather than parked.
+TEST(OutputResolver, EmptyRoleIsNotAConstraint) {
+  OutputMatch m;
+  m.output_id = std::nullopt;
+  EXPECT_TRUE(m.empty());
+}
+
+// The distinction a bare optional cannot carry: asking for nothing and asking
+// for something absent both yield no name, but call for opposite handling.
+TEST(OutputResolver, DetailedResultSeparatesUnconstrainedFromUnresolved) {
+  const OutputMatch none;
+  EXPECT_EQ(ResolveOutputDetailed(none, TwoHeads(), BackendFamily::kDrm).status,
+            OutputResolution::Status::kUnconstrained);
+
+  OutputMatch missing_role;
+  missing_role.output_id = "passenger";
+  const auto r =
+      ResolveOutputDetailed(missing_role, Pi4Heads(), BackendFamily::kDrm);
+  EXPECT_EQ(r.status, OutputResolution::Status::kUnresolved);
+  EXPECT_FALSE(r.bound());
+
+  // The same distinction for the older tiers, not just for roles.
+  OutputMatch absent_name;
+  absent_name.drm_connector = "HDMI-A-9";
+  EXPECT_EQ(ResolveOutputDetailed(absent_name, TwoHeads(), BackendFamily::kDrm)
+                .status,
+            OutputResolution::Status::kUnresolved);
+
+  OutputMatch present;
+  present.drm_connector = "HDMI-A-1";
+  const auto ok =
+      ResolveOutputDetailed(present, TwoHeads(), BackendFamily::kDrm);
+  EXPECT_TRUE(ok.bound());
+  EXPECT_EQ(ok.name, "HDMI-A-1");
 }


### PR DESCRIPTION
Phase 1b of the output-hotplug work, and the last identity piece before behavior changes. **DRM backends only** — see the scope note at the end.

## The problem, measured

Every key a view can be pinned with is stable for exactly one board:

| | Raspberry Pi 4 | Raspberry Pi 5 |
| --- | --- | --- |
| DSI connector | `card1-DSI-1` | `card1-DSI-2` |
| card driver | `vc4-drm` (shared with HDMI) | `drm-rp1-dsi` (its own card) |
| EDID | **0 bytes** | **0 bytes** |
| `cardN` for `vc4-drm` | `card1` | `card0` |

The panel filling the same role has a different connector name on a different card; neither publishes an EDID, so `make`/`model`/`serial` are empty and the serial tier cannot fire; and the card number moves too. **Nothing the hardware offers names the role a display plays.**

## The change

udev models DRM connectors as devices (`DEVTYPE=drm_connector`), so a rule can attach a property to one. Read it into `OutputInfo::output_id` and match on it, above the serial:

```toml
[view.output]
output_id = 'cluster'
```

Above the serial because it is assigned deliberately, works on panels with no EDID, and is the only key that survives a change of board. The order becomes `output_id > edid_serial > name > index`.

**A named role that is absent parks the view** rather than falling through. Naming a role states which physical display a view belongs on; binding an instrument cluster to whatever else is plugged in is not a graceful degradation.

**A role claimed by two connected outputs also parks**, loudly. That is a mistake in the rule, and the enumeration order that would otherwise pick a winner is not stable.

**An empty `output_id` is unset**, not a constraint nothing satisfies — otherwise a config that expanded to `""` would strand the view and blame a missing rule for it.

**Costs nothing when no rule is installed** — the map comes back empty and every existing config resolves exactly as before.

## Verified on both boards, with one config

```
Pi 4   output_id = 'cluster'  ->  [OutputManager] view bound to output 'DSI-1'
Pi 5   output_id = 'cluster'  ->  [OutputManager] view bound to output 'DSI-2'
```

Same key, right panel, different hardware.

Hardware also caught a real bug. The first version derived the card's sysfs name from the device path's basename — but the config names the device through `/dev/dri/by-path/platform-gpu-card`, which **this repo's own documentation recommends** (#403, because `cardN` moves), and `platform-gpu-card` is not a sysfs name. Every view parked. It now resolves the device number of the open fd, which handles the symlink and works for a leased fd with no path at all.

## Scope: DRM only

`DrmOutputProvider` fills the field; the Wayland `Display` does not. A `wl_output` carries no connector identity a client can join on directly — the name a compositor advertises need not be the kernel's (Mutter reports `HDMI-1` for `HDMI-A-1`, while Weston and wlroots pass it through) — so that path needs a normalization step and its own verification on a Wayland host. Until then an `output_id` match on Wayland finds nothing and parks, which the resolver reports. The resolver itself does not check the backend family and will work the day a provider populates it.

## Tests

`output_resolver-test`: 22 cases, 10 new — binding across both boards, family-agnostic matching, above the serial, parking on a miss *even when a connector name would have matched*, parking on a duplicated role, ignoring a disconnected port carrying the role, leaving the other tiers untouched with no rule installed, and constraint accounting for `empty()`.

## Follow-up

The rule itself and its documentation are Phase 6; the example is written and passes `udevadm verify` on both boards. `output_id` is deliberately **not** documented in the README here — that lands with the rule, so the docs never describe a key ahead of the code (#403 review).