### PR TITLE
docs: document output_id, the udev rule, and what happens on unplug

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ annotated all-keys file see
 | `[view.output]` | `index` | `int` | `(none)` | `int` | all |
 | `[view.output]` | `name` | `string` | `(primary)` | `e.g. DP-1, HDMI-A-1` | all |
 | `[view.output]` | `on_disconnect` | `string` | `suspend` | `suspend\|teardown` | all |
+| `[view.output]` | `output_id` | `string` | `(none)` | `role name from a udev rule` | drm |
 | `[view.output]` | `preload` | `bool` | `false` | `true\|false` | all |
 | `[view.output]` | `serial` | `string` | `(none)` | `EDID serial` | drm |
 | `[view.output]` | `touch_device` | `string` | `(primary)` | `device-name substring` | all |
@@ -526,12 +527,76 @@ a fixed port often publishes no EDID at all (both Raspberry Pi DSI panels report
 zero bytes), and two identical monitors commonly share one. When a serial is
 ambiguous the resolver says so and falls back to the connector name.
 
-**There is currently no key that is portable across boards.** Every option above
-is stable per board and none survives a hardware change, so a config that must
-serve more than one board needs one file per board today — or a `name` that
-happens to agree, which is not something to rely on. A role-naming mechanism
-(an integrator-supplied udev property) is planned to close this; until it lands,
-prefer per-board configuration over a key that looks portable and is not.
+**For a config that must serve more than one board, name the role.** Every key
+above is stable per board and none survives a hardware change: the connector
+name moves, the card number moves, and a panel with no EDID has no serial to
+match on. Nothing the hardware reports names the *role* a display plays.
+
+A udev rule can. udev models DRM connectors as devices (`DEVTYPE=drm_connector`),
+so a rule can attach a property to one, and `[view.output] output_id` matches on
+it:
+
+```toml
+[view.output]
+output_id = 'cluster'
+```
+
+```
+# /etc/udev/rules.d/99-ihs-outputs.rules
+ENV{ID_PATH}=="platform-gpu", KERNEL=="card*-DSI-1", ENV{IHS_OUTPUT_NAME}="cluster"
+```
+
+One config then binds correctly on both boards, which is the whole point: the
+DSI panel is `DSI-1` on a Pi 4 and `DSI-2` on a Pi 5, and `output_id = 'cluster'`
+reaches it on either. A worked example covering both boards ships as
+[`99-ihs-outputs.rules`](docs/config-examples/99-ihs-outputs.rules).
+
+Two things to know when writing the rule:
+
+- `DEVTYPE` is a property, not a match key of its own — it must be written
+  `ENV{DEVTYPE}=="drm_connector"`, and `udevadm verify` rejects the other form.
+- `ID_PATH` is per GPU, **not** per connector. On a Pi 4 all three connectors
+  share `platform-gpu`, so `ID_PATH` alone cannot identify one; pair it with a
+  `KERNEL` pattern as above.
+
+`output_id` is matched *above* `serial`, and unlike the other keys a miss parks
+the view rather than falling through to a lower tier — naming a role is a
+deliberate statement about which physical display a view belongs on, and
+quietly binding an instrument cluster to the passenger screen because the rule
+was missing is not a graceful degradation. Check the log if a view does not
+appear:
+
+```
+[OutputResolver] output_id 'cluster' matches no connected output; the view is parked
+```
+
+**DRM only for now.** `DrmOutputProvider` fills `output_id`; the Wayland
+`Display` does not, because a `wl_output` carries no connector identity a client
+can join on — and the name a compositor advertises need not be the kernel's (see
+the Mutter caveat above). An `output_id` match on Wayland therefore finds
+nothing and parks, which the log reports.
+
+### When an output disappears
+
+Both backends report connector hotplug: Wayland through `wl_output`
+add/remove/`done`, DRM through a udev connector monitor. On each change every
+view on that display is re-resolved and compared with the output it is actually
+on, and `[view.output] on_disconnect` decides what happens to a view whose
+output has gone:
+
+- `suspend` (the default) parks the view. Its platform views are told to stop
+  producing — a camera or video plugin should pause its decode there — and
+  frame production stops by withholding the vsync baton, so the UI thread,
+  rasterizer, GPU and scanout all go quiet. The engine and the surface are kept,
+  so returning is immediate: the view resumes when its output comes back.
+- `teardown` is **not implemented yet**. It warns and suspends instead, rather
+  than appearing to free the engine.
+
+`preload` is likewise parsed but not acted on yet: a view is built either way.
+
+Moving a running view onto a *different* output is also not implemented — the
+transition is detected, logged, and the view's platform views are told their
+grant is stale, but the view is not rebound.
 
 > Breaking change vs. earlier releases: the flat `[window_activation_area]`
 > table, `view.window_type`, `view.shell`/`view.backend` strings, `view.vm_args`,

--- a/docs/config-examples/99-ihs-outputs.rules
+++ b/docs/config-examples/99-ihs-outputs.rules
@@ -1,0 +1,54 @@
+# ivi-homescreen: give each display a stable role name.
+#
+# Install as /etc/udev/rules.d/99-ihs-outputs.rules
+#
+# Why this exists. A view is pinned to an output with [view.output], and every
+# key available for that is board-specific:
+#
+#   - the connector name moves: the DSI panel is DSI-1 on a Raspberry Pi 4 and
+#     DSI-2 on a Pi 5, on different cards;
+#   - the EDID serial is unusable: both Pi DSI panels publish no EDID at all,
+#     and identical monitors routinely share a serial;
+#   - /dev/dri/cardN is assigned in probe order, so the numbers differ per board.
+#
+# IHS_OUTPUT_NAME names the *role* instead, so one config binds correctly on
+# every board: [view.output] output_id = 'cluster'.
+#
+# Matching. DRM connectors appear to udev as DEVTYPE=drm_connector, matched as
+# ENV{DEVTYPE} -- DEVTYPE is a property, not a match key of its own. ID_PATH is
+# per GPU, NOT per connector -- on a Pi 4 all three connectors share
+# "platform-gpu" -- so ID_PATH alone cannot identify one. Each rule therefore
+# pairs ID_PATH with a KERNEL pattern, and the pattern uses card* because the
+# card number is not stable.
+#
+# Only the rules whose ID_PATH matches the running board take effect, so this
+# one file can serve both. Adjust the names on the right to your product.
+
+ACTION=="remove", GOTO="ihs_outputs_end"
+SUBSYSTEM!="drm", GOTO="ihs_outputs_end"
+ENV{DEVTYPE}!="drm_connector", GOTO="ihs_outputs_end"
+
+# ---- Raspberry Pi 4 (vc4-drm; DSI and both HDMI ports on one card) ----------
+# Verified on a Pi 4 Model B Rev 1.2: DSI-1 + HDMI-A-1 connected, ID_PATH
+# "platform-gpu" shared by all three connectors.
+ENV{ID_PATH}=="platform-gpu", KERNEL=="card*-DSI-1", \
+    ENV{IHS_OUTPUT_NAME}="cluster"
+ENV{ID_PATH}=="platform-gpu", KERNEL=="card*-HDMI-A-1", \
+    ENV{IHS_OUTPUT_NAME}="center-stack"
+ENV{ID_PATH}=="platform-gpu", KERNEL=="card*-HDMI-A-2", \
+    ENV{IHS_OUTPUT_NAME}="passenger"
+
+# ---- Raspberry Pi 5 --------------------------------------------------------
+# The DSI panel hangs off its own controller (drm-rp1-dsi), so it has an
+# ID_PATH of its own and the KERNEL pattern is belt-and-braces. Verified on a
+# Pi 5 Model B Rev 1.0: DSI-2 connected at "platform-1f00130000.dsi".
+ENV{ID_PATH}=="platform-1f00130000.dsi", KERNEL=="card*-DSI-*", \
+    ENV{IHS_OUTPUT_NAME}="cluster"
+
+# HDMI on the Pi 5 is on the vc4 card, a different ID_PATH from the Pi 4's.
+ENV{ID_PATH}=="platform-axi:gpu", KERNEL=="card*-HDMI-A-1", \
+    ENV{IHS_OUTPUT_NAME}="center-stack"
+ENV{ID_PATH}=="platform-axi:gpu", KERNEL=="card*-HDMI-A-2", \
+    ENV{IHS_OUTPUT_NAME}="passenger"
+
+LABEL="ihs_outputs_end"

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -208,11 +208,15 @@
   # type=string default=(primary) values=e.g. DP-1, HDMI-A-1 applies=all
   name =
 
-  # What to do with the view when its output disappears.
+  # What to do with the view when its output disappears. suspend parks it: platform views are told to stop producing and frame production stops, with the engine kept warm so returning is immediate. teardown (free the engine) is not implemented yet -- it warns and suspends instead.
   # type=string default=suspend values=suspend|teardown applies=all
   on_disconnect =
 
-  # Warm the engine (suspended) at startup even if the output is absent.
+  # Bind by integrator-assigned role (the connector's IHS_OUTPUT_NAME udev property) rather than by port. The only key that survives a change of board; matched above serial. A miss parks the view instead of falling through. DRM only: the Wayland backend does not populate it yet.
+  # type=string default=(none) values=role name from a udev rule applies=drm
+  output_id =
+
+  # Warm the engine (suspended) at startup even if the output is absent. Parsed but not acted on yet: a view is built either way.
   # type=bool default=false values=true|false applies=all
   preload =
 

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -106,8 +106,9 @@ META = {
     "output.drm_connector": ("(none)", "e.g. HDMI-A-1", "drm", "DRM: match this connector name (overrides output.name)."),
     "output.serial": ("(none)", "EDID serial", "drm", "DRM: refine the match to this EDID serial when it is unique."),
     "output.index": ("(none)", "int", "all", "Deprecated: match the Nth connected output (prefer a name)."),
-    "output.preload": ("false", "true|false", "all", "Warm the engine (suspended) at startup even if the output is absent."),
-    "output.on_disconnect": ("suspend", "suspend|teardown", "all", "What to do with the view when its output disappears."),
+    "output.preload": ("false", "true|false", "all", "Warm the engine (suspended) at startup even if the output is absent. Parsed but not acted on yet: a view is built either way."),
+    "output.output_id": ("(none)", "role name from a udev rule", "drm", "Bind by integrator-assigned role (the connector's IHS_OUTPUT_NAME udev property) rather than by port. The only key that survives a change of board; matched above serial. A miss parks the view instead of falling through. DRM only: the Wayland backend does not populate it yet."),
+    "output.on_disconnect": ("suspend", "suspend|teardown", "all", "What to do with the view when its output disappears. suspend parks it: platform views are told to stop producing and frame production stops, with the engine kept warm so returning is immediate. teardown (free the engine) is not implemented yet -- it warns and suspends instead."),
     "output.x": ("0", "int (px)", "all", "This display's X position in the combined desktop space (multi-display input layout)."),
     "output.y": ("0", "int (px)", "all", "This display's Y position in the combined desktop space (multi-display input layout)."),
     "output.touch_device": ("(primary)", "device-name substring", "all", "Route touch from this panel (libinput device-name substring) to this view; unset sends touch to the primary view."),
@@ -180,21 +181,28 @@ def extract():
         keys.setdefault("sentry." + k, "string")
     # [view.output] entries are read through a table helper (ParseOutputMatch
     # reads t["<field>"]), and [[view.output]] arrays iterate the node, so the
-    # at_path() scraper above can't see the leaf keys. List them here so they
-    # stay in the reference table.
-    for k, t in (
-        ("output.name", "string"),
-        ("output.wl_name", "string"),
-        ("output.drm_connector", "string"),
-        ("output.serial", "string"),
-        ("output.index", "int"),
-        ("output.preload", "bool"),
-        ("output.on_disconnect", "string"),
-        ("output.x", "int"),
-        ("output.y", "int"),
-        ("output.touch_device", "string"),
-    ):
-        keys.setdefault(k, t)
+    # at_path() scraper above cannot see the leaf keys. Scrape that helper
+    # directly rather than listing them here: a hand-kept list silently stops
+    # covering this table the moment someone adds a key, which is exactly how
+    # output_id shipped undocumented.
+    #
+    # Anchored on the definition line and the next brace at column 0, and any
+    # is_*() predicate counts -- mapping only the ones in use today would put
+    # the hole straight back for the first key parsed with a different one.
+    m = re.search(r"^\w[^\n]*\bParseOutputMatch\b[^\n]*\{[^\S\n]*$", text, re.M)
+    if m is None:
+        # Never silently yield nothing: that would drop the whole table from
+        # the reference and from the "every key needs META" check with it.
+        sys.exit(
+            "error: ParseOutputMatch definition not found in "
+            f"{CFG}; update the scraper in {Path(__file__).name}"
+        )
+    body = text[m.end() :]
+    close = re.search(r"^\}", body, re.M)
+    if close is not None:
+        body = body[: close.start()]
+    for key, tok in re.findall(r't\["([a-z_]+)"\]\.(is_\w+)\(\)', body):
+        keys.setdefault("output." + key, TYPE.get(tok, tok))
     return keys
 
 


### PR DESCRIPTION
The last of the output hotplug series. Follows #412.

## The docs said the feature was still planned

That section ended with:

> **There is currently no key that is portable across boards.** … A role-naming mechanism (an integrator-supplied udev property) is planned to close this; until it lands, prefer per-board configuration.

`output_id` landed in #406. It now documents the mechanism, ships a worked rule, and describes what a view does when its output disappears.

## The generator's safety net had a hole

`gen_config_reference.py` promises that *"adding a key to the parser forces a doc update"* — it errors on any parsed key with no META entry. But `[view.output]` keys are read through a table helper the `at_path()` scraper cannot see, so they were carried as a **hand-maintained list**. That list silently stopped covering the table the moment someone added a key, which is precisely how `output_id` shipped undocumented.

It now scrapes `ParseOutputMatch` for `t["<field>"].is_<type>()`. Applying that immediately errored with:

```
error: parser keys with no META entry (update scripts/gen_config_reference.py):
  output.output_id
```

which is the safety net doing its job for the first time on this table.

## Two descriptions were promising behavior that does not exist

Corrected rather than left flattering:

- `on_disconnect = teardown` — warns and suspends instead of freeing the engine.
- `preload` — parsed but not acted on; a view is built either way.

The new prose also states that moving a running view to a *different* output is not implemented: the transition is detected, logged, and plugins are told their grant is stale, but the view is not rebound.

## The rule

[`docs/config-examples/99-ihs-outputs.rules`](https://github.com/toyota-connected/ivi-homescreen/blob/jw/output-docs/docs/config-examples/99-ihs-outputs.rules) covers both verification boards in one file — only the rules whose `ID_PATH` matches the running board take effect. It records the two things that cost time to work out:

- `DEVTYPE` is a property, so it must be matched as `ENV{DEVTYPE}=="drm_connector"`; `udevadm verify` rejects the bare form.
- `ID_PATH` is per **GPU**, not per connector — on a Pi 4 all three connectors share `platform-gpu` — so it must be paired with a `KERNEL` pattern.

## Checked, not remembered

Given how this series has gone, I verified each claim in the new prose against the code rather than from memory: the tier order (`output_id` above `serial`), that a miss parks, the exact parked log line, that the Wayland provider does not populate `output_id`, that `teardown` warns, that `preload` is unread anywhere, and that no rebind path exists.

Also: `udevadm verify` accepts the shipped rule, the generator is idempotent (running it twice reports "nothing to update"), and the links resolve **from the repository root** — `README.md` is the real file and `docs/source/readme.md` is a symlink to it, so my first attempt at a docs-relative path would have been broken on GitHub.
