### PR TITLE
accessibility: enrich semantics nodes, roll embedder.h forward, add the hub ABI

### DIFF
--- a/shared/include/ihs/ihs_semantics.h
+++ b/shared/include/ihs/ihs_semantics.h
@@ -1,0 +1,428 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * ihs_shared semantics hub: the single fan-out point for the Flutter semantics
+ * tree, and the single funnel for actions dispatched back into it.
+ *
+ * The shell mirrors each FlutterSemanticsUpdate2 into a mutable tree on the
+ * platform thread. That tree is never exposed. Instead, at every batch
+ * boundary the hub publishes an immutable, refcounted IhsSemanticsSnapshot;
+ * consumers read snapshots and never touch the mutable tree, so a slow
+ * consumer cannot stall the platform thread.
+ *
+ * This surface is deliberately free of any dependency on embedder.h. A
+ * consumer may be an out-of-tree FFI plugin that has no Flutter headers at
+ * all, so roles, states and actions are re-expressed here rather than
+ * forwarded. See docs/PLUGIN_ABI.md for the boundary rules.
+ *
+ * Lifecycle of one consumer:
+ *   1. Fill an IhsSemanticsConsumerDesc (name, allowed actions, notify fd) and
+ *      call ihs_semantics_register. Registration is process-global and may
+ *      happen at any time -- a client attaching mid-session needs no restart.
+ *   2. The hub reference-counts registrations to drive semantics on and off in
+ *      the engine. With no consumer registered the engine is never asked to
+ *      produce semantics at all, so a build with adapters compiled in but none
+ *      configured pays nothing.
+ *   3. Wait on the notify fd. Each readable event means "a newer generation
+ *      exists"; events are edge-coalesced, so a consumer that wakes once for
+ *      three updates has missed nothing. Always fetch the latest snapshot on
+ *      wake rather than trying to track individual updates.
+ *   4. ihs_semantics_acquire_snapshot for the current tree; release it when
+ *      done. Acquire/release are lock-free and callable from any thread.
+ *   5. ihs_semantics_dispatch to invoke an action. The hub serializes onto the
+ *      platform thread, enforces the consumer's action_allow_mask, and traces
+ *      the dispatch with the consumer name so "which actor did this" is
+ *      answerable after the fact.
+ *   6. ihs_semantics_unregister drains any in-flight dispatch for that
+ *      consumer before returning.
+ *
+ * Notification is by file descriptor, not callback, on purpose: one consumer
+ * that blocks in a callback would delay notification of every other, and
+ * "must not block" is a contract that erodes. Consumers poll in their own
+ * event loop instead.
+ *
+ * Threading: register/unregister and dispatch are callable from any thread.
+ * Snapshot acquire/release are callable from any thread and are lock-free. The
+ * done callback passed to dispatch is invoked on the platform thread. Snapshot
+ * contents are immutable for the lifetime of the reference held.
+ */
+
+#ifndef IHS_SEMANTICS_H_
+#define IHS_SEMANTICS_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ihs/ihs_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* An immutable published tree. Refcounted; contents never change for the
+ * lifetime of a reference. */
+typedef struct IhsSemanticsSnapshot IhsSemanticsSnapshot;
+
+/* A registered consumer. Valid until ihs_semantics_unregister returns. */
+typedef struct IhsSemanticsConsumer IhsSemanticsConsumer;
+
+/* Status codes. Negative values are errors. */
+typedef enum IhsSemanticsStatus {
+  IHS_SEMANTICS_OK = 0,
+  /* A required argument was null, or a struct_size was not recognized. */
+  IHS_SEMANTICS_ERR_INVALID = -1,
+  /* The action is not set in the consumer's action_allow_mask. This is a
+   * policy denial, not a missing node -- see IhsSemanticsConsumerDesc. */
+  IHS_SEMANTICS_ERR_DENIED = -2,
+  /* No node with the requested id in the current tree. */
+  IHS_SEMANTICS_ERR_NO_SUCH_NODE = -3,
+  /* The node exists but does not offer the requested action. */
+  IHS_SEMANTICS_ERR_UNSUPPORTED_ACTION = -4,
+  /* The hub is not running: semantics never started, or is shutting down. */
+  IHS_SEMANTICS_ERR_UNAVAILABLE = -5
+} IhsSemanticsStatus;
+
+/*
+ * A property that may not apply at all. The distinction matters: a checkbox
+ * that is unchecked and a node for which "checked" is meaningless are not the
+ * same thing, and flattening both to false loses the difference. Consumers
+ * should surface all three states rather than collapsing to a bool.
+ */
+typedef enum IhsSemanticsTristate {
+  IHS_SEMANTICS_TRISTATE_NONE = 0, /* property does not apply to this node */
+  IHS_SEMANTICS_TRISTATE_TRUE = 1,
+  IHS_SEMANTICS_TRISTATE_FALSE = 2
+} IhsSemanticsTristate;
+
+/* Check state, which unlike the other tristates has a fourth value. */
+typedef enum IhsSemanticsCheckState {
+  IHS_SEMANTICS_CHECK_NONE = 0, /* not a checkable node */
+  IHS_SEMANTICS_CHECK_TRUE = 1,
+  IHS_SEMANTICS_CHECK_FALSE = 2,
+  IHS_SEMANTICS_CHECK_MIXED = 3
+} IhsSemanticsCheckState;
+
+/*
+ * Backend-neutral role. Derived from the framework's flags rather than
+ * forwarded, so it is stable across engine revisions that reshuffle their own
+ * flag representation. IHS_SEMANTICS_ROLE_UNKNOWN is the honest fallback and
+ * consumers must handle it.
+ */
+typedef enum IhsSemanticsRole {
+  IHS_SEMANTICS_ROLE_UNKNOWN = 0,
+  IHS_SEMANTICS_ROLE_WINDOW = 1,
+  IHS_SEMANTICS_ROLE_BUTTON = 2,
+  IHS_SEMANTICS_ROLE_TEXT_INPUT = 3,
+  IHS_SEMANTICS_ROLE_MULTILINE_TEXT_INPUT = 4,
+  IHS_SEMANTICS_ROLE_PASSWORD_INPUT = 5,
+  IHS_SEMANTICS_ROLE_SLIDER = 6,
+  IHS_SEMANTICS_ROLE_SWITCH = 7,
+  IHS_SEMANTICS_ROLE_CHECK_BOX = 8,
+  IHS_SEMANTICS_ROLE_RADIO_BUTTON = 9,
+  IHS_SEMANTICS_ROLE_LINK = 10,
+  IHS_SEMANTICS_ROLE_IMAGE = 11,
+  IHS_SEMANTICS_ROLE_HEADING = 12,
+  IHS_SEMANTICS_ROLE_SCROLL_VIEW = 13,
+  IHS_SEMANTICS_ROLE_PANE = 14,
+  IHS_SEMANTICS_ROLE_LABEL = 15,
+  IHS_SEMANTICS_ROLE_GENERIC_CONTAINER = 16
+} IhsSemanticsRole;
+
+/*
+ * Action bits, for IhsSemanticsNode::actions and for the per-consumer
+ * action_allow_mask. Values are this ABI's own and are never renumbered;
+ * they are not the framework's bit positions and must not be assumed equal to
+ * them.
+ *
+ * An action absent from a node's `actions` is not invocable on it: the
+ * framework registered no handler, and dispatching anyway is silently dropped
+ * on the far side. Check before dispatching so the caller sees a real error.
+ */
+#define IHS_SEMANTICS_ACTION_TAP UINT64_C(0x0000000000000001)
+#define IHS_SEMANTICS_ACTION_LONG_PRESS UINT64_C(0x0000000000000002)
+#define IHS_SEMANTICS_ACTION_SCROLL_LEFT UINT64_C(0x0000000000000004)
+#define IHS_SEMANTICS_ACTION_SCROLL_RIGHT UINT64_C(0x0000000000000008)
+#define IHS_SEMANTICS_ACTION_SCROLL_UP UINT64_C(0x0000000000000010)
+#define IHS_SEMANTICS_ACTION_SCROLL_DOWN UINT64_C(0x0000000000000020)
+#define IHS_SEMANTICS_ACTION_INCREASE UINT64_C(0x0000000000000040)
+#define IHS_SEMANTICS_ACTION_DECREASE UINT64_C(0x0000000000000080)
+#define IHS_SEMANTICS_ACTION_SHOW_ON_SCREEN UINT64_C(0x0000000000000100)
+#define IHS_SEMANTICS_ACTION_MOVE_CURSOR_FORWARD_CHAR \
+  UINT64_C(0x0000000000000200)
+#define IHS_SEMANTICS_ACTION_MOVE_CURSOR_BACKWARD_CHAR \
+  UINT64_C(0x0000000000000400)
+#define IHS_SEMANTICS_ACTION_SET_SELECTION UINT64_C(0x0000000000000800)
+#define IHS_SEMANTICS_ACTION_COPY UINT64_C(0x0000000000001000)
+#define IHS_SEMANTICS_ACTION_CUT UINT64_C(0x0000000000002000)
+#define IHS_SEMANTICS_ACTION_PASTE UINT64_C(0x0000000000004000)
+#define IHS_SEMANTICS_ACTION_DID_GAIN_A11Y_FOCUS UINT64_C(0x0000000000008000)
+#define IHS_SEMANTICS_ACTION_DID_LOSE_A11Y_FOCUS UINT64_C(0x0000000000010000)
+#define IHS_SEMANTICS_ACTION_CUSTOM_ACTION UINT64_C(0x0000000000020000)
+#define IHS_SEMANTICS_ACTION_DISMISS UINT64_C(0x0000000000040000)
+#define IHS_SEMANTICS_ACTION_MOVE_CURSOR_FORWARD_WORD \
+  UINT64_C(0x0000000000080000)
+#define IHS_SEMANTICS_ACTION_MOVE_CURSOR_BACKWARD_WORD \
+  UINT64_C(0x0000000000100000)
+#define IHS_SEMANTICS_ACTION_SET_TEXT UINT64_C(0x0000000000200000)
+#define IHS_SEMANTICS_ACTION_FOCUS UINT64_C(0x0000000000400000)
+#define IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET UINT64_C(0x0000000000800000)
+#define IHS_SEMANTICS_ACTION_EXPAND UINT64_C(0x0000000001000000)
+#define IHS_SEMANTICS_ACTION_COLLAPSE UINT64_C(0x0000000002000000)
+
+/*
+ * Every action this ABI version knows. Useful as an allow-mask for a fully
+ * trusted consumer; prefer naming the bits you actually need.
+ *
+ * Spelled as the OR of the named bits rather than a literal so it cannot drift
+ * out of step with them when an action is added.
+ */
+#define IHS_SEMANTICS_ACTION_ALL                                          \
+  (IHS_SEMANTICS_ACTION_TAP | IHS_SEMANTICS_ACTION_LONG_PRESS |           \
+   IHS_SEMANTICS_ACTION_SCROLL_LEFT | IHS_SEMANTICS_ACTION_SCROLL_RIGHT | \
+   IHS_SEMANTICS_ACTION_SCROLL_UP | IHS_SEMANTICS_ACTION_SCROLL_DOWN |    \
+   IHS_SEMANTICS_ACTION_INCREASE | IHS_SEMANTICS_ACTION_DECREASE |        \
+   IHS_SEMANTICS_ACTION_SHOW_ON_SCREEN |                                  \
+   IHS_SEMANTICS_ACTION_MOVE_CURSOR_FORWARD_CHAR |                        \
+   IHS_SEMANTICS_ACTION_MOVE_CURSOR_BACKWARD_CHAR |                       \
+   IHS_SEMANTICS_ACTION_SET_SELECTION | IHS_SEMANTICS_ACTION_COPY |       \
+   IHS_SEMANTICS_ACTION_CUT | IHS_SEMANTICS_ACTION_PASTE |                \
+   IHS_SEMANTICS_ACTION_DID_GAIN_A11Y_FOCUS |                             \
+   IHS_SEMANTICS_ACTION_DID_LOSE_A11Y_FOCUS |                             \
+   IHS_SEMANTICS_ACTION_CUSTOM_ACTION | IHS_SEMANTICS_ACTION_DISMISS |    \
+   IHS_SEMANTICS_ACTION_MOVE_CURSOR_FORWARD_WORD |                        \
+   IHS_SEMANTICS_ACTION_MOVE_CURSOR_BACKWARD_WORD |                       \
+   IHS_SEMANTICS_ACTION_SET_TEXT | IHS_SEMANTICS_ACTION_FOCUS |           \
+   IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET | IHS_SEMANTICS_ACTION_EXPAND |  \
+   IHS_SEMANTICS_ACTION_COLLAPSE)
+
+/*
+ * The two accessibility-focus actions move a screen reader's cursor. A
+ * consumer driving the UI programmatically should not hold these: doing so
+ * lets it yank the cursor out from under someone reading the screen. This is
+ * the intended allow-mask for an automation consumer.
+ */
+#define IHS_SEMANTICS_ACTION_NO_A11Y_FOCUS                                \
+  (IHS_SEMANTICS_ACTION_ALL & ~IHS_SEMANTICS_ACTION_DID_GAIN_A11Y_FOCUS & \
+   ~IHS_SEMANTICS_ACTION_DID_LOSE_A11Y_FOCUS)
+
+/* A rectangle in screen space. The publisher composes each node's transform
+ * down the traversal path once, at snapshot build, so consumers never do
+ * matrix work and every rect in a snapshot is directly comparable. */
+typedef struct IhsSemanticsRect {
+  double left;
+  double top;
+  double right;
+  double bottom;
+} IhsSemanticsRect;
+
+/*
+ * A custom action declared by the application. Referenced by nodes via
+ * custom_action_ids; the label and hint live here once rather than being
+ * repeated on every referencing node.
+ */
+typedef struct IhsSemanticsCustomAction {
+  int32_t id;
+  const char* label; /* never null; "" when undeclared */
+  const char* hint;  /* never null; "" when undeclared */
+} IhsSemanticsCustomAction;
+
+/*
+ * One node. All pointers are owned by the snapshot and valid exactly as long
+ * as the reference that produced them; copy anything you need to outlive it.
+ * All string fields are non-null -- an absent string is "", never NULL, so
+ * consumers need no null checks.
+ */
+typedef struct IhsSemanticsNode {
+  /* Stable within a tree but not across rebuilds. Use `identifier` where the
+   * application provides one. */
+  int32_t id;
+
+  /*
+   * Application-assigned stable identifier, or "" when unannotated.
+   *
+   * Note this is empty on every node for engines that predate the field, not
+   * only for unannotated ones, so a consumer cannot distinguish "the app did
+   * not annotate" from "this engine cannot report it". Treat emptiness as
+   * "fall back to label and role" in both cases.
+   */
+  const char* identifier;
+
+  IhsSemanticsRole role;
+
+  const char* label;
+  const char* hint;
+  const char* value;
+  const char* tooltip;
+
+  /* Screen space, transforms already composed. */
+  IhsSemanticsRect rect;
+
+  /* State. Tristates carry "does not apply" as a distinct value; see
+   * IhsSemanticsTristate before collapsing any of these to a bool. */
+  IhsSemanticsCheckState checked;
+  IhsSemanticsTristate enabled;
+  IhsSemanticsTristate selected;
+  IhsSemanticsTristate toggled;
+  IhsSemanticsTristate expanded;
+  IhsSemanticsTristate focused;
+  IhsSemanticsTristate required;
+
+  bool hidden;
+  bool read_only;
+  bool obscured;
+  bool live_region;
+  bool focusable;
+  bool a11y_focus_blocked;
+
+  /* Bitwise OR of IHS_SEMANTICS_ACTION_*. */
+  uint64_t actions;
+
+  /* Indices into IhsSemanticsSnapshot::nodes, in traversal order. Indices, not
+   * ids, so a consumer walks the tree without a lookup per step. */
+  const uint32_t* child_indices;
+  size_t child_count;
+
+  /* Ids into IhsSemanticsSnapshot::custom_actions; resolve with
+   * ihs_semantics_find_custom_action. */
+  const int32_t* custom_action_ids;
+  size_t custom_action_count;
+} IhsSemanticsNode;
+
+/*
+ * A published tree. Access the fields through the accessors below rather than
+ * dereferencing: the struct is opaque so it can gain members without breaking
+ * consumers built against an older header.
+ */
+
+/* Monotonically increasing. A consumer that has already seen this generation
+ * has nothing new to read. Never wraps in any realistic session. */
+IHS_EXPORT uint64_t
+ihs_semantics_snapshot_generation(const IhsSemanticsSnapshot* snapshot);
+
+/* Node count. Index 0 is the root when count is non-zero. */
+IHS_EXPORT size_t
+ihs_semantics_snapshot_node_count(const IhsSemanticsSnapshot* snapshot);
+
+/* Node by index, or null when out of range. Pointer valid for the life of the
+ * reference. */
+IHS_EXPORT const IhsSemanticsNode* ihs_semantics_snapshot_node_at(
+    const IhsSemanticsSnapshot* snapshot,
+    size_t index);
+
+/* Node by tree id, or null when absent. O(1). */
+IHS_EXPORT const IhsSemanticsNode* ihs_semantics_snapshot_node_by_id(
+    const IhsSemanticsSnapshot* snapshot,
+    int32_t node_id);
+
+/* Custom action declaration by id, or null when never declared. */
+IHS_EXPORT const IhsSemanticsCustomAction* ihs_semantics_find_custom_action(
+    const IhsSemanticsSnapshot* snapshot,
+    int32_t action_id);
+
+/*
+ * Take a reference on the current tree, or null when semantics is not running.
+ * Lock-free and callable from any thread. Every successful acquire must be
+ * paired with exactly one release.
+ */
+IHS_EXPORT const IhsSemanticsSnapshot* ihs_semantics_acquire_snapshot(void);
+
+/* Drop a reference. Passing null is a no-op. */
+IHS_EXPORT void ihs_semantics_release_snapshot(
+    const IhsSemanticsSnapshot* snapshot);
+
+/*
+ * Consumer registration.
+ *
+ * notify_fd is owned by the caller and must outlive the registration. The hub
+ * writes to it when a newer generation is published and never reads or closes
+ * it. An eventfd is the expected choice; any writable fd the caller can poll
+ * works. Pass -1 for a consumer that only ever polls on its own schedule.
+ */
+typedef struct IhsSemanticsConsumerDesc {
+  size_t struct_size; /* sizeof(IhsSemanticsConsumerDesc) */
+
+  /* Stable, human-meaningful, and used in dispatch traces. Not optional: the
+   * audit trail is worth more than the convenience of skipping it. */
+  const char* name;
+
+  /* Bitwise OR of IHS_SEMANTICS_ACTION_*. Dispatch of anything outside this
+   * set fails with IHS_SEMANTICS_ERR_DENIED and never reaches the framework.
+   * See IHS_SEMANTICS_ACTION_NO_A11Y_FOCUS for the automation default. */
+  uint64_t action_allow_mask;
+
+  /* Written on publish; -1 to opt out. */
+  int notify_fd;
+} IhsSemanticsConsumerDesc;
+
+/*
+ * Register. On success *out_consumer receives a handle. Registering the first
+ * consumer causes semantics to be enabled in the engine; the first snapshot
+ * follows asynchronously, so a consumer should expect
+ * ihs_semantics_acquire_snapshot to return null until one arrives.
+ */
+IHS_EXPORT int ihs_semantics_register(const IhsSemanticsConsumerDesc* desc,
+                                      IhsSemanticsConsumer** out_consumer);
+
+/*
+ * Unregister. Drains any dispatch already in flight for this consumer before
+ * returning, so no done callback can fire afterwards. Unregistering the last
+ * consumer disables semantics in the engine. Snapshots the caller still holds
+ * remain valid: their lifetime is independent of any consumer's.
+ */
+IHS_EXPORT void ihs_semantics_unregister(IhsSemanticsConsumer* consumer);
+
+/*
+ * Invoked on the platform thread when a dispatch has been handed to the
+ * framework. `status` is IHS_SEMANTICS_OK, or the reason it went no further.
+ *
+ * Delivery to the framework is not the same as the UI having reacted: the
+ * framework routes the action to whatever handler the widget registered, and
+ * that may complete later, or do nothing at all. A caller that needs to know
+ * what changed should compare snapshot generations rather than infer anything
+ * from this callback.
+ */
+typedef void (*IhsSemanticsDoneCallback)(int status, void* user_data);
+
+/*
+ * Dispatch an action.
+ *
+ * The only path back into the framework. Consumers never call the engine
+ * directly, so the hub can serialize onto the platform thread, enforce the
+ * consumer's allow mask, and attribute every dispatch to a named actor.
+ *
+ * `data`/`data_length` carry arguments for the actions that take them (set
+ * text, set selection, scroll to offset); pass NULL/0 otherwise. The buffer is
+ * copied before this returns.
+ *
+ * Returns immediately; `done` fires on the platform thread and may be null.
+ * Callable from any thread.
+ */
+IHS_EXPORT int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
+                                      int64_t view_id,
+                                      int32_t node_id,
+                                      uint64_t action,
+                                      const uint8_t* data,
+                                      size_t data_length,
+                                      IhsSemanticsDoneCallback done,
+                                      void* user_data);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* IHS_SEMANTICS_H_ */

--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -43,17 +43,11 @@ void AccessibilityNode::Update(const FlutterSemanticsNode2& fl_node) {
   m_value = fl_node.value ? fl_node.value : "";
   m_tooltip = fl_node.tooltip ? fl_node.tooltip : "";
   m_bounds = fl_node.rect;
+  // Parent-local bounds are only meaningful alongside the node-to-parent
+  // transform, so retain it here rather than composing at read time.
+  m_transform = fl_node.transform;
   m_flags = fl_node.flags;
-
-  // Role. This inline mapping is a stopgap; the SemanticsTranslator owns the
-  // full role/state/action table.
-  if (fl_node.id == 0) {
-    m_role = SEMANTIC_ROLE_WINDOW;
-  } else if (fl_node.flags & kFlutterSemanticsFlagIsButton) {
-    m_role = SEMANTIC_ROLE_BUTTON;
-  } else {
-    m_role = SEMANTIC_ROLE_UNKNOWN;
-  }
+  m_actions = fl_node.actions;
 
   // Replace (not append) the children in traversal order, so a reorder or a
   // removed child is reflected when the node is re-sent.
@@ -65,6 +59,39 @@ void AccessibilityNode::Update(const FlutterSemanticsNode2& fl_node) {
   } else {
     m_children.clear();
   }
+
+  // Same replace-don't-append discipline for the custom action IDs: an action
+  // the application withdraws from a node must not linger on it.
+  if (fl_node.custom_accessibility_actions_count > 0 &&
+      fl_node.custom_accessibility_actions != nullptr) {
+    m_custom_actions.assign(
+        fl_node.custom_accessibility_actions,
+        fl_node.custom_accessibility_actions +
+            static_cast<size_t>(fl_node.custom_accessibility_actions_count));
+  } else {
+    m_custom_actions.clear();
+  }
+
+  // Derive role and states last: Translate() disambiguates a label-only leaf
+  // from a generic container, so it needs the refreshed label and children.
+  m_spec = accessibility::Translate(m_id, m_flags, m_actions, !m_label.empty(),
+                                    !m_children.empty());
+}
+
+uint8_t AccessibilityNode::GetRole() const {
+  // The AccessKit bridge consumes accesskit_role numerically. Only the two
+  // roles that have a SemanticRole constant are mapped; the rest report
+  // unknown, matching what this node reported before roles were derived
+  // through the translator. Widening this mapping belongs at the AccessKit
+  // boundary, where the accesskit_role values are in scope.
+  switch (m_spec.role) {
+    case accessibility::Role::kWindow:
+      return SEMANTIC_ROLE_WINDOW;
+    case accessibility::Role::kButton:
+      return SEMANTIC_ROLE_BUTTON;
+    default:
+      return SEMANTIC_ROLE_UNKNOWN;
+  }
 }
 
 AccessibilityTree::AccessibilityTree() : focused_node(0) {}
@@ -72,6 +99,26 @@ AccessibilityTree::~AccessibilityTree() = default;
 
 void AccessibilityTree::HandleFlutterUpdate(
     const FlutterSemanticsUpdate2* update) {
+  // Resolve the custom action declarations before the nodes, so a node that
+  // references an action declared in this same batch can be looked up as soon
+  // as the batch is applied.
+  if (update->custom_actions != nullptr) {
+    for (size_t i = 0; i < update->custom_action_count; i++) {
+      const FlutterSemanticsCustomAction2* fl_action =
+          update->custom_actions[i];
+      if (fl_action == nullptr) {
+        continue;
+      }
+      AccessibilityCustomAction& action = custom_actions[fl_action->id];
+      action.id = fl_action->id;
+      action.override_action = fl_action->override_action;
+      // Owned copies, for the same reason the node text is owned: the
+      // embedder's strings are only valid for this callback, and may be null.
+      action.label = fl_action->label ? fl_action->label : "";
+      action.hint = fl_action->hint ? fl_action->hint : "";
+    }
+  }
+
   // Upsert every node in this update: create the ones we have not seen and
   // refresh the rest. Update() replaces fields and children, so stale labels
   // and detached children never accumulate across successive updates.
@@ -119,10 +166,12 @@ void AccessibilityTree::HandleFlutterUpdate(
   // Drop any node no longer reachable from the root: a subtree Flutter
   // detached is removed from the mirror instead of lingering forever.
   PruneUnreachable();
+}
 
-  for (size_t j = 0; j < update->custom_action_count; j++) {
-    // TODO: handle custom actions
-  }
+const AccessibilityCustomAction* AccessibilityTree::FindCustomAction(
+    const int32_t id) const {
+  const auto it = custom_actions.find(id);
+  return it != custom_actions.end() ? &it->second : nullptr;
 }
 
 void AccessibilityTree::PruneUnreachable() {
@@ -215,8 +264,24 @@ void AccessibilityTree::DumpTree(const char* target_file) const {
     bounds_obj.AddMember("bottom", node->GetBounds().bottom, allocator);
     node_obj.AddMember("bounds", bounds_obj, allocator);
 
-    // Flags
+    // Node-to-parent transform. Bounds above are in the node's own coordinate
+    // system, so the transform is what makes them comparable across the tree.
+    const FlutterTransformation& transform = node->GetTransform();
+    rapidjson::Value transform_obj(rapidjson::kObjectType);
+    transform_obj.AddMember("scaleX", transform.scaleX, allocator);
+    transform_obj.AddMember("skewX", transform.skewX, allocator);
+    transform_obj.AddMember("transX", transform.transX, allocator);
+    transform_obj.AddMember("skewY", transform.skewY, allocator);
+    transform_obj.AddMember("scaleY", transform.scaleY, allocator);
+    transform_obj.AddMember("transY", transform.transY, allocator);
+    transform_obj.AddMember("pers0", transform.pers0, allocator);
+    transform_obj.AddMember("pers1", transform.pers1, allocator);
+    transform_obj.AddMember("pers2", transform.pers2, allocator);
+    node_obj.AddMember("transform", transform_obj, allocator);
+
+    // Flags and actions, as the raw bitmasks the embedder supplied.
     node_obj.AddMember("flags", node->GetFlags(), allocator);
+    node_obj.AddMember("actions", node->GetActions(), allocator);
 
     // Children as array
     rapidjson::Value children_array(rapidjson::kArrayType);
@@ -226,10 +291,43 @@ void AccessibilityTree::DumpTree(const char* target_file) const {
     }
     node_obj.AddMember("children", children_array, allocator);
 
+    // IDs of the custom actions this node offers; the declarations are
+    // emitted once in the tree-level "custom_actions" table below.
+    rapidjson::Value node_custom_actions(rapidjson::kArrayType);
+    for (uint32_t i = 0; i < node->NumberOfCustomActions(); i++) {
+      node_custom_actions.PushBack(
+          node->GetCustomActionId(static_cast<int32_t>(i)), allocator);
+    }
+    node_obj.AddMember("custom_actions", node_custom_actions, allocator);
+
     nodes_array.PushBack(node_obj, allocator);
   }
 
   doc.AddMember("nodes", nodes_array, allocator);
+
+  // Custom action declarations, shared by ID across the nodes above. Emitted
+  // in ID order: the declarations live in an unordered_map, and a dump that
+  // reshuffles between runs cannot be diffed against an earlier one.
+  std::vector<int32_t> action_ids;
+  action_ids.reserve(custom_actions.size());
+  for (const auto& entry : custom_actions) {
+    action_ids.push_back(entry.first);
+  }
+  std::sort(action_ids.begin(), action_ids.end());
+
+  rapidjson::Value custom_actions_array(rapidjson::kArrayType);
+  for (const int32_t id : action_ids) {
+    const AccessibilityCustomAction& action = custom_actions.at(id);
+    rapidjson::Value action_obj(rapidjson::kObjectType);
+    action_obj.AddMember("id", action.id, allocator);
+    action_obj.AddMember("override_action", action.override_action, allocator);
+    action_obj.AddMember(
+        "label", rapidjson::Value(action.label.c_str(), allocator), allocator);
+    action_obj.AddMember(
+        "hint", rapidjson::Value(action.hint.c_str(), allocator), allocator);
+    custom_actions_array.PushBack(action_obj, allocator);
+  }
+  doc.AddMember("custom_actions", custom_actions_array, allocator);
 
   // Write to file
   rapidjson::StringBuffer buffer;

--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -17,9 +17,41 @@
 #include "accessibility_tree.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <filesystem>
 #include <fstream>
 #include <unordered_set>
+
+namespace {
+
+// The engine sets `struct_size` to the size of the FlutterSemanticsNode2 the
+// *engine* was built against, which may be older than the header this port
+// compiles with. Members appended by a later embedder revision then lie past
+// the end of the engine's allocation, so reading them is an out-of-bounds
+// read, not merely a stale value.
+//
+// Both members below were added after the original FlutterSemanticsNode2, so
+// every read of them is gated on the engine having written that far. Members
+// present in the original struct (id, rect, transform, actions,
+// custom_accessibility_actions, the text fields) need no gate.
+constexpr bool NodeWroteThrough(const FlutterSemanticsNode2& node,
+                                const size_t member_end) {
+  return node.struct_size >= member_end;
+}
+
+constexpr size_t kIdentifierEnd =
+    offsetof(FlutterSemanticsNode2, identifier) + sizeof(const char*);
+constexpr size_t kFlags2End =
+    offsetof(FlutterSemanticsNode2, flags2) + sizeof(FlutterSemanticsFlags*);
+
+// Catches a member changing type or moving to the end of the struct, either of
+// which would silently break the bounds arithmetic above.
+static_assert(kIdentifierEnd <= sizeof(FlutterSemanticsNode2),
+              "identifier bounds overrun FlutterSemanticsNode2");
+static_assert(kFlags2End <= sizeof(FlutterSemanticsNode2),
+              "flags2 bounds overrun FlutterSemanticsNode2");
+
+}  // namespace
 
 #include <rapidjson/document.h>
 #include <rapidjson/prettywriter.h>
@@ -42,11 +74,18 @@ void AccessibilityNode::Update(const FlutterSemanticsNode2& fl_node) {
   m_hint = fl_node.hint ? fl_node.hint : "";
   m_value = fl_node.value ? fl_node.value : "";
   m_tooltip = fl_node.tooltip ? fl_node.tooltip : "";
+  // Application-assigned stable ID. Unlike `id`, it survives tree rebuilds and
+  // is the addressing key a caller should prefer. Empty when unannotated, and
+  // when the engine predates the field entirely.
+  const bool has_identifier = NodeWroteThrough(fl_node, kIdentifierEnd);
+  m_identifier = (has_identifier && fl_node.identifier != nullptr)
+                     ? fl_node.identifier
+                     : "";
   m_bounds = fl_node.rect;
   // Parent-local bounds are only meaningful alongside the node-to-parent
   // transform, so retain it here rather than composing at read time.
   m_transform = fl_node.transform;
-  m_flags = fl_node.flags;
+  m_flags = fl_node.flags__deprecated__;
   m_actions = fl_node.actions;
 
   // Replace (not append) the children in traversal order, so a reorder or a
@@ -74,8 +113,13 @@ void AccessibilityNode::Update(const FlutterSemanticsNode2& fl_node) {
 
   // Derive role and states last: Translate() disambiguates a label-only leaf
   // from a generic container, so it needs the refreshed label and children.
-  m_spec = accessibility::Translate(m_id, m_flags, m_actions, !m_label.empty(),
-                                    !m_children.empty());
+  // Prefer the FlutterSemanticsFlags struct. An engine predating the member
+  // never wrote it, and one that has it may still leave it null; Translate()
+  // falls back to the deprecated enum in both cases.
+  const FlutterSemanticsFlags* flags2 =
+      NodeWroteThrough(fl_node, kFlags2End) ? fl_node.flags2 : nullptr;
+  m_spec = accessibility::Translate(m_id, flags2, m_flags, m_actions,
+                                    !m_label.empty(), !m_children.empty());
 }
 
 uint8_t AccessibilityNode::GetRole() const {
@@ -126,7 +170,9 @@ void AccessibilityTree::HandleFlutterUpdate(
     const FlutterSemanticsNode2* node = update->nodes[i];
     AccessibilityNode* mirror = GetNode(*node);
     mirror->Update(*node);
-    if (node->flags & kFlutterSemanticsFlagIsFocused) {
+    // Read focus off the derived spec rather than the raw bitmask, so the
+    // FlutterSemanticsFlags struct is honored when the engine supplies it.
+    if (mirror->GetSpec().focused) {
       SetFocusedNode(node->id);
     }
   }
@@ -246,6 +292,9 @@ void AccessibilityTree::DumpTree(const char* target_file) const {
   for (auto& node : nodes) {
     rapidjson::Value node_obj(rapidjson::kObjectType);
     node_obj.AddMember("id", node->GetId(), allocator);
+    node_obj.AddMember("identifier",
+                       rapidjson::Value(node->GetIdentifier(), allocator),
+                       allocator);
     node_obj.AddMember("label", rapidjson::Value(node->GetLabel(), allocator),
                        allocator);
     node_obj.AddMember("hint", rapidjson::Value(node->GetHint(), allocator),
@@ -279,7 +328,9 @@ void AccessibilityTree::DumpTree(const char* target_file) const {
     transform_obj.AddMember("pers2", transform.pers2, allocator);
     node_obj.AddMember("transform", transform_obj, allocator);
 
-    // Flags and actions, as the raw bitmasks the embedder supplied.
+    // Actions as the raw bitmask the embedder supplied. `flags` is the
+    // deprecated enum bitmask, retained for continuity of this dump's shape;
+    // the authoritative derived state is in the node's spec.
     node_obj.AddMember("flags", node->GetFlags(), allocator);
     node_obj.AddMember("actions", node->GetActions(), allocator);
 

--- a/shell/accessibility/accessibility_tree.h
+++ b/shell/accessibility/accessibility_tree.h
@@ -28,12 +28,27 @@
 
 #include <shell/platform/embedder/embedder.h>
 
+#include "semantics_translator.h"
+
 // Enum representing semantic roles for accessibility nodes.
 // These roles are used to describe the purpose of a UI element.
 enum SemanticRole {
   SEMANTIC_ROLE_UNKNOWN = 0,  // Default role for unknown elements.
   SEMANTIC_ROLE_BUTTON = 18,  // Role for button elements.
   SEMANTIC_ROLE_WINDOW = 137  // Role for window elements.
+};
+
+// A custom semantics action declared by the application, resolved from the
+// FlutterSemanticsCustomAction2 batch that accompanies a semantics update.
+// Nodes reference these by ID; the labels and hints live here once rather than
+// being duplicated onto every referencing node.
+struct AccessibilityCustomAction {
+  int32_t id = -1;
+  // For an action override, the standard action this replaces; zero otherwise.
+  FlutterSemanticsAction override_action =
+      static_cast<FlutterSemanticsAction>(0);
+  std::string label;  // Owned copy; the embedder's string is transient.
+  std::string hint;   // Owned copy; the embedder's string is transient.
 };
 
 // Class representing an accessibility node in the accessibility tree.
@@ -48,14 +63,25 @@ class AccessibilityNode {
   // Returns the ID of the node.
   [[nodiscard]] int32_t GetId() const { return m_id; };
 
-  // Refreshes all fields (label / hint / value / tooltip, bounds, flags, role)
-  // and REPLACES the children list from a Flutter semantics node. Called on
-  // create and on every subsequent update, so stale labels or detached
-  // children never accumulate across updates.
+  // Refreshes all fields (label / hint / value / tooltip, bounds, transform,
+  // flags, actions, role) and REPLACES the children and custom-action ID lists
+  // from a Flutter semantics node. Called on create and on every subsequent
+  // update, so stale labels or detached children never accumulate across
+  // updates.
   void Update(const FlutterSemanticsNode2& fl_node);
 
-  // Returns the role of the node.
-  [[nodiscard]] uint8_t GetRole() const { return m_role; };
+  // Returns the role of the node, in the numeric encoding the AccessKit bridge
+  // consumes. Narrower than GetSpec().role: only the roles that have a
+  // SemanticRole constant are distinguished, the rest collapse to unknown.
+  // Prefer GetSpec() for anything that is not the AccessKit boundary.
+  [[nodiscard]] uint8_t GetRole() const;
+
+  // Returns the derived, backend-neutral role/state/action attributes of the
+  // node. This is the full translation of flags and actions; see
+  // semantics_translator.h.
+  [[nodiscard]] const accessibility::NodeSpec& GetSpec() const {
+    return m_spec;
+  };
 
   // Returns the label of the node. Backed by an owned copy, so the pointer
   // stays valid for the node's lifetime (unlike the embedder's transient
@@ -71,14 +97,33 @@ class AccessibilityNode {
   // Returns the value of the node.
   [[nodiscard]] const char* GetValue() const { return m_value.c_str(); };
 
-  // Returns the bounds of the node.
+  // Returns the bounds of the node, in its own coordinate system. Composing
+  // GetTransform() down the traversal path yields screen space.
   [[nodiscard]] FlutterRect GetBounds() const { return m_bounds; };
+
+  // Returns the transform from this node's coordinate system to its parent's.
+  [[nodiscard]] const FlutterTransformation& GetTransform() const {
+    return m_transform;
+  };
 
   // Returns the flags associated with the node.
   [[nodiscard]] FlutterSemanticsFlag GetFlags() const { return m_flags; };
 
+  // Returns the set of semantics actions applicable to this node, as a
+  // FlutterSemanticsAction bitmask.
+  [[nodiscard]] FlutterSemanticsAction GetActions() const { return m_actions; };
+
+  // Returns whether every bit in `action` is set on this node. Pass a single
+  // action bit to test one action.
+  [[nodiscard]] bool HasAction(const FlutterSemanticsAction action) const {
+    return (static_cast<uint32_t>(m_actions) & static_cast<uint32_t>(action)) ==
+           static_cast<uint32_t>(action);
+  }
+
   // Returns the number of child nodes.
-  [[nodiscard]] uint32_t NumberOfChildren() const { return m_children.size(); };
+  [[nodiscard]] uint32_t NumberOfChildren() const {
+    return static_cast<uint32_t>(m_children.size());
+  };
 
   // Returns the child node ID at the specified index.
   // If the index is out of bounds, returns -1.
@@ -88,20 +133,38 @@ class AccessibilityNode {
                : -1;
   }
 
+  // Returns the number of custom semantics actions referenced by this node.
+  [[nodiscard]] uint32_t NumberOfCustomActions() const {
+    return static_cast<uint32_t>(m_custom_actions.size());
+  };
+
+  // Returns the custom action ID at the specified index. Resolve it to a
+  // label and hint with AccessibilityTree::FindCustomAction().
+  // If the index is out of bounds, returns -1.
+  [[nodiscard]] int32_t GetCustomActionId(const int32_t idx) const {
+    return idx >= 0 && static_cast<size_t>(idx) < m_custom_actions.size()
+               ? m_custom_actions[static_cast<size_t>(idx)]
+               : -1;
+  }
+
  private:
   // The scalar members are set unconditionally by Update() (called from the
   // constructor), but carry in-class initializers so the type is never left
   // with an indeterminate field on any construction path.
-  uint8_t m_role = SEMANTIC_ROLE_UNKNOWN;  // Role of the node.
-  int32_t m_id = -1;                       // ID of the node.
-  std::string m_label;                     // Label of the node (owned copy).
+  int32_t m_id = -1;       // ID of the node.
+  std::string m_label;     // Label of the node (owned copy).
   std::string m_hint;      // Hint text of the node (owned copy).
   std::string m_value;     // Value of the node (owned copy).
   std::string m_tooltip;   // Tooltip text of the node (owned copy).
   FlutterRect m_bounds{};  // Bounds of the node.
+  FlutterTransformation m_transform{};  // Node-to-parent transform.
   FlutterSemanticsFlag m_flags =
       static_cast<FlutterSemanticsFlag>(0);  // Flags associated with the node.
-  std::vector<int32_t> m_children;           // List of child node IDs.
+  FlutterSemanticsAction m_actions =
+      static_cast<FlutterSemanticsAction>(0);  // Applicable action bitmask.
+  accessibility::NodeSpec m_spec;   // Role and states derived from the above.
+  std::vector<int32_t> m_children;  // List of child node IDs.
+  std::vector<int32_t> m_custom_actions;  // Referenced custom action IDs.
 };
 
 // Class representing the accessibility tree.
@@ -147,6 +210,18 @@ class AccessibilityTree {
     return static_cast<int32_t>(nodes.size());
   };
 
+  // Resolves a custom action ID (from AccessibilityNode::GetCustomActionId())
+  // to its declaration. Returns nullptr if the ID has not been declared.
+  // Declarations are never erased, so a non-null result stays valid for the
+  // life of the tree, but a later update may refresh its label and hint.
+  [[nodiscard]] const AccessibilityCustomAction* FindCustomAction(
+      int32_t id) const;
+
+  // Returns the number of declared custom semantics actions.
+  [[nodiscard]] size_t NumberOfCustomActions() const {
+    return custom_actions.size();
+  };
+
 #if ENABLE_ACCESSKIT
   // Initializes AccessKit support.
   void Init_AccessKit();
@@ -171,6 +246,13 @@ class AccessibilityTree {
   // O(1) instead of a linear scan (semantics updates touch many nodes per
   // update, which would otherwise be O(n^2)). Non-owning.
   std::unordered_map<int32_t, AccessibilityNode*> node_index;
+  // Declared custom actions, keyed by ID. Deliberately not pruned alongside
+  // the nodes: Flutter assigns a custom action its ID once and may send the
+  // declaration in an earlier batch than the node that references it, so
+  // dropping an unreferenced entry would lose it permanently. The set is
+  // bounded by the number of distinct CustomSemanticsAction values the
+  // application declares, not by tree size or update count.
+  std::unordered_map<int32_t, AccessibilityCustomAction> custom_actions;
   int32_t focused_node;  // ID of the currently focused node.
 
 #if ENABLE_ACCESSKIT

--- a/shell/accessibility/accessibility_tree.h
+++ b/shell/accessibility/accessibility_tree.h
@@ -97,6 +97,13 @@ class AccessibilityNode {
   // Returns the value of the node.
   [[nodiscard]] const char* GetValue() const { return m_value.c_str(); };
 
+  // Returns the application-assigned stable identifier, or "" when the node
+  // carries no annotation. Unlike GetId(), this survives tree rebuilds, so it
+  // is the addressing key a caller should prefer where it is present.
+  [[nodiscard]] const char* GetIdentifier() const {
+    return m_identifier.c_str();
+  };
+
   // Returns the bounds of the node, in its own coordinate system. Composing
   // GetTransform() down the traversal path yields screen space.
   [[nodiscard]] FlutterRect GetBounds() const { return m_bounds; };
@@ -151,12 +158,13 @@ class AccessibilityNode {
   // The scalar members are set unconditionally by Update() (called from the
   // constructor), but carry in-class initializers so the type is never left
   // with an indeterminate field on any construction path.
-  int32_t m_id = -1;       // ID of the node.
-  std::string m_label;     // Label of the node (owned copy).
-  std::string m_hint;      // Hint text of the node (owned copy).
-  std::string m_value;     // Value of the node (owned copy).
-  std::string m_tooltip;   // Tooltip text of the node (owned copy).
-  FlutterRect m_bounds{};  // Bounds of the node.
+  int32_t m_id = -1;         // ID of the node.
+  std::string m_label;       // Label of the node (owned copy).
+  std::string m_hint;        // Hint text of the node (owned copy).
+  std::string m_value;       // Value of the node (owned copy).
+  std::string m_tooltip;     // Tooltip text of the node (owned copy).
+  std::string m_identifier;  // App-assigned stable ID (owned copy); may be "".
+  FlutterRect m_bounds{};    // Bounds of the node.
   FlutterTransformation m_transform{};  // Node-to-parent transform.
   FlutterSemanticsFlag m_flags =
       static_cast<FlutterSemanticsFlag>(0);  // Flags associated with the node.

--- a/shell/accessibility/semantics_translator.cc
+++ b/shell/accessibility/semantics_translator.cc
@@ -28,56 +28,177 @@ bool Has(FlutterSemanticsAction actions, FlutterSemanticsAction bit) {
   return (static_cast<uint32_t>(actions) & static_cast<uint32_t>(bit)) != 0;
 }
 
+// The two flag representations normalized to one shape, so the role table and
+// the state table below are written once rather than once per source.
+//
+// The struct form carries tristates where the enum needed a pair of bits
+// ("has X state" + "is X"); both collapse to the same present/value pair here.
+struct FlagView {
+  bool is_text_field = false;
+  bool is_obscured = false;
+  bool is_multiline = false;
+  bool is_slider = false;
+  bool is_button = false;
+  bool is_link = false;
+  bool is_image = false;
+  bool is_header = false;
+  bool is_keyboard_key = false;
+  bool is_in_mutually_exclusive_group = false;
+  bool has_implicit_scrolling = false;
+  bool scopes_route = false;
+  bool names_route = false;
+
+  bool has_enabled_state = false;
+  bool is_enabled = false;
+  bool has_checked_state = false;
+  bool is_checked = false;
+  bool is_check_state_mixed = false;
+  bool has_toggled_state = false;
+  bool is_toggled = false;
+  bool has_expanded_state = false;
+  bool is_expanded = false;
+
+  bool is_hidden = false;
+  bool is_read_only = false;
+  bool is_selected = false;
+  bool is_live_region = false;
+  bool is_focusable = false;
+  bool is_focused = false;
+
+  // No legacy enum bit exists for these; they stay false when translated from
+  // the enum rather than being guessed at.
+  bool is_required = false;
+  bool is_accessibility_focus_blocked = false;
+};
+
+FlagView FromLegacy(FlutterSemanticsFlag flags) {
+  FlagView v;
+  v.is_text_field = Has(flags, kFlutterSemanticsFlagIsTextField);
+  v.is_obscured = Has(flags, kFlutterSemanticsFlagIsObscured);
+  v.is_multiline = Has(flags, kFlutterSemanticsFlagIsMultiline);
+  v.is_slider = Has(flags, kFlutterSemanticsFlagIsSlider);
+  v.is_button = Has(flags, kFlutterSemanticsFlagIsButton);
+  v.is_link = Has(flags, kFlutterSemanticsFlagIsLink);
+  v.is_image = Has(flags, kFlutterSemanticsFlagIsImage);
+  v.is_header = Has(flags, kFlutterSemanticsFlagIsHeader);
+  v.is_keyboard_key = Has(flags, kFlutterSemanticsFlagIsKeyboardKey);
+  v.is_in_mutually_exclusive_group =
+      Has(flags, kFlutterSemanticsFlagIsInMutuallyExclusiveGroup);
+  v.has_implicit_scrolling =
+      Has(flags, kFlutterSemanticsFlagHasImplicitScrolling);
+  v.scopes_route = Has(flags, kFlutterSemanticsFlagScopesRoute);
+  v.names_route = Has(flags, kFlutterSemanticsFlagNamesRoute);
+
+  v.has_enabled_state = Has(flags, kFlutterSemanticsFlagHasEnabledState);
+  v.is_enabled = Has(flags, kFlutterSemanticsFlagIsEnabled);
+  v.has_checked_state = Has(flags, kFlutterSemanticsFlagHasCheckedState);
+  v.is_checked = Has(flags, kFlutterSemanticsFlagIsChecked);
+  v.is_check_state_mixed = Has(flags, kFlutterSemanticsFlagIsCheckStateMixed);
+  v.has_toggled_state = Has(flags, kFlutterSemanticsFlagHasToggledState);
+  v.is_toggled = Has(flags, kFlutterSemanticsFlagIsToggled);
+  v.has_expanded_state = Has(flags, kFlutterSemanticsFlagHasExpandedState);
+  v.is_expanded = Has(flags, kFlutterSemanticsFlagIsExpanded);
+
+  v.is_hidden = Has(flags, kFlutterSemanticsFlagIsHidden);
+  v.is_read_only = Has(flags, kFlutterSemanticsFlagIsReadOnly);
+  v.is_selected = Has(flags, kFlutterSemanticsFlagIsSelected);
+  v.is_live_region = Has(flags, kFlutterSemanticsFlagIsLiveRegion);
+  v.is_focusable = Has(flags, kFlutterSemanticsFlagIsFocusable);
+  v.is_focused = Has(flags, kFlutterSemanticsFlagIsFocused);
+  return v;
+}
+
+FlagView FromStruct(const FlutterSemanticsFlags& flags) {
+  FlagView v;
+  v.is_text_field = flags.is_text_field;
+  v.is_obscured = flags.is_obscured;
+  v.is_multiline = flags.is_multiline;
+  v.is_slider = flags.is_slider;
+  v.is_button = flags.is_button;
+  v.is_link = flags.is_link;
+  v.is_image = flags.is_image;
+  v.is_header = flags.is_header;
+  v.is_keyboard_key = flags.is_keyboard_key;
+  v.is_in_mutually_exclusive_group = flags.is_in_mutually_exclusive_group;
+  v.has_implicit_scrolling = flags.has_implicit_scrolling;
+  v.scopes_route = flags.scopes_route;
+  v.names_route = flags.names_route;
+
+  // Tristate/check-state to present+value. kFlutterTristateNone and
+  // kFlutterCheckStateNone mean the property does not apply to this node,
+  // which is what the legacy enum spelled as "has X state" being unset.
+  v.has_enabled_state = flags.is_enabled != kFlutterTristateNone;
+  v.is_enabled = flags.is_enabled == kFlutterTristateTrue;
+  v.has_checked_state = flags.is_checked != kFlutterCheckStateNone;
+  v.is_checked = flags.is_checked == kFlutterCheckStateTrue;
+  v.is_check_state_mixed = flags.is_checked == kFlutterCheckStateMixed;
+  v.has_toggled_state = flags.is_toggled != kFlutterTristateNone;
+  v.is_toggled = flags.is_toggled == kFlutterTristateTrue;
+  v.has_expanded_state = flags.is_expanded != kFlutterTristateNone;
+  v.is_expanded = flags.is_expanded == kFlutterTristateTrue;
+
+  v.is_hidden = flags.is_hidden;
+  v.is_read_only = flags.is_read_only;
+  v.is_selected = flags.is_selected == kFlutterTristateTrue;
+  v.is_live_region = flags.is_live_region;
+  // The struct has no is_focusable; a node the engine reports a focus state
+  // for is focusable by construction.
+  v.is_focusable = flags.is_focused != kFlutterTristateNone;
+  v.is_focused = flags.is_focused == kFlutterTristateTrue;
+
+  v.is_required = flags.is_required == kFlutterTristateTrue;
+  v.is_accessibility_focus_blocked = flags.is_accessibility_focus_blocked;
+  return v;
+}
+
 // Role, first-match-wins. The order encodes precedence: a text field that is
 // also focusable is a text input, not a generic container; a checkbox in a
 // mutually-exclusive group is a radio button; etc.
 Role DeriveRole(int32_t id,
-                FlutterSemanticsFlag flags,
+                const FlagView& flags,
                 bool has_label,
                 bool has_children) {
   if (id == 0) {
     return Role::kWindow;
   }
-  if (Has(flags, kFlutterSemanticsFlagIsTextField)) {
-    if (Has(flags, kFlutterSemanticsFlagIsObscured)) {
+  if (flags.is_text_field) {
+    if (flags.is_obscured) {
       return Role::kPasswordInput;
     }
-    if (Has(flags, kFlutterSemanticsFlagIsMultiline)) {
+    if (flags.is_multiline) {
       return Role::kMultilineTextInput;
     }
     return Role::kTextInput;
   }
-  if (Has(flags, kFlutterSemanticsFlagIsSlider)) {
+  if (flags.is_slider) {
     return Role::kSlider;
   }
-  if (Has(flags, kFlutterSemanticsFlagHasToggledState)) {
+  if (flags.has_toggled_state) {
     return Role::kSwitch;
   }
-  if (Has(flags, kFlutterSemanticsFlagHasCheckedState)) {
-    return Has(flags, kFlutterSemanticsFlagIsInMutuallyExclusiveGroup)
-               ? Role::kRadioButton
-               : Role::kCheckBox;
+  if (flags.has_checked_state) {
+    return flags.is_in_mutually_exclusive_group ? Role::kRadioButton
+                                                : Role::kCheckBox;
   }
-  if (Has(flags, kFlutterSemanticsFlagIsButton)) {
+  if (flags.is_button) {
     return Role::kButton;
   }
-  if (Has(flags, kFlutterSemanticsFlagIsLink)) {
+  if (flags.is_link) {
     return Role::kLink;
   }
-  if (Has(flags, kFlutterSemanticsFlagIsImage)) {
+  if (flags.is_image) {
     return Role::kImage;
   }
-  if (Has(flags, kFlutterSemanticsFlagIsHeader)) {
+  if (flags.is_header) {
     return Role::kHeading;
   }
-  if (Has(flags, kFlutterSemanticsFlagIsKeyboardKey)) {
+  if (flags.is_keyboard_key) {
     return Role::kButton;  // documented approximation: no AT-SPI keyboard-key
   }
-  if (Has(flags, kFlutterSemanticsFlagHasImplicitScrolling)) {
+  if (flags.has_implicit_scrolling) {
     return Role::kScrollView;
   }
-  if (Has(flags, kFlutterSemanticsFlagScopesRoute) ||
-      Has(flags, kFlutterSemanticsFlagNamesRoute)) {
+  if (flags.scopes_route || flags.names_route) {
     return Role::kPane;
   }
   if (has_label && !has_children) {
@@ -86,31 +207,27 @@ Role DeriveRole(int32_t id,
   return Role::kGenericContainer;
 }
 
-}  // namespace
-
-NodeSpec Translate(int32_t id,
-                   FlutterSemanticsFlag flags,
-                   FlutterSemanticsAction actions,
-                   bool has_label,
-                   bool has_children) {
+NodeSpec TranslateView(int32_t id,
+                       const FlagView& flags,
+                       FlutterSemanticsAction actions,
+                       bool has_label,
+                       bool has_children) {
   NodeSpec spec;
   spec.role = DeriveRole(id, flags, has_label, has_children);
 
-  spec.disabled = Has(flags, kFlutterSemanticsFlagHasEnabledState) &&
-                  !Has(flags, kFlutterSemanticsFlagIsEnabled);
-  spec.hidden = Has(flags, kFlutterSemanticsFlagIsHidden);
-  spec.read_only = Has(flags, kFlutterSemanticsFlagIsReadOnly);
-  spec.selected = Has(flags, kFlutterSemanticsFlagIsSelected);
-  spec.expanded = Has(flags, kFlutterSemanticsFlagHasExpandedState) &&
-                  Has(flags, kFlutterSemanticsFlagIsExpanded);
-  spec.checked = Has(flags, kFlutterSemanticsFlagHasCheckedState) &&
-                 Has(flags, kFlutterSemanticsFlagIsChecked);
-  spec.checked_mixed = Has(flags, kFlutterSemanticsFlagIsCheckStateMixed);
-  spec.toggled = Has(flags, kFlutterSemanticsFlagHasToggledState) &&
-                 Has(flags, kFlutterSemanticsFlagIsToggled);
-  spec.live = Has(flags, kFlutterSemanticsFlagIsLiveRegion);
-  spec.focusable = Has(flags, kFlutterSemanticsFlagIsFocusable);
-  spec.focused = Has(flags, kFlutterSemanticsFlagIsFocused);
+  spec.disabled = flags.has_enabled_state && !flags.is_enabled;
+  spec.hidden = flags.is_hidden;
+  spec.read_only = flags.is_read_only;
+  spec.selected = flags.is_selected;
+  spec.expanded = flags.has_expanded_state && flags.is_expanded;
+  spec.checked = flags.has_checked_state && flags.is_checked;
+  spec.checked_mixed = flags.is_check_state_mixed;
+  spec.toggled = flags.has_toggled_state && flags.is_toggled;
+  spec.live = flags.is_live_region;
+  spec.focusable = flags.is_focusable;
+  spec.focused = flags.is_focused;
+  spec.required = flags.is_required;
+  spec.a11y_focus_blocked = flags.is_accessibility_focus_blocked;
 
   spec.action_tap = Has(actions, kFlutterSemanticsActionTap);
   spec.action_long_press = Has(actions, kFlutterSemanticsActionLongPress);
@@ -124,8 +241,33 @@ NodeSpec Translate(int32_t id,
       Has(actions, kFlutterSemanticsActionShowOnScreen);
   spec.action_set_text = Has(actions, kFlutterSemanticsActionSetText);
   spec.action_focus = Has(actions, kFlutterSemanticsActionFocus);
+  spec.action_scroll_to_offset =
+      Has(actions, kFlutterSemanticsActionScrollToOffset);
+  spec.action_expand = Has(actions, kFlutterSemanticsActionExpand);
+  spec.action_collapse = Has(actions, kFlutterSemanticsActionCollapse);
 
   return spec;
+}
+
+}  // namespace
+
+NodeSpec Translate(int32_t id,
+                   const FlutterSemanticsFlags* flags,
+                   FlutterSemanticsFlag legacy_flags,
+                   FlutterSemanticsAction actions,
+                   bool has_label,
+                   bool has_children) {
+  return TranslateView(
+      id, flags != nullptr ? FromStruct(*flags) : FromLegacy(legacy_flags),
+      actions, has_label, has_children);
+}
+
+NodeSpec Translate(int32_t id,
+                   FlutterSemanticsFlag flags,
+                   FlutterSemanticsAction actions,
+                   bool has_label,
+                   bool has_children) {
+  return TranslateView(id, FromLegacy(flags), actions, has_label, has_children);
 }
 
 }  // namespace accessibility

--- a/shell/accessibility/semantics_translator.cc
+++ b/shell/accessibility/semantics_translator.cc
@@ -16,9 +16,27 @@
 
 #include "semantics_translator.h"
 
+#include <cstddef>
+
 namespace accessibility {
 
 namespace {
+
+// FlutterSemanticsFlags carries its own struct_size, filled in by the engine,
+// and members are appended to it across engine revisions exactly as they are
+// on FlutterSemanticsNode2. A member the engine did not write lies past the
+// end of its allocation, so reading it is an out-of-bounds read.
+//
+// `is_accessibility_focus_blocked` is the only member appended after the
+// oldest engine revision this port supports; everything above it is present in
+// all of them. Any member added later needs the same gate.
+constexpr size_t kA11yFocusBlockedEnd =
+    offsetof(FlutterSemanticsFlags, is_accessibility_focus_blocked) +
+    sizeof(bool);
+
+static_assert(kA11yFocusBlockedEnd <= sizeof(FlutterSemanticsFlags),
+              "is_accessibility_focus_blocked bounds overrun "
+              "FlutterSemanticsFlags");
 
 bool Has(FlutterSemanticsFlag flags, FlutterSemanticsFlag bit) {
   return (static_cast<uint32_t>(flags) & static_cast<uint32_t>(bit)) != 0;
@@ -147,7 +165,11 @@ FlagView FromStruct(const FlutterSemanticsFlags& flags) {
   v.is_focused = flags.is_focused == kFlutterTristateTrue;
 
   v.is_required = flags.is_required == kFlutterTristateTrue;
-  v.is_accessibility_focus_blocked = flags.is_accessibility_focus_blocked;
+  // Appended after this port's oldest supported engine; absent means false,
+  // never a read past the end of what the engine wrote.
+  v.is_accessibility_focus_blocked =
+      flags.struct_size >= kA11yFocusBlockedEnd &&
+      flags.is_accessibility_focus_blocked;
   return v;
 }
 

--- a/shell/accessibility/semantics_translator.h
+++ b/shell/accessibility/semantics_translator.h
@@ -56,17 +56,22 @@ struct NodeSpec {
   Role role = Role::kUnknown;
 
   // States derived from flags.
-  bool disabled = false;       // HasEnabledState && !IsEnabled
+  bool disabled = false;       // enabled state present and not enabled
   bool hidden = false;         // IsHidden
   bool read_only = false;      // IsReadOnly
   bool selected = false;       // IsSelected
-  bool expanded = false;       // HasExpandedState && IsExpanded
-  bool checked = false;        // HasCheckedState && IsChecked
-  bool checked_mixed = false;  // IsCheckStateMixed
-  bool toggled = false;        // HasToggledState && IsToggled
+  bool expanded = false;       // expanded state present and expanded
+  bool checked = false;        // checked state present and checked
+  bool checked_mixed = false;  // checked state is mixed (tristate checkbox)
+  bool toggled = false;        // toggled state present and on
   bool live = false;           // IsLiveRegion
   bool focusable = false;      // IsFocusable
   bool focused = false;        // IsFocused
+
+  // States only the FlutterSemanticsFlags struct can express. Always false
+  // when translated from the legacy enum, which has no equivalent bit.
+  bool required = false;            // input required before form submission
+  bool a11y_focus_blocked = false;  // node blocks accessibility focus
 
   // Actions the AT can invoke, from the action bitmask.
   bool action_tap = false;
@@ -80,12 +85,30 @@ struct NodeSpec {
   bool action_show_on_screen = false;
   bool action_set_text = false;
   bool action_focus = false;
+  bool action_scroll_to_offset = false;
+  bool action_expand = false;
+  bool action_collapse = false;
 };
 
 // Pure translation from a Flutter semantics node's identity + flags + actions
 // to a NodeSpec. `has_label` / `has_children` disambiguate a label-only leaf
 // from a generic container when no stronger role flag matches. Stateless and
 // side-effect free.
+//
+// Preferred form. `flags` is `FlutterSemanticsNode2::flags2`, which the engine
+// may leave null; when it is null the translation falls back to `legacy_flags`
+// (`flags__deprecated__`). The struct is the richer source — its tristates
+// distinguish "property does not apply" from "applies and is false", which the
+// enum could only encode as a pair of bits — so it wins whenever present.
+NodeSpec Translate(int32_t id,
+                   const FlutterSemanticsFlags* flags,
+                   FlutterSemanticsFlag legacy_flags,
+                   FlutterSemanticsAction actions,
+                   bool has_label,
+                   bool has_children);
+
+// Legacy-enum-only overload, equivalent to passing a null `flags`. Retained
+// for callers that have no FlutterSemanticsFlags to hand.
 NodeSpec Translate(int32_t id,
                    FlutterSemanticsFlag flags,
                    FlutterSemanticsAction actions,

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -402,7 +402,15 @@ FlutterEngineResult Engine::SetWindowSize(const size_t height,
       // view_id targeted a non-existent view on every engine past the first, so
       // that engine never scheduled a frame. One engine driving multiple views
       // (FlutterEngineAddView) would use the real per-view ids here.
-      .view_id = 0};
+      .view_id = 0,
+      // The engine gained optional size constraints; this port does not
+      // negotiate them, so declare their absence explicitly rather than
+      // leaving the trailing members to implicit initialization.
+      .has_constraints = false,
+      .min_width_constraint = 0,
+      .min_height_constraint = 0,
+      .max_width_constraint = 0,
+      .max_height_constraint = 0};
 
   if (LibFlutterEngine->SendWindowMetricsEvent(m_flutter_engine, &fwme) !=
       kSuccess) {
@@ -470,7 +478,15 @@ FlutterEngineResult Engine::AddView(const int64_t view_id,
       .physical_view_inset_bottom = 0,
       .physical_view_inset_left = 0,
       .display_id = display_id,
-      .view_id = view_id};
+      .view_id = view_id,
+      // The engine gained optional size constraints; this port does not
+      // negotiate them, so declare their absence explicitly rather than
+      // leaving the trailing members to implicit initialization.
+      .has_constraints = false,
+      .min_width_constraint = 0,
+      .min_height_constraint = 0,
+      .max_width_constraint = 0,
+      .max_height_constraint = 0};
   const FlutterAddViewInfo info = {
       .struct_size = sizeof(FlutterAddViewInfo),
       .view_id = view_id,
@@ -523,7 +539,15 @@ FlutterEngineResult Engine::SetPixelRatio(double pixel_ratio) {
       // view_id targeted a non-existent view on every engine past the first, so
       // that engine never scheduled a frame. One engine driving multiple views
       // (FlutterEngineAddView) would use the real per-view ids here.
-      .view_id = 0};
+      .view_id = 0,
+      // The engine gained optional size constraints; this port does not
+      // negotiate them, so declare their absence explicitly rather than
+      // leaving the trailing members to implicit initialization.
+      .has_constraints = false,
+      .min_width_constraint = 0,
+      .min_height_constraint = 0,
+      .max_width_constraint = 0,
+      .max_height_constraint = 0};
 
   const auto result =
       LibFlutterEngine->SendWindowMetricsEvent(m_flutter_engine, &fwme);

--- a/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
+++ b/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
@@ -16,9 +16,13 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <fstream>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <rapidjson/document.h>
 
 #include "gtest/gtest.h"
 
@@ -34,6 +38,7 @@ struct NodeBuilder {
   FlutterSemanticsNode2 node{};
   std::string label;
   std::vector<int32_t> children;
+  std::vector<int32_t> custom_action_ids;
 
   NodeBuilder(int32_t id, std::vector<int32_t> kids, std::string lbl) {
     label = std::move(lbl);
@@ -53,16 +58,46 @@ struct NodeBuilder {
         children.empty() ? nullptr : children.data();
     node.children_in_hit_test_order = node.children_in_traversal_order;
   }
+
+  // Points the node at an owned custom-action ID array, mirroring how the
+  // embedder hands over a borrowed array the tree must copy.
+  void WithCustomActions(std::vector<int32_t> ids) {
+    custom_action_ids = std::move(ids);
+    node.custom_accessibility_actions_count = custom_action_ids.size();
+    node.custom_accessibility_actions =
+        custom_action_ids.empty() ? nullptr : custom_action_ids.data();
+  }
 };
 
-// Drives HandleFlutterUpdate from a set of already-built nodes.
-void Apply(AccessibilityTree& tree, std::vector<FlutterSemanticsNode2*> nodes) {
+// Owns the backing strings for a FlutterSemanticsCustomAction2, for the same
+// reason NodeBuilder owns the node's: the embedder's pointers are transient.
+struct CustomActionBuilder {
+  FlutterSemanticsCustomAction2 action{};
+  std::string label;
+  std::string hint;
+
+  CustomActionBuilder(int32_t id, std::string lbl, std::string hnt) {
+    label = std::move(lbl);
+    hint = std::move(hnt);
+    action.struct_size = sizeof(FlutterSemanticsCustomAction2);
+    action.id = id;
+    action.override_action = static_cast<FlutterSemanticsAction>(0);
+    action.label = label.c_str();
+    action.hint = hint.c_str();
+  }
+};
+
+// Drives HandleFlutterUpdate from a set of already-built nodes and custom
+// action declarations.
+void Apply(AccessibilityTree& tree,
+           std::vector<FlutterSemanticsNode2*> nodes,
+           std::vector<FlutterSemanticsCustomAction2*> actions = {}) {
   FlutterSemanticsUpdate2 update{};
   update.struct_size = sizeof(FlutterSemanticsUpdate2);
   update.node_count = nodes.size();
   update.nodes = nodes.data();
-  update.custom_action_count = 0;
-  update.custom_actions = nullptr;
+  update.custom_action_count = actions.size();
+  update.custom_actions = actions.empty() ? nullptr : actions.data();
   tree.HandleFlutterUpdate(&update);
 }
 
@@ -186,4 +221,312 @@ TEST_F(AccessibilityTreeTest,
   EXPECT_EQ(tree.NumberOfNodes(), 1);
   EXPECT_EQ(FindById(tree, 1), nullptr);
   EXPECT_EQ(tree.GetFocusedNode(), 0);  // focus fell back to root
+}
+
+// The action bitmask is retained verbatim, and HasAction() tests single bits
+// against it. Without this the node cannot say which verbs a caller may invoke.
+TEST_F(AccessibilityTreeTest, RetainsActionBitmask) {
+  NodeBuilder slider(0, {}, "Volume");
+  slider.node.actions = static_cast<FlutterSemanticsAction>(
+      kFlutterSemanticsActionIncrease | kFlutterSemanticsActionDecrease);
+
+  AccessibilityNode node(slider.node);
+  EXPECT_EQ(static_cast<uint32_t>(node.GetActions()),
+            static_cast<uint32_t>(kFlutterSemanticsActionIncrease |
+                                  kFlutterSemanticsActionDecrease));
+  EXPECT_TRUE(node.HasAction(kFlutterSemanticsActionIncrease));
+  EXPECT_TRUE(node.HasAction(kFlutterSemanticsActionDecrease));
+  EXPECT_FALSE(node.HasAction(kFlutterSemanticsActionTap));
+}
+
+// HasAction() requires every requested bit, so a caller can test a combination
+// without it passing on a partial match.
+TEST_F(AccessibilityTreeTest, HasActionRequiresAllRequestedBits) {
+  NodeBuilder builder(0, {}, "partial");
+  builder.node.actions = kFlutterSemanticsActionIncrease;
+
+  const AccessibilityNode node(builder.node);
+  EXPECT_FALSE(node.HasAction(static_cast<FlutterSemanticsAction>(
+      kFlutterSemanticsActionIncrease | kFlutterSemanticsActionDecrease)));
+}
+
+// The node-to-parent transform is retained: parent-local bounds are not
+// comparable across the tree without it.
+TEST_F(AccessibilityTreeTest, RetainsTransform) {
+  NodeBuilder builder(0, {}, "root");
+  builder.node.transform = {2.0, 0.0, 30.0, 0.0, 4.0, 50.0, 0.0, 0.0, 1.0};
+
+  const AccessibilityNode node(builder.node);
+  EXPECT_DOUBLE_EQ(node.GetTransform().scaleX, 2.0);
+  EXPECT_DOUBLE_EQ(node.GetTransform().scaleY, 4.0);
+  EXPECT_DOUBLE_EQ(node.GetTransform().transX, 30.0);
+  EXPECT_DOUBLE_EQ(node.GetTransform().transY, 50.0);
+  EXPECT_DOUBLE_EQ(node.GetTransform().pers2, 1.0);
+}
+
+// A custom action batch is resolved into the tree's declaration table and the
+// referencing node keeps the IDs. Previously the batch was iterated and
+// discarded, so custom actions were invisible to every consumer.
+TEST_F(AccessibilityTreeTest, ResolvesCustomActionsAgainstDeclarations) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {}, "root");
+  root.WithCustomActions({3, 7});
+  CustomActionBuilder sync(3, "Sync zones", "Copies the driver setting");
+  CustomActionBuilder reset(7, "Reset", "");
+  Apply(tree, {&root.node}, {&sync.action, &reset.action});
+
+  const AccessibilityNode* node = FindById(tree, 0);
+  ASSERT_NE(node, nullptr);
+  ASSERT_EQ(node->NumberOfCustomActions(), 2u);
+  EXPECT_EQ(node->GetCustomActionId(0), 3);
+  EXPECT_EQ(node->GetCustomActionId(1), 7);
+  EXPECT_EQ(node->GetCustomActionId(2), -1);   // out of bounds
+  EXPECT_EQ(node->GetCustomActionId(-1), -1);  // out of bounds
+
+  EXPECT_EQ(tree.NumberOfCustomActions(), 2u);
+  const AccessibilityCustomAction* action = tree.FindCustomAction(3);
+  ASSERT_NE(action, nullptr);
+  EXPECT_EQ(action->id, 3);
+  EXPECT_EQ(action->label, "Sync zones");
+  EXPECT_EQ(action->hint, "Copies the driver setting");
+  EXPECT_EQ(tree.FindCustomAction(99), nullptr);  // never declared
+}
+
+// The declaration's strings are owned, like the node text: the embedder frees
+// its buffers when the update callback returns.
+TEST_F(AccessibilityTreeTest, CustomActionStringsSurviveSourceDestruction) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {}, "root");
+  {
+    CustomActionBuilder sync(3, "Sync zones", "Copies the driver setting");
+    Apply(tree, {&root.node}, {&sync.action});
+  }  // the embedder's backing strings are gone from here on
+
+  const AccessibilityCustomAction* action = tree.FindCustomAction(3);
+  ASSERT_NE(action, nullptr);
+  EXPECT_EQ(action->label, "Sync zones");
+  EXPECT_EQ(action->hint, "Copies the driver setting");
+}
+
+// A null label or hint on a declaration coalesces to empty rather than being
+// fed to std::string(nullptr) (undefined behavior), matching the node text.
+TEST_F(AccessibilityTreeTest, CustomActionNullStringsCoalesceToEmpty) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {}, "root");
+  CustomActionBuilder bare(4, "", "");
+  bare.action.label = nullptr;
+  bare.action.hint = nullptr;
+  Apply(tree, {&root.node}, {&bare.action});
+
+  const AccessibilityCustomAction* action = tree.FindCustomAction(4);
+  ASSERT_NE(action, nullptr);
+  EXPECT_EQ(action->label, "");
+  EXPECT_EQ(action->hint, "");
+}
+
+// A null entry inside the declaration array is skipped rather than
+// dereferenced, and does not abort the rest of the batch.
+TEST_F(AccessibilityTreeTest, NullCustomActionEntryIsSkipped) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {}, "root");
+  CustomActionBuilder sync(3, "Sync zones", "");
+  Apply(tree, {&root.node}, {nullptr, &sync.action});
+
+  EXPECT_EQ(tree.NumberOfCustomActions(), 1u);
+  ASSERT_NE(tree.FindCustomAction(3), nullptr);
+}
+
+// Custom action IDs follow the same replace-don't-append rule as children: an
+// action the application withdraws from a node must not linger on it.
+TEST_F(AccessibilityTreeTest, UpdateReplacesNodeCustomActions) {
+  AccessibilityTree tree;
+  NodeBuilder root1(0, {}, "root");
+  root1.WithCustomActions({3, 7});
+  CustomActionBuilder sync(3, "Sync zones", "");
+  CustomActionBuilder reset(7, "Reset", "");
+  Apply(tree, {&root1.node}, {&sync.action, &reset.action});
+  ASSERT_EQ(FindById(tree, 0)->NumberOfCustomActions(), 2u);
+
+  NodeBuilder root2(0, {}, "root");
+  root2.WithCustomActions({7});
+  Apply(tree, {&root2.node});
+  const AccessibilityNode* node = FindById(tree, 0);
+  ASSERT_EQ(node->NumberOfCustomActions(), 1u);
+  EXPECT_EQ(node->GetCustomActionId(0), 7);
+}
+
+// Declarations deliberately outlive the nodes that reference them: Flutter
+// assigns a custom action its ID once and may declare it in an earlier batch
+// than the node that uses it, so dropping an unreferenced entry would lose it
+// permanently.
+TEST_F(AccessibilityTreeTest, CustomActionDeclarationsSurviveNodePruning) {
+  AccessibilityTree tree;
+  NodeBuilder root1(0, {1}, "root");
+  NodeBuilder child(1, {}, "child");
+  child.WithCustomActions({3});
+  CustomActionBuilder sync(3, "Sync zones", "");
+  Apply(tree, {&root1.node, &child.node}, {&sync.action});
+  ASSERT_EQ(tree.NumberOfCustomActions(), 1u);
+
+  // Detach the only node that referenced the action.
+  NodeBuilder root2(0, {}, "root");
+  Apply(tree, {&root2.node});
+  ASSERT_EQ(FindById(tree, 1), nullptr);
+  EXPECT_EQ(tree.NumberOfCustomActions(), 1u);
+  ASSERT_NE(tree.FindCustomAction(3), nullptr);
+}
+
+// Re-declaring an ID refreshes the label and hint in place rather than
+// accumulating a second entry.
+TEST_F(AccessibilityTreeTest, RedeclaringCustomActionReplacesIt) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {}, "root");
+  CustomActionBuilder before(3, "Sync zones", "old");
+  Apply(tree, {&root.node}, {&before.action});
+  CustomActionBuilder after(3, "Sync all zones", "new");
+  Apply(tree, {&root.node}, {&after.action});
+
+  EXPECT_EQ(tree.NumberOfCustomActions(), 1u);
+  const AccessibilityCustomAction* action = tree.FindCustomAction(3);
+  ASSERT_NE(action, nullptr);
+  EXPECT_EQ(action->label, "Sync all zones");
+  EXPECT_EQ(action->hint, "new");
+}
+
+// Role and states now come from accessibility::Translate() rather than an
+// inline flag check, so the node reports the full derived role.
+TEST_F(AccessibilityTreeTest, SpecIsDerivedThroughTheTranslator) {
+  NodeBuilder field(5, {}, "Name");
+  field.node.flags = static_cast<FlutterSemanticsFlag>(
+      kFlutterSemanticsFlagIsTextField | kFlutterSemanticsFlagHasEnabledState);
+  field.node.actions = kFlutterSemanticsActionSetText;
+
+  const AccessibilityNode node(field.node);
+  EXPECT_EQ(node.GetSpec().role, accessibility::Role::kTextInput);
+  EXPECT_TRUE(node.GetSpec().disabled);  // HasEnabledState && !IsEnabled
+  EXPECT_TRUE(node.GetSpec().action_set_text);
+  EXPECT_FALSE(node.GetSpec().action_tap);
+}
+
+// Translate() distinguishes a label-only leaf from a generic container, so the
+// spec must be derived after the label and children have been refreshed.
+TEST_F(AccessibilityTreeTest, SpecReflectsRefreshedLabelAndChildren) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {1}, "root");
+  NodeBuilder leaf(1, {}, "Now playing");
+  Apply(tree, {&root.node, &leaf.node});
+  ASSERT_EQ(FindById(tree, 1)->GetSpec().role, accessibility::Role::kLabel);
+
+  // Re-send the same node with a child: it is a container now, not a label.
+  NodeBuilder branch(1, {2}, "Now playing");
+  NodeBuilder grandchild(2, {}, "");
+  NodeBuilder root2(0, {1}, "root");
+  Apply(tree, {&root2.node, &branch.node, &grandchild.node});
+  EXPECT_EQ(FindById(tree, 1)->GetSpec().role,
+            accessibility::Role::kGenericContainer);
+}
+
+// GetRole() still reports the numeric encoding the AccessKit bridge consumes.
+// Only window and button have a SemanticRole constant; every other derived
+// role collapses to unknown, which is what this node reported before roles
+// were derived through the translator.
+TEST_F(AccessibilityTreeTest, GetRoleMapsOnlyWindowAndButton) {
+  NodeBuilder root(0, {}, "root");
+  EXPECT_EQ(AccessibilityNode(root.node).GetRole(), SEMANTIC_ROLE_WINDOW);
+
+  NodeBuilder button(1, {}, "Play");
+  button.node.flags = kFlutterSemanticsFlagIsButton;
+  const AccessibilityNode button_node(button.node);
+  EXPECT_EQ(button_node.GetRole(), SEMANTIC_ROLE_BUTTON);
+  EXPECT_EQ(button_node.GetSpec().role, accessibility::Role::kButton);
+
+  NodeBuilder slider(2, {}, "Volume");
+  slider.node.flags = kFlutterSemanticsFlagIsSlider;
+  const AccessibilityNode slider_node(slider.node);
+  EXPECT_EQ(slider_node.GetRole(), SEMANTIC_ROLE_UNKNOWN);
+  EXPECT_EQ(slider_node.GetSpec().role, accessibility::Role::kSlider);
+}
+
+// The dump is the only way to inspect a running shell's tree, so the retained
+// fields have to reach it — a field kept on the node but omitted here is
+// invisible in the field.
+TEST_F(AccessibilityTreeTest, DumpTreeEmitsActionsTransformAndCustomActions) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {}, "root");
+  root.node.actions = static_cast<FlutterSemanticsAction>(
+      kFlutterSemanticsActionIncrease | kFlutterSemanticsActionDecrease);
+  root.node.transform = {2.0, 0.0, 30.0, 0.0, 4.0, 50.0, 0.0, 0.0, 1.0};
+  root.WithCustomActions({3});
+  CustomActionBuilder sync(3, "Sync zones", "Copies the driver setting");
+  Apply(tree, {&root.node}, {&sync.action});
+
+  const std::string target =
+      std::string(TEST_SCRATCH_DIR) + "/dump_tree_enriched.json";
+  tree.DumpTree(target.c_str());
+
+  std::ifstream ifs(target);
+  ASSERT_TRUE(ifs.is_open());
+  const std::string json((std::istreambuf_iterator<char>(ifs)),
+                         std::istreambuf_iterator<char>());
+
+  rapidjson::Document doc;
+  ASSERT_FALSE(doc.Parse(json.c_str()).HasParseError());
+  ASSERT_TRUE(doc.HasMember("nodes"));
+  ASSERT_EQ(doc["nodes"].Size(), 1u);
+  const rapidjson::Value& node = doc["nodes"][0];
+
+  // 1 << 6 | 1 << 7 — the increase/decrease bits, emitted as the raw mask.
+  ASSERT_TRUE(node.HasMember("actions"));
+  EXPECT_EQ(node["actions"].GetInt(), (1 << 6) | (1 << 7));
+
+  ASSERT_TRUE(node.HasMember("transform"));
+  EXPECT_DOUBLE_EQ(node["transform"]["scaleX"].GetDouble(), 2.0);
+  EXPECT_DOUBLE_EQ(node["transform"]["transY"].GetDouble(), 50.0);
+
+  ASSERT_TRUE(node.HasMember("custom_actions"));
+  ASSERT_EQ(node["custom_actions"].Size(), 1u);
+  EXPECT_EQ(node["custom_actions"][0].GetInt(), 3);
+
+  // The declarations are emitted once at the top level, not per node.
+  ASSERT_TRUE(doc.HasMember("custom_actions"));
+  ASSERT_EQ(doc["custom_actions"].Size(), 1u);
+  EXPECT_EQ(doc["custom_actions"][0]["id"].GetInt(), 3);
+  EXPECT_STREQ(doc["custom_actions"][0]["label"].GetString(), "Sync zones");
+  EXPECT_STREQ(doc["custom_actions"][0]["hint"].GetString(),
+               "Copies the driver setting");
+}
+
+// The declarations live in an unordered_map, so the dump sorts them by ID.
+// Without that, two dumps of the same tree can differ only in ordering and
+// cannot be compared.
+TEST_F(AccessibilityTreeTest, DumpTreeEmitsCustomActionsInIdOrder) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {}, "root");
+  root.WithCustomActions({9, 1, 5});
+  CustomActionBuilder c9(9, "nine", "");
+  CustomActionBuilder c1(1, "one", "");
+  CustomActionBuilder c5(5, "five", "");
+  Apply(tree, {&root.node}, {&c9.action, &c1.action, &c5.action});
+
+  const std::string target =
+      std::string(TEST_SCRATCH_DIR) + "/dump_tree_action_order.json";
+  tree.DumpTree(target.c_str());
+
+  std::ifstream ifs(target);
+  ASSERT_TRUE(ifs.is_open());
+  const std::string json((std::istreambuf_iterator<char>(ifs)),
+                         std::istreambuf_iterator<char>());
+
+  rapidjson::Document doc;
+  ASSERT_FALSE(doc.Parse(json.c_str()).HasParseError());
+  ASSERT_EQ(doc["custom_actions"].Size(), 3u);
+  EXPECT_EQ(doc["custom_actions"][0]["id"].GetInt(), 1);
+  EXPECT_EQ(doc["custom_actions"][1]["id"].GetInt(), 5);
+  EXPECT_EQ(doc["custom_actions"][2]["id"].GetInt(), 9);
+
+  // The per-node ID list keeps the order the application declared it in.
+  ASSERT_EQ(doc["nodes"][0]["custom_actions"].Size(), 3u);
+  EXPECT_EQ(doc["nodes"][0]["custom_actions"][0].GetInt(), 9);
+  EXPECT_EQ(doc["nodes"][0]["custom_actions"][1].GetInt(), 1);
+  EXPECT_EQ(doc["nodes"][0]["custom_actions"][2].GetInt(), 5);
 }

--- a/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
+++ b/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <fstream>
 #include <iterator>
 #include <memory>
@@ -37,15 +39,17 @@ namespace {
 struct NodeBuilder {
   FlutterSemanticsNode2 node{};
   std::string label;
+  std::string identifier;
   std::vector<int32_t> children;
   std::vector<int32_t> custom_action_ids;
+  FlutterSemanticsFlags flags2{};
 
   NodeBuilder(int32_t id, std::vector<int32_t> kids, std::string lbl) {
     label = std::move(lbl);
     children = std::move(kids);
     node.struct_size = sizeof(FlutterSemanticsNode2);
     node.id = id;
-    node.flags = static_cast<FlutterSemanticsFlag>(0);
+    node.flags__deprecated__ = static_cast<FlutterSemanticsFlag>(0);
     node.actions = static_cast<FlutterSemanticsAction>(0);
     node.label = label.c_str();
     node.hint = "";
@@ -53,6 +57,10 @@ struct NodeBuilder {
     node.increased_value = "";
     node.decreased_value = "";
     node.tooltip = "";
+    node.identifier = "";
+    // Default to the legacy path: the engine only populates flags2 on newer
+    // revisions, and Update() must stay correct when it is absent.
+    node.flags2 = nullptr;
     node.child_count = children.size();
     node.children_in_traversal_order =
         children.empty() ? nullptr : children.data();
@@ -66,6 +74,21 @@ struct NodeBuilder {
     node.custom_accessibility_actions_count = custom_action_ids.size();
     node.custom_accessibility_actions =
         custom_action_ids.empty() ? nullptr : custom_action_ids.data();
+  }
+
+  // Points the node at an owned identifier string, as the embedder does.
+  void WithIdentifier(std::string id) {
+    identifier = std::move(id);
+    node.identifier = identifier.c_str();
+  }
+
+  // Opts this node into the FlutterSemanticsFlags struct, returning it for
+  // field assignment. struct_size is set so the node looks like a newer
+  // engine's output.
+  FlutterSemanticsFlags& WithFlags2() {
+    flags2.struct_size = sizeof(FlutterSemanticsFlags);
+    node.flags2 = &flags2;
+    return flags2;
   }
 };
 
@@ -131,7 +154,7 @@ TEST_F(AccessibilityTreeTest, LabelSurvivesSourceBufferDestruction) {
   FlutterSemanticsNode2 fl{};
   fl.struct_size = sizeof(FlutterSemanticsNode2);
   fl.id = 0;
-  fl.flags = static_cast<FlutterSemanticsFlag>(0);
+  fl.flags__deprecated__ = static_cast<FlutterSemanticsFlag>(0);
   fl.actions = static_cast<FlutterSemanticsAction>(0);
   fl.label = source->c_str();
   fl.hint = "";
@@ -152,7 +175,7 @@ TEST_F(AccessibilityTreeTest, NullStringsCoalesceToEmpty) {
   FlutterSemanticsNode2 fl{};
   fl.struct_size = sizeof(FlutterSemanticsNode2);
   fl.id = 7;
-  fl.flags = static_cast<FlutterSemanticsFlag>(0);
+  fl.flags__deprecated__ = static_cast<FlutterSemanticsFlag>(0);
   fl.actions = static_cast<FlutterSemanticsAction>(0);
   fl.label = nullptr;
   fl.hint = nullptr;
@@ -210,7 +233,7 @@ TEST_F(AccessibilityTreeTest,
   AccessibilityTree tree;
   NodeBuilder root1(0, {1}, "root");
   NodeBuilder child(1, {}, "child");
-  child.node.flags = kFlutterSemanticsFlagIsFocused;
+  child.node.flags__deprecated__ = kFlutterSemanticsFlagIsFocused;
   Apply(tree, {&root1.node, &child.node});
   ASSERT_EQ(tree.NumberOfNodes(), 2);
   ASSERT_EQ(tree.GetFocusedNode(), 1);
@@ -397,7 +420,7 @@ TEST_F(AccessibilityTreeTest, RedeclaringCustomActionReplacesIt) {
 // inline flag check, so the node reports the full derived role.
 TEST_F(AccessibilityTreeTest, SpecIsDerivedThroughTheTranslator) {
   NodeBuilder field(5, {}, "Name");
-  field.node.flags = static_cast<FlutterSemanticsFlag>(
+  field.node.flags__deprecated__ = static_cast<FlutterSemanticsFlag>(
       kFlutterSemanticsFlagIsTextField | kFlutterSemanticsFlagHasEnabledState);
   field.node.actions = kFlutterSemanticsActionSetText;
 
@@ -435,13 +458,13 @@ TEST_F(AccessibilityTreeTest, GetRoleMapsOnlyWindowAndButton) {
   EXPECT_EQ(AccessibilityNode(root.node).GetRole(), SEMANTIC_ROLE_WINDOW);
 
   NodeBuilder button(1, {}, "Play");
-  button.node.flags = kFlutterSemanticsFlagIsButton;
+  button.node.flags__deprecated__ = kFlutterSemanticsFlagIsButton;
   const AccessibilityNode button_node(button.node);
   EXPECT_EQ(button_node.GetRole(), SEMANTIC_ROLE_BUTTON);
   EXPECT_EQ(button_node.GetSpec().role, accessibility::Role::kButton);
 
   NodeBuilder slider(2, {}, "Volume");
-  slider.node.flags = kFlutterSemanticsFlagIsSlider;
+  slider.node.flags__deprecated__ = kFlutterSemanticsFlagIsSlider;
   const AccessibilityNode slider_node(slider.node);
   EXPECT_EQ(slider_node.GetRole(), SEMANTIC_ROLE_UNKNOWN);
   EXPECT_EQ(slider_node.GetSpec().role, accessibility::Role::kSlider);
@@ -457,6 +480,7 @@ TEST_F(AccessibilityTreeTest, DumpTreeEmitsActionsTransformAndCustomActions) {
       kFlutterSemanticsActionIncrease | kFlutterSemanticsActionDecrease);
   root.node.transform = {2.0, 0.0, 30.0, 0.0, 4.0, 50.0, 0.0, 0.0, 1.0};
   root.WithCustomActions({3});
+  root.WithIdentifier("hvac.temp.driver");
   CustomActionBuilder sync(3, "Sync zones", "Copies the driver setting");
   Apply(tree, {&root.node}, {&sync.action});
 
@@ -474,6 +498,9 @@ TEST_F(AccessibilityTreeTest, DumpTreeEmitsActionsTransformAndCustomActions) {
   ASSERT_TRUE(doc.HasMember("nodes"));
   ASSERT_EQ(doc["nodes"].Size(), 1u);
   const rapidjson::Value& node = doc["nodes"][0];
+
+  ASSERT_TRUE(node.HasMember("identifier"));
+  EXPECT_STREQ(node["identifier"].GetString(), "hvac.temp.driver");
 
   // 1 << 6 | 1 << 7 — the increase/decrease bits, emitted as the raw mask.
   ASSERT_TRUE(node.HasMember("actions"));
@@ -494,6 +521,148 @@ TEST_F(AccessibilityTreeTest, DumpTreeEmitsActionsTransformAndCustomActions) {
   EXPECT_STREQ(doc["custom_actions"][0]["label"].GetString(), "Sync zones");
   EXPECT_STREQ(doc["custom_actions"][0]["hint"].GetString(),
                "Copies the driver setting");
+}
+
+// The application-assigned identifier is retained, owned, and null-safe — it
+// is the addressing key that survives tree rebuilds, unlike `id`.
+TEST_F(AccessibilityTreeTest, RetainsIdentifier) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {}, "root");
+  {
+    NodeBuilder scoped(0, {}, "root");
+    scoped.WithIdentifier("hvac.temp.driver");
+    Apply(tree, {&scoped.node});
+  }  // the embedder's backing string is gone from here on
+
+  const AccessibilityNode* node = FindById(tree, 0);
+  ASSERT_NE(node, nullptr);
+  EXPECT_STREQ(node->GetIdentifier(), "hvac.temp.driver");
+
+  // Unannotated and explicitly-null both coalesce to empty, never a null deref.
+  NodeBuilder bare(1, {}, "bare");
+  EXPECT_STREQ(AccessibilityNode(bare.node).GetIdentifier(), "");
+  bare.node.identifier = nullptr;
+  EXPECT_STREQ(AccessibilityNode(bare.node).GetIdentifier(), "");
+}
+
+// An identifier the application withdraws must not linger on the node.
+TEST_F(AccessibilityTreeTest, UpdateReplacesIdentifier) {
+  AccessibilityTree tree;
+  NodeBuilder before(0, {}, "root");
+  before.WithIdentifier("old.id");
+  Apply(tree, {&before.node});
+  ASSERT_STREQ(FindById(tree, 0)->GetIdentifier(), "old.id");
+
+  NodeBuilder after(0, {}, "root");
+  Apply(tree, {&after.node});
+  EXPECT_STREQ(FindById(tree, 0)->GetIdentifier(), "");
+}
+
+// When the engine supplies FlutterSemanticsFlags it is authoritative, even
+// where it disagrees with the deprecated enum bitmask on the same node.
+TEST_F(AccessibilityTreeTest, Flags2WinsOverLegacyEnum) {
+  NodeBuilder builder(1, {}, "control");
+  builder.node.flags__deprecated__ = kFlutterSemanticsFlagIsButton;
+  builder.WithFlags2().is_slider = true;
+
+  const AccessibilityNode node(builder.node);
+  EXPECT_EQ(node.GetSpec().role, accessibility::Role::kSlider);
+}
+
+// Tristates carry information the enum could not: "applies and is false" is
+// distinct from "does not apply". A node explicitly reported as not-enabled is
+// disabled; one where enablement does not apply is not.
+TEST_F(AccessibilityTreeTest, Flags2TristatesDistinguishAbsentFromFalse) {
+  NodeBuilder disabled(1, {}, "Save");
+  FlutterSemanticsFlags& d = disabled.WithFlags2();
+  d.is_button = true;
+  d.is_enabled = kFlutterTristateFalse;
+  EXPECT_TRUE(AccessibilityNode(disabled.node).GetSpec().disabled);
+
+  NodeBuilder inapplicable(2, {}, "Label");
+  FlutterSemanticsFlags& i = inapplicable.WithFlags2();
+  i.is_enabled = kFlutterTristateNone;
+  EXPECT_FALSE(AccessibilityNode(inapplicable.node).GetSpec().disabled);
+
+  // Mixed check state arrives as its own value rather than a companion bit.
+  NodeBuilder mixed(3, {}, "Select all");
+  mixed.WithFlags2().is_checked = kFlutterCheckStateMixed;
+  const AccessibilityNode mixed_node(mixed.node);
+  EXPECT_EQ(mixed_node.GetSpec().role, accessibility::Role::kCheckBox);
+  EXPECT_TRUE(mixed_node.GetSpec().checked_mixed);
+  EXPECT_FALSE(mixed_node.GetSpec().checked);
+}
+
+// A null flags2 (older engine) must still translate, via the deprecated enum.
+TEST_F(AccessibilityTreeTest, NullFlags2FallsBackToLegacyEnum) {
+  NodeBuilder builder(1, {}, "Play");
+  builder.node.flags2 = nullptr;
+  builder.node.flags__deprecated__ = kFlutterSemanticsFlagIsButton;
+
+  EXPECT_EQ(AccessibilityNode(builder.node).GetSpec().role,
+            accessibility::Role::kButton);
+}
+
+// Focus tracking reads the derived spec, so it follows flags2 when present
+// rather than only the deprecated bitmask.
+TEST_F(AccessibilityTreeTest, FocusTrackedThroughFlags2) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {1}, "root");
+  NodeBuilder child(1, {}, "child");
+  child.WithFlags2().is_focused = kFlutterTristateTrue;
+  Apply(tree, {&root.node, &child.node});
+
+  EXPECT_EQ(tree.GetFocusedNode(), 1);
+}
+
+// An engine older than this header writes a shorter FlutterSemanticsNode2 and
+// reports that length in struct_size. Members appended after that point are
+// past the end of its allocation, so they must not be read at all — under ASan
+// this test fails outright if the struct_size gate is dropped.
+//
+// The node is placed at the very end of a heap allocation sized to the *old*
+// struct, so any read past it is a genuine out-of-bounds access rather than a
+// read of adjacent live memory that happens to look fine.
+TEST_F(AccessibilityTreeTest, OlderEngineStructSizeIsNotReadPast) {
+  constexpr size_t kOldSize = offsetof(FlutterSemanticsNode2, flags2);
+  ASSERT_LT(kOldSize, sizeof(FlutterSemanticsNode2))
+      << "flags2/identifier must be appended members for this test to mean "
+         "anything";
+
+  auto storage = std::make_unique<unsigned char[]>(kOldSize);
+  std::memset(storage.get(), 0, kOldSize);
+  auto* fl = reinterpret_cast<FlutterSemanticsNode2*>(storage.get());
+  fl->struct_size = kOldSize;  // engine predating flags2 and identifier
+  fl->id = 3;
+  fl->flags__deprecated__ = kFlutterSemanticsFlagIsButton;
+  fl->actions = kFlutterSemanticsActionTap;
+  fl->label = "Play";
+  fl->hint = "";
+  fl->value = "";
+  fl->tooltip = "";
+
+  const AccessibilityNode node(*fl);
+  EXPECT_EQ(node.GetId(), 3);
+  EXPECT_STREQ(node.GetLabel(), "Play");
+  EXPECT_STREQ(node.GetIdentifier(), "");  // absent, not garbage
+  // Role still derives, via the deprecated enum.
+  EXPECT_EQ(node.GetSpec().role, accessibility::Role::kButton);
+  EXPECT_TRUE(node.GetSpec().action_tap);
+}
+
+// Actions added after the enum's original ceiling are retained like any other.
+TEST_F(AccessibilityTreeTest, RetainsActionsAddedAfterLegacyCeiling) {
+  NodeBuilder builder(1, {}, "Details");
+  builder.node.actions = static_cast<FlutterSemanticsAction>(
+      kFlutterSemanticsActionScrollToOffset | kFlutterSemanticsActionExpand |
+      kFlutterSemanticsActionCollapse);
+
+  const AccessibilityNode node(builder.node);
+  EXPECT_TRUE(node.HasAction(kFlutterSemanticsActionScrollToOffset));
+  EXPECT_TRUE(node.GetSpec().action_scroll_to_offset);
+  EXPECT_TRUE(node.GetSpec().action_expand);
+  EXPECT_TRUE(node.GetSpec().action_collapse);
+  EXPECT_FALSE(node.GetSpec().action_tap);
 }
 
 // The declarations live in an unordered_map, so the dump sorts them by ID.

--- a/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
+++ b/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
@@ -650,6 +650,58 @@ TEST_F(AccessibilityTreeTest, OlderEngineStructSizeIsNotReadPast) {
   EXPECT_TRUE(node.GetSpec().action_tap);
 }
 
+// The concrete deployed case, not a synthetic one: the engine revision this
+// port targets writes a FlutterSemanticsNode2 that ends just before
+// `identifier`, but does carry `flags2`. The gate must reject exactly one of
+// the two. Sizing the allocation to that struct turns a mistake in the offset
+// arithmetic into an ASan fault rather than a silently garbage pointer.
+TEST_F(AccessibilityTreeTest, TargetEngineNodeSizeReadsFlags2ButNotIdentifier) {
+  constexpr size_t kTargetSize = offsetof(FlutterSemanticsNode2, identifier);
+  ASSERT_LT(kTargetSize, sizeof(FlutterSemanticsNode2));
+
+  auto storage = std::make_unique<unsigned char[]>(kTargetSize);
+  std::memset(storage.get(), 0, kTargetSize);
+  auto* fl = reinterpret_cast<FlutterSemanticsNode2*>(storage.get());
+  fl->struct_size = kTargetSize;
+  fl->id = 4;
+  fl->label = "Volume";
+  fl->hint = "";
+  fl->value = "";
+  fl->tooltip = "";
+
+  FlutterSemanticsFlags flags{};
+  flags.struct_size = sizeof(FlutterSemanticsFlags);
+  flags.is_slider = true;
+  fl->flags2 = &flags;
+
+  const AccessibilityNode node(*fl);
+  EXPECT_STREQ(node.GetIdentifier(), "");  // past struct_size, not read
+  // flags2 is within struct_size, so it is honored.
+  EXPECT_EQ(node.GetSpec().role, accessibility::Role::kSlider);
+}
+
+// FlutterSemanticsFlags is versioned by struct_size too, and gains members the
+// same way the node does. Reading a member the engine did not write is an
+// out-of-bounds read on the flags allocation rather than the node's.
+TEST_F(AccessibilityTreeTest, ShorterFlags2StructIsNotReadPast) {
+  constexpr size_t kShortFlags =
+      offsetof(FlutterSemanticsFlags, is_accessibility_focus_blocked);
+  ASSERT_LT(kShortFlags, sizeof(FlutterSemanticsFlags));
+
+  auto storage = std::make_unique<unsigned char[]>(kShortFlags);
+  std::memset(storage.get(), 0, kShortFlags);
+  auto* flags = reinterpret_cast<FlutterSemanticsFlags*>(storage.get());
+  flags->struct_size = kShortFlags;
+  flags->is_button = true;
+
+  NodeBuilder builder(1, {}, "Save");
+  builder.node.flags2 = flags;
+
+  const AccessibilityNode node(builder.node);
+  EXPECT_EQ(node.GetSpec().role, accessibility::Role::kButton);
+  EXPECT_FALSE(node.GetSpec().a11y_focus_blocked);  // absent, not garbage
+}
+
 // Actions added after the enum's original ceiling are retained like any other.
 TEST_F(AccessibilityTreeTest, RetainsActionsAddedAfterLegacyCeiling) {
   NodeBuilder builder(1, {}, "Details");

--- a/third_party/flutter/shell/platform/embedder/embedder.h
+++ b/third_party/flutter/shell/platform/embedder/embedder.h
@@ -105,6 +105,15 @@ typedef enum {
   kFlutterAccessibilityFeatureHighContrast = 1 << 5,
   /// Request to show on/off labels inside switches.
   kFlutterAccessibilityFeatureOnOffSwitchLabels = 1 << 6,
+  /// Indicate the platform does not support announcements.
+  kFlutterAccessibilityFeatureNoAnnounce = 1 << 7,
+  /// Indicate the platform disallows auto-playing animated images.
+  kFlutterAccessibilityFeatureNoAutoPlayAnimatedImages = 1 << 8,
+  /// Indicate the platform disallows auto-playing videos.
+  kFlutterAccessibilityFeatureNoAutoPlayVideos = 1 << 9,
+  /// Request to show deterministic (non-blinking) cursor in editable text
+  /// fields.
+  kFlutterAccessibilityFeatureDeterministicCursor = 1 << 10,
 } FlutterAccessibilityFeature;
 
 /// The set of possible actions that can be conveyed to a semantics node.
@@ -164,11 +173,22 @@ typedef enum {
   kFlutterSemanticsActionSetText = 1 << 21,
   /// Request that the respective focusable widget gain input focus.
   kFlutterSemanticsActionFocus = 1 << 22,
+  /// Request that scrolls the current scrollable container to a given scroll
+  /// offset.
+  kFlutterSemanticsActionScrollToOffset = 1 << 23,
+  /// A request that the node should be expanded.
+  kFlutterSemanticsActionExpand = 1 << 24,
+  /// A request that the node should be collapsed.
+  kFlutterSemanticsActionCollapse = 1 << 25,
 } FlutterSemanticsAction;
 
 /// The set of properties that may be associated with a semantics node.
 ///
 /// Must match the `SemanticsFlag` enum in semantics.dart.
+///
+/// @deprecated     Use `FlutterSemanticsFlags` instead. No new flags will
+///                 be added to `FlutterSemanticsFlag`. New flags will
+///                 continue to be added to `FlutterSemanticsFlags`.
 typedef enum {
   /// The semantics node has the quality of either being "checked" or
   /// "unchecked".
@@ -243,7 +263,105 @@ typedef enum {
   kFlutterSemanticsFlagHasExpandedState = 1 << 26,
   /// Whether a semantic node that hasExpandedState is currently expanded.
   kFlutterSemanticsFlagIsExpanded = 1 << 27,
+  /// The semantics node has the quality of either being "selected" or
+  /// "not selected".
+  kFlutterSemanticsFlagHasSelectedState = 1 << 28,
+  /// Whether a semantics node has the quality of being required.
+  kFlutterSemanticsFlagHasRequiredState = 1 << 29,
+  /// Whether user input is required on the semantics node before a form can be
+  /// submitted.
+  ///
+  /// Only applicable when kFlutterSemanticsFlagHasRequiredState flag is on.
+  kFlutterSemanticsFlagIsRequired = 1 << 30,
 } FlutterSemanticsFlag;
+
+typedef enum {
+  /// The property is not applicable to this semantics node.
+  kFlutterTristateNone,
+  /// The property is applicable and its state is "true" or "on".
+  kFlutterTristateTrue,
+  /// The property is applicable and its state is "false" or "off".
+  kFlutterTristateFalse,
+} FlutterTristate;
+
+typedef enum {
+  /// The semantics node does not have check state.
+  kFlutterCheckStateNone,
+  /// The semantics node is checked.
+  kFlutterCheckStateTrue,
+  /// The semantics node is not checked.
+  kFlutterCheckStateFalse,
+  /// The semantics node represents a checkbox in mixed state.
+  kFlutterCheckStateMixed,
+} FlutterCheckState;
+
+typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterSemanticsFlags).
+  size_t struct_size;
+  /// Whether a semantics node is checked.
+  FlutterCheckState is_checked;
+  /// Whether a semantics node is selected.
+  FlutterTristate is_selected;
+  /// Whether a semantic node is currently enabled.
+  FlutterTristate is_enabled;
+  /// If true, the semantics node is "on". If false, the semantics node is
+  /// "off".
+  FlutterTristate is_toggled;
+  /// Whether a semantic node that is currently expanded.
+  FlutterTristate is_expanded;
+  /// Whether user input is required on the semantics node before a form can be
+  /// submitted.
+  FlutterTristate is_required;
+  /// Whether the semantic node currently holds the user's focus.
+  FlutterTristate is_focused;
+  /// Whether the semantic node represents a button.
+  bool is_button;
+  /// Whether the semantic node represents a text field.
+  bool is_text_field;
+  /// Whether a semantic node is in a mutually exclusive group.
+  bool is_in_mutually_exclusive_group;
+  /// Whether a semantic node is a header that divides content into sections.
+  bool is_header;
+  /// Whether the value of the semantics node is obscured.
+  bool is_obscured;
+  /// Whether the semantics node is the root of a subtree for which a route name
+  /// should be announced.
+  bool scopes_route;
+  /// Whether the semantics node label is the name of a visually distinct route.
+  bool names_route;
+  /// Whether the semantics node is considered hidden.
+  bool is_hidden;
+  /// Whether the semantics node represents an image.
+  bool is_image;
+  /// Whether the semantics node is a live region.
+  bool is_live_region;
+  /// Whether the platform can scroll the semantics node when the user attempts
+  /// to move the accessibility focus to an offscreen child.
+  ///
+  /// For example, a `ListView` widget has implicit scrolling so that users can
+  /// easily move the accessibility focus to the next set of children. A
+  /// `PageView` widget does not have implicit scrolling, so that users don't
+  /// navigate to the next page when reaching the end of the current one.
+  bool has_implicit_scrolling;
+  /// Whether the value of the semantics node is coming from a multi-line text
+  /// field.
+  ///
+  /// This is used for text fields to distinguish single-line text fields from
+  /// multi-line ones.
+  bool is_multiline;
+  /// Whether the semantic node is read only.
+  ///
+  /// Only applicable when kFlutterSemanticsFlagIsTextField flag is on.
+  bool is_read_only;
+  /// Whether the semantics node represents a link.
+  bool is_link;
+  /// Whether the semantics node represents a slider.
+  bool is_slider;
+  /// Whether the semantics node represents a keyboard key.
+  bool is_keyboard_key;
+  /// Whether to block a11y focus for the semantics node.
+  bool is_accessibility_focus_blocked;
+} FlutterSemanticsFlags;
 
 typedef enum {
   /// Text has unknown text direction.
@@ -304,6 +422,9 @@ typedef enum {
   /// Specifies an OpenGL frame-buffer target type. Framebuffers are specified
   /// using the FlutterOpenGLFramebuffer struct.
   kFlutterOpenGLTargetTypeFramebuffer,
+  /// Specifies an OpenGL on-screen surface target type. Surfaces are specified
+  /// using the FlutterOpenGLSurface struct.
+  kFlutterOpenGLTargetTypeSurface,
 } FlutterOpenGLTargetType;
 
 /// A pixel format to be used for software rendering.
@@ -318,9 +439,10 @@ typedef enum {
 ///     occupying the lowest memory address.
 ///
 ///   - all other formats are called packed formats, and the component order
-///     as specified in the format name refers to the order in the native type.
-///     for example, for kFlutterSoftwarePixelFormatRGB565, the R component
-///     uses the 5 least significant bits of the uint16_t pixel value.
+///     as specified in the format name refers to the order from most
+///     significant to least significant bits in the native type. for example,
+///     for kFlutterSoftwarePixelFormatRGB565, R occupies the 5 most significant
+///     bits, G the middle 6 bits, and B the 5 least significant bits.
 ///
 /// Each pixel format in this list is documented with an example on how to get
 /// the color components from the pixel.
@@ -333,33 +455,61 @@ typedef enum {
 ///   can get the p for a RGBA8888 formatted buffer like this:
 ///   const uint8_t *p = ((const uint8_t*) allocation) + row_bytes*y + x*4;
 typedef enum {
-  /// pixel with 8 bit grayscale value.
+  /// Pixel with 8 bit grayscale value.
   /// The grayscale value is the luma value calculated from r, g, b
   /// according to BT.709. (gray = r*0.2126 + g*0.7152 + b*0.0722)
   kFlutterSoftwarePixelFormatGray8,
 
-  /// pixel with 5 bits red, 6 bits green, 5 bits blue, in 16-bit word.
-  ///   r = p & 0x3F; g = (p>>5) & 0x3F; b = p>>11;
+  /// Pixel with 5 bits red, 6 bits green, 5 bits blue, in 16-bit word.
+  ///   r = (p >> 11) & 0x1F;
+  ///   g = (p >> 5) & 0x3F;
+  ///   b = p & 0x1F;
+  ///
+  /// On most (== little-endian) systems, this is equivalent to wayland format
+  /// RGB565 (WL_DRM_FORMAT_RGB565, WL_SHM_FORMAT_RGB565).
   kFlutterSoftwarePixelFormatRGB565,
 
-  /// pixel with 4 bits for alpha, red, green, blue; in 16-bit word.
-  ///   r = p & 0xF;  g = (p>>4) & 0xF;  b = (p>>8) & 0xF;   a = p>>12;
+  /// Pixel with 4 bits each for alpha, red, green, blue; in 16-bit word.
+  ///   r = (p >> 8) & 0xF;
+  ///   g = (p >> 4) & 0xF;
+  ///   b = p & 0xF;
+  ///   a = (p >> 12) & 0xF;
+  ///
+  /// On most (== little-endian) systems, this is equivalent to wayland format
+  /// RGBA4444 (WL_DRM_FORMAT_RGBA4444, WL_SHM_FORMAT_RGBA4444).
   kFlutterSoftwarePixelFormatRGBA4444,
 
-  /// pixel with 8 bits for red, green, blue, alpha.
-  ///   r = p[0]; g = p[1]; b = p[2]; a = p[3];
+  /// Pixel with 8 bits each for red, green, blue, alpha.
+  ///   r = p[0];
+  ///   g = p[1];
+  ///   b = p[2];
+  ///   a = p[3];
+  ///
+  /// This is equivalent to wayland format ABGR8888 (WL_DRM_FORMAT_ABGR8888,
+  /// WL_SHM_FORMAT_ABGR8888).
   kFlutterSoftwarePixelFormatRGBA8888,
 
-  /// pixel with 8 bits for red, green and blue and 8 unused bits.
-  ///   r = p[0]; g = p[1]; b = p[2];
+  /// Pixel with 8 bits each for red, green and blue and 8 unused bits.
+  ///   r = p[0];
+  ///   g = p[1];
+  ///   b = p[2];
+  ///
+  /// This is equivalent to wayland format XBGR8888 (WL_DRM_FORMAT_XBGR8888,
+  /// WL_SHM_FORMAT_XBGR8888).
   kFlutterSoftwarePixelFormatRGBX8888,
 
-  /// pixel with 8 bits for blue, green, red and alpha.
-  ///   r = p[2]; g = p[1]; b = p[0]; a = p[3];
+  /// Pixel with 8 bits each for blue, green, red and alpha.
+  ///   r = p[2];
+  ///   g = p[1];
+  ///   b = p[0];
+  ///   a = p[3];
+  ///
+  /// This is equivalent to wayland format ARGB8888 (WL_DRM_FORMAT_ARGB8888,
+  /// WL_SHM_FORMAT_ARGB8888).
   kFlutterSoftwarePixelFormatBGRA8888,
 
-  /// either kFlutterSoftwarePixelFormatBGRA8888 or
-  /// kFlutterSoftwarePixelFormatRGBA8888 depending on CPU endianess and OS
+  /// Either kFlutterSoftwarePixelFormatBGRA8888 or
+  /// kFlutterSoftwarePixelFormatRGBA8888 depending on CPU endianess and OS.
   kFlutterSoftwarePixelFormatNative32,
 } FlutterSoftwarePixelFormat;
 
@@ -387,9 +537,14 @@ typedef struct {
 } FlutterOpenGLTexture;
 
 typedef struct {
-  /// The target of the color attachment of the frame-buffer. For example,
-  /// GL_TEXTURE_2D or GL_RENDERBUFFER. In case of ambiguity when dealing with
-  /// Window bound frame-buffers, 0 may be used.
+  /// The format of the color attachment of the frame-buffer. For example,
+  /// GL_RGBA8.
+  ///
+  /// In case of ambiguity when dealing with Window bound frame-buffers, 0 may
+  /// be used.
+  ///
+  /// @bug      This field is incorrectly named as "target" when it actually
+  ///           refers to a format.
   uint32_t target;
 
   /// The name of the framebuffer.
@@ -402,6 +557,62 @@ typedef struct {
   /// collect the framebuffer.
   VoidCallback destruction_callback;
 } FlutterOpenGLFramebuffer;
+
+typedef bool (*FlutterOpenGLSurfaceCallback)(void* /* user data */,
+                                             bool* /* opengl state changed */);
+
+typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterOpenGLSurface).
+  size_t struct_size;
+
+  /// User data to be passed to the make_current, clear_current and
+  /// destruction callbacks.
+  void* user_data;
+
+  /// Callback invoked (on an engine-managed thread) that asks the embedder to
+  /// make the surface current.
+  ///
+  /// Should return true if the operation succeeded, false if the surface could
+  /// not be made current and rendering should be cancelled.
+  ///
+  /// The second parameter 'opengl state changed' should be set to true if
+  /// any OpenGL API state is different than before this callback was called.
+  /// In that case, Flutter will invalidate the internal OpenGL API state cache,
+  /// which is a somewhat expensive operation.
+  ///
+  /// @attention required. (non-null)
+  FlutterOpenGLSurfaceCallback make_current_callback;
+
+  /// Callback invoked (on an engine-managed thread) when the current surface
+  /// can be cleared.
+  ///
+  /// Should return true if the operation succeeded, false if an error ocurred.
+  /// That error will be logged but otherwise not handled by the engine.
+  ///
+  /// The second parameter 'opengl state changed' is the same as with the
+  /// @ref make_current_callback.
+  ///
+  /// The embedder might clear the surface here after it was previously made
+  /// current. That's not required however, it's also possible to clear it in
+  /// the destruction callback. There's no way to signal OpenGL state
+  /// changes in the destruction callback though.
+  ///
+  /// @attention required. (non-null)
+  FlutterOpenGLSurfaceCallback clear_current_callback;
+
+  /// Callback invoked (on an engine-managed thread) that asks the embedder to
+  /// collect the surface.
+  ///
+  /// @attention required. (non-null)
+  VoidCallback destruction_callback;
+
+  /// The surface format.
+  ///
+  /// Allowed values:
+  ///   - GL_RGBA8
+  ///   - GL_BGRA8_EXT
+  uint32_t format;
+} FlutterOpenGLSurface;
 
 typedef bool (*BoolCallback)(void* /* user data */);
 typedef FlutterTransformation (*TransformationCallback)(void* /* user data */);
@@ -863,6 +1074,29 @@ typedef struct {
   FlutterEngineDisplayId display_id;
   /// The view that this event is describing.
   int64_t view_id;
+  /// If `true`, the window has size constraints.
+  /// If `false`, the constraint values are ignored.
+  bool has_constraints;
+  /// Minimum physical width of the window.
+  ///
+  /// If |has_constraints| is `true`, this must be less than or equal to
+  /// |max_width_constraint| and |width|.
+  size_t min_width_constraint;
+  /// Minimum physical height of the window.
+  ///
+  /// If |has_constraints| is `true`, this must be less than or equal to
+  /// |max_height_constraint| and |height|.
+  size_t min_height_constraint;
+  /// Maximum physical width of the window.
+  ///
+  /// If |has_constraints| is `true`, this must be greater than or equal to
+  /// |min_width_constraint| and |width|.
+  size_t max_width_constraint;
+  /// Maximum physical height of the window.
+  ///
+  /// If |has_constraints| is `true`, this must be greater than or equal to
+  /// |min_height_constraint| and |height|.
+  size_t max_height_constraint;
 } FlutterWindowMetricsEvent;
 
 typedef struct {
@@ -960,6 +1194,74 @@ typedef struct {
   /// The |result| argument will be deallocated when the callback returns.
   FlutterRemoveViewCallback remove_view_callback;
 } FlutterRemoveViewInfo;
+
+/// Represents the direction in which the focus transitioned across
+/// [FlutterView]s.
+typedef enum {
+  /// Indicates the focus transition did not have a direction.
+  ///
+  /// This is typically associated with focus being programmatically requested
+  /// or when focus is lost.
+  kUndefined,
+
+  /// Indicates the focus transition was performed in a forward direction.
+  ///
+  /// This is typically result of the user pressing tab.
+  kForward,
+
+  /// Indicates the focus transition was performed in a backward direction.
+  ///
+  /// This is typically result of the user pressing shift + tab.
+  kBackward,
+} FlutterViewFocusDirection;
+
+/// Represents the focus state of a given [FlutterView].
+typedef enum {
+  /// Specifies that a view does not have platform focus.
+  kUnfocused,
+
+  /// Specifies that a view has platform focus.
+  kFocused,
+} FlutterViewFocusState;
+
+/// A view focus event is sent to the engine by the embedder when a native view
+/// focus state has changed.
+///
+/// Passed through FlutterEngineSendViewFocusEvent.
+typedef struct {
+  /// The size of this struct.
+  /// Must be sizeof(FlutterViewFocusEvent).
+  size_t struct_size;
+
+  /// The identifier of the view that received the focus event.
+  FlutterViewId view_id;
+
+  /// The focus state of the view.
+  FlutterViewFocusState state;
+
+  /// The direction in which the focus transitioned across [FlutterView]s.
+  FlutterViewFocusDirection direction;
+} FlutterViewFocusEvent;
+
+/// A FlutterViewFocusChangeRequest is sent by the engine to the embedder when
+/// when a FlutterView focus state has changed and native view focus
+/// needs to be updated.
+///
+/// Received in FlutterProjectArgs.view_focus_change_request_callback.
+typedef struct {
+  /// The size of this struct.
+  /// Must be sizeof(FlutterViewFocusChangeRequest).
+  size_t struct_size;
+
+  /// The identifier of the view that received the focus event.
+  FlutterViewId view_id;
+
+  /// The focus state of the view.
+  FlutterViewFocusState state;
+
+  /// The direction in which the focus transitioned across [FlutterView]s.
+  FlutterViewFocusDirection direction;
+} FlutterViewFocusChangeRequest;
 
 /// The phase of the pointer event.
 typedef enum {
@@ -1069,6 +1371,14 @@ typedef struct {
   double rotation;
   /// The identifier of the view that received the pointer event.
   FlutterViewId view_id;
+  /// The pressure of the current pointer, where 0.0 is the default value.
+  double pressure;
+  /// The minimum bound of the pressure of the current pointer, where 0.0 is the
+  /// default minimum bound.
+  double pressure_min;
+  /// The maximum bound of the pressure of the current pointer, where 0.0 is the
+  /// default maximum bound.
+  double pressure_max;
 } FlutterPointerEvent;
 
 typedef enum {
@@ -1320,6 +1630,10 @@ typedef struct {
   FlutterPlatformViewIdentifier platform_view_id;
   /// A textual tooltip attached to the node.
   const char* tooltip;
+  /// The heading level for this node. A value of 0 means the node is not a
+  /// heading; higher values (1, 2, …) indicate the heading rank, with lower
+  /// numbers being higher-level headings.
+  int32_t heading_level;
 } FlutterSemanticsNode;
 
 /// A node in the Flutter semantics tree.
@@ -1336,7 +1650,11 @@ typedef struct {
   /// The unique identifier for this node.
   int32_t id;
   /// The set of semantics flags associated with this node.
-  FlutterSemanticsFlag flags;
+  ///
+  /// @deprecated     Use `flags2` instead. No new flags will
+  ///                 be added to `FlutterSemanticsFlag`. New flags will
+  ///                 continue to be added to `FlutterSemanticsFlags`.
+  FlutterSemanticsFlag flags__deprecated__;
   /// The set of semantics actions applicable to this node.
   FlutterSemanticsAction actions;
   /// The position at which the text selection originates.
@@ -1420,6 +1738,18 @@ typedef struct {
   // Array of string attributes associated with the `decreased_value`.
   // Has length `decreased_value_attribute_count`.
   const FlutterStringAttribute** decreased_value_attributes;
+  // The set of semantics flags associated with this node. Prefer to use this
+  // over `flags__deprecated__`.
+  FlutterSemanticsFlags* flags2;
+  /// The heading level for this node. A value of 0 means the node is not a
+  /// heading; higher values (1, 2, …) indicate the heading rank, with lower
+  /// numbers being higher-level headings.
+  int32_t heading_level;
+  /// An identifier for the semantics node in native accessibility hierarchy.
+  /// This value should not be exposed to the users of the app.
+  /// This is usually used for UI testing with tools that work by querying the
+  /// native accessibility, like UI Automator, XCUITest, or Appium.
+  const char* identifier;
 } FlutterSemanticsNode2;
 
 /// `FlutterSemanticsCustomAction` ID used as a sentinel to signal the end of a
@@ -1513,6 +1843,8 @@ typedef struct {
   /// Array of semantics custom action pointers. Has length
   /// `custom_action_count`.
   FlutterSemanticsCustomAction2** custom_actions;
+  // The ID of the view that this update is associated with.
+  FlutterViewId view_id;
 } FlutterSemanticsUpdate2;
 
 typedef void (*FlutterUpdateSemanticsNodeCallback)(
@@ -1533,7 +1865,7 @@ typedef void (*FlutterUpdateSemanticsCallback2)(
 
 /// An update to whether a message channel has a listener set or not.
 typedef struct {
-  // The size of the struct. Must be sizeof(FlutterChannelUpdate).
+  /// The size of the struct. Must be sizeof(FlutterChannelUpdate).
   size_t struct_size;
   /// The name of the channel.
   const char* channel;
@@ -1543,6 +1875,10 @@ typedef struct {
 
 typedef void (*FlutterChannelUpdateCallback)(
     const FlutterChannelUpdate* /* channel update */,
+    void* /* user data */);
+
+typedef void (*FlutterViewFocusChangeRequestCallback)(
+    const FlutterViewFocusChangeRequest* /* request */,
     void* /* user data */);
 
 typedef struct _FlutterTaskRunner* FlutterTaskRunner;
@@ -1584,6 +1920,8 @@ typedef struct {
   /// A unique identifier for the task runner. If multiple task runners service
   /// tasks on the same thread, their identifiers must match.
   size_t identifier;
+  /// The callback invoked when the task runner is destroyed.
+  VoidCallback destruction_callback;
 } FlutterTaskRunnerDescription;
 
 typedef struct {
@@ -1602,6 +1940,10 @@ typedef struct {
   /// Specify a callback that is used to set the thread priority for embedder
   /// task runners.
   void (*thread_priority_setter)(FlutterThreadPriority);
+  /// Specify the task runner for the thread on which the UI tasks will be run.
+  /// This may be same as platform_task_runner, in which case the Flutter engine
+  /// will run the UI isolate on platform thread.
+  const FlutterTaskRunnerDescription* ui_task_runner;
 } FlutterCustomTaskRunners;
 
 typedef struct {
@@ -1614,6 +1956,9 @@ typedef struct {
     /// A framebuffer for Flutter to render into. The embedder must ensure that
     /// the framebuffer is complete.
     FlutterOpenGLFramebuffer framebuffer;
+    /// A surface for Flutter to render into. Basically a wrapper around
+    /// a closure that'll be called when the surface should be made current.
+    FlutterOpenGLSurface surface;
   };
 } FlutterOpenGLBackingStore;
 
@@ -1635,6 +1980,7 @@ typedef struct {
 } FlutterSoftwareBackingStore;
 
 typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterSoftwareBackingStore2).
   size_t struct_size;
   /// A pointer to the raw bytes of the allocation described by this software
   /// backing store.
@@ -1651,7 +1997,8 @@ typedef struct {
   /// store.
   VoidCallback destruction_callback;
   /// The pixel format that the engine should use to render into the allocation.
-  /// In most cases, kR
+  ///
+  /// On Linux, kFlutterSoftwarePixelFormatBGRA8888 is most commonly used.
   FlutterSoftwarePixelFormat pixel_format;
 } FlutterSoftwareBackingStore2;
 
@@ -1808,6 +2155,7 @@ typedef struct {
 /// Contains additional information about the backing store provided
 /// during presentation to the embedder.
 typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterBackingStorePresentInfo).
   size_t struct_size;
 
   /// The area of the backing store that contains Flutter contents. Pixels
@@ -1920,6 +2268,14 @@ typedef struct {
   /// The callback should return true if the operation was successful.
   FlutterLayersPresentCallback present_layers_callback;
   /// Avoid caching backing stores provided by this compositor.
+  ///
+  /// The engine has an internal backing store cache. Instead of
+  /// creating & destroying backing stores for every frame, created
+  /// backing stores are automatically reused for subsequent frames.
+  ///
+  /// If you wish to change this behavior and destroy backing stores after
+  /// they've been used once, and create new backing stores for every frame,
+  /// you can set this bool to true.
   bool avoid_backing_store_cache;
   /// Callback invoked by the engine to composite the contents of each layer
   /// onto the specified view.
@@ -1969,7 +2325,7 @@ typedef const FlutterLocale* (*FlutterComputePlatformResolvedLocaleCallback)(
     size_t /* Number of locales*/);
 
 typedef struct {
-  /// This size of this struct. Must be sizeof(FlutterDisplay).
+  /// The size of this struct. Must be sizeof(FlutterEngineDisplay).
   size_t struct_size;
 
   FlutterEngineDisplayId display_id;
@@ -2434,7 +2790,43 @@ typedef struct {
   /// being registered on the framework side. The callback is invoked from
   /// a task posted to the platform thread.
   FlutterChannelUpdateCallback channel_update_callback;
+
+  /// The callback invoked by the engine when FlutterView focus state has
+  /// changed. The embedder can use this callback to request focus change for
+  /// the native view. The callback is invoked from a task posted to the
+  /// platform thread.
+  FlutterViewFocusChangeRequestCallback view_focus_change_request_callback;
+
+  /// Opaque identifier provided by the engine. Accessible in Dart code through
+  /// `PlatformDispatcher.instance.engineId`. Can be used in native code to
+  /// retrieve the engine instance that is running the Dart code.
+  int64_t engine_id;
+
+  /// If true, the engine will decode images in wide gamut color spaces
+  /// (Display P3) when supported. If false, images are decoded to sRGB.
+  bool enable_wide_gamut;
 } FlutterProjectArgs;
+
+typedef struct {
+  /// The size of this struct. Must be
+  /// sizeof(FlutterSendSemanticsActionInfo).
+  size_t struct_size;
+
+  /// The ID of the view that includes the node.
+  FlutterViewId view_id;
+
+  /// The semantics node identifier.
+  uint64_t node_id;
+
+  /// The semantics action.
+  FlutterSemanticsAction action;
+
+  /// Data associated with the action.
+  const uint8_t* data;
+
+  /// The data length.
+  size_t data_length;
+} FlutterSendSemanticsActionInfo;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES
 
@@ -2483,8 +2875,8 @@ FlutterEngineResult FlutterEngineCollectAOTData(FlutterEngineAOTData data);
 ///             engine may need the embedder to post tasks back to it before
 ///             `FlutterEngineRun` has returned. Embedders can only post tasks
 ///             to the engine if they have a handle to the engine. In such
-///             cases, embedders are advised to get the engine handle via the
-///             `FlutterInitializeCall`. Then they can call
+///             cases, embedders are advised to get the engine handle by calling
+///             `FlutterEngineInitialize`. Then they can call
 ///             `FlutterEngineRunInitialized` knowing that they will be able to
 ///             service custom tasks on other threads with the engine handle.
 ///
@@ -2637,6 +3029,16 @@ FLUTTER_EXPORT
 FlutterEngineResult FlutterEngineRemoveView(FLUTTER_API_SYMBOL(FlutterEngine)
                                                 engine,
                                             const FlutterRemoveViewInfo* info);
+
+//------------------------------------------------------------------------------
+/// @brief      Notifies the engine that platform view focus state has changed.
+///
+/// @param[in]  engine  A running engine instance
+/// @param[in]  event   The focus event data describing the change.
+FLUTTER_EXPORT
+FlutterEngineResult FlutterEngineSendViewFocusEvent(
+    FLUTTER_API_SYMBOL(FlutterEngine) engine,
+    const FlutterViewFocusEvent* event);
 
 FLUTTER_EXPORT
 FlutterEngineResult FlutterEngineSendWindowMetricsEvent(
@@ -2859,7 +3261,10 @@ FlutterEngineResult FlutterEngineUpdateAccessibilityFeatures(
     FlutterAccessibilityFeature features);
 
 //------------------------------------------------------------------------------
-/// @brief      Dispatch a semantics action to the specified semantics node.
+/// @brief      Dispatch a semantics action to the specified semantics node
+///             in the implicit view.
+///
+/// @deprecated Use `FlutterEngineSendSemanticsAction` instead.
 ///
 /// @param[in]  engine       A running engine instance.
 /// @param[in]  node_id      The semantics node identifier.
@@ -2876,6 +3281,22 @@ FlutterEngineResult FlutterEngineDispatchSemanticsAction(
     FlutterSemanticsAction action,
     const uint8_t* data,
     size_t data_length);
+
+//------------------------------------------------------------------------------
+/// @brief      Dispatch a semantics action to the specified semantics node
+///             within a specific view.
+///
+/// @param[in]  engine  A running engine instance.
+/// @param[in]  info    The dispatch semantics on view arguments.
+///                     This can be deallocated once
+///                     |FlutterEngineSendSemanticsAction| returns.
+///
+/// @return     The result of the call.
+///
+FLUTTER_EXPORT
+FlutterEngineResult FlutterEngineSendSemanticsAction(
+    FLUTTER_API_SYMBOL(FlutterEngine) engine,
+    const FlutterSendSemanticsActionInfo* info);
 
 //------------------------------------------------------------------------------
 /// @brief      Notify the engine that a vsync event occurred. A baton passed to
@@ -2994,7 +3415,7 @@ uint64_t FlutterEngineGetCurrentTime();
 
 //------------------------------------------------------------------------------
 /// @brief      Inform the engine to run the specified task. This task has been
-///             given to the engine via the
+///             given to the embedder via the
 ///             `FlutterTaskRunnerDescription.post_task_callback`. This call
 ///             must only be made at the target time specified in that callback.
 ///             Running the task before that time is undefined behavior.
@@ -3264,6 +3685,9 @@ typedef FlutterEngineResult (*FlutterEngineDispatchSemanticsActionFnPtr)(
     FlutterSemanticsAction action,
     const uint8_t* data,
     size_t data_length);
+typedef FlutterEngineResult (*FlutterEngineSendSemanticsActionFnPtr)(
+    FLUTTER_API_SYMBOL(FlutterEngine) engine,
+    const FlutterSendSemanticsActionInfo* info);
 typedef FlutterEngineResult (*FlutterEngineOnVsyncFnPtr)(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
     intptr_t baton,
@@ -3314,6 +3738,9 @@ typedef FlutterEngineResult (*FlutterEngineAddViewFnPtr)(
 typedef FlutterEngineResult (*FlutterEngineRemoveViewFnPtr)(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
     const FlutterRemoveViewInfo* info);
+typedef FlutterEngineResult (*FlutterEngineSendViewFocusEventFnPtr)(
+    FLUTTER_API_SYMBOL(FlutterEngine) engine,
+    const FlutterViewFocusEvent* event);
 
 /// Function-pointer-based versions of the APIs above.
 typedef struct {
@@ -3362,6 +3789,8 @@ typedef struct {
   FlutterEngineSetNextFrameCallbackFnPtr SetNextFrameCallback;
   FlutterEngineAddViewFnPtr AddView;
   FlutterEngineRemoveViewFnPtr RemoveView;
+  FlutterEngineSendViewFocusEventFnPtr SendViewFocusEvent;
+  FlutterEngineSendSemanticsActionFnPtr SendSemanticsAction;
 } FlutterEngineProcTable;
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Three commits. The first retains fields the semantics mirror was dropping; the second rolls the vendored `embedder.h` forward; the third fixes a bounds bug the version audit turned up.

## Deployment context (read this first)

meta-flutter pins `FLUTTER_SDK_TAG ??= "3.38.3"`, so **3.38.3 is what we link at runtime**, while the header vendored here is **3.44.2**. The gap is narrow but real, and it drives the design below:

| Capability | 3.38.3 (deployed) | 3.44.2 (vendored header) |
|---|---|---|
| `FlutterSemanticsFlags` + `flags2` | ✅ | ✅ |
| `FlutterEngineSendSemanticsAction` (with `view_id`) | ✅ | ✅ |
| `ScrollToOffset` / `Expand` / `Collapse` | ✅ | ✅ |
| `FlutterSemanticsNode2.identifier` | ❌ **absent** | ✅ |
| `FlutterSemanticsFlags.is_accessibility_focus_blocked` | ❌ **absent** | ✅ |

Both deltas are **clean appends** — every shared member is at an identical offset in both revisions, verified member-by-member against `git show 3.38.3:...embedder.h`. So `struct_size` gating is exactly sufficient and nothing is silently reinterpreted.

**Practical upshot: `GetIdentifier()` returns `""` on every node on a shipping target today.** The field and its code path are live; 3.38.3 simply never writes it. That is expected, not a bug, and it resolves when the engine floor moves.

## 1. Retain actions, transform, and custom actions

A consumer of the tree could describe a node but not what it accepts.

- **`actions` bitmask** — `GetActions()` plus a `HasAction()` bit test.
- **`transform`** — parent-local bounds are not comparable across the tree without it.
- **`custom_accessibility_actions`** — the `FlutterSemanticsCustomAction2` batch was previously iterated and discarded. It now resolves into a tree-level table keyed by ID, via `FindCustomAction()`.

**Custom action declarations are deliberately not pruned with the nodes.** Flutter assigns a custom action its ID once and may declare it in an earlier batch than the node referencing it, so dropping an unreferenced entry would lose it permanently. The set is bounded by the app's distinct `CustomSemanticsAction` values, not by tree size.

Role derivation moved onto `accessibility::Translate()`, which was already written and unit-tested but had no call sites.

## 2. Roll `embedder.h` forward

`identifier` is retained and exposed. Role derivation now takes `FlutterSemanticsFlags`, falling back to the deprecated enum when `flags2` is null. The struct is the richer source: tristates distinguish "the property does not apply" from "it applies and is false", which the enum could only encode as paired bits. Both representations normalize into one internal view so the role precedence chain stays written once.

Fallout, both caught at compile time: the node's `flags` member is now `flags__deprecated__`; `FlutterWindowMetricsEvent` gained size-constraint members, which this port does not negotiate, so the three initializers in `engine.cc` now declare their absence explicitly.

## 3. Bounds-check the flags struct — the interesting one

**`FlutterSemanticsFlags` is versioned independently of the node that points at it.** It carries its own `struct_size` and grows on its own schedule. Commit 2 gated the node struct and — precisely because that felt like the whole job — missed that the flags struct hanging off it had *also* grown a member. `is_accessibility_focus_blocked` is absent at 3.38.3, so reading it unconditionally was an out-of-bounds read on the flags allocation against **every deployed engine**.

That was found by auditing the version floor, not by any test. It is now gated with a `static_assert` on the offset arithmetic.

### Why the tests are shaped the way they are

Both regression tests size the allocation to the **actual deployed struct** rather than a synthetic short one, and place it at the *end* of a heap allocation — so an unguarded read faults instead of picking up adjacent live memory that happens to look plausible. Verified by deliberately removing each gate:

```
ERROR: AddressSanitizer: heap-buffer-overflow
SUMMARY: heap-buffer-overflow accessibility_tree.cc:75 in AccessibilityNode::Update()
SUMMARY: heap-buffer-overflow semantics_translator.cc:170 in FromStruct
```

**The generalizable rule: a gate on a containing struct says nothing about a struct it points to.** Each embedder struct the port consumes needs its own audit. `FlutterSemanticsCustomAction2` and `FlutterSemanticsUpdate2` are next if they ever grow.

## On the dispatch API

`FlutterEngineSendSemanticsAction` is declared by the rolled header **and exported by 3.38.3, with `view_id`** — so it works at the floor. Nothing here adds it to the dlsym table regardless: `libflutter_engine.cc` resolves with `require()`, which aborts load on a missing symbol, so a hard dependency would turn any engine below the floor from degraded into non-starting. A caller wanting it should resolve it optionally and fall back to the `DispatchSemanticsAction` entry already present.

`GetRole()` still reports the narrow numeric encoding the AccessKit bridge consumes, so that path is behaviorally unchanged — worth a look from anyone who builds with `ENABLE_ACCESSKIT`, since `find_package(ACCESSKIT)` fails on my host and that block never compiled locally.

## Testing

- 23 new cases in `test_case_accessibility_tree.cc` (7 → 30): action bitmask, transform, identifier retention and replacement, custom-action resolution and string ownership, null-pointer and null-string handling, the no-prune property, `flags2`-over-enum precedence, tristate semantics, null-`flags2` fallback, post-ceiling actions, both ASan bounds tests, and dump output.
- 22/22 ctest green; accessibility and translator suites clean under ASan + UBSan.
- clang-tidy clean on changed files; clang-format applied.
- `BUILD_ACCESSIBILITY=ON` builds warning-free.

**Suggested follow-up:** a CI leg pinned to a 3.38.3 engine, so the degradation paths are executed rather than reasoned about. Every conclusion above about 3.38.3 comes from reading its header, not from running against it.

Unrelated, not addressed here: building a single unit-test target fails because `homescreen_ut_shell` does not depend on the wayland-cxx-scanner generation targets. Generating `shell/wayland-protocols/*.hpp` first works around it.