### PR TITLE
build: add BUILD_ACCESSKIT and make the AccessKit probe explicit

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -431,6 +431,55 @@ else ()
 endif ()
 
 #
+# AccessKit platform accessibility adapter
+#
+# Off by default. Needs BUILD_ACCESSIBILITY, since the adapter is fed by the
+# semantics tree.
+#
+# The AccessKit C bindings are not a system package on any target here and are
+# not fetched by the build. Supply them by unpacking an accesskit-c release and
+# pointing CMake at the resulting directory:
+#
+#   -D BUILD_ACCESSKIT=ON -D CMAKE_PREFIX_PATH=/path/to/accesskit-c-<version>
+#
+# (or ACCESSKIT_DIR). The release is consumed *in place*: its
+# accesskit-config.cmake sits at the archive root and is never installed, and
+# its install() rules write back into its own tree rather than into
+# CMAKE_INSTALL_PREFIX, so pointing at an install prefix does not work.
+#
+# Automating this through the .emb augment mechanism was tried and does not fit,
+# for two independent reasons worth recording so it is not retried blind:
+#
+#   1. An augment builds and installs into the overlay sysroot, but this
+#      package installs into its own directory, so the overlay stays empty and
+#      find_package still fails. Native `--target local` reaches exactly this
+#      point: the augment builds, then configuration fails to find ACCESSKIT.
+#   2. Cross-compiling additionally fails before that. accesskit-c's CMakeLists
+#      pulls Corrosion and calls cargo; an augment is configured with the plain
+#      cross toolchain, so cargo links the crate's *host* build scripts with the
+#      aarch64 gcc and dies on `unrecognized command-line option '-m64'`. emb
+#      solves this in cargoEnv() with target-suffixed CC_<triple> /
+#      CARGO_TARGET_<TRIPLE>_LINKER, but that is wired into the cargo module
+#      path, not into augments, whose build kinds are only cmake and meson.
+#      Building for aarch64 would also need `rustup target add
+#      aarch64-unknown-linux-gnu`.
+#
+# Unpacking the prebuilt libraries instead does not cover the boards: the
+# release ships linux/x86_64 and linux/x86 only, while accesskit.cmake maps
+# aarch64 to a lib/linux/arm64 directory the archive does not contain.
+option(BUILD_ACCESSKIT "Build the AccessKit accessibility adapter" OFF)
+if (BUILD_ACCESSKIT AND NOT BUILD_ACCESSIBILITY)
+    MESSAGE(FATAL_ERROR
+            "BUILD_ACCESSKIT requires BUILD_ACCESSIBILITY: the adapter is fed "
+            "by the semantics tree. Configure with -D BUILD_ACCESSIBILITY=ON.")
+endif ()
+if (BUILD_ACCESSKIT)
+    MESSAGE(STATUS "AccessKit ............... Enabled")
+else ()
+    MESSAGE(STATUS "AccessKit ............... Disabled")
+endif ()
+
+#
 # Static linking
 #
 option(ENABLE_STATIC_LINK "Link stdlib with static libs" OFF)

--- a/shell/platform/homescreen/CMakeLists.txt
+++ b/shell/platform/homescreen/CMakeLists.txt
@@ -69,8 +69,18 @@ target_link_libraries(platform_homescreen PUBLIC PkgConfig::XKBCOMMON_PLATFORM)
 # Wayland protocol headers directly. The generated protocol headers attach to
 # the shell binary in shell/CMakeLists.txt.
 
-find_package(ACCESSKIT QUIET)
-if (ACCESSKIT_FOUND)
+# AccessKit, when asked for. REQUIRED rather than QUIET: this used to probe
+# silently and skip the adapter when the package was absent, so a build that
+# meant to include AccessKit and did not find it produced a binary without it
+# and said nothing. Now the request is explicit (BUILD_ACCESSKIT) and so is the
+# failure. The package arrives through the .emb augment gated on the same
+# define; ACCESSKIT_DIR or CMAKE_PREFIX_PATH also work for a local checkout.
+#
+# ENABLE_ACCESSKIT stays the compile definition the sources guard on, so
+# nothing in the C++ changes: BUILD_ACCESSKIT is the request, ENABLE_ACCESSKIT
+# is the result.
+if (BUILD_ACCESSKIT)
+    find_package(ACCESSKIT REQUIRED)
     target_include_directories(platform_homescreen PUBLIC
             ${ACCESSKIT_INCLUDE_DIRS}
     )


### PR DESCRIPTION
**Scope reduced after actually running the builds.** The original version added an `.emb` augment to fetch and build the bindings. You asked me to run it for `rpi5-trixie`; it fails, and so does the native target, for two independent reasons. The augment is gone; what remains is the part I verified end to end.

## The adapter has never been compiled

`find_package(ACCESSKIT QUIET)` only succeeds if the bindings are already somewhere CMake looks. They aren't a system package on any target here, and nothing fetched them — so every build has taken the silent `else` branch and shipped without the adapter, saying nothing.

This adds `BUILD_ACCESSKIT` (requiring `BUILD_ACCESSIBILITY`) and makes the probe **`REQUIRED`**. Silent skipping is exactly why this went unnoticed. `ENABLE_ACCESSKIT` stays the compile define, so no C++ changes.

Supply the bindings by pointing at an unpacked release:

```
-D BUILD_ACCESSKIT=ON -D CMAKE_PREFIX_PATH=/path/to/accesskit-c-0.22.3
```

## Why the augment approach was dropped

Both failures are recorded next to the option so nobody retries this blind.

**1. Native (`--target local`) — the augment builds, then configure fails.** accesskit-c is consumed *in place*. Its `accesskit-config.cmake` sits at the archive root and is never installed, and its `install()` rules use `ACCESSKIT_INCLUDE_DIR` / `ACCESSKIT_LIBRARIES_DIR`, both absolute paths back into its own tree (`${CMAKE_CURRENT_LIST_DIR}/...`) rather than `CMAKE_INSTALL_PREFIX`. So an augment builds it, the overlay sysroot stays empty, and `find_package` fails. Observed exactly: `augment : accesskit-c built (27.7s)`, then `Could not find a package configuration file provided by "ACCESSKIT"`.

**2. Cross (`--target rpi5-trixie`) — fails earlier.** accesskit-c shells out to cargo through Corrosion. An augment is configured with the plain cross toolchain, so bare `CC` is the aarch64 gcc, and cargo uses it to link the crate's **host** build scripts (proc-macro2, libc, rustix, nix, serde, memchr, crossbeam-utils):

```
aarch64-none-linux-gnu-gcc: error: unrecognized command-line option '-m64'
```

emb already solves this — `cargoEnv()` sets target-suffixed `CC_<triple>` / `CARGO_TARGET_<TRIPLE>_LINKER` specifically so host build scripts keep the host toolchain — but it's wired into the cargo **module** path, and augments support only `cmake` and `meson` build kinds. Building for aarch64 would also need `rustup target add aarch64-unknown-linux-gnu` (only `x86_64-unknown-linux-gnu` is installed here).

Also worth recording: I'd written `toolchain: rust` in the augment. That field doesn't exist in the schema (`CrossLib` has `pkg`, `url`, `min`, `patches`, `build`, `static`, `defines`, `host`, `requires_define`) and was silently ignored.

**Prebuilt isn't an escape either:** the release carries `linux/x86_64` and `linux/x86` only, while `accesskit.cmake` maps aarch64 to a `lib/linux/arm64` directory the archive doesn't contain.

## Verified

- **The adapter compiles for the first time** with a release supplied.
- The define reaches `accessibility_tree.cc` in the shell target and both test targets that carry it, so the block is genuinely compiled rather than skipped.
- **24/24 tests pass with it compiled in**, including the accessibility tree tests, which now build `Init_AccessKit()` and its callbacks.
- Default build unchanged; `BUILD_ACCESSKIT=ON` without the package fails configure.

## What would make the augment work

Either emb grows a cargo-aware augment path (reusing `cargoEnv()`), or the package gets patched — augments do support `patches:` — so its install rules target `CMAKE_INSTALL_PREFIX` and it ships a config file. Both are real work and a call for you rather than something to land quietly.