### PR TITLE
build: gate the semantics hub behind BUILD_ACCESSIBILITY

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -32,6 +32,10 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     if (NOT DEFINED ENABLE_DLT)
         option(ENABLE_DLT "Build the DLT logging bridge into ihs_shared" ON)
     endif ()
+    if (NOT DEFINED BUILD_ACCESSIBILITY)
+        option(BUILD_ACCESSIBILITY
+                "Build the semantics hub into ihs_shared" OFF)
+    endif ()
     if (NOT DEFINED BUILD_MCP)
         option(BUILD_MCP "Build the MCP provider registry into ihs_shared" OFF)
     endif ()
@@ -48,7 +52,6 @@ add_library(ihs_shared SHARED
         src/trace.cc
         src/config.cc
         src/platform_view.cc
-        src/semantics.cc
 )
 add_library(ivi_homescreen::ihs_shared ALIAS ihs_shared)
 
@@ -153,6 +156,24 @@ if (ENABLE_DLT)
 endif ()
 
 #
+# Semantics hub.
+#
+# Only useful alongside the accessibility semantics tree that feeds it -- with
+# BUILD_ACCESSIBILITY off nothing ever calls ihs_semantics_publish, so the hub
+# would sit in every image as code that cannot be reached. Gated for the same
+# reason as the MCP registry, though the case is milder: this is accessibility
+# infrastructure rather than remote control.
+#
+# BUILD_MCP requires BUILD_ACCESSIBILITY in the homescreen tree, so an MCP
+# build always has the hub the semantics provider reads from.
+if (BUILD_ACCESSIBILITY)
+    target_sources(ihs_shared PRIVATE src/semantics.cc)
+    message(STATUS "Semantics hub ......... Enabled")
+else ()
+    message(STATUS "Semantics hub ......... Disabled")
+endif ()
+
+#
 # MCP provider registry.
 #
 # Default OFF, and off in production images: this is the registration point for
@@ -241,6 +262,11 @@ install(TARGETS ihs_shared EXPORT ihs_shared_targets
 # an out-of-tree consumer compile against a surface that is not there and fail
 # at link instead of at the include.
 set(_ihs_header_excludes PATTERN "flutter_desktop_bridge.h" EXCLUDE)
+if (NOT BUILD_ACCESSIBILITY)
+    list(APPEND _ihs_header_excludes
+            PATTERN "ihs_semantics.h" EXCLUDE
+            PATTERN "ihs_semantics_host.h" EXCLUDE)
+endif ()
 if (NOT BUILD_MCP)
     list(APPEND _ihs_header_excludes
             PATTERN "ihs_mcp_provider.h" EXCLUDE

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -28,12 +28,14 @@
 
 #include "ihs/config.h"
 #include "ihs/ihs.h"
-#include "ihs/ihs_semantics.h"
-
-/* The MCP headers are only installed when the package was built with
- * BUILD_MCP, so a consumer discovers the surface by its presence rather than
- * being told out of band. */
+/* The semantics and MCP headers are only installed when the package was built
+ * with BUILD_ACCESSIBILITY / BUILD_MCP, so a consumer discovers each surface by
+ * its presence rather than being told out of band. */
 #if defined(__has_include)
+#if __has_include("ihs/ihs_semantics.h")
+#include "ihs/ihs_semantics.h"
+#define CONSUMER_HAS_SEMANTICS 1
+#endif
 #if __has_include("ihs/ihs_mcp_provider.h")
 #include "ihs/ihs_mcp_provider.h"
 #define CONSUMER_HAS_MCP 1
@@ -213,6 +215,7 @@ int main(void) {
    * Exercised, not merely included: an unreferenced header would still compile
    * if a declaration were unresolvable at link time. */
   {
+#ifdef CONSUMER_HAS_SEMANTICS
     const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
     /* No engine in this process, so there is nothing published. */
     CHECK(snapshot == NULL, "no semantics snapshot without an engine");
@@ -223,6 +226,7 @@ int main(void) {
     CHECK((IHS_SEMANTICS_ACTION_NO_A11Y_FOCUS &
            IHS_SEMANTICS_ACTION_DID_GAIN_A11Y_FOCUS) == 0,
           "the automation mask withholds accessibility focus");
+#endif
 
 #ifdef CONSUMER_HAS_MCP
     CHECK(ihs_mcp_provider_register(NULL, NULL) == IHS_MCP_ERR_INVALID,
@@ -233,12 +237,19 @@ int main(void) {
 #endif
   }
 
-  printf("OK ihs_shared consumer smoke: abi=0x%08x logging=%s mcp=%s\n",
-         api->abi_version, api->logging != NULL ? "present" : "absent",
-#ifdef CONSUMER_HAS_MCP
-         "present"
+  printf(
+      "OK ihs_shared consumer smoke: abi=0x%08x logging=%s semantics=%s "
+      "mcp=%s\n",
+      api->abi_version, api->logging != NULL ? "present" : "absent",
+#ifdef CONSUMER_HAS_SEMANTICS
+      "present",
 #else
-         "absent"
+      "absent",
+#endif
+#ifdef CONSUMER_HAS_MCP
+      "present"
+#else
+      "absent"
 #endif
   );
   return 0;

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -187,7 +187,6 @@ add_subdirectory(platform_view_registry-test)
 add_subdirectory(backend_output_binding-test)
 add_subdirectory(vsync_park-test)
 add_subdirectory(mutation_stack-test)
-add_subdirectory(semantics_hub-test)
 # The MCP registry is only compiled into ihs_shared when BUILD_MCP is on, so
 # its tests would have nothing to link against otherwise.
 if (BUILD_MCP)
@@ -206,4 +205,6 @@ if (BUILD_ACCESSIBILITY)
     add_subdirectory(semantics_translator-test)
     add_subdirectory(accessibility_tree-test)
     add_subdirectory(semantics_publisher-test)
+    # The hub itself is only in ihs_shared when BUILD_ACCESSIBILITY is on.
+    add_subdirectory(semantics_hub-test)
 endif ()


### PR DESCRIPTION
Follow-up to the `BUILD_MCP` gate in #416. The hub had the same oversight: compiled into `libihs_shared` unconditionally, so with `BUILD_ACCESSIBILITY` off it sat in every image as code nothing could reach — 14 exported symbols and the snapshot machinery behind them.

Gated the same way: no source compiled, no `ihs_semantics_*` symbols, headers not installed. The consumer smoke test now discovers **both** surfaces via `__has_include` and reports which the package it found actually has.

## Why the case is milder than MCP

This is accessibility infrastructure, not remote control of the UI. The argument is "unreachable code shouldn't ship", not "a dangerous surface must be opt-in". It stays in `ihs_shared` for the same reason as before — a consumer or provider in a dlopen'd FFI plugin can only bind to a shared object.

## One thing I deliberately did *not* couple

`BUILD_MCP` requires `BUILD_ACCESSIBILITY` in the homescreen tree, so an MCP build always has the hub the semantics provider will read from.

The **standalone** `shared` build does not tie them, and shouldn't: the MCP registry has no dependency on semantics — it's transport-free and capability-agnostic — so a build registering only non-semantics providers is legitimate. `ACC=OFF MCP=ON` is a real configuration, not an accident.

## Verified across the matrix

| config | semantics syms | mcp syms | headers | consumer |
|---|---|---|---|---|
| ACC=OFF MCP=OFF | 0 | 0 | 0 | `semantics=absent mcp=absent` |
| ACC=OFF MCP=ON | 0 | 9 | 2 | `semantics=absent mcp=present` |
| ACC=ON MCP=OFF | 14 | 0 | 2 | `semantics=present mcp=absent` |
| ACC=ON MCP=ON | 14 | 9 | 4 | `semantics=present mcp=present` |

All four build, install, and link the out-of-tree `find_package` consumer, which passes in every one.

In the homescreen tree: bare default now exports neither surface and its suite is unchanged; 24 tests under `BUILD_ACCESSIBILITY`, 25 adding `BUILD_MCP`.

CMake-only change — no source touched. clang-tidy clean on `semantics.cc` and `mcp_provider.cc`.