### PR TITLE
drm-kms-egl: HDR — drive connector HDR_OUTPUT_METADATA from a PV's HDR frame

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2676,6 +2676,28 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
         drm::span<const drm::scene::ExternalPlaneInfo>(planes.data(), np),
         std::move(acquire));
   };
+  // Stand up a fresh ExternalDmaBufPool for a PV's decoder ring at the frame's
+  // geometry. Used both on first sight and when a live PV's buffer geometry
+  // changes (swapped in place via replace_source). The deferred on_release
+  // holds a displaced buffer until the next present's flip completes, then
+  // returns it to the producer (see deferred_releases_).
+  const auto make_pv_pool = [this](
+                                const ICompositorSurface::Dmabuf& db,
+                                std::shared_ptr<ICompositorSurface> surface) {
+    drm::scene::ExternalDmaBufPool::Options opts{};
+    opts.on_release = [this, surface = std::move(surface)](
+                          std::uintptr_t key,
+                          std::optional<drm::sync::SyncFence>) {
+      if (!surface) {
+        return;
+      }
+      const std::scoped_lock lock(deferred_releases_mu_);
+      deferred_releases_.push_back({surface, static_cast<uint32_t>(key)});
+    };
+    return drm::scene::ExternalDmaBufPool::create(backend_->device(), db.width,
+                                                  db.height, db.fourcc,
+                                                  db.modifier, std::move(opts));
+  };
   for (auto& fl : frame_layers) {
     ++z_index;
     const bool is_ui = (z_index == 0);
@@ -2748,22 +2770,39 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
               pool->format().modifier == db.modifier) {
             submit_pv_pool(pool, db);
           } else {
-            // Source isn't our pool, or the producer's geometry changed under a
-            // fixed-generation pool (an ABR rendition switch). Drop the layer
-            // so the new loop re-adds it at the new geometry next present, and
-            // release this frame's buffer so its ring slot isn't leaked. Count
-            // it as a prune: removing the plane is a topology change, so this
-            // frame must take the blocking ALLOW_MODESET commit below rather
-            // than a NONBLOCK one that could hit a transient EBUSY.
-            scene_->remove_layer(layer->handle());
-            scene_pv_tags_.erase(std::remove(scene_pv_tags_.begin(),
-                                             scene_pv_tags_.end(), fl.pv_tag),
-                                 scene_pv_tags_.end());
-            if (fl.pv_surface) {
-              fl.pv_surface->OnScanoutRelease(db.buffer_id);
+            // The source isn't our pool, or the frame's buffer geometry changed
+            // -- a real ABR rendition switch, or subpixel resize jitter on the
+            // box demo. Swap the source in place with a fresh pool at the new
+            // geometry (replace_source) rather than pruning + re-adding next
+            // present: the layer keeps its plane assignment, geometry, and
+            // HDR/Colorspace signaling, so there is no gap frame (which blinks
+            // the view and toggles the connector's auto-derived HDR/Colorspace)
+            // and no per-jitter modeset. The displaced pool is retired by the
+            // scene as its in-flight buffers drain.
+            bool swapped = false;
+            if (auto new_pool = make_pv_pool(db, fl.pv_surface); new_pool) {
+              auto* np_raw = new_pool.value().get();
+              if (scene_->replace_source(layer->handle(),
+                                         std::move(new_pool.value()))) {
+                submit_pv_pool(np_raw, db);
+                swapped = true;
+              }
             }
-            ++pv_pruned;
-            continue;
+            if (!swapped) {
+              // Pool-create / replace failed: fall back to prune + re-add. This
+              // removes the plane (a topology change), so the frame takes the
+              // blocking ALLOW_MODESET commit below rather than a NONBLOCK one
+              // that could hit a transient EBUSY.
+              scene_->remove_layer(layer->handle());
+              scene_pv_tags_.erase(std::remove(scene_pv_tags_.begin(),
+                                               scene_pv_tags_.end(), fl.pv_tag),
+                                   scene_pv_tags_.end());
+              if (fl.pv_surface) {
+                fl.pv_surface->OnScanoutRelease(db.buffer_id);
+              }
+              ++pv_pruned;
+              continue;
+            }
           }
         }
         layer->set_dst_rect_if_changed(dst_rect);
@@ -2780,25 +2819,10 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       // producer when it leaves scanout, which drives the ihs_pv release path.
       // The retained surface shared_ptr keeps the view alive across a release
       // even if it is concurrently disposed.
-      drm::scene::ExternalDmaBufPool::Options opts{};
-      // Defer the release by one present: the buffer is displaced now but stays
-      // on the plane until this commit's flip completes, so returning it to the
-      // producer here would let it be overwritten under scanout. Hold it and
-      // fire OnScanoutRelease at the next present's top
-      // (post-WaitForPendingFlip), when the flip is done. See
-      // deferred_releases_.
-      opts.on_release = [this, surface = fl.pv_surface](
-                            std::uintptr_t key,
-                            std::optional<drm::sync::SyncFence>) {
-        if (!surface) {
-          return;
-        }
-        const std::scoped_lock lock(deferred_releases_mu_);
-        deferred_releases_.push_back({surface, static_cast<uint32_t>(key)});
-      };
-      auto pool = drm::scene::ExternalDmaBufPool::create(
-          backend_->device(), db.width, db.height, db.fourcc, db.modifier,
-          std::move(opts));
+      // First sight: stand up the pool at this frame's geometry (deferred
+      // release holds a displaced buffer until the next present's flip; see
+      // deferred_releases_).
+      auto pool = make_pv_pool(db, fl.pv_surface);
       if (!pool) {
         ihs::log::warn(
             "[DrmCompositor] ExternalDmaBufPool::create (pv): {}; routing "

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -48,6 +48,8 @@
 #include "backend/drm_kms_egl/drm_cursor.h"
 #include "backend/drm_kms_egl/scene_layer_source_gl.h"
 #include "display/drm_display.h"
+#include "drm-cxx/src/display/connector_info.hpp"  // ColorimetryInfo / Chromaticity
+#include "drm-cxx/src/display/hdr_metadata.hpp"  // HdrSourceMetadata / TransferFunction
 #include "drm-cxx/src/modeset/atomic.hpp"
 #include "ihs/platform_view.h"
 #include "libflutter_engine.h"
@@ -88,6 +90,36 @@ std::optional<drm::planes::ColorRange> ToColorRange(uint8_t color_range) {
     default:
       return std::nullopt;
   }
+}
+
+// Map the frame's HDR static metadata (mirrored IhsHdrMetadata, valid only when
+// Dmabuf::has_hdr) to drm-cxx's HdrSourceMetadata for the connector's
+// HDR_OUTPUT_METADATA. Primaries are 0.00002-unit uint16 -> CIE xy float;
+// luminances clamp to the CTA-861.3 uint16 fields.
+drm::display::HdrSourceMetadata ToHdrSourceMetadata(
+    const ICompositorSurface::Dmabuf::HdrMetadata& h) {
+  drm::display::HdrSourceMetadata out{};
+  // IhsTransfer: 2=HLG, otherwise PQ (has_hdr implies PQ or HLG).
+  out.eotf = h.transfer == 2 ? drm::display::TransferFunction::Bt2100Hlg
+                             : drm::display::TransferFunction::SmpteSt2084Pq;
+  const auto xy = [](uint16_t v) { return static_cast<float>(v) * 0.00002F; };
+  out.display_primaries.red = {xy(h.display_primaries_x[0]),
+                               xy(h.display_primaries_y[0])};
+  out.display_primaries.green = {xy(h.display_primaries_x[1]),
+                                 xy(h.display_primaries_y[1])};
+  out.display_primaries.blue = {xy(h.display_primaries_x[2]),
+                                xy(h.display_primaries_y[2])};
+  out.display_primaries.white = {xy(h.white_point_x), xy(h.white_point_y)};
+  const auto clamp16 = [](uint32_t v) {
+    return static_cast<uint16_t>(v > 0xFFFFU ? 0xFFFFU : v);
+  };
+  out.max_display_mastering_luminance =
+      clamp16(h.max_display_mastering_luminance);
+  out.min_display_mastering_luminance =
+      clamp16(h.min_display_mastering_luminance);
+  out.max_content_light_level = h.max_content_light_level;
+  out.max_frame_average_light_level = h.max_frame_average_light_level;
+  return out;
 }
 
 // The planar/packed YUV fourccs a video producer submits — so the scene
@@ -2435,6 +2467,11 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   frame_batons.reserve(layer_count);
   frame_pv_tags.reserve(layer_count);
 
+  // The connector's HDR_OUTPUT_METADATA this present: set from an HDR video
+  // PV's frame (the topmost such PV wins), or left empty for SDR — which clears
+  // any prior HDR signaling. Applied to the scene just before commit.
+  std::optional<drm::display::HdrSourceMetadata> output_hdr;
+
   // GetDmabuf hands back an owned (dup'd) fd per platform view; close them on
   // every exit path (each GL-fallback return below, and the normal exit). The
   // pool's first-sight import dups again for the KMS framebuffer, so closing
@@ -2541,6 +2578,15 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
           continue;
         }
         return PresentViaGlFallback(layers, layer_count);
+      }
+      // An HDR video PV drives the connector's HDR_OUTPUT_METADATA. Read the
+      // view's *persisted* HDR (not the deliver-once frame) so it holds steady
+      // across reuse presents — toggling it would re-sync the sink's HDR mode
+      // every few frames (flicker). Layers walk bottom-to-top, so the topmost
+      // HDR PV wins.
+      ICompositorSurface::Dmabuf::HdrMetadata hmeta{};
+      if (surface->GetHdrMetadata(&hmeta)) {
+        output_hdr = ToHdrSourceMetadata(hmeta);
       }
       frame_layers.push_back(
           {fl, nullptr, nullptr, surface.get(), db, surface});
@@ -2783,6 +2829,18 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
                                  : drm::planes::ContentType::Generic;
       desc.display.color_encoding = ToColorEncoding(db.color_space);
       desc.display.color_range = ToColorRange(db.color_range);
+      // HDR video also carries its wide-gamut primaries + source EOTF, so the
+      // scene auto-derives the connector's Colorspace (BT.2020) and the HDR
+      // signaling from the layer — without which the sink never sees BT.2020
+      // colorimetry and stays in SDR. The frame's mastering metadata
+      // (luminance / MaxCLL) rides set_output_metadata above.
+      ICompositorSurface::Dmabuf::HdrMetadata hmeta{};
+      if (fl.pv_surface && fl.pv_surface->GetHdrMetadata(&hmeta)) {
+        desc.display.color_primaries = drm::scene::ColorPrimaries::Bt2020;
+        desc.display.source_eotf =
+            hmeta.transfer == 2 ? drm::display::TransferFunction::Bt2100Hlg
+                                : drm::display::TransferFunction::SmpteSt2084Pq;
+      }
       desc.identity_tag = fl.pv_tag;
       auto handle = scene_->add_layer(std::move(desc));
       if (!handle) {
@@ -2890,6 +2948,12 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       blocking_modeset ? DRM_MODE_ATOMIC_ALLOW_MODESET
                        : (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK);
   const uint64_t t2 = profile ? NsNow() : 0;
+
+  // Signal this frame's HDR metadata on the connector (or clear to SDR when no
+  // HDR PV). The scene wires it into the commit below; a no-op on connectors
+  // without HDR_OUTPUT_METADATA, and content-hashed so an unchanged value is
+  // cheap on repeat.
+  scene_->set_output_metadata(output_hdr);
 
   auto report = scene_->commit(commit_flags, static_cast<IFlipSink*>(this));
   if (!report) {

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2467,9 +2467,13 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   frame_batons.reserve(layer_count);
   frame_pv_tags.reserve(layer_count);
 
-  // The connector's HDR_OUTPUT_METADATA this present: set from an HDR video
-  // PV's frame (the topmost such PV wins), or left empty for SDR — which clears
-  // any prior HDR signaling. Applied to the scene just before commit.
+  // The connector's HDR_OUTPUT_METADATA this present. Set below from the HDR
+  // PVs that actually survive into the committed scene (reused or newly added)
+  // -- NOT during the pre-scan, since a PV can still be pruned mid-frame (the
+  // replace_source fallback), which would otherwise leave HDR signaled over SDR
+  // content. The add/update loop walks bottom-to-top, so the topmost surviving
+  // HDR PV wins. Left empty for SDR, which clears any prior HDR signaling.
+  // Applied to the scene just before commit.
   std::optional<drm::display::HdrSourceMetadata> output_hdr;
 
   // GetDmabuf hands back an owned (dup'd) fd per platform view; close them on
@@ -2578,15 +2582,6 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
           continue;
         }
         return PresentViaGlFallback(layers, layer_count);
-      }
-      // An HDR video PV drives the connector's HDR_OUTPUT_METADATA. Read the
-      // view's *persisted* HDR (not the deliver-once frame) so it holds steady
-      // across reuse presents — toggling it would re-sync the sink's HDR mode
-      // every few frames (flicker). Layers walk bottom-to-top, so the topmost
-      // HDR PV wins.
-      ICompositorSurface::Dmabuf::HdrMetadata hmeta{};
-      if (surface->GetHdrMetadata(&hmeta)) {
-        output_hdr = ToHdrSourceMetadata(hmeta);
       }
       frame_layers.push_back(
           {fl, nullptr, nullptr, surface.get(), db, surface});
@@ -2807,6 +2802,14 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
         }
         layer->set_dst_rect_if_changed(dst_rect);
         layer->set_zpos_if_changed(overlay_zpos);  // restack on reorder
+        // This PV survives into the committed scene, so it drives the
+        // connector's HDR_OUTPUT_METADATA (persisted metadata, steady across
+        // reuse presents). A PV pruned above (replace_source fallback) never
+        // reaches here, so it can't signal HDR over content it isn't showing.
+        ICompositorSurface::Dmabuf::HdrMetadata reused_hdr{};
+        if (fl.pv_surface && fl.pv_surface->GetHdrMetadata(&reused_hdr)) {
+          output_hdr = ToHdrSourceMetadata(reused_hdr);
+        }
         ++pv_reused;
         continue;
       }
@@ -2859,7 +2862,9 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       // colorimetry and stays in SDR. The frame's mastering metadata
       // (luminance / MaxCLL) rides set_output_metadata above.
       ICompositorSurface::Dmabuf::HdrMetadata hmeta{};
-      if (fl.pv_surface && fl.pv_surface->GetHdrMetadata(&hmeta)) {
+      const bool pv_is_hdr =
+          fl.pv_surface && fl.pv_surface->GetHdrMetadata(&hmeta);
+      if (pv_is_hdr) {
         desc.display.color_primaries = drm::scene::ColorPrimaries::Bt2020;
         desc.display.source_eotf =
             hmeta.transfer == 2 ? drm::display::TransferFunction::Bt2100Hlg
@@ -2877,6 +2882,11 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
         return PresentViaGlFallback(layers, layer_count);
       }
       scene_pv_tags_.push_back(fl.pv_tag);
+      // Now committed into the scene, this PV drives the connector's
+      // HDR_OUTPUT_METADATA (topmost surviving HDR PV wins).
+      if (pv_is_hdr) {
+        output_hdr = ToHdrSourceMetadata(hmeta);
+      }
       // Submit the first frame: imports this slot and caches its fb_id.
       submit_pv_pool(pool_raw, db);
       if (backend_->cfg_.debug_backend) {

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -300,9 +300,13 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     drm_plane_id.store(plane_id, std::memory_order_relaxed);
   }
 
+#if IVI_HAVE_EGL
   // Persisted HDR metadata (from the last submit), so the compositor holds the
   // connector's HDR_OUTPUT_METADATA steady while this view is on screen even on
   // presents with no fresh frame. Compositor thread; guarded like the frame.
+  // EGL-only: the persisted HDR rides pending_egl, and the DRM scene path (the
+  // sole consumer) is EGL-backed. In Vulkan-only builds the base
+  // ICompositorSurface::GetHdrMetadata default (false) applies.
   [[nodiscard]] bool GetHdrMetadata(
       ICompositorSurface::Dmabuf::HdrMetadata* out) const override {
     const std::lock_guard<std::mutex> lock(mutex);
@@ -323,6 +327,7 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     out->max_frame_average_light_level = h.max_frame_average_light_level;
     return true;
   }
+#endif  // IVI_HAVE_EGL
 
 #if IVI_HAVE_VULKAN
   // The compositor samples the most recently submitted buffer. Null until the

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -245,6 +245,11 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     // rides OnScanoutRelease) from one superseded before it was ever scanned
     // out (its release eventfd must be signalled at supersede instead).
     uint64_t stash_seq{0};
+    // Owned copy of the frame's HDR metadata: frame.hdr points at plugin memory
+    // we must not retain, so its contents are copied here at submit and
+    // frame.hdr nulled. has_hdr is false for SDR frames.
+    bool has_hdr{false};
+    IhsHdrMetadata hdr{};
   };
   mutable PendingEglFrame pending_egl;
   mutable std::map<uint32_t, EglDmabufImporter::ImportedTexture> buffers_egl;
@@ -293,6 +298,30 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // thread; the field is atomic.
   void SetScanoutPlane(uint32_t plane_id) override {
     drm_plane_id.store(plane_id, std::memory_order_relaxed);
+  }
+
+  // Persisted HDR metadata (from the last submit), so the compositor holds the
+  // connector's HDR_OUTPUT_METADATA steady while this view is on screen even on
+  // presents with no fresh frame. Compositor thread; guarded like the frame.
+  [[nodiscard]] bool GetHdrMetadata(
+      ICompositorSurface::Dmabuf::HdrMetadata* out) const override {
+    const std::lock_guard<std::mutex> lock(mutex);
+    if (!pending_egl.valid || !pending_egl.has_hdr) {
+      return false;
+    }
+    const IhsHdrMetadata& h = pending_egl.hdr;
+    out->transfer = h.transfer;
+    for (int i = 0; i < 3; ++i) {
+      out->display_primaries_x[i] = h.display_primaries_x[i];
+      out->display_primaries_y[i] = h.display_primaries_y[i];
+    }
+    out->white_point_x = h.white_point_x;
+    out->white_point_y = h.white_point_y;
+    out->max_display_mastering_luminance = h.max_display_mastering_luminance;
+    out->min_display_mastering_luminance = h.min_display_mastering_luminance;
+    out->max_content_light_level = h.max_content_light_level;
+    out->max_frame_average_light_level = h.max_frame_average_light_level;
+    return true;
   }
 
 #if IVI_HAVE_VULKAN
@@ -427,6 +456,9 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     out->modifier = f.format.modifier;
     out->color_space = f.color_space;  // YUV colorimetry for the plane CSC
     out->color_range = f.color_range;
+    // HDR metadata is not carried per-frame on the Dmabuf: the DRM scene path
+    // reads the view's persisted metadata via GetHdrMetadata (steady across
+    // reuse presents) rather than the deliver-once frame.
     out->width = f.width;
     out->height = f.height;
     out->plane_count = np;
@@ -1165,7 +1197,13 @@ int HostSubmit(void* user_data,
         close(v->pending_egl.acquire_fence_fd);
       }
     }
-    v->pending_egl.frame = *frame;       // take ownership of the plane fds
+    v->pending_egl.frame = *frame;  // take ownership of the plane fds
+    // Copy the HDR metadata contents while the plugin's pointer is still valid,
+    // then null the retained pointer (it aims at plugin-owned memory).
+    v->pending_egl.has_hdr = frame->hdr != nullptr;
+    if (v->pending_egl.has_hdr) {
+      v->pending_egl.hdr = *frame->hdr;
+    }
     v->pending_egl.frame.hdr = nullptr;  // do not retain the plugin's hdr ptr
     v->pending_egl.acquire_fence_fd = acquire_fence_fd;  // ownership moves here
     v->pending_egl.stash_seq = v->submit_seq;

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -226,6 +226,22 @@ class ICompositorSurface {
     // COLOR_ENCODING / COLOR_RANGE CSC. DEFAULT (0) leaves the scene's default.
     uint8_t color_space{0};
     uint8_t color_range{0};
+    // HDR static metadata for an HDR (PQ/HLG) video, mirrored from the
+    // producer's IhsHdrMetadata. Not carried per-frame on the Dmabuf — the DRM
+    // scene path reads the view's persisted value via @c GetHdrMetadata (steady
+    // across reuse presents) and lowers it to the connector's
+    // HDR_OUTPUT_METADATA. This is the shape @c GetHdrMetadata fills.
+    struct HdrMetadata {
+      uint8_t transfer{0};                // 0=SDR, 1=PQ, 2=HLG (IhsTransfer)
+      uint16_t display_primaries_x[3]{};  // R,G,B in 0.00002 units
+      uint16_t display_primaries_y[3]{};
+      uint16_t white_point_x{0};
+      uint16_t white_point_y{0};
+      uint32_t max_display_mastering_luminance{0};  // cd/m^2
+      uint32_t min_display_mastering_luminance{0};  // 0.0001 cd/m^2
+      uint16_t max_content_light_level{0};
+      uint16_t max_frame_average_light_level{0};
+    };
     int acquire_fence_fd{-1};
     // The producer's identity for this frame (IhsFrame.buffer_id, its ring
     // slot). The compositor hands it back via OnScanoutRelease when the plane
@@ -248,6 +264,22 @@ class ICompositorSurface {
    * closes it once it has imported the buffer.
    */
   [[nodiscard]] virtual bool GetDmabuf(Dmabuf* /*out*/) const { return false; }
+
+  /**
+   * @brief The surface's current HDR static metadata, if its content is HDR.
+   *
+   * Unlike @c GetDmabuf (deliver-once — valid only on a fresh frame), this
+   * reports the view's *persisted* HDR state, so the compositor can hold the
+   * connector's HDR_OUTPUT_METADATA steady across presents where the view is
+   * merely reused (no new frame). Toggling it per-present would re-sync the
+   * sink's HDR mode every few frames — visible flicker. Returns false for SDR
+   * content (the default), which clears HDR only when the HDR view actually
+   * leaves the scene.
+   */
+  [[nodiscard]] virtual bool GetHdrMetadata(
+      Dmabuf::HdrMetadata* /*out*/) const {
+    return false;
+  }
 
   /**
    * @brief Whether the Vulkan image is a dma-buf the producer rewrites on


### PR DESCRIPTION
## What

Drive the DRM connector's `HDR_OUTPUT_METADATA` from an HDR (PQ/HLG) video platform view, so a direct-scanned-out HDR video signals HDR to the sink. Two commits:

1. **`HDR_OUTPUT_METADATA` signaling** — the producer's `IhsHdrMetadata` is copied into the view at submit (the plugin pointer is nulled, never retained) and exposed as *persisted* state via `ICompositorSurface::GetHdrMetadata`. Persisted rather than per-frame so the connector signal holds steady across reuse presents; toggling it re-syncs the sink's HDR mode every few frames (flicker). In the DRM scene path the topmost HDR PV's metadata is mapped to drm-cxx's `HdrSourceMetadata` (0.00002-unit primaries → CIE xy, luminance clamped to the CTA-861.3 `uint16` fields) and applied via `LayerScene::set_output_metadata` before commit; SDR clears it. The HDR layer also carries BT.2020 `color_primaries` + its source EOTF so the scene auto-derives the connector Colorspace. No-op on connectors without `HDR_OUTPUT_METADATA`.

2. **`replace_source` PV-resize robustness** (general, split out) — when a live PV's dma-buf geometry changes under its fixed-generation pool (ABR rendition switch, or subpixel resize jitter), swap the source in place via `LayerScene::replace_source` with a fresh pool instead of prune + re-add next present. The layer keeps its plane assignment, geometry, and auto-derived HDR/Colorspace signaling → no gap frame (which blinks the view and toggles the connector's HDR/Colorspace) and no per-jitter modeset. Prune + re-add remains the fallback.

## ABI note

`Dmabuf::HdrMetadata` is a nested **type** only — there is no `Dmabuf` member of it, so the `Dmabuf` layout is unchanged. The compositor reads HDR through the new `GetHdrMetadata` virtual, not the `Dmabuf`.

## Validation

- Monitor-validated on a **Raspberry Pi 5 (HDMI, vc4)** into an HDR display: the panel enters HDR mode. The `HDR_OUTPUT_METADATA` InfoFrame this path emits (`eotf=02`/PQ, mastering 1000 nits, MaxCLL 1000/MaxFALL 400) matches byte-for-byte the drm-cxx reference `hdr_demo`, which drives the same display into HDR.
- Full host clang build (all backends + compositor): 178/178, links clean.
- clang-tidy-19 clean, clang-format-19 applied.

## Known gaps (tracked separately, not this PR)

- Connector `Colorspace` stays `Default` on vc4 even for the reference `hdr_demo` — a drm-cxx/vc4 apply issue, not needed to enter HDR.
- `max bpc` stays 8; true 10-bit needs a drm-cxx setter + a bandwidth-viable mode (4K60 10-bit RGB exceeds HDMI 2.0).

Exercised via the companion plugin PR (`LP_PV_HDR` test producer).
