### PR TITLE
app: notice when a view's output changes

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -32,6 +32,11 @@
 
 #include "config/common.h"
 
+#include "display/output_manager.h"
+#include "display/output_provider.h"
+#if BUILD_COMPOSITOR
+#include "platform/homescreen/platform_views/platform_view_registry.h"
+#endif
 #include "main_loop_waker.h"
 #include "timer.h"
 #include "view/flutter_view.h"
@@ -85,6 +90,45 @@ std::string ContextKey(const backend::BackendRegistry& reg,
 }
 
 }  // namespace
+
+namespace {
+
+const char* EventName(const homescreen::OutputEvent event) {
+  switch (event) {
+    case homescreen::OutputEvent::kAdded:
+      return "appeared";
+    case homescreen::OutputEvent::kRemoved:
+      return "disappeared";
+    case homescreen::OutputEvent::kChanged:
+      return "changed";
+  }
+  return "changed";
+}
+
+}  // namespace
+
+// One display's outputs, reported to App with the display it happened on.
+class App::OutputWatch final : public homescreen::IOutputListener {
+ public:
+  OutputWatch(App* app, IDisplay* display) : app_(app), display_(display) {}
+
+  void OnOutputAdded(const homescreen::OutputInfo& output) override {
+    app_->OnDisplayOutputsChanged(display_, homescreen::OutputEvent::kAdded,
+                                  output.name);
+  }
+  void OnOutputRemoved(const std::string_view name) override {
+    app_->OnDisplayOutputsChanged(display_, homescreen::OutputEvent::kRemoved,
+                                  name);
+  }
+  void OnOutputChanged(const homescreen::OutputInfo& output) override {
+    app_->OnDisplayOutputsChanged(display_, homescreen::OutputEvent::kChanged,
+                                  output.name);
+  }
+
+ private:
+  App* app_;
+  IDisplay* display_;
+};
 
 std::vector<std::shared_ptr<IDisplay>> App::BuildDisplays(
     const std::vector<Configuration::Config>& configs) {
@@ -213,6 +257,22 @@ App::App(const std::vector<Configuration::Config>& configs) {
   }
 #endif
 
+  // Watch outputs before the event sources start, so nothing announced in the
+  // first burst is missed. Views already exist above, so the first re-resolve
+  // compares against a real binding and finds nothing to do -- which is the
+  // correct answer at startup, not a special case.
+  for (const auto& display : m_displays) {
+    auto* provider = display->GetOutputProvider();
+    if (provider == nullptr || !provider->SupportsHotplug()) {
+      continue;  // e.g. the software sink, and DRM until its monitor is wired
+    }
+    auto watch = std::make_unique<OutputWatch>(this, display.get());
+    provider->SetOutputListener(watch.get());
+    m_output_watches.push_back(std::move(watch));
+    ihs::log::debug("[App] watching outputs on a display ({} live now)",
+                    provider->EnumerateOutputs().size());
+  }
+
   for (const auto& display : m_displays) {
     display->StartEvents();
   }
@@ -235,6 +295,15 @@ App::~App() {
   // backend (owned by the views/displays below) is still alive.
   vk_export_bridge_.reset();
 #endif
+  // Unhook before the displays stop: a watch points at App, and a late event
+  // must not reach a half-destroyed one.
+  for (const auto& display : m_displays) {
+    if (auto* provider = display->GetOutputProvider()) {
+      provider->SetOutputListener(nullptr);
+    }
+  }
+  m_output_watches.clear();
+
   for (const auto& display : m_displays) {
     display->StopEvents();
   }
@@ -242,6 +311,99 @@ App::~App() {
   Watchdog::getInstance().stop(WATCHDOG_SOURCE_RENDER_THREAD);
   Watchdog::getInstance().stop(WATCHDOG_SOURCE_MAIN_THREAD);
 #endif
+}
+
+void App::RenegotiateView(const FlutterView* view) {
+#if !BUILD_COMPOSITOR
+  // Platform views are a BUILD_COMPOSITOR feature; with it off there is no
+  // registry and no plugin to notify. The transition is still detected and
+  // logged above -- that part is not compositor-specific.
+  ihs::log::debug(
+      "[App] view {}: platform views are not built; nothing to notify",
+      view->GetIndex());
+#else
+  // Hop to the platform thread: this is called from the reactor, and the
+  // registry is platform-thread-only. Capturing the view raw is safe because
+  // App owns every view and tears the watches down before the views go.
+  const bool posted = view->PostToPlatformThread([view] {
+    auto* registry = view->GetPlatformViewRegistry();
+    if (registry == nullptr) {
+      return;
+    }
+    // Per view, not RenegotiateAll(): a second view on another output of the
+    // same display has not moved and must not be told it has.
+    const auto ids = registry->InstanceIds();
+    size_t notified = 0;
+    for (const int32_t id : ids) {
+      notified += registry->Renegotiate(id) ? 1 : 0;
+    }
+    ihs::log::debug("[App] view {}: renegotiated {}/{} platform view(s)",
+                    view->GetIndex(), notified, ids.size());
+  });
+  if (!posted) {
+    ihs::log::debug("[App] view {} has no running engine; nothing to notify",
+                    view->GetIndex());
+  }
+#endif
+}
+
+void App::OnDisplayOutputsChanged(IDisplay* display,
+                                  const homescreen::OutputEvent event,
+                                  const std::string_view output_name) {
+#if BUILD_BACKEND_WAYLAND_EGL || BUILD_BACKEND_WAYLAND_VULKAN
+  const auto family = dynamic_cast<Display*>(display) != nullptr
+                          ? homescreen::BackendFamily::kWayland
+                          : homescreen::BackendFamily::kDrm;
+#else
+  const auto family = homescreen::BackendFamily::kDrm;
+#endif
+
+  for (const auto& view : m_views) {
+    if (!view || view->GetIDisplay() != display) {
+      continue;
+    }
+    const std::optional<std::string> current = view->BoundOutput();
+    const homescreen::OutputResolution wanted =
+        homescreen::OutputManager::ResolveForViewDetailed(view->GetConfig(),
+                                                          display, family);
+    const homescreen::OutputTransition transition =
+        homescreen::ClassifyOutputTransition(current, wanted, event,
+                                             output_name);
+    if (transition == homescreen::OutputTransition::kNone) {
+      continue;
+    }
+
+    const char* what = "was reconfigured";
+    switch (transition) {
+      case homescreen::OutputTransition::kMoved:
+        what = "belongs on a different output";
+        break;
+      case homescreen::OutputTransition::kAppeared:
+        what = "has an output to bind to";
+        break;
+      case homescreen::OutputTransition::kLost:
+        what = "lost its output";
+        // Forget the placement now that it is gone, so the same output coming
+        // back reads as an arrival rather than as "already there".
+        view->NoteOutputLost();
+        break;
+      case homescreen::OutputTransition::kReconfigured:
+      case homescreen::OutputTransition::kNone:
+        break;
+    }
+    // States the transition only. What is done about it varies by build and
+    // by whether the view has any platform views, so RenegotiateView reports
+    // that itself rather than being announced for in advance.
+    ihs::log::info("[App] output '{}' {}: view {} {} (on '{}', wants '{}')",
+                   output_name, EventName(event), view->GetIndex(), what,
+                   current.value_or("-"), wanted.bound() ? wanted.name : "-");
+
+    // Tell the plugins their grant is stale. Actually moving the view to
+    // another output, or parking it when its output went away, needs the
+    // suspend/resume path that does not exist yet -- so a view whose output
+    // vanished keeps its surface for now and is only notified.
+    RenegotiateView(view.get());
+  }
 }
 
 bool App::AnyHasRepeatTimer() const {

--- a/shell/app.h
+++ b/shell/app.h
@@ -19,9 +19,11 @@
 #include <EGL/egl.h>
 #include <chrono>
 #include <memory>
+#include <string_view>
 
 #include "config/common.h"  // ENABLE_DLT — keep before logger.hpp / member decl
 #include "configuration/configuration.h"
+#include "display/output.h"
 #include "logging/logger.hpp"
 #include "view/flutter_view.h"
 
@@ -79,10 +81,29 @@ class App final {
   std::vector<std::shared_ptr<IDisplay>> BuildDisplays(
       const std::vector<Configuration::Config>& configs);
 
+  // Watches one display's outputs on App's behalf. IOutputListener reports
+  // what changed but not which display reported it, and App can drive several
+  // -- so one listener per display, each carrying its own display pointer,
+  // rather than App implementing the interface once and having to guess.
+  class OutputWatch;
+
+  // Re-resolve every view on @p display and act on what changed. Runs on the
+  // App reactor thread (the one reading the Wayland fd), not the Flutter
+  // platform thread -- anything touching the engine hops via
+  // FlutterView::PostToPlatformThread.
+  void OnDisplayOutputsChanged(IDisplay* display,
+                               homescreen::OutputEvent event,
+                               std::string_view output_name);
+
+  // Tell one view's platform views their grant is stale.
+  static void RenegotiateView(const FlutterView* view);
+
   // The displays the App drives. One entry per distinct device-context; a
   // homogeneous config set yields a single shared display.
   std::vector<std::shared_ptr<IDisplay>> m_displays;
   std::vector<std::unique_ptr<FlutterView>> m_views;
+  // One per display that reports hotplug; cleared before the displays go.
+  std::vector<std::unique_ptr<OutputWatch>> m_output_watches;
 #if BUILD_WATCHDOG
   mutable std::chrono::steady_clock::time_point next_pet_;
 #endif

--- a/shell/display/output.cc
+++ b/shell/display/output.cc
@@ -141,4 +141,37 @@ OutputResolution ResolveOutputDetailed(const OutputMatch& match,
   return {OutputResolution::Status::kUnresolved, {}};
 }
 
+OutputTransition ClassifyOutputTransition(
+    const std::optional<std::string>& current,
+    const OutputResolution& wanted,
+    const OutputEvent event,
+    const std::string_view changed) {
+  const bool on_the_changed_output = event == OutputEvent::kChanged &&
+                                     current.has_value() && changed == *current;
+
+  if (wanted.bound()) {
+    if (!current.has_value()) {
+      return OutputTransition::kAppeared;
+    }
+    if (*current != wanted.name) {
+      return OutputTransition::kMoved;
+    }
+    // Where it belongs. Still worth a notification if that output was itself
+    // reconfigured, since the mode it was negotiated against may be gone.
+    return on_the_changed_output ? OutputTransition::kReconfigured
+                                 : OutputTransition::kNone;
+  }
+
+  if (wanted.status == OutputResolution::Status::kUnresolved &&
+      current.has_value()) {
+    return OutputTransition::kLost;
+  }
+
+  // Unconstrained: the backend's own pick stands, and re-resolving says
+  // nothing about it. Only a reconfiguration of the very output the view is on
+  // is actionable here.
+  return on_the_changed_output ? OutputTransition::kReconfigured
+                               : OutputTransition::kNone;
+}
+
 }  // namespace homescreen

--- a/shell/display/output.h
+++ b/shell/display/output.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace homescreen {
@@ -125,6 +126,43 @@ struct OutputResolution {
 
   [[nodiscard]] bool bound() const { return status == Status::kBound; }
 };
+
+// What the output layer reported.
+enum class OutputEvent {
+  kAdded,
+  kRemoved,
+  kChanged,  // same output, new mode / EDID
+};
+
+// What an output event means for one view.
+enum class OutputTransition {
+  kNone,          // still where it belongs; nothing to do
+  kMoved,         // the constraint now resolves to a different output
+  kAppeared,      // the constraint resolves and the view is not on it yet
+  kLost,          // the view's output no longer satisfies the constraint
+  kReconfigured,  // same output, but its mode or EDID changed
+};
+
+/**
+ * @brief Decide what an output event means for a single view.
+ *
+ * Split out of the listener because this is the part that can be wrong: the
+ * caller supplies where the view is and what its config now resolves to, and
+ * the decision is a pure function of those. A view is only "lost" when a
+ * constraint was set and went unsatisfied -- an unconstrained view keeps
+ * whatever the backend chose, so its output vanishing is the backend's problem
+ * to report, not a resolution failure.
+ *
+ * @param[in] current the view's actual output, from FlutterView::BoundOutput()
+ * @param[in] wanted  the freshly re-resolved constraint
+ * @param[in] event   what happened
+ * @param[in] changed the output the event names; only meaningful for kChanged
+ */
+[[nodiscard]] OutputTransition ClassifyOutputTransition(
+    const std::optional<std::string>& current,
+    const OutputResolution& wanted,
+    OutputEvent event,
+    std::string_view changed);
 
 // As ResolveOutput, but distinguishing kUnconstrained from kUnresolved.
 [[nodiscard]] OutputResolution ResolveOutputDetailed(

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -23,6 +23,8 @@
 #include <memory>
 #include <utility>
 
+#include "asio/post.hpp"
+
 #include "app.h"
 #include "backend/backend_registry.h"
 #include "backend/register_backends.h"
@@ -210,11 +212,6 @@ FlutterView::FlutterView(Configuration::Config config,
             m_config, display.get(), homescreen::BackendFamily::kWayland)) {
       if (const auto idx = wl->WlOutputIndexForName(*resolved)) {
         wl_output_index = *idx;
-        // Remember what we landed on. Only on the branch that took effect:
-        // when the name is not live the view stays on wl_output_index, which
-        // is a different output, and recording the requested name there would
-        // make BoundOutput() describe a placement that did not happen.
-        m_wayland_bound_output = *resolved;
       } else {
         ihs::log::warn(
             "[FlutterView] resolved wl_output '{}' is not live; using "
@@ -222,6 +219,13 @@ FlutterView::FlutterView(Configuration::Config config,
             *resolved, wl_output_index);
       }
     }
+    // Record the output the view actually landed on, by index rather than by
+    // what the config asked for. Those differ in two ordinary cases: no
+    // [view.output] at all, and a named output that is not live -- in both the
+    // view still sits on some real output, and a listener that cannot name it
+    // cannot tell that a mode change underneath it matters.
+    m_wayland_bound_output = wl->WlOutputNameForIndex(wl_output_index);
+
     m_wayland_window = std::make_shared<WaylandWindow>(
         m_index, std::dynamic_pointer_cast<Display>(display),
         m_config.view.window_type, wl->GetWlOutput(wl_output_index),
@@ -391,6 +395,18 @@ std::optional<std::string> FlutterView::BoundOutput() const {
     }
   }
   return m_wayland_bound_output;
+}
+
+bool FlutterView::PostToPlatformThread(std::function<void()> fn) const {
+  if (!m_flutter_engine) {
+    return false;
+  }
+  auto* runner = m_flutter_engine->GetPlatformTaskRunner();
+  if (runner == nullptr || runner->GetStrandContext() == nullptr) {
+    return false;
+  }
+  asio::post(*runner->GetStrandContext(), std::move(fn));
+  return true;
 }
 
 PlatformViewRegistry* FlutterView::GetPlatformViewRegistry() const {

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -16,6 +16,7 @@
 
 #include "config/common.h"
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -146,9 +147,9 @@ class FlutterView {
    * compares it with this to decide whether anything has to move.
    *
    * @return the output name in the form OutputInfo::name carries (e.g.
-   *         "DSI-1"); nullopt when the backend does not track one, which is
-   *         the case for the software backend and for a Wayland view with no
-   *         [view.output] constraint.
+   *         "DSI-1"); nullopt when neither the backend nor the view can name
+   *         one -- the software backend, or a Wayland output whose first
+   *         wl_output.done has not landed.
    * @relation
    * internal
    */
@@ -167,6 +168,47 @@ class FlutterView {
    * internal
    */
   [[nodiscard]] PlatformViewRegistry* GetPlatformViewRegistry() const;
+
+  /**
+   * @brief The config this view was built from.
+   *
+   * The [view.output] constraint lives here, and re-resolving it is how a
+   * hotplug listener decides whether the view still belongs where it is.
+   *
+   * @relation
+   * internal
+   */
+  [[nodiscard]] const Configuration::Config& GetConfig() const {
+    return m_config;
+  }
+
+  /**
+   * @brief Run @p fn on the Flutter platform thread.
+   *
+   * Output events reach App on its own reactor thread -- the one reading the
+   * Wayland fd -- and PlatformViewRegistry may only be touched on the platform
+   * thread, which TaskRunner owns separately. This is the hop between them.
+   *
+   * @return false if the engine is not running, in which case @p fn is not
+   *         called and never will be.
+   * @relation
+   * internal
+   */
+  bool PostToPlatformThread(std::function<void()> fn) const;
+
+  /**
+   * @brief Forget the output this view was placed on, because it is gone.
+   *
+   * Wayland only, and only where the view recorded its own placement: the DRM
+   * binding comes from the backend, which corrects itself when it re-modesets.
+   * Without this the record outlives the output, and a replug of the same name
+   * looks like "already there" -- so the view would never be told to
+   * renegotiate against the new one.
+   *
+   * @relation
+   * internal
+   */
+  void NoteOutputLost() { m_wayland_bound_output.reset(); }
 
   /**
    * @brief Get pointer to Display object
@@ -324,10 +366,12 @@ class FlutterView {
 
   uint64_t m_pointer_events{};
 
-  // The Wayland output this view was placed on, by name, when [view.output]
-  // resolved one. The DRM side is not mirrored here: DrmBackend knows which
-  // connector it programmed, so BoundOutput() asks it rather than keeping a
-  // second copy that could disagree.
+  // The Wayland output this view was placed on, by name -- taken from the
+  // index actually used, so it is set whether the placement came from
+  // [view.output], from wl_output_index, or from the default. The DRM side is
+  // not mirrored here: DrmBackend knows which connector it programmed, so
+  // BoundOutput() asks it rather than keeping a second copy that could
+  // disagree.
   std::optional<std::string> m_wayland_bound_output;
 
   // Temporary owner of FlutterDesktopEngineState between FlutterView

--- a/shell/wayland/display.cc
+++ b/shell/wayland/display.cc
@@ -1266,6 +1266,24 @@ std::vector<homescreen::OutputInfo> Display::EnumerateOutputs() const {
 
 void Display::SetOutputListener(homescreen::IOutputListener* listener) {
   m_output_listener = listener;
+  if (listener == nullptr) {
+    return;
+  }
+  // Everything already bound counts as announced. A listener attaching after
+  // the registry roundtrip -- which is every listener, since the outputs are
+  // bound in the constructor -- reads the current set through
+  // EnumerateOutputs() instead. Without this the flag stays false, and two
+  // things go wrong: the next `done` on a long-standing output is reported as
+  // an arrival, and its removal is not reported at all, because
+  // HandleGlobalRemove only notifies for outputs it believes were announced.
+  for (const auto& oi : m_all_outputs) {
+    // Only the ones EnumerateOutputs() would expose, i.e. those whose first
+    // `done` has landed. A global bound but not yet described has genuinely
+    // not been announced, and its first `done` is an arrival.
+    if (oi && oi->done) {
+      oi->announced = true;
+    }
+  }
 }
 
 void Display::EmitOutputDone(output_info_t* oi) {
@@ -1287,10 +1305,16 @@ void Display::HandleGlobalRemove(const uint32_t global_name) {
     if (!oi || oi->global_id != global_name) {
       continue;
     }
-    if (m_output_listener != nullptr && oi->announced) {
-      m_output_listener->OnOutputRemoved(oi->name);
-    }
+    // Drop it first, then notify. A listener re-reads the live set through
+    // EnumerateOutputs() to decide what the removal means, and it must not
+    // still find the output that just went away -- doing so makes a departed
+    // output look present and the event look like a no-op.
+    const std::string name = oi->name;
+    const bool was_announced = oi->announced;
     m_all_outputs.erase(it);
+    if (m_output_listener != nullptr && was_announced) {
+      m_output_listener->OnOutputRemoved(name);
+    }
     return;
   }
 }

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -348,6 +348,22 @@ class Display : public IDisplay,
    * @relation
    * wayland, flutter
    */
+  /**
+   * @brief Name of the wl_output at @p index, as OutputInfo::name carries it.
+   *
+   * The inverse of WlOutputIndexForName. A view records this so it knows which
+   * output it was actually placed on, including when it was placed by index
+   * rather than by name.
+   */
+  [[nodiscard]] std::optional<std::string> WlOutputNameForIndex(
+      const uint32_t index) const {
+    if (index < m_all_outputs.size() && m_all_outputs[index] &&
+        m_all_outputs[index]->done) {
+      return m_all_outputs[index]->name;
+    }
+    return std::nullopt;
+  }
+
   [[nodiscard]] std::optional<uint32_t> WlOutputIndexForName(
       const std::string& name) const {
     for (size_t i = 0; i < m_all_outputs.size(); ++i) {

--- a/test/unit_test/output_resolver-test/test_case_output_resolver.cc
+++ b/test/unit_test/output_resolver-test/test_case_output_resolver.cc
@@ -24,9 +24,12 @@
 #include "display/output.h"
 
 using homescreen::BackendFamily;
+using homescreen::ClassifyOutputTransition;
+using homescreen::OutputEvent;
 using homescreen::OutputInfo;
 using homescreen::OutputMatch;
 using homescreen::OutputResolution;
+using homescreen::OutputTransition;
 using homescreen::ResolveOutput;
 using homescreen::ResolveOutputDetailed;
 
@@ -309,4 +312,88 @@ TEST(OutputResolver, DetailedResultSeparatesUnconstrainedFromUnresolved) {
       ResolveOutputDetailed(present, TwoHeads(), BackendFamily::kDrm);
   EXPECT_TRUE(ok.bound());
   EXPECT_EQ(ok.name, "HDMI-A-1");
+}
+
+// ---------------------------------------------------------------------------
+// ClassifyOutputTransition: what an output event means for one view. Split out
+// of App's listener so the decision can be exercised without a display, an
+// engine or a compositor.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+OutputResolution Bound(std::string name) {
+  return {OutputResolution::Status::kBound, std::move(name)};
+}
+OutputResolution Unconstrained() {
+  return {OutputResolution::Status::kUnconstrained, {}};
+}
+OutputResolution Unresolved() {
+  return {OutputResolution::Status::kUnresolved, {}};
+}
+
+}  // namespace
+
+TEST(OutputTransitions, StayingPutIsNotAnEvent) {
+  // The common case by far: something changed elsewhere on the display.
+  EXPECT_EQ(
+      ClassifyOutputTransition(std::optional<std::string>{"DSI-1"},
+                               Bound("DSI-1"), OutputEvent::kAdded, "HDMI-A-1"),
+      OutputTransition::kNone);
+}
+
+TEST(OutputTransitions, ConstraintNowResolvesElsewhere) {
+  EXPECT_EQ(
+      ClassifyOutputTransition(std::optional<std::string>{"HDMI-A-1"},
+                               Bound("DSI-1"), OutputEvent::kAdded, "DSI-1"),
+      OutputTransition::kMoved);
+}
+
+TEST(OutputTransitions, AnUnboundViewGainsAnOutput) {
+  EXPECT_EQ(ClassifyOutputTransition(std::nullopt, Bound("DSI-1"),
+                                     OutputEvent::kAdded, "DSI-1"),
+            OutputTransition::kAppeared);
+}
+
+TEST(OutputTransitions, AConstraintThatStopsResolvingLosesTheOutput) {
+  EXPECT_EQ(
+      ClassifyOutputTransition(std::optional<std::string>{"HDMI-A-1"},
+                               Unresolved(), OutputEvent::kRemoved, "HDMI-A-1"),
+      OutputTransition::kLost);
+}
+
+TEST(OutputTransitions, AnUnconstrainedViewIsNeverLost) {
+  // No constraint means the backend's own pick stands, and re-resolving says
+  // nothing about it -- reporting "lost" here would park a view that is still
+  // perfectly placed.
+  EXPECT_EQ(ClassifyOutputTransition(std::optional<std::string>{"DSI-1"},
+                                     Unconstrained(), OutputEvent::kRemoved,
+                                     "HDMI-A-1"),
+            OutputTransition::kNone);
+}
+
+TEST(OutputTransitions, ReconfiguringTheViewsOwnOutputCounts) {
+  EXPECT_EQ(
+      ClassifyOutputTransition(std::optional<std::string>{"DSI-1"},
+                               Bound("DSI-1"), OutputEvent::kChanged, "DSI-1"),
+      OutputTransition::kReconfigured);
+  // ... and an unconstrained view on that output is equally affected: its mode
+  // may have changed underneath it.
+  EXPECT_EQ(
+      ClassifyOutputTransition(std::optional<std::string>{"DSI-1"},
+                               Unconstrained(), OutputEvent::kChanged, "DSI-1"),
+      OutputTransition::kReconfigured);
+}
+
+TEST(OutputTransitions, ReconfiguringSomeOtherOutputDoesNot) {
+  EXPECT_EQ(ClassifyOutputTransition(std::optional<std::string>{"DSI-1"},
+                                     Bound("DSI-1"), OutputEvent::kChanged,
+                                     "HDMI-A-1"),
+            OutputTransition::kNone);
+}
+
+TEST(OutputTransitions, AViewWithNoBindingAndNoConstraintHasNothingToDo) {
+  EXPECT_EQ(ClassifyOutputTransition(std::nullopt, Unconstrained(),
+                                     OutputEvent::kChanged, "DSI-1"),
+            OutputTransition::kNone);
 }


### PR DESCRIPTION
Part 3 of output hotplug renegotiation. Follows #406 and #407.

## What was missing

Every piece existed and none were connected: `Display` emits add/remove/change on `wl_output.done`, `IOutputListener` had no implementer, and `SetOutputListener` was never called. This connects them.

App watches each display that reports hotplug — one listener per display, because `IOutputListener` says *what* changed but not *where*, and App can drive several. On an event it re-resolves every view on that display and compares the answer with where the view actually is (#407).

## Two real bugs, found by testing against a real compositor

I ran this under nested headless **sway**, whose outputs can be created and unplugged on demand. That turned up two defects in the emit layer that no unit test would have caught, because App is its first listener:

1. **Removals were silently dropped.** `EmitOutputDone` returned early when no listener was attached — *before* setting `announced`. Every output is bound in the `Display` constructor and every listener attaches after it, so outputs stayed marked un-announced: their next `done` was reported as an *arrival*, and their removal wasn't reported at all, since `HandleGlobalRemove` only notifies for outputs it believes were announced.

2. **The removal callback lied about the live set.** `HandleGlobalRemove` notified *before* erasing. A listener re-reads the live set to decide what a removal means — so it still found the output that had just gone away, resolved the constraint successfully, and concluded nothing had happened. The correct outcome only arrived later via an unrelated event on another output. Pure luck, and it would not have held on a single-output system.

Both are fixed here. The first run of the feature looked like it worked; it only survived scrutiny because I checked *which* output the event named.

## Design note

The comparison is a free function, `ClassifyOutputTransition`, rather than a branch inside the listener — it's the part that can be wrong, and as a pure function of `(current, re-resolved, event)` it can be exercised without a display, an engine or a compositor.

Worth review: **an unconstrained view is never "lost."** With no `[view.output]`, the backend's own pick stands and re-resolving says nothing about it, so treating an absent output as a resolution failure would park a view that is still correctly placed.

## Scope

Acting on a transition is limited to telling that view's platform views their grant is stale — per view, not `RenegotiateAll()`, since a second view on another output of the same display has not moved. The call hops to the platform thread: events arrive on the reactor thread reading the Wayland fd, and `PlatformViewRegistry` is platform-thread only.

Moving a view to another output, or parking one whose output vanished, needs a suspend path that does not exist yet (Phase 4). A view does forget its placement when its output is lost, so the same output returning reads as an arrival rather than "already there".

## Verified

Nested sway, all four transitions:

| action | result |
|---|---|
| create the named output | `has an output to bind to (on '-', wants 'HEADLESS-9')` |
| unplug it | `lost its output` |
| change its mode | `was reconfigured` |
| unrelated output changes | silent |

Pi 4: DRM unaffected — the view still binds `DSI-1`, and no watch is installed because `DrmOutputProvider` still reports no hotplug support (Phase 5).

Builds and tests pass with `BUILD_COMPOSITOR` both **on** (20 suites) and **off** (19) — platform views are gated on it, so the renegotiate call is too.

## Tests

Eight cases on the classifier, including the two easiest to get backwards: an unconstrained view is not lost when some *other* output disappears, and a reconfiguration of an output the view is not on is not an event for it.

**Not unit-tested:** the listener wiring and thread hop — those need a compositor, and are covered by the sway runs above.
