### PR TITLE
drm: report connector hotplug to the output layer

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -32,6 +32,9 @@
 
 #include "config/common.h"
 
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
+#include "display/drm_display.h"
+#endif
 #include "display/output_manager.h"
 #include "display/output_provider.h"
 #if BUILD_COMPOSITOR
@@ -252,6 +255,17 @@ App::App(const std::vector<Configuration::Config>& configs) {
   // primary_ioc_.
   for (const auto& display : m_displays) {
     if (auto* d = dynamic_cast<Display*>(display.get())) {
+      d->SetEventLoop(primary_ioc_);
+    }
+  }
+#endif
+
+#if BUILD_BACKEND_DRM_KMS_EGL || BUILD_BACKEND_DRM_KMS_VULKAN
+  // Same for the DRM displays: their hotplug uevents arrive on the session's
+  // own thread, and installing the reactor here is what lets them be
+  // marshalled onto it before any listener is attached below.
+  for (const auto& display : m_displays) {
+    if (auto* d = dynamic_cast<DrmDisplay*>(display.get())) {
       d->SetEventLoop(primary_ioc_);
     }
   }

--- a/shell/display/drm_display.cc
+++ b/shell/display/drm_display.cc
@@ -278,6 +278,18 @@ DrmDisplay::DrmDisplay(AdoptFd,
 }
 
 DrmDisplay::~DrmDisplay() {
+  // Detach the hotplug descriptor before anything else. The fd belongs to the
+  // HotplugMonitor, so release() it -- closing it here would leave the monitor
+  // holding a stale fd, and asio would close it a second time. Cancel first so
+  // no handler is left queued on a reactor that is going away.
+  if (hotplug_fd_.has_value()) {
+    std::error_code ec;
+    hotplug_fd_->cancel(ec);
+    (void)hotplug_fd_->release();
+    hotplug_fd_.reset();
+  }
+  hotplug_.reset();
+
   // Stop the per-card flip reader first -- it runs its own thread and holds the
   // fd via flip_descriptor_, so it must be torn down before the fd is closed.
   StopFlipReader();
@@ -463,6 +475,66 @@ void DrmDisplay::ReservePlanes(const std::vector<uint32_t>& planes) {
 std::vector<uint32_t> DrmDisplay::ReservedPlanes() const {
   const std::lock_guard<std::mutex> lock(reserved_planes_mu_);
   return reserved_planes_;
+}
+
+void DrmDisplay::SetEventLoop(asio::io_context& ioc) {
+  // Same gate the session's monitor honors.
+  const char* gate = std::getenv("IVI_DRM_HOTPLUG");
+  if (gate != nullptr && std::string_view(gate) == "0") {
+    ihs::log::debug(
+        "[DrmDisplay] connector hotplug disabled (IVI_DRM_HOTPLUG=0)");
+    return;
+  }
+
+  auto hp = drm::display::HotplugMonitor::open();
+  if (!hp) {
+    // Non-fatal: everything else works, just without connector notifications.
+    ihs::log::warn("[DrmDisplay] hotplug monitor unavailable: {}",
+                   hp.error().message());
+    return;
+  }
+  hotplug_.emplace(std::move(*hp));
+  hotplug_->set_handler([this](const drm::display::HotplugEvent& e) {
+    // Only note that something happened. dispatch() calls this once per
+    // accepted uevent, and a plug event routinely produces several; rescanning
+    // here would re-enumerate the card once per event and report the same
+    // change repeatedly. The rescan happens once, after the drain.
+    //
+    // The CONNECTOR hint is deliberately ignored: it is absent on older
+    // kernels and on blanket events (GPU reset), and a full rescan is correct
+    // in every case -- including the one the hint would get wrong.
+    (void)e;
+    hotplug_pending_ = true;
+  });
+
+  hotplug_fd_.emplace(ioc, hotplug_->fd());
+  ArmHotplugWait();
+  output_provider_.SetHotplugAvailable(true);
+  ihs::log::debug("[DrmDisplay] connector hotplug wired to the App reactor");
+}
+
+void DrmDisplay::ArmHotplugWait() {
+  if (!hotplug_fd_.has_value()) {
+    return;
+  }
+  hotplug_fd_->async_wait(
+      asio::posix::stream_descriptor::wait_read,
+      [this](const std::error_code& ec) {
+        if (ec) {
+          return;  // cancelled at teardown
+        }
+        // dispatch() drains every pending uevent and calls the handler for
+        // each that passes its DRM + HOTPLUG filter; the handler only sets the
+        // flag, so a burst of events becomes one rescan here.
+        hotplug_pending_ = false;
+        if (hotplug_ && !hotplug_->dispatch()) {
+          ihs::log::warn("[DrmDisplay] hotplug dispatch failed");
+        }
+        if (hotplug_pending_) {
+          output_provider_.RescanAndNotify();
+        }
+        ArmHotplugWait();
+      });
 }
 
 void DrmDisplay::StartEvents() {

--- a/shell/display/drm_display.h
+++ b/shell/display/drm_display.h
@@ -31,6 +31,8 @@
 #include "asio/io_context.hpp"
 #include "asio/posix/stream_descriptor.hpp"
 
+#include <drm-cxx/display/hotplug_monitor.hpp>
+
 #include "display/drm_output_provider.h"
 #include "display/idisplay.h"
 #include "input/iseat.h"
@@ -137,6 +139,19 @@ class DrmDisplay final : public IDisplay {
   // DrmBackend consults this to route its DRM device open through the
   // seat; when null, the backend falls back to direct open + the legacy
   // VT/master guards.
+  /**
+   * @brief Wire the App reactor that output callbacks must run on.
+   *
+   * Hotplug uevents arrive on the DrmSession's own dispatch thread, and
+   * IOutputListener is contracted to run on the loop thread -- App's handler
+   * walks its views and calls into backends, so it must not run concurrently
+   * with the reactor. Installing the loop here is what lets the uevent be
+   * marshalled onto it, and is also what enables hotplug reporting at all.
+   *
+   * Mirrors the Wayland Display's SetEventLoop; App calls both.
+   */
+  void SetEventLoop(asio::io_context& ioc);
+
   [[nodiscard]] homescreen::DrmSession* session() const {
     return session_.get();
   }
@@ -309,6 +324,17 @@ class DrmDisplay final : public IDisplay {
 
   // Enumerates this card's connectors as outputs (libdrm only, no master).
   homescreen::DrmOutputProvider output_provider_;
+  // Connector hotplug, owned here rather than on DrmSession: the monitor is a
+  // plain udev netlink socket and needs no seat, while the session is absent
+  // on the direct-open path (--drm-no-seat) that headless and kiosk targets
+  // use -- exactly where hotplug still has to work.
+  std::optional<drm::display::HotplugMonitor> hotplug_;
+  // Wraps hotplug_'s fd for the reactor. Owned by the monitor, so this must
+  // release() -- never close() -- it on teardown.
+  std::optional<asio::posix::stream_descriptor> hotplug_fd_;
+  // Set by the uevent handler, read once after the drain: see ArmHotplugWait.
+  bool hotplug_pending_{false};
+  void ArmHotplugWait();
 
   // Active cursor sprite retargeting sink (set by FlutterView after the
   // backend creates its cursor). Owned by DrmBackend; null when no cursor.

--- a/shell/display/drm_output_provider.cc
+++ b/shell/display/drm_output_provider.cc
@@ -169,14 +169,54 @@ std::vector<OutputInfo> DrmOutputProvider::EnumerateOutputs() const {
 
 void DrmOutputProvider::SetOutputListener(IOutputListener* listener) {
   listener_ = listener;
+  // Seed the baseline at install time so the first rescan reports what changed
+  // from here on. Without it every connected output would look new the first
+  // time a uevent arrived, and views already bound to them would be told their
+  // output had just appeared.
+  last_ = listener != nullptr ? EnumerateOutputs() : std::vector<OutputInfo>{};
+}
+
+void DrmOutputProvider::SetHotplugAvailable(const bool available) {
+  hotplug_available_ = available;
+}
+
+void DrmOutputProvider::RescanAndNotify() {
+  if (listener_ == nullptr) {
+    return;
+  }
+  std::vector<OutputInfo> now = EnumerateOutputs();
+  const std::vector<OutputChange> changes = DiffOutputs(last_, now);
+  last_ = std::move(now);
+  if (changes.empty()) {
+    // Common: a uevent that does not change the connector set (a GPU reset, or
+    // a property nobody here reads). Traced so the path is observable when
+    // nothing comes of it -- otherwise a silent rescan is indistinguishable
+    // from a uevent that never arrived.
+    ihs::log::debug("[DrmOutputProvider] uevent: no output changes");
+    return;
+  }
+  ihs::log::debug("[DrmOutputProvider] {} output change(s) after a uevent",
+                  changes.size());
+  for (const auto& c : changes) {
+    switch (c.event) {
+      case OutputEvent::kRemoved:
+        listener_->OnOutputRemoved(c.output.name);
+        break;
+      case OutputEvent::kAdded:
+        listener_->OnOutputAdded(c.output);
+        break;
+      case OutputEvent::kChanged:
+        listener_->OnOutputChanged(c.output);
+        break;
+    }
+  }
 }
 
 bool DrmOutputProvider::SupportsHotplug() const {
-  // DRM connectors hotplug, but the udev monitor that would diff the connector
-  // set and drive the listener is not wired here yet -- so outputs are
-  // enumerated on demand and no change callbacks are delivered. This reports
-  // that honestly (per the method contract) until the monitor lands.
-  return false;
+  // True once a udev connector monitor is feeding RescanAndNotify. Without one
+  // outputs are still enumerated on demand, but no callbacks are delivered --
+  // which is what this reports, per the method contract.
+  return hotplug_available_;
 }
 
 }  // namespace homescreen

--- a/shell/display/drm_output_provider.h
+++ b/shell/display/drm_output_provider.h
@@ -57,6 +57,21 @@ class DrmOutputProvider final : public IOutputProvider {
   // LeaseHold that owns it). -1 (the default) restores the open-by-path path.
   void SetEnumerationFd(int fd);
 
+  /**
+   * @brief Re-enumerate and report what changed since the last look.
+   *
+   * Called after a connector uevent. Diffing rather than trusting the event's
+   * CONNECTOR hint is deliberate: the hint is absent on older kernels and on
+   * blanket events (GPU reset), and a rescan is correct in every case.
+   *
+   * Must run on the thread the listener expects -- the caller marshals.
+   */
+  void RescanAndNotify();
+
+  /// Tells the provider a hotplug source is live, so SupportsHotplug() stops
+  /// reporting that no callbacks are delivered.
+  void SetHotplugAvailable(bool available);
+
  private:
   // The card this provider enumerates (e.g. "/dev/dri/card1"). Unused when
   // enumeration_fd_ is set, except for diagnostics.
@@ -67,6 +82,10 @@ class DrmOutputProvider final : public IOutputProvider {
 
   // Set by SetOutputListener; consumed once the hotplug monitor is wired.
   IOutputListener* listener_ = nullptr;
+  bool hotplug_available_ = false;
+  // Last enumeration, to diff the next one against. Seeded when a listener is
+  // installed so the first rescan reports changes since then, not everything.
+  std::vector<OutputInfo> last_;
 };
 
 }  // namespace homescreen

--- a/shell/display/output.cc
+++ b/shell/display/output.cc
@@ -141,6 +141,74 @@ OutputResolution ResolveOutputDetailed(const OutputMatch& match,
   return {OutputResolution::Status::kUnresolved, {}};
 }
 
+namespace {
+
+// The fields a view cares about. The name alone is the join key (see
+// FindByName), so a change in any of these on a still-connected connector is
+// what "reconfigured" means: a different mode, or a different panel behind the
+// same port -- a swap keeps the name and lands here rather than as a
+// remove/add pair.
+bool SameConfiguration(const OutputInfo& a, const OutputInfo& b) {
+  return a.width_px == b.width_px && a.height_px == b.height_px &&
+         a.refresh_hz == b.refresh_hz && a.mm_width == b.mm_width &&
+         a.mm_height == b.mm_height && a.make == b.make && a.model == b.model &&
+         a.serial == b.serial && a.output_id == b.output_id;
+}
+
+const OutputInfo* FindByName(const std::vector<OutputInfo>& v,
+                             const std::string& name) {
+  for (const auto& o : v) {
+    if (o.name == name) {
+      return &o;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+std::vector<OutputChange> DiffOutputs(const std::vector<OutputInfo>& before,
+                                      const std::vector<OutputInfo>& after) {
+  std::vector<OutputChange> removed;
+  std::vector<OutputChange> added;
+  std::vector<OutputChange> changed;
+
+  for (const auto& was : before) {
+    if (!was.connected) {
+      continue;  // was not usable; its staying unusable is not an event
+    }
+    const OutputInfo* now = FindByName(after, was.name);
+    if (now == nullptr || !now->connected) {
+      // Either the connector object is gone, or it is still enumerated with
+      // nothing attached. Both mean the display a view could bind to is away.
+      removed.push_back({OutputEvent::kRemoved, was});
+    } else if (!SameConfiguration(was, *now)) {
+      changed.push_back({OutputEvent::kChanged, *now});
+    }
+  }
+
+  for (const auto& now : after) {
+    if (!now.connected) {
+      continue;
+    }
+    const OutputInfo* was = FindByName(before, now.name);
+    if (was == nullptr || !was->connected) {
+      added.push_back({OutputEvent::kAdded, now});
+    }
+  }
+
+  // Removals first. When one enumeration both loses and gains outputs -- a
+  // card whose DSI goes away as HDMI arrives -- a listener that saw the
+  // addition first would re-resolve while the departed output was still in its
+  // picture and conclude the view had not moved.
+  std::vector<OutputChange> out;
+  out.reserve(removed.size() + added.size() + changed.size());
+  out.insert(out.end(), removed.begin(), removed.end());
+  out.insert(out.end(), added.begin(), added.end());
+  out.insert(out.end(), changed.begin(), changed.end());
+  return out;
+}
+
 OutputTransition ClassifyOutputTransition(
     const std::optional<std::string>& current,
     const OutputResolution& wanted,

--- a/shell/display/output.h
+++ b/shell/display/output.h
@@ -143,6 +143,39 @@ enum class OutputTransition {
   kReconfigured,  // same output, but its mode or EDID changed
 };
 
+// One change between two enumerations of a card's outputs.
+struct OutputChange {
+  OutputEvent event;
+  // For kAdded and kChanged this is the output as it is now. For kRemoved
+  // there is no "now" -- the port is disconnected or the connector is gone --
+  // so it is the last state the output was seen in. Read it for the name and
+  // nothing else on a removal.
+  OutputInfo output;
+};
+
+/**
+ * @brief Diff two enumerations of the same card's outputs.
+ *
+ * A DRM connector is not created and destroyed as displays come and go: it
+ * stays enumerated and its `connected` flag moves, so an unplug is a
+ * connected->disconnected transition rather than a disappearance. A connector
+ * object vanishing entirely is a different thing (MST teardown, or the card
+ * going away) and is reported as a removal too, since the output is equally
+ * gone from the view's point of view.
+ *
+ * Only connected outputs are reported: a port that was disconnected and still
+ * is has not changed, and nothing can bind to it either way.
+ *
+ * @param[in] before the previous enumeration
+ * @param[in] after  the current one
+ * @return the changes, in a stable order: removals first, then additions, then
+ *         modifications, so a caller applying them in order never sees two
+ *         outputs claiming the same name.
+ */
+[[nodiscard]] std::vector<OutputChange> DiffOutputs(
+    const std::vector<OutputInfo>& before,
+    const std::vector<OutputInfo>& after);
+
 /**
  * @brief Decide what an output event means for a single view.
  *

--- a/test/unit_test/output_resolver-test/test_case_output_resolver.cc
+++ b/test/unit_test/output_resolver-test/test_case_output_resolver.cc
@@ -25,6 +25,8 @@
 
 using homescreen::BackendFamily;
 using homescreen::ClassifyOutputTransition;
+using homescreen::DiffOutputs;
+using homescreen::OutputChange;
 using homescreen::OutputEvent;
 using homescreen::OutputInfo;
 using homescreen::OutputMatch;
@@ -396,4 +398,99 @@ TEST(OutputTransitions, AViewWithNoBindingAndNoConstraintHasNothingToDo) {
   EXPECT_EQ(ClassifyOutputTransition(std::nullopt, Unconstrained(),
                                      OutputEvent::kChanged, "DSI-1"),
             OutputTransition::kNone);
+}
+
+// ---------------------------------------------------------------------------
+// DiffOutputs: turning two enumerations of a card into add/remove/change
+// events. A DRM connector persists across an unplug with `connected` moving,
+// so this is not a set difference on names.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+OutputInfo Head(std::string name, const bool connected, const int w = 1920) {
+  OutputInfo o;
+  o.name = std::move(name);
+  o.connected = connected;
+  o.width_px = w;
+  o.height_px = 1080;
+  o.refresh_hz = 60.0;
+  return o;
+}
+
+}  // namespace
+
+TEST(OutputDiff, NoChangeYieldsNothing) {
+  const std::vector<OutputInfo> heads{Head("DSI-1", true),
+                                      Head("HDMI-A-1", false)};
+  EXPECT_TRUE(DiffOutputs(heads, heads).empty());
+}
+
+TEST(OutputDiff, UnplugIsAConnectedFlagGoingFalse) {
+  // The connector object stays; only `connected` moves. Treating this as a
+  // set difference on names would report nothing at all.
+  const std::vector<OutputInfo> before{Head("HDMI-A-1", true)};
+  const std::vector<OutputInfo> after{Head("HDMI-A-1", false)};
+  const auto d = DiffOutputs(before, after);
+  ASSERT_EQ(d.size(), 1u);
+  EXPECT_EQ(d[0].event, OutputEvent::kRemoved);
+  EXPECT_EQ(d[0].output.name, "HDMI-A-1");
+}
+
+TEST(OutputDiff, AConnectorVanishingIsAlsoARemoval) {
+  const std::vector<OutputInfo> before{Head("DP-2", true)};
+  const std::vector<OutputInfo> after{};
+  const auto d = DiffOutputs(before, after);
+  ASSERT_EQ(d.size(), 1u);
+  EXPECT_EQ(d[0].event, OutputEvent::kRemoved);
+}
+
+TEST(OutputDiff, APortThatWasNeverConnectedIsNotAnEvent) {
+  // Every DRM card enumerates ports with nothing attached; they must not look
+  // like arrivals or departures.
+  const std::vector<OutputInfo> before{Head("HDMI-A-2", false)};
+  const std::vector<OutputInfo> after{Head("HDMI-A-2", false)};
+  EXPECT_TRUE(DiffOutputs(before, after).empty());
+}
+
+TEST(OutputDiff, PlugInIsAnAddition) {
+  const std::vector<OutputInfo> before{Head("HDMI-A-1", false)};
+  const std::vector<OutputInfo> after{Head("HDMI-A-1", true)};
+  const auto d = DiffOutputs(before, after);
+  ASSERT_EQ(d.size(), 1u);
+  EXPECT_EQ(d[0].event, OutputEvent::kAdded);
+}
+
+TEST(OutputDiff, AModeChangeOnTheSamePanelIsAChange) {
+  const std::vector<OutputInfo> before{Head("DSI-1", true, 1920)};
+  const std::vector<OutputInfo> after{Head("DSI-1", true, 1280)};
+  const auto d = DiffOutputs(before, after);
+  ASSERT_EQ(d.size(), 1u);
+  EXPECT_EQ(d[0].event, OutputEvent::kChanged);
+  EXPECT_EQ(d[0].output.width_px, 1280);
+}
+
+TEST(OutputDiff, SwappingPanelsOnOnePortIsAReconfiguration) {
+  // Scenario 3: a different monitor on the same connector. The connector never
+  // reports disconnected in a single rescan, so this is not a remove/add pair
+  // -- it is one connector whose panel identity changed, and a view bound by
+  // name stays bound and is told to renegotiate.
+  OutputInfo old_panel = Head("HDMI-A-1", true);
+  old_panel.serial = "AAA";
+  OutputInfo new_panel = Head("HDMI-A-1", true);
+  new_panel.serial = "BBB";
+
+  const auto d = DiffOutputs({old_panel}, {new_panel});
+  ASSERT_EQ(d.size(), 1u) << "same name, still connected: a reconfiguration";
+  EXPECT_EQ(d[0].event, OutputEvent::kChanged);
+  EXPECT_EQ(d[0].output.serial, "BBB");
+}
+
+TEST(OutputDiff, RemovalsAreOrderedBeforeAdditions) {
+  const std::vector<OutputInfo> before{Head("DSI-1", true)};
+  const std::vector<OutputInfo> after{Head("HDMI-A-1", true)};
+  const auto d = DiffOutputs(before, after);
+  ASSERT_EQ(d.size(), 2u);
+  EXPECT_EQ(d[0].event, OutputEvent::kRemoved);
+  EXPECT_EQ(d[1].event, OutputEvent::kAdded);
 }


### PR DESCRIPTION
Phase 5 of output hotplug renegotiation. Follows #410.

The udev monitor, `IOutputListener`, and App's handler all already existed — nothing joined them, and `DrmOutputProvider::SupportsHotplug()` returned `false` to say so. A display unplugged on a DRM target went unnoticed. This joins them and flips that to the truth.

## Ownership: the display, not the session

`HotplugMonitor` is a plain udev netlink socket and needs no seat. `DrmSession` **is** absent on the direct-open path (`--drm-no-seat`) that headless and kiosk targets use — exactly where hotplug still has to work.

I hit this rather than reasoned it. My first cut hung the handler off the session, and the Pi 4 said:

```
[DrmDisplay] no session; connector hotplug will not be reported
```

Owned by the display, it comes up either way:

```
[DrmDisplay] connector hotplug wired to the App reactor
[App] watching outputs on a display (3 live now)
```

## Threading

The fd is armed on the App reactor, so the callback lands on the thread `IOutputListener` is contracted to run on — App's handler walks its views and calls into backends, and must not race the loop. `dispatch()` drains every pending uevent per readable edge, so a burst collapses into one rescan rather than one per event.

The kernel's `CONNECTOR=` hint is deliberately ignored: it's absent on older kernels and on blanket events (GPU reset), and a rescan is correct in every case — including the ones the hint would get wrong.

## The diff is where the DRM shape bites

Split out as a pure function, because this is easy to get wrong: **a connector is not created and destroyed as displays come and go.** It stays enumerated with `connected` moving, so an unplug is a flag transition — a set difference on names would report nothing at all. A connector object that *does* vanish (MST teardown, card removal) is a removal too. Ports that were never connected aren't events; every card enumerates some.

**Removals are ordered before additions.** A panel swapped on one port is a removal and an addition carrying the same name, and a listener seeing the addition first would find the view already bound and conclude nothing happened — silently breaking scenario 3.

Eight unit cases cover it, including the swap ordering and the never-connected ports.

## Verified, and what is not

On the Pi 4: the monitor opens on the **no-seat** path, arms on the reactor, App watches all three connectors, and teardown stays clean — the fd belongs to the monitor, so the descriptor `release()`s rather than closes it.

**Not verified on hardware: an actual connector transition end to end.** Both HDMI ports on that board are empty and forcing a connector state needs root. The diff is covered by the unit cases; the uevent→rescan path is wired and traced (`[DrmOutputProvider] uevent: no output changes`) but has not been fired by a real plug event. Flagging that rather than implying it.

Builds and tests pass in all three local configs including every backend touched, plus aarch64; clang-tidy clean on the changed files (the two warnings in `drm_display.cc` are pre-existing, at lines well above this diff).
