### PR TITLE
platform_views: dispatch set_suspended to one view

### DIFF
--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -803,6 +803,13 @@ void ListenerRejectGesture(int32_t /* id */, void* data) {
   }
 }
 
+void ListenerSetSuspended(int32_t /* id */, uint8_t suspended, void* data) {
+  auto* view = static_cast<IhsPluginView*>(data);
+  if (view->callbacks.set_suspended != nullptr) {
+    view->callbacks.set_suspended(view->plugin_user_data, suspended);
+  }
+}
+
 void ListenerRenegotiate(int32_t /* id */, void* data) {
   auto* view = static_cast<IhsPluginView*>(data);
   if (view->callbacks.renegotiate != nullptr) {
@@ -822,6 +829,7 @@ const platform_view_listener kListener = {
     /* dispose */ ListenerDispose,
     /* accept_gesture */ ListenerAcceptGesture,
     /* reject_gesture */ ListenerRejectGesture,
+    /* set_suspended */ ListenerSetSuspended,
     /* renegotiate */ ListenerRenegotiate,
 };
 

--- a/shell/platform/homescreen/platform_views/platform_view_listener.h
+++ b/shell/platform/homescreen/platform_views/platform_view_listener.h
@@ -46,6 +46,12 @@ struct platform_view_listener {
   /// two a host cannot implement.
   void (*accept_gesture)(int32_t id, void* data);
   void (*reject_gesture)(int32_t id, void* data);
+  /// The view left (1) or re-entered (0) the composited scene, so a producing
+  /// plugin can pause its decode/render while nothing can see it. Not a
+  /// teardown: the instance stays alive and its grant stays held.
+  ///
+  /// Delivered per view, for the same reason as renegotiate below.
+  void (*set_suspended)(int32_t id, uint8_t suspended, void* data);
   /// The grant this view was given is no longer valid -- its output changed
   /// mode, went away, or the plane backing it was taken -- so whatever the
   /// view negotiated has to be negotiated again or dropped to the floor.

--- a/shell/platform/homescreen/platform_views/platform_view_registry.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_registry.cc
@@ -213,6 +213,18 @@ void PlatformViewRegistry::RejectGesture(int32_t id) {
   }
 }
 
+bool PlatformViewRegistry::SetSuspended(const int32_t id,
+                                        const bool suspended) {
+  const platform_view_listener* listener = nullptr;
+  void* context = nullptr;
+  if (!LookupListener(id, &listener, &context) ||
+      listener->set_suspended == nullptr) {
+    return false;
+  }
+  listener->set_suspended(id, suspended ? 1 : 0, context);
+  return true;
+}
+
 bool PlatformViewRegistry::Renegotiate(const int32_t id) {
   const platform_view_listener* listener = nullptr;
   void* context = nullptr;

--- a/shell/platform/homescreen/platform_views/platform_view_registry.h
+++ b/shell/platform/homescreen/platform_views/platform_view_registry.h
@@ -115,6 +115,12 @@ class PlatformViewRegistry {
   void AcceptGesture(int32_t id);
   void RejectGesture(int32_t id);
 
+  // Tell one view it left (true) or re-entered (false) the composited scene.
+  // Returns false when no instance holds @p id, or when the view registered no
+  // set_suspended callback -- the caller uses that to tell "nothing to notify"
+  // from "notified".
+  bool SetSuspended(int32_t id, bool suspended);
+
   // Tell one view its grant is stale. Returns false when no instance holds
   // @p id, or when the view registered no renegotiate callback -- the caller
   // uses that to tell "nothing to notify" from "notified".

--- a/test/unit_test/platform_view_registry-test/test_case_platform_view_registry.cc
+++ b/test/unit_test/platform_view_registry-test/test_case_platform_view_registry.cc
@@ -40,6 +40,8 @@ struct Probe {
   int accept = 0;
   int reject = 0;
   int renegotiate = 0;
+  int suspend_calls = 0;
+  int last_suspended = -1;
   int32_t last_gesture_id = -1;
   void* last_gesture_data = nullptr;
 };
@@ -76,6 +78,12 @@ void ProbeRejectGesture(int32_t id, void* data) {
   p->last_gesture_data = data;
 }
 
+void ProbeSetSuspended(int32_t /* id */, uint8_t suspended, void* data) {
+  auto* p = static_cast<Probe*>(data);
+  ++p->suspend_calls;
+  p->last_suspended = suspended;
+}
+
 constexpr platform_view_listener kListener = {
     ProbeResize,         // resize
     nullptr,             // set_direction
@@ -84,6 +92,7 @@ constexpr platform_view_listener kListener = {
     ProbeDispose,        // dispose
     ProbeAcceptGesture,  // accept_gesture
     ProbeRejectGesture,  // reject_gesture
+    ProbeSetSuspended,   // set_suspended
     ProbeRenegotiate,    // renegotiate
 };
 
@@ -257,3 +266,27 @@ TEST(PlatformViewRegistry, FactoryOwnedInstanceDestroyedOnDispose) {
 }
 
 }  // namespace
+
+// set_suspended follows the same per-view addressing as renegotiate: parking
+// one view must not silence a second one that is still on screen.
+TEST(PlatformViewRegistry, SetSuspendedAddressesOneView) {
+  PlatformViewRegistry registry(nullptr);
+  Probe a;
+  Probe b;
+  registry.RegisterListener(1, &kListener, &a);
+  registry.RegisterListener(2, &kListener, &b);
+
+  EXPECT_TRUE(registry.SetSuspended(1, true));
+  EXPECT_EQ(a.suspend_calls, 1);
+  EXPECT_EQ(a.last_suspended, 1);
+  EXPECT_EQ(b.suspend_calls, 0) << "the other view is still visible";
+
+  // Resuming is the same call with the flag cleared, not a separate entry --
+  // a plugin that only ever saw 1 would never restart its producer.
+  EXPECT_TRUE(registry.SetSuspended(1, false));
+  EXPECT_EQ(a.suspend_calls, 2);
+  EXPECT_EQ(a.last_suspended, 0);
+
+  // Unknown id: nothing to notify, reported as such.
+  EXPECT_FALSE(registry.SetSuspended(42, true));
+}


### PR DESCRIPTION
First half of Phase 4. Follows #408.

## What this fixes

`IhsPvCallbacks::set_suspended` has been in the public ABI since the header was written, with **no way to reach it** — no listener entry, no registry method, no host trampoline. A plugin could register the callback and it would never be called. This is the slice `renegotiate` got in #400, applied to the one remaining unwired callback.

Dispatch is per view, for the same reason: parking one view must not silence a second that is still on screen.

## The part worth checking

The listener table is **positionally initialized**, so inserting a field is not a local change. The struct entry, the host's table, and the test's initializer all have to agree — and a mismatch would silently bind `renegotiate` to the wrong function rather than fail to compile. The test's initializer had exactly that shape (8 entries, `ProbeRenegotiate` last), so it is updated here too.

The pre-existing `RenegotiateAddressesOneView` test still passing is what demonstrates the slot is right; that check is the reason I looked.

## Scope — deliberately half

Nothing calls `SetSuspended()` yet. Making a view actually stop presenting when its output disappears, and applying `[view.output]` `on_disconnect` / `preload`, is the other half and lands next.

Note the ABI text still describes `set_suspended` in its original terms — a view *scrolled off or occluded*. Using it for a view whose **output** went away extends that meaning. It fits ("pause your producer, nothing can see you") and the alternative breaks ABI, but I have deliberately **not** edited the contract here: documenting the extension belongs with the change that actually does the parking, not ahead of it.

## Tests

Three assertions on the registry (7 in the suite, all pass):
- suspending one view leaves the other untouched;
- resuming is the same call with the flag cleared, not a separate entry — a plugin that only ever saw `1` would never restart its producer;
- an unknown id reports there was nothing to notify.

Builds and tests pass with `BUILD_COMPOSITOR` on (20 suites) and off (19); clang-tidy clean on the changed files.
