### PR TITLE
osgi: add ENABLE_OSGI build gate and [osgi] config parsing

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -562,6 +562,40 @@ message(STATUS "Wayland (any conn.) .... ${IVI_WAYLAND_ANY}")
 message(STATUS "Leased DRM tiers ....... egl=${IVI_LEASED_DRM_EGL} vulkan=${IVI_LEASED_DRM_VULKAN} software=${IVI_LEASED_DRM_SOFTWARE}")
 
 #
+# OSGi multi-bundle framework
+#
+# Runs several Flutter bundles as independently-managed "bundles" with an OSGi
+# lifecycle, a shared service registry, and a Dart-side framework isolate. The
+# shell side is additive: with ENABLE_OSGI=OFF no OSGi translation unit is
+# compiled and the binary is byte-for-byte what it was before.
+#
+# Requires the dynamically-linked Dart API (dart_api_dl) to hand each bundle
+# isolate its framework SendPort -- see
+# third_party/flutter/third_party/dart/runtime/include/PROVENANCE.md.
+option(ENABLE_OSGI "Enable OSGi multi-bundle framework" OFF)
+if (ENABLE_OSGI)
+    MESSAGE(STATUS "OSGi ................... Enabled")
+    set(DART_INCLUDE_DIR
+            "${CMAKE_SOURCE_DIR}/third_party/flutter/third_party/dart/runtime/include"
+            CACHE INTERNAL "Vendored Dart embedding headers (incl. dart_api_dl)")
+    # Fail at configure time rather than with a wall of missing-symbol errors.
+    # The DL files are vendored, not fetched, so a shallow/partial checkout or a
+    # stale tree is the likely cause.
+    foreach (_dart_dl_file dart_api_dl.h dart_api_dl.c dart_native_api.h
+            dart_version.h internal/dart_api_dl_impl.h)
+        if (NOT EXISTS "${DART_INCLUDE_DIR}/${_dart_dl_file}")
+            message(FATAL_ERROR
+                    "ENABLE_OSGI requires the vendored Dart DL headers, but "
+                    "${DART_INCLUDE_DIR}/${_dart_dl_file} is missing. See "
+                    "${DART_INCLUDE_DIR}/PROVENANCE.md for how to re-pin them.")
+        endif ()
+    endforeach ()
+    unset(_dart_dl_file)
+else ()
+    MESSAGE(STATUS "OSGi ................... Disabled")
+endif ()
+
+#
 # Docs
 #
 option(BUILD_DOCS "Build documentation" OFF)

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -494,6 +494,19 @@ if (BUILD_CRASH_HANDLER)
     target_sources(${PROJECT_NAME} PRIVATE crash_handler.cc)
 endif ()
 
+# OSGi multi-bundle framework. Strictly additive: nothing here is compiled
+# unless ENABLE_OSGI=ON. The Dart DL symbol table lives in the dart_api_dl
+# target (third_party/CMakeLists.txt), which also carries its include dir.
+if (ENABLE_OSGI)
+    target_sources(${PROJECT_NAME} PRIVATE
+            osgi/bundle_manifest.cc
+            osgi/cpu_affinity.cc
+            osgi/osgi_config.cc
+    )
+    target_link_libraries(${PROJECT_NAME} PRIVATE dart_api_dl)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ENABLE_OSGI=1)
+endif ()
+
 target_compile_definitions(${PROJECT_NAME}
         PRIVATE
         HAVE_STRCHRNUL

--- a/shell/osgi/bundle_manifest.cc
+++ b/shell/osgi/bundle_manifest.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bundle_manifest.h"
+
+namespace ihs::osgi {
+
+bool ParsePriority(const std::string_view text, Priority& out) {
+  if (text == "critical") {
+    out = Priority::kCritical;
+    return true;
+  }
+  if (text == "normal") {
+    out = Priority::kNormal;
+    return true;
+  }
+  if (text == "background") {
+    out = Priority::kBackground;
+    return true;
+  }
+  return false;
+}
+
+std::string_view PriorityName(const Priority priority) {
+  switch (priority) {
+    case Priority::kCritical:
+      return "critical";
+    case Priority::kNormal:
+      return "normal";
+    case Priority::kBackground:
+      return "background";
+  }
+  return "normal";
+}
+
+}  // namespace ihs::osgi

--- a/shell/osgi/bundle_manifest.h
+++ b/shell/osgi/bundle_manifest.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "configuration/configuration.h"
+
+namespace ihs::osgi {
+
+// When a bundle is brought up relative to the asio reactor.
+//
+//   kCritical   started (and waited on) before the reactor runs. A cluster or
+//               an alarm surface must be ACTIVE before anything else competes
+//               for the GPU, so the orchestrator blocks on each one up to
+//               startup_timeout_ms.
+//   kNormal     started after the reactor is running, staggered, so several
+//               bundles do not contend for the same first-frame resources.
+//   kBackground services with no view (CAN decoders, telemetry); started last
+//               and never waited on.
+enum class Priority : uint8_t {
+  kCritical,
+  kNormal,
+  kBackground,
+};
+
+// Parses "critical" | "normal" | "background". Returns false (leaving @out
+// untouched) for anything else, so callers can report the offending spelling.
+bool ParsePriority(std::string_view text, Priority& out);
+
+// The canonical spelling, for logs and round-tripping.
+std::string_view PriorityName(Priority priority);
+
+// One [[osgi.bundles]] entry.
+//
+// `config` is a full Configuration::Config built by the same code path that
+// builds a [[view]] entry, so a bundle may use any [view.*] key -- backend,
+// output pinning, args, shell/window type -- with identical semantics. The
+// OSGi-specific keys are the ones alongside it.
+struct BundleManifest {
+  // OSGi symbolic name; unique within a process. Required.
+  std::string symbolic_name;
+
+  // Bring-up tier. Defaults to kNormal.
+  Priority priority{Priority::kNormal};
+
+  // CPU to pin this bundle's engine thread to via pthread_setaffinity_np.
+  // -1 (the default) leaves the thread unpinned. Validated at parse time
+  // against the process affinity mask, not against a core count -- see
+  // cpu_affinity.h for why those differ.
+  int cpu_core{-1};
+
+  // How long StartCriticalBundles() waits for this bundle to report ACTIVE.
+  // Ignored for kNormal / kBackground, which are never waited on.
+  int startup_timeout_ms{500};
+
+  // Everything a [[view]] entry can express, including view.bundle_path.
+  Configuration::Config config;
+};
+
+}  // namespace ihs::osgi

--- a/shell/osgi/cpu_affinity.cc
+++ b/shell/osgi/cpu_affinity.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cpu_affinity.h"
+
+#include <sched.h>
+
+#include "logging/logging.h"
+
+namespace ihs::osgi {
+
+namespace {
+
+// The mask is read once. A process's affinity can change under it
+// (sched_setaffinity from outside), but re-reading per query would let one
+// bundle validate against a different mask than the next, turning config
+// validation into a race. One snapshot, taken before any bundle starts, keeps
+// the whole config judged against a single view of the machine.
+struct AffinitySnapshot {
+  cpu_set_t set{};
+  bool known{false};
+
+  AffinitySnapshot() {
+    CPU_ZERO(&set);
+    if (sched_getaffinity(0, sizeof(set), &set) == 0) {
+      known = true;
+      return;
+    }
+    // Not fatal: affinity only tunes scheduling. Fall through with known=false
+    // so validation admits any core rather than refusing to start.
+    ihs::log::warn(
+        "[osgi] sched_getaffinity failed; cpu_core values will not be "
+        "validated against the available CPUs");
+  }
+};
+
+const AffinitySnapshot& Snapshot() {
+  static const AffinitySnapshot snapshot;
+  return snapshot;
+}
+
+}  // namespace
+
+bool CpuAffinityKnown() {
+  return Snapshot().known;
+}
+
+bool IsCpuAvailable(const int cpu) {
+  // CPU_ISSET is undefined outside [0, CPU_SETSIZE), so bound before asking.
+  if (cpu < 0 || cpu >= CPU_SETSIZE) {
+    return false;
+  }
+  const auto& snapshot = Snapshot();
+  if (!snapshot.known) {
+    return true;
+  }
+  return CPU_ISSET(static_cast<size_t>(cpu), &snapshot.set) != 0;
+}
+
+std::optional<int> HighestAvailableCpu() {
+  const auto& snapshot = Snapshot();
+  if (!snapshot.known) {
+    return std::nullopt;
+  }
+  for (int cpu = CPU_SETSIZE - 1; cpu >= 0; --cpu) {
+    if (CPU_ISSET(static_cast<size_t>(cpu), &snapshot.set) != 0) {
+      return cpu;
+    }
+  }
+  return std::nullopt;
+}
+
+std::string AvailableCpuList() {
+  const auto& snapshot = Snapshot();
+  if (!snapshot.known) {
+    return {};
+  }
+
+  std::string out;
+  int run_start = -1;
+  // <= CPU_SETSIZE so the final iteration closes a run ending at the last CPU.
+  for (int cpu = 0; cpu <= CPU_SETSIZE; ++cpu) {
+    const bool present =
+        cpu < CPU_SETSIZE && CPU_ISSET(static_cast<size_t>(cpu), &snapshot.set);
+    if (present && run_start < 0) {
+      run_start = cpu;
+    } else if (!present && run_start >= 0) {
+      if (!out.empty()) {
+        out += ',';
+      }
+      out += std::to_string(run_start);
+      if (cpu - 1 != run_start) {
+        out += '-';
+        out += std::to_string(cpu - 1);
+      }
+      run_start = -1;
+    }
+  }
+  return out;
+}
+
+}  // namespace ihs::osgi

--- a/shell/osgi/cpu_affinity.h
+++ b/shell/osgi/cpu_affinity.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace ihs::osgi {
+
+// Which CPUs this process may actually be pinned to, from sched_getaffinity.
+//
+// This is deliberately not std::thread::hardware_concurrency(), and not a core
+// *count*. Under a cpuset -- a container, systemd CPUAffinity=, taskset, or the
+// core partitioning an IVI integrator applies to separate a cluster from
+// infotainment -- the two disagree in both directions. Confined to CPUs 2,3 on
+// a 32-way host, hardware_concurrency() still answers 32, while a count-based
+// check would admit indices 0 and 1, which are precisely the ones
+// pthread_setaffinity_np will refuse.
+//
+// The affinity mask is the same set pthread_setaffinity_np validates against,
+// so it is the only bound that makes a config error at parse time and a pinning
+// failure at startup agree.
+
+// True when the process affinity mask was readable. When false, every
+// IsCpuAvailable() query returns true: a sched_getaffinity failure must not
+// block startup over a knob that only tunes scheduling.
+[[nodiscard]] bool CpuAffinityKnown();
+
+// True when @cpu may be pinned to. Out-of-range indices are always false.
+[[nodiscard]] bool IsCpuAvailable(int cpu);
+
+// The allowed CPUs in compact range form ("2-3", "0-7,16-23"), for diagnostics.
+// Empty when the mask is unknown.
+[[nodiscard]] std::string AvailableCpuList();
+
+// Highest allowed CPU index, or nullopt when the mask is unknown or empty.
+[[nodiscard]] std::optional<int> HighestAvailableCpu();
+
+}  // namespace ihs::osgi

--- a/shell/osgi/osgi_config.cc
+++ b/shell/osgi/osgi_config.cc
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "osgi_config.h"
+
+#include <sched.h>
+
+#include <filesystem>
+#include <optional>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "cpu_affinity.h"
+#include "logging/logging.h"
+
+namespace ihs::osgi {
+
+namespace {
+
+// A startup barrier longer than this is a typo, not an intent: the orchestrator
+// blocks the reactor on it.
+constexpr int kMaxTimeoutMs = 3600000;  // one hour
+
+// Validate a core index against the CPUs this process may actually be pinned
+// to. -1 means unpinned and is always accepted.
+//
+// Rejecting here rather than at pin time is deliberate. pthread_setaffinity_np
+// against an unavailable core fails at startup, and a critical bundle that
+// silently runs unpinned has lost exactly the scheduling guarantee its
+// cpu_core was written to obtain -- the failure would show up as jitter on a
+// cluster or an alarm surface, far from its cause.
+bool ValidateCpuCore(const int core,
+                     const std::string_view what,
+                     const std::string_view who) {
+  if (core == -1 || IsCpuAvailable(core)) {
+    return true;
+  }
+  if (CpuAffinityKnown()) {
+    ihs::log::critical(
+        "[osgi] {}{} is {}, which this process may not be pinned to; "
+        "available CPUs: {}",
+        who, what, core, AvailableCpuList());
+  } else {
+    ihs::log::critical(
+        "[osgi] {}{} is {}; expected -1 (unpinned) or a core "
+        "index",
+        who, what, core);
+  }
+  return false;
+}
+
+// Read a TOML integer, rejecting anything outside [min, max].
+//
+// TOML integers are int64_t. Narrowing with value<int>() yields an empty
+// optional when the value does not fit, so calling .value() on it would throw
+// std::bad_optional_access on a config that is merely malformed -- a config
+// typo must be a diagnosed error, never a crash. Read the declared width and
+// range-check here instead.
+bool ReadBoundedInt(const toml::node_view<toml::node>& node,
+                    const int64_t min,
+                    const int64_t max,
+                    int& out) {
+  const std::optional<int64_t> raw = node.value<int64_t>();
+  if (!raw.has_value() || *raw < min || *raw > max) {
+    return false;
+  }
+  out = static_cast<int>(*raw);
+  return true;
+}
+
+// Pull one [[osgi.bundles]] entry into @manifest. Returns false having logged
+// the reason; @index is only for the message, since a malformed entry may not
+// have a usable symbolic name to name itself with.
+//
+// @base_dir, when non-empty, is the directory of the config file: a relative
+// 'bundle' path resolves against it, matching how [[view]] entries are resolved
+// in Configuration::parse_config. Without this the same relative path would
+// mean different things in the [[view]] and [[osgi.bundles]] halves of one
+// file.
+bool ParseBundle(toml::table& tbl,
+                 const size_t index,
+                 const std::filesystem::path& base_dir,
+                 BundleManifest& manifest) {
+  if (!tbl.at_path("symbolic_name").is_string()) {
+    ihs::log::critical(
+        "[osgi] [[osgi.bundles]] #{} is missing a 'symbolic_name' string",
+        index);
+    return false;
+  }
+  manifest.symbolic_name =
+      tbl.at_path("symbolic_name").as_string()->value_or("");
+  if (manifest.symbolic_name.empty()) {
+    ihs::log::critical(
+        "[osgi] [[osgi.bundles]] #{} has an empty 'symbolic_name'", index);
+    return false;
+  }
+
+  // The bundle directory. Named 'bundle' to match [[view]], where the same key
+  // carries the same meaning.
+  if (!tbl.at_path("bundle").is_string()) {
+    ihs::log::critical("[osgi] bundle '{}' is missing a 'bundle' path",
+                       manifest.symbolic_name);
+    return false;
+  }
+  const std::string bundle = tbl.at_path("bundle").as_string()->value_or("");
+  if (bundle.empty()) {
+    ihs::log::critical("[osgi] bundle '{}' has an empty 'bundle' path",
+                       manifest.symbolic_name);
+    return false;
+  }
+  if (std::filesystem::path bundle_path(bundle);
+      bundle_path.is_relative() && !base_dir.empty()) {
+    manifest.config.view.bundle_path = (base_dir / bundle_path).string();
+  } else {
+    manifest.config.view.bundle_path = bundle;
+  }
+
+  if (const auto node = tbl.at_path("priority"); node.is_string()) {
+    const std::string text = node.as_string()->value_or("");
+    if (!ParsePriority(text, manifest.priority)) {
+      ihs::log::critical(
+          "[osgi] bundle '{}' has priority '{}'; expected "
+          "critical|normal|background",
+          manifest.symbolic_name, text);
+      return false;
+    }
+  }
+
+  if (tbl.contains("cpu_core")) {
+    if (!ReadBoundedInt(tbl.at_path("cpu_core"), -1, CPU_SETSIZE - 1,
+                        manifest.cpu_core)) {
+      ihs::log::critical(
+          "[osgi] bundle '{}' has an out-of-range cpu_core; expected -1 "
+          "(unpinned) or a core index below {}",
+          manifest.symbolic_name, CPU_SETSIZE);
+      return false;
+    }
+    if (!ValidateCpuCore(manifest.cpu_core, "cpu_core",
+                         "bundle '" + manifest.symbolic_name + "' ")) {
+      return false;
+    }
+  }
+
+  if (tbl.contains("startup_timeout_ms") &&
+      !ReadBoundedInt(tbl.at_path("startup_timeout_ms"), 1, kMaxTimeoutMs,
+                      manifest.startup_timeout_ms)) {
+    ihs::log::critical(
+        "[osgi] bundle '{}' has an invalid startup_timeout_ms; expected a "
+        "positive millisecond count up to {}",
+        manifest.symbolic_name, kMaxTimeoutMs);
+    return false;
+  }
+
+  // Everything else -- backend, output, args, shell/window, geometry -- is a
+  // [view] key with [view] semantics, so it goes through the same parser rather
+  // than being reimplemented here. Keys it does not recognize (the OSGi ones
+  // handled above) are ignored.
+  Configuration::get_view_parameters(&tbl, manifest.config);
+  return true;
+}
+
+}  // namespace
+
+bool ParseOsgiTable(toml::table& root,
+                    OsgiConfig& out,
+                    const std::filesystem::path& base_dir) {
+  const auto osgi_node = root.at_path("osgi");
+  if (!osgi_node) {
+    // No [osgi] table. A stock config under an ENABLE_OSGI build.
+    return true;
+  }
+  if (!osgi_node.is_table()) {
+    ihs::log::critical("[osgi] 'osgi' must be a table");
+    return false;
+  }
+
+  if (osgi_node.as_table()->contains("framework_core")) {
+    if (!ReadBoundedInt(root.at_path("osgi.framework_core"), -1,
+                        CPU_SETSIZE - 1, out.framework_core)) {
+      ihs::log::critical(
+          "[osgi] out-of-range framework_core; expected -1 (unpinned) or a "
+          "core index below {}",
+          CPU_SETSIZE);
+      return false;
+    }
+    if (!ValidateCpuCore(out.framework_core, "framework_core", "")) {
+      return false;
+    }
+  }
+
+  const auto bundles_node = root.at_path("osgi.bundles");
+  if (!bundles_node) {
+    ihs::log::warn("[osgi] [osgi] present with no [[osgi.bundles]] entries");
+    return true;
+  }
+  if (!bundles_node.is_array()) {
+    ihs::log::critical(
+        "[osgi] 'osgi.bundles' must be an array of tables ([[osgi.bundles]])");
+    return false;
+  }
+
+  // Two identities must be unique across the process: the symbolic name (OSGi
+  // requires it) and, for ivi-shell views, the ivi_surface_id -- a collision
+  // there silently hands two bundles the same compositor surface.
+  std::unordered_set<std::string> seen_names;
+  std::unordered_map<uint32_t, std::string> seen_surface_ids;
+
+  // A BundleManifest embeds a whole Configuration::Config (dozens of strings,
+  // vectors and optionals), so growth reallocation is not free. The entry count
+  // is known up front.
+  // Not const: Configuration::get_view_parameters takes a mutable toml::table*,
+  // so the elements have to stay non-const all the way down.
+  auto* bundles = bundles_node.as_array();
+  out.bundles.reserve(out.bundles.size() + bundles->size());
+
+  size_t index = 0;
+  for (auto&& element : *bundles) {
+    auto* tbl = element.as_table();
+    if (tbl == nullptr) {
+      ihs::log::critical("[osgi] [[osgi.bundles]] #{} is not a table", index);
+      return false;
+    }
+
+    BundleManifest manifest;
+    if (!ParseBundle(*tbl, index, base_dir, manifest)) {
+      return false;
+    }
+
+    if (!seen_names.insert(manifest.symbolic_name).second) {
+      ihs::log::critical("[osgi] duplicate symbolic_name '{}'",
+                         manifest.symbolic_name);
+      return false;
+    }
+
+    if (manifest.config.view.ivi_surface_id.has_value()) {
+      const uint32_t surface_id = *manifest.config.view.ivi_surface_id;
+      const auto [it, inserted] =
+          seen_surface_ids.emplace(surface_id, manifest.symbolic_name);
+      if (!inserted) {
+        ihs::log::critical(
+            "[osgi] bundles '{}' and '{}' both request ivi-shell surface_id {}",
+            it->second, manifest.symbolic_name, surface_id);
+        return false;
+      }
+    }
+
+    out.bundles.push_back(std::move(manifest));
+    ++index;
+  }
+
+  return true;
+}
+
+bool LoadOsgiConfig(const std::string& config_toml_path, OsgiConfig& out) {
+  if (!std::filesystem::exists(config_toml_path)) {
+    ihs::log::critical("[osgi] config file not found: {}", config_toml_path);
+    return false;
+  }
+
+  // configuration.h compiles tomlplusplus with TOML_EXCEPTIONS 0, so
+  // parse_file returns a result to test rather than throwing.
+  auto result = toml::parse_file(config_toml_path);
+  if (!result) {
+    ihs::log::critical("[osgi] TOML parsing failed: {} — {}", config_toml_path,
+                       result.error().description());
+    return false;
+  }
+
+  // Relative bundle paths resolve against the config file's directory, exactly
+  // as Configuration::parse_config resolves them for [[view]].
+  return ParseOsgiTable(result.table(), out,
+                        std::filesystem::path(config_toml_path).parent_path());
+}
+
+}  // namespace ihs::osgi

--- a/shell/osgi/osgi_config.h
+++ b/shell/osgi/osgi_config.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+// Must precede any tomlplusplus include: configuration.h (reached through
+// bundle_manifest.h) compiles toml++ with TOML_EXCEPTIONS 0, and that macro is
+// only honored on the header's first inclusion. Including
+// <tomlplusplus/toml.hpp> above this line would fix the library in throwing
+// mode for this TU while the rest of the shell expects the result-returning
+// API.
+#include "bundle_manifest.h"
+
+namespace ihs::osgi {
+
+// The process-level [osgi] table.
+struct OsgiConfig {
+  // CPU to pin the Dart framework isolate's thread to. -1 = unpinned.
+  int framework_core{-1};
+
+  // [[osgi.bundles]], in declaration order. Bring-up order is decided by the
+  // orchestrator from Priority, not by this vector's order.
+  std::vector<BundleManifest> bundles;
+
+  [[nodiscard]] bool empty() const { return bundles.empty(); }
+};
+
+// Parse the [osgi] table out of an already-parsed document @root.
+//
+// A document with no [osgi] table is not an error: @out is left empty and the
+// function succeeds. That is the ENABLE_OSGI=ON, no-bundles-configured case,
+// which must behave exactly like a stock build.
+//
+// Returns false on a malformed [osgi] table, having logged the specific
+// problem. Callers should treat that as fatal: a bundle set that silently
+// dropped an entry is worse than not starting.
+// @root is taken by mutable reference only because the Configuration parsing
+// helpers it delegates to take a non-const toml::table*; nothing is modified.
+//
+// @base_dir, when non-empty, is the directory holding the config file. Relative
+// 'bundle' paths resolve against it, matching how Configuration::parse_config
+// resolves them for [[view]]. Callers parsing an in-memory document with no
+// backing file leave it empty, and relative paths then stay as written.
+bool ParseOsgiTable(toml::table& root,
+                    OsgiConfig& out,
+                    const std::filesystem::path& base_dir = {});
+
+// Read @config_toml_path and parse its [osgi] table. Returns false if the file
+// is missing or does not parse.
+bool LoadOsgiConfig(const std::string& config_toml_path, OsgiConfig& out);
+
+}  // namespace ihs::osgi

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -155,6 +155,9 @@ add_subdirectory(utils-test)
 # (Display::Display calls wl_display_connect / App::BuildDisplays).  They have
 # been moved to test/integration/ and are not run by the unit-test-coverage job.
 add_subdirectory(configuration-test-case)
+if (ENABLE_OSGI)
+    add_subdirectory(osgi_config-test)
+endif ()
 add_subdirectory(output_resolver-test)
 add_subdirectory(ihs_pv-test)
 # T1 — drives the real LeaseClient against a mock drm-lease-v1 compositor.

--- a/test/unit_test/osgi_config-test/CMakeLists.txt
+++ b/test/unit_test/osgi_config-test/CMakeLists.txt
@@ -1,0 +1,18 @@
+# test-case specific settings
+# when creating new test-case, you need to change here
+set(TESTCASE_NAME "homescreen_osgi_config_ut_test_driver")
+set(TESTCASE_CC test_case_osgi_config.cc;)
+
+add_executable(${TESTCASE_NAME} ${TESTCASE_CC})
+add_sanitizers(${TESTCASE_NAME})
+target_compile_definitions(${TESTCASE_NAME} PRIVATE
+    SOURCE_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+)
+target_link_libraries(${TESTCASE_NAME} PRIVATE gtest_main homescreen_ut_shell)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)
+
+install(DIRECTORY files DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/unit_test/osgi_config-test/files/osgi_two_bundles.toml
+++ b/test/unit_test/osgi_config-test/files/osgi_two_bundles.toml
@@ -1,0 +1,48 @@
+# Fixture for OsgiConfig.LoadOsgiConfigReadsFromDisk.
+#
+# Exercises the on-disk path: a [global] table the OSGi parser must ignore, an
+# [[view]] entry alongside the OSGi bundles, and per-bundle backend/args tables
+# that reach Configuration::get_view_parameters.
+
+[global]
+app_id = 'homescreen'
+
+[[view]]
+bundle = '/bundles/primary'
+width = 1920
+height = 1080
+
+[osgi]
+# No framework_core/cpu_core here on purpose: they are validated against the
+# process affinity mask, which varies by runner. Affinity behavior is covered
+# by the mask-derived cases in the test source instead.
+
+[[osgi.bundles]]
+symbolic_name = 'com.ivi.cluster'
+bundle = '/usr/share/ivi/bundles/cluster'
+priority = 'critical'
+startup_timeout_ms = 500
+width = 1280
+height = 720
+
+  [osgi.bundles.backend]
+  type = 'drm-kms-egl'
+
+    [osgi.bundles.backend.drm]
+    connector = 'eDP-1'
+    mode = '1280x720@60'
+
+  [osgi.bundles.args]
+  engine = ['--old_gen_heap_size=32']
+  dart = []
+
+[[osgi.bundles]]
+symbolic_name = 'com.ivi.navigation'
+bundle = '/usr/share/ivi/bundles/navigation'
+priority = 'normal'
+
+  [osgi.bundles.backend]
+  type = 'wayland-egl'
+
+  [osgi.bundles.args]
+  engine = ['--old_gen_heap_size=64']

--- a/test/unit_test/osgi_config-test/test_case_osgi_config.cc
+++ b/test/unit_test/osgi_config-test/test_case_osgi_config.cc
@@ -1,0 +1,483 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+
+#include "osgi/cpu_affinity.h"
+#include "osgi/osgi_config.h"
+
+namespace {
+
+// Parse a TOML document from a literal. Keeps each case readable as the schema
+// it is testing rather than as a file fixture.
+bool ParseText(const std::string& text, ihs::osgi::OsgiConfig& out) {
+  auto result = toml::parse(text);
+  EXPECT_TRUE(result) << "fixture itself failed to parse";
+  if (!result) {
+    return false;
+  }
+  return ihs::osgi::ParseOsgiTable(result.table(), out);
+}
+
+// One bundle whose only interesting key is cpu_core.
+std::string BundleWithCpuCore(const int core) {
+  return
+      R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/cluster"
+cpu_core = )" +
+      std::to_string(core) + "\n";
+}
+
+}  // namespace
+
+// A document with no [osgi] table must succeed and yield nothing. This is the
+// ENABLE_OSGI=ON, stock-config case: it has to behave like an OSGi-free build.
+TEST(OsgiConfig, NoOsgiTableIsNotAnError) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_TRUE(ParseText("[global]\napp_id = 'homescreen'\n", cfg));
+  EXPECT_TRUE(cfg.empty());
+  EXPECT_EQ(cfg.framework_core, -1);
+}
+
+TEST(OsgiConfig, ParsesFrameworkCoreAndBundles) {
+  // Both core values are validated against the affinity mask, so pick one the
+  // mask actually contains rather than assuming core 0 or 1 is usable.
+  int core = -1;
+  for (int cpu = 0; cpu < 1024 && core < 0; ++cpu) {
+    if (ihs::osgi::IsCpuAvailable(cpu)) {
+      core = cpu;
+    }
+  }
+  ASSERT_GE(core, 0) << "no CPU available to pin to";
+  const std::string core_text = std::to_string(core);
+
+  ihs::osgi::OsgiConfig cfg;
+  ASSERT_TRUE(ParseText(R"(
+[osgi]
+framework_core = )" + core_text +
+                            R"(
+
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/usr/share/ivi/bundles/cluster"
+priority = "critical"
+cpu_core = )" + core_text +
+                            R"(
+startup_timeout_ms = 750
+
+[[osgi.bundles]]
+symbolic_name = "com.ivi.navigation"
+bundle = "/usr/share/ivi/bundles/navigation"
+)",
+                        cfg));
+
+  EXPECT_EQ(cfg.framework_core, core);
+  ASSERT_EQ(cfg.bundles.size(), 2u);
+
+  EXPECT_EQ(cfg.bundles[0].symbolic_name, "com.ivi.cluster");
+  EXPECT_EQ(cfg.bundles[0].config.view.bundle_path,
+            "/usr/share/ivi/bundles/cluster");
+  EXPECT_EQ(cfg.bundles[0].priority, ihs::osgi::Priority::kCritical);
+  EXPECT_EQ(cfg.bundles[0].cpu_core, core);
+  EXPECT_EQ(cfg.bundles[0].startup_timeout_ms, 750);
+
+  // Defaults apply to anything the second entry left unset.
+  EXPECT_EQ(cfg.bundles[1].priority, ihs::osgi::Priority::kNormal);
+  EXPECT_EQ(cfg.bundles[1].cpu_core, -1);
+  EXPECT_EQ(cfg.bundles[1].startup_timeout_ms, 500);
+}
+
+// The point of delegating to Configuration::get_view_parameters: a bundle gets
+// the full [view] key surface, with [view] semantics, for free.
+TEST(OsgiConfig, DelegatesViewKeysToConfigurationParser) {
+  ihs::osgi::OsgiConfig cfg;
+  ASSERT_TRUE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/cluster"
+width = 1280
+height = 720
+
+  [osgi.bundles.backend]
+  type = "drm-kms-egl"
+
+    [osgi.bundles.backend.drm]
+    connector = "eDP-1"
+    mode = "1280x720@60"
+
+  [osgi.bundles.args]
+  engine = ["--old_gen_heap_size=32"]
+
+  [osgi.bundles.output]
+  name = "eDP-1"
+)",
+                        cfg));
+
+  ASSERT_EQ(cfg.bundles.size(), 1u);
+  const auto& view = cfg.bundles[0].config.view;
+  EXPECT_EQ(view.width, 1280u);
+  EXPECT_EQ(view.height, 720u);
+  ASSERT_TRUE(view.backend.has_value());
+  EXPECT_EQ(*view.backend, "drm-kms-egl");
+  ASSERT_TRUE(view.drm_connector.has_value());
+  EXPECT_EQ(*view.drm_connector, "eDP-1");
+  ASSERT_TRUE(view.drm_mode.has_value());
+  EXPECT_EQ(*view.drm_mode, "1280x720@60");
+  ASSERT_EQ(view.engine_args.size(), 1u);
+  EXPECT_EQ(view.engine_args[0], "--old_gen_heap_size=32");
+  // [view.output] name is the cross-backend convenience: it fills both the
+  // Wayland and DRM name fields so one bundle config works on either backend.
+  ASSERT_TRUE(view.output.wl_name.has_value());
+  EXPECT_EQ(*view.output.wl_name, "eDP-1");
+  ASSERT_TRUE(view.output.drm_connector.has_value());
+  EXPECT_EQ(*view.output.drm_connector, "eDP-1");
+}
+
+// [osgi.bundles.shell] reaches ivi_surface_id through the same path
+// [view.shell] does -- no separate OSGi-side schema for it.
+TEST(OsgiConfig, ParsesIviShellSurfaceId) {
+  ihs::osgi::OsgiConfig cfg;
+  ASSERT_TRUE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/cluster"
+
+  [osgi.bundles.shell]
+  type = "ivi"
+  surface_id = 1001
+)",
+                        cfg));
+
+  ASSERT_EQ(cfg.bundles.size(), 1u);
+  EXPECT_EQ(cfg.bundles[0].config.view.shell, "ivi");
+  ASSERT_TRUE(cfg.bundles[0].config.view.ivi_surface_id.has_value());
+  EXPECT_EQ(*cfg.bundles[0].config.view.ivi_surface_id, 1001u);
+}
+
+TEST(OsgiConfig, RejectsMissingSymbolicName) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(R"(
+[[osgi.bundles]]
+bundle = "/bundles/cluster"
+)",
+                         cfg));
+}
+
+TEST(OsgiConfig, RejectsMissingBundlePath) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+)",
+                         cfg));
+}
+
+TEST(OsgiConfig, RejectsUnknownPriority) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/cluster"
+priority = "urgent"
+)",
+                         cfg));
+}
+
+TEST(OsgiConfig, RejectsDuplicateSymbolicName) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/a"
+
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/b"
+)",
+                         cfg));
+}
+
+// Two bundles sharing an ivi-shell surface_id would silently collide on the
+// compositor. Fail at parse time instead.
+TEST(OsgiConfig, RejectsDuplicateIviSurfaceId) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/a"
+
+  [osgi.bundles.shell]
+  surface_id = 7
+
+[[osgi.bundles]]
+symbolic_name = "com.ivi.navigation"
+bundle = "/bundles/b"
+
+  [osgi.bundles.shell]
+  surface_id = 7
+)",
+                         cfg));
+}
+
+// Distinct ids are the normal multi-bundle ivi-shell case and must pass.
+TEST(OsgiConfig, AcceptsDistinctIviSurfaceIds) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_TRUE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/a"
+
+  [osgi.bundles.shell]
+  surface_id = 7
+
+[[osgi.bundles]]
+symbolic_name = "com.ivi.navigation"
+bundle = "/bundles/b"
+
+  [osgi.bundles.shell]
+  surface_id = 8
+)",
+                        cfg));
+  EXPECT_EQ(cfg.bundles.size(), 2u);
+}
+
+TEST(OsgiConfig, RejectsNonPositiveStartupTimeout) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/cluster"
+startup_timeout_ms = 0
+)",
+                         cfg));
+}
+
+// A TOML integer is int64_t. These do not fit in int, and must be diagnosed as
+// bad config rather than crashing the shell on a narrowing conversion.
+TEST(OsgiConfig, RejectsOutOfRangeIntegersWithoutCrashing) {
+  for (const char* doc : {R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/cluster"
+cpu_core = 99999999999
+)",
+                          R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/cluster"
+startup_timeout_ms = 99999999999
+)",
+                          "[osgi]\nframework_core = 99999999999\n"}) {
+    ihs::osgi::OsgiConfig cfg;
+    EXPECT_FALSE(ParseText(doc, cfg)) << doc;
+  }
+}
+
+TEST(OsgiConfig, RejectsNegativeCpuCoreBelowUnpinned) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "/bundles/cluster"
+cpu_core = -2
+)",
+                         cfg));
+}
+
+// cpu_core is validated against the process affinity mask, so the values these
+// cases use are derived from that mask at run time. Hardcoding a core number
+// would make the test pass or fail according to what the CI runner was pinned
+// to.
+TEST(OsgiConfig, AcceptsAvailableCpuCore) {
+  if (!ihs::osgi::CpuAffinityKnown()) {
+    GTEST_SKIP() << "process affinity mask unavailable";
+  }
+  int available = -1;
+  for (int cpu = 0; cpu < 1024; ++cpu) {
+    if (ihs::osgi::IsCpuAvailable(cpu)) {
+      available = cpu;
+      break;
+    }
+  }
+  ASSERT_GE(available, 0) << "no CPU available to pin to";
+
+  ihs::osgi::OsgiConfig cfg;
+  ASSERT_TRUE(ParseText(BundleWithCpuCore(available), cfg));
+  ASSERT_EQ(cfg.bundles.size(), 1u);
+  EXPECT_EQ(cfg.bundles[0].cpu_core, available);
+}
+
+// The case a plain core *count* check would wrongly admit: an index inside
+// [0, count) that the affinity mask nonetheless excludes, or one past the top
+// of the mask. Either way pthread_setaffinity_np would refuse it later.
+TEST(OsgiConfig, RejectsCpuCoreOutsideAffinityMask) {
+  if (!ihs::osgi::CpuAffinityKnown()) {
+    GTEST_SKIP() << "process affinity mask unavailable";
+  }
+  const std::optional<int> highest = ihs::osgi::HighestAvailableCpu();
+  ASSERT_TRUE(highest.has_value());
+
+  // First index above the mask that is still a legal CPU_SETSIZE index.
+  int unavailable = -1;
+  for (int cpu = *highest + 1; cpu < 1024; ++cpu) {
+    if (!ihs::osgi::IsCpuAvailable(cpu)) {
+      unavailable = cpu;
+      break;
+    }
+  }
+  if (unavailable < 0) {
+    GTEST_SKIP() << "every CPU index is available; nothing to reject";
+  }
+
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(BundleWithCpuCore(unavailable), cfg));
+}
+
+// The precise case that separates a mask check from a core-count check: an
+// index *below* the highest available one that the mask still excludes. Under
+// `taskset -c 2,3` that is index 0 or 1 -- both inside [0, count) for a count
+// of 2, and both refused by pthread_setaffinity_np. Skipped when the mask
+// happens to be contiguous from 0, where the two checks agree.
+TEST(OsgiConfig, RejectsExcludedCpuBelowHighestAvailable) {
+  if (!ihs::osgi::CpuAffinityKnown()) {
+    GTEST_SKIP() << "process affinity mask unavailable";
+  }
+  const std::optional<int> highest = ihs::osgi::HighestAvailableCpu();
+  ASSERT_TRUE(highest.has_value());
+
+  int excluded = -1;
+  for (int cpu = 0; cpu < *highest; ++cpu) {
+    if (!ihs::osgi::IsCpuAvailable(cpu)) {
+      excluded = cpu;
+      break;
+    }
+  }
+  if (excluded < 0) {
+    GTEST_SKIP() << "affinity mask is contiguous from 0; no excluded index "
+                    "below the top to test";
+  }
+
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(BundleWithCpuCore(excluded), cfg))
+      << "cpu " << excluded << " is outside the mask but was accepted";
+}
+
+TEST(OsgiConfig, RejectsFrameworkCoreOutsideAffinityMask) {
+  if (!ihs::osgi::CpuAffinityKnown()) {
+    GTEST_SKIP() << "process affinity mask unavailable";
+  }
+  const std::optional<int> highest = ihs::osgi::HighestAvailableCpu();
+  ASSERT_TRUE(highest.has_value());
+  int unavailable = -1;
+  for (int cpu = *highest + 1; cpu < 1024; ++cpu) {
+    if (!ihs::osgi::IsCpuAvailable(cpu)) {
+      unavailable = cpu;
+      break;
+    }
+  }
+  if (unavailable < 0) {
+    GTEST_SKIP() << "every CPU index is available; nothing to reject";
+  }
+
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText(
+      "[osgi]\nframework_core = " + std::to_string(unavailable) + "\n", cfg));
+}
+
+// -1 means "do not pin" and must be accepted whatever the mask looks like.
+TEST(OsgiConfig, AcceptsUnpinnedSentinel) {
+  ihs::osgi::OsgiConfig cfg;
+  ASSERT_TRUE(ParseText(BundleWithCpuCore(-1), cfg));
+  ASSERT_EQ(cfg.bundles.size(), 1u);
+  EXPECT_EQ(cfg.bundles[0].cpu_core, -1);
+}
+
+// A relative 'bundle' must resolve against the config file's directory, the
+// same way Configuration::parse_config resolves it for [[view]]. Otherwise one
+// path spelling means two different things within a single file.
+TEST(OsgiConfig, ResolvesRelativeBundlePathAgainstBaseDir) {
+  ihs::osgi::OsgiConfig cfg;
+  auto result = toml::parse(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "cluster"
+
+[[osgi.bundles]]
+symbolic_name = "com.ivi.navigation"
+bundle = "/absolute/navigation"
+)");
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(ihs::osgi::ParseOsgiTable(result.table(), cfg, "/etc/ivi"));
+
+  ASSERT_EQ(cfg.bundles.size(), 2u);
+  EXPECT_EQ(cfg.bundles[0].config.view.bundle_path, "/etc/ivi/cluster");
+  // An absolute path is never rewritten.
+  EXPECT_EQ(cfg.bundles[1].config.view.bundle_path, "/absolute/navigation");
+}
+
+// With no base dir (an in-memory document), a relative path stays as written.
+TEST(OsgiConfig, LeavesRelativeBundlePathWhenNoBaseDir) {
+  ihs::osgi::OsgiConfig cfg;
+  ASSERT_TRUE(ParseText(R"(
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "cluster"
+)",
+                        cfg));
+  ASSERT_EQ(cfg.bundles.size(), 1u);
+  EXPECT_EQ(cfg.bundles[0].config.view.bundle_path, "cluster");
+}
+
+TEST(OsgiConfig, RejectsBundlesAsNonArray) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ParseText("[osgi]\nbundles = 3\n", cfg));
+}
+
+TEST(OsgiConfig, PriorityNamesRoundTrip) {
+  for (const auto priority :
+       {ihs::osgi::Priority::kCritical, ihs::osgi::Priority::kNormal,
+        ihs::osgi::Priority::kBackground}) {
+    ihs::osgi::Priority parsed{};
+    ASSERT_TRUE(
+        ihs::osgi::ParsePriority(ihs::osgi::PriorityName(priority), parsed));
+    EXPECT_EQ(parsed, priority);
+  }
+}
+
+TEST(OsgiConfig, LoadOsgiConfigReportsMissingFile) {
+  ihs::osgi::OsgiConfig cfg;
+  EXPECT_FALSE(ihs::osgi::LoadOsgiConfig(
+      std::string(SOURCE_ROOT_DIR) + "/files/does_not_exist.toml", cfg));
+}
+
+TEST(OsgiConfig, LoadOsgiConfigReadsFromDisk) {
+  ihs::osgi::OsgiConfig cfg;
+  ASSERT_TRUE(ihs::osgi::LoadOsgiConfig(
+      std::string(SOURCE_ROOT_DIR) + "/files/osgi_two_bundles.toml", cfg));
+  // The fixture deliberately sets no framework_core, so it keeps the unpinned
+  // default; pinning is covered by the affinity-mask cases above.
+  EXPECT_EQ(cfg.framework_core, -1);
+  ASSERT_EQ(cfg.bundles.size(), 2u);
+  EXPECT_EQ(cfg.bundles[0].symbolic_name, "com.ivi.cluster");
+  EXPECT_EQ(cfg.bundles[0].priority, ihs::osgi::Priority::kCritical);
+  EXPECT_EQ(cfg.bundles[1].symbolic_name, "com.ivi.navigation");
+  EXPECT_EQ(cfg.bundles[1].priority, ihs::osgi::Priority::kNormal);
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -45,6 +45,36 @@ target_compile_options(tomlplusplus_tomlplusplus INTERFACE
 )
 
 #
+# Dart dynamically-linked embedding API (dart_api_dl)
+#
+# Only built for ENABLE_OSGI: the OSGi bridge hands each bundle isolate its
+# framework SendPort with Dart_PostCObject_DL, which requires the DL symbol
+# table that dart_api_dl.c defines and Dart_InitializeApiDL() populates.
+#
+# A separate target rather than a source on the shell: the file is C (the shell
+# target is a C++ source list), and test/unit_test harvests the shell target's
+# SOURCES property and PREPENDs shell/ to every entry, which an absolute path
+# into third_party/ would corrupt. Linking keeps it out of that harvest while
+# LINK_LIBRARIES carries it into the test targets unchanged.
+if (ENABLE_OSGI)
+    add_library(dart_api_dl STATIC
+            flutter/third_party/dart/runtime/include/dart_api_dl.c)
+    target_include_directories(dart_api_dl PUBLIC
+            flutter/third_party/dart/runtime/include)
+    set_target_properties(dart_api_dl PROPERTIES
+            C_STANDARD 11
+            POSITION_INDEPENDENT_CODE ON)
+    # Vendored upstream source we do not edit: quiet its own build (it trips
+    # -Wunused-parameter), and re-publish the include dir as SYSTEM so the Dart
+    # headers are -isystem for consumers. Mirrors the sdbus-c++ handling in the
+    # root CMakeLists.
+    target_compile_options(dart_api_dl PRIVATE -w)
+    set_target_properties(dart_api_dl PROPERTIES
+            INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+            "${CMAKE_CURRENT_SOURCE_DIR}/flutter/third_party/dart/runtime/include")
+endif ()
+
+#
 # Vulkan-Headers
 #
 # Expose the top-level include dir (not include/vulkan) so the canonical

--- a/third_party/flutter/third_party/dart/runtime/include/PROVENANCE.md
+++ b/third_party/flutter/third_party/dart/runtime/include/PROVENANCE.md
@@ -1,0 +1,53 @@
+# Vendored Dart embedding headers
+
+Source: https://github.com/dart-lang/sdk — `runtime/include/`
+
+| | |
+|---|---|
+| Dart SDK revision | `d684a576a6aa954ae107a03b2b4e1d61c3bebe93` |
+| Pinned by | `flutter/flutter` tag `3.44.2`, `DEPS` → `dart_revision` |
+| Matches | `.flutter-version` (3.44.2) |
+| `DART_API_DL` ABI | major 2, minor 6 (`dart_version.h`) |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `dart_api.h` | Core embedding API types (`Dart_Handle`, `Dart_Port`, …) |
+| `dart_tools_api.h` | Timeline/tools API; used by `fml/trace_event.h` |
+| `dart_native_api.h` | `Dart_CObject`, `Dart_PostCObject` — message posting |
+| `dart_api_dl.h` | Dynamically-linked API declarations |
+| `dart_api_dl.c` | DL symbol table initializer; **must be compiled in** |
+| `dart_version.h` | `DART_API_DL_{MAJOR,MINOR}_VERSION` |
+| `internal/dart_api_dl_impl.h` | DL function-pointer table |
+
+## Why the whole set was refreshed together
+
+`dart_native_api.h` at this revision uses `DART_API_WARN_UNUSED_RESULT`, which
+the previously vendored `dart_api.h` did not define (it had the older
+`DART_WARN_UNUSED_RESULT` spelling). Mixing revisions does not compile, so the
+whole include set moves together.
+
+Nothing in the tree consumed the previous `dart_api.h` / `dart_tools_api.h`:
+`fml/trace_event.h` is the only includer and nothing includes *it*. The refresh
+is therefore behavior-neutral for existing code.
+
+## Updating
+
+When `.flutter-version` changes, re-pin from the corresponding
+`flutter/flutter` tag:
+
+```sh
+REV=$(curl -sSf "https://raw.githubusercontent.com/flutter/flutter/$(cat .flutter-version)/DEPS" \
+      | sed -n "s/.*'dart_revision': '\([0-9a-f]\{40\}\)'.*/\1/p")
+BASE="https://raw.githubusercontent.com/dart-lang/sdk/$REV/runtime/include"
+for f in dart_api.h dart_tools_api.h dart_native_api.h \
+         dart_api_dl.h dart_api_dl.c dart_version.h; do
+  curl -sSf "$BASE/$f" -o "$f"
+done
+curl -sSf "$BASE/internal/dart_api_dl_impl.h" -o internal/dart_api_dl_impl.h
+```
+
+`Dart_InitializeApiDL()` version-checks against the running VM at runtime, so a
+skew between these headers and the loaded `libflutter_engine.so` fails loudly
+at init rather than corrupting memory. Keep them pinned regardless.

--- a/third_party/flutter/third_party/dart/runtime/include/dart_api.h
+++ b/third_party/flutter/third_party/dart/runtime/include/dart_api.h
@@ -25,6 +25,10 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
+#if defined(__Fuchsia__)
+#include <zircon/types.h>
+#endif
+
 #ifdef __cplusplus
 #define DART_EXTERN_C extern "C"
 #else
@@ -53,11 +57,14 @@
 #endif
 
 #if __GNUC__
-#define DART_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#define DART_API_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#define DART_API_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #elif _MSC_VER
-#define DART_WARN_UNUSED_RESULT _Check_return_
+#define DART_API_WARN_UNUSED_RESULT _Check_return_
+#define DART_API_DEPRECATED(msg) __declspec(deprecated(msg))
 #else
-#define DART_WARN_UNUSED_RESULT
+#define DART_API_WARN_UNUSED_RESULT
+#define DART_API_DEPRECATED(msg)
 #endif
 
 /*
@@ -499,14 +506,6 @@ DART_EXPORT void Dart_DeleteWeakPersistentHandle(
     Dart_WeakPersistentHandle object);
 
 /**
- * Updates the external memory size for the given weak persistent handle.
- *
- * May trigger garbage collection.
- */
-DART_EXPORT void Dart_UpdateExternalSize(Dart_WeakPersistentHandle object,
-                                         intptr_t external_allocation_size);
-
-/**
  * Allocates a finalizable handle for an object.
  *
  * This handle has the lifetime of the current isolate group unless the object
@@ -557,19 +556,6 @@ Dart_NewFinalizableHandle(Dart_Handle object,
 DART_EXPORT void Dart_DeleteFinalizableHandle(Dart_FinalizableHandle object,
                                               Dart_Handle strong_ref_to_object);
 
-/**
- * Updates the external memory size for the given finalizable handle.
- *
- * The caller has to provide the actual Dart object the handle was created from
- * to prove the object (and therefore the finalizable handle) is still alive.
- *
- * May trigger garbage collection.
- */
-DART_EXPORT void Dart_UpdateFinalizableExternalSize(
-    Dart_FinalizableHandle object,
-    Dart_Handle strong_ref_to_object,
-    intptr_t external_allocation_size);
-
 /*
  * ==========================
  * Initialization and Globals
@@ -593,7 +579,7 @@ DART_EXPORT const char* Dart_VersionString(void);
  * for each part.
  */
 
-#define DART_FLAGS_CURRENT_VERSION (0x0000000c)
+#define DART_FLAGS_CURRENT_VERSION (0x0000000d)
 
 typedef struct {
   int32_t version;
@@ -602,10 +588,13 @@ typedef struct {
   bool use_osr;
   bool obfuscate;
   bool load_vmservice_library;
-  bool copy_parent_code;
   bool null_safety;
   bool is_system_isolate;
+  bool is_service_isolate;
+  bool is_kernel_isolate;
   bool snapshot_is_dontneed_safe;
+  bool branch_coverage;
+  bool coverage;
 } Dart_IsolateFlags;
 
 /**
@@ -705,13 +694,6 @@ typedef bool (*Dart_InitializeIsolateCallback)(void** child_isolate_data,
                                                char** error);
 
 /**
- * An isolate unhandled exception callback function.
- *
- * This callback has been DEPRECATED.
- */
-typedef void (*Dart_IsolateUnhandledExceptionCallback)(Dart_Handle error);
-
-/**
  * An isolate shutdown callback function.
  *
  * This callback, provided by the embedder, is called before the vm
@@ -761,6 +743,15 @@ typedef void (*Dart_IsolateCleanupCallback)(void* isolate_group_data,
  *
  */
 typedef void (*Dart_IsolateGroupCleanupCallback)(void* isolate_group_data);
+
+/**
+ * A thread start callback function.
+ * This callback, provided by the embedder, is called after a thread in the
+ * vm thread pool starts.
+ * This function could be used to adjust thread priority or attach native
+ * resources to the thread.
+ */
+typedef void (*Dart_ThreadStartCallback)(void);
 
 /**
  * A thread death callback function.
@@ -846,7 +837,7 @@ typedef Dart_Handle (*Dart_GetVMServiceAssetsArchive)(void);
  * The current version of the Dart_InitializeFlags. Should be incremented every
  * time Dart_InitializeFlags changes in a binary incompatible way.
  */
-#define DART_INITIALIZE_PARAMS_CURRENT_VERSION (0x00000005)
+#define DART_INITIALIZE_PARAMS_CURRENT_VERSION (0x0000000A)
 
 /** Forward declaration */
 struct Dart_CodeObserver;
@@ -871,50 +862,6 @@ typedef struct Dart_CodeObserver {
 
   Dart_OnNewCodeCallback on_new_code;
 } Dart_CodeObserver;
-
-typedef struct _Dart_Task* Dart_Task;
-typedef enum {
-  Dart_TaskPriority_Default,
-} Dart_TaskPriority;
-typedef struct {
-  /**
-   * Placeholder.
-   */
-  Dart_TaskPriority priority;
-  /**
-   * Time after which the task should run according to the clock of
-   * Dart_TimelineGetMicros.
-   */
-  int64_t time_point;
-} Dart_TaskData;
-/**
- * Callback provided by the embedder that is used by the VM to eventually run
- * various tasks. If no callback is provided, these tasks will run on a
- * VM-internal thread pool. This callback allows the embedder to make its own
- * choices around the scheduling of these tasks: when they run, how many threads
- * are servicing these tasks, the priorities of said threads, etc.
- * The callback can be invoked as early as during the Dart_Initialize call.
- *
- * \param post_task_data
- *     The data provided to Dart_InitializeParams.post_task_data.
- * \param task
- *     A task that should eventually be passed to Dart_RunTask.
- * \param task_data
- *     Hints about when the task should run.
- */
-typedef void (*Dart_PostTaskCallback)(void* post_task_data,
-                                      Dart_Task task,
-                                      Dart_TaskData task_data);
-
-/**
- * Runs a task given to the Dart_PostTaskCallback. Must not be called
- * synchronously in response to any callback from the VM. In particular, must
- * not be called synchronously by the implemention of a Dart native function
- * or Dart_Post_TaskCallback.
- *
- * Requires there to be no current isolate or isolate group.
- */
-DART_EXPORT void Dart_RunTask(Dart_Task task);
 
 /**
  * Describes how to initialize the VM. Used with Dart_Initialize.
@@ -972,6 +919,7 @@ typedef struct {
    */
   Dart_IsolateGroupCleanupCallback cleanup_group;
 
+  Dart_ThreadStartCallback thread_start;
   Dart_ThreadExitCallback thread_exit;
   Dart_FileOpenCallback file_open;
   Dart_FileReadCallback file_read;
@@ -982,6 +930,8 @@ typedef struct {
   /**
    * A function to be called by the service isolate when it requires the
    * vmservice assets archive. See Dart_GetVMServiceAssetsArchive.
+   * 
+   * This field is deprecated and has no effect.
    */
   Dart_GetVMServiceAssetsArchive get_service_assets;
 
@@ -992,13 +942,6 @@ typedef struct {
    * as early as during the Dart_Initialize() call.
    */
   Dart_CodeObserver* code_observer;
-
-  /**
-   * A task scheduling callback function. See Dart_PostTaskCallback.
-   */
-  Dart_PostTaskCallback post_task;
-
-  void* post_task_data;
 } Dart_InitializeParams;
 
 /**
@@ -1010,7 +953,7 @@ typedef struct {
  * \return NULL if initialization is successful. Returns an error message
  *   otherwise. The caller is responsible for freeing the error message.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Initialize(
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_Initialize(
     Dart_InitializeParams* params);
 
 /**
@@ -1022,7 +965,7 @@ DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Initialize(
  * NOTE: This function must not be called on a thread that was created by the VM
  * itself.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Cleanup(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_Cleanup(void);
 
 /**
  * Sets command line flags. Should be called before Dart_Initialize.
@@ -1035,8 +978,9 @@ DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_Cleanup(void);
  *
  * NOTE: This call does not store references to the passed in c-strings.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_SetVMFlags(int argc,
-                                                          const char** argv);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_SetVMFlags(
+    int argc,
+    const char** argv);
 
 /**
  * Returns true if the named VM flag is of boolean type, specified, and set to
@@ -1112,7 +1056,7 @@ Dart_CreateIsolateGroup(const char* script_uri,
  *   shutdown (may be NULL).
  * \param cleanup_callback A callback to be called when the isolate is being
  *   cleaned up (may be NULL).
- * \param isolate_data The embedder-specific data associated with this isolate.
+ * \param child_isolate_data The embedder-specific data associated with this isolate.
  * \param error Set to NULL if creation is successful, set to an error
  *   message otherwise. The caller is responsible for calling free() on the
  *   error message.
@@ -1212,6 +1156,14 @@ DART_EXPORT Dart_IsolateGroup Dart_CurrentIsolateGroup(void);
 DART_EXPORT void* Dart_CurrentIsolateGroupData(void);
 
 /**
+ * Gets an id that uniquely identifies current isolate group.
+ *
+ * It is the responsibility of the caller to free the returned ID.
+ */
+typedef int64_t Dart_IsolateGroupId;
+DART_EXPORT Dart_IsolateGroupId Dart_CurrentIsolateGroupId(void);
+
+/**
  * Returns the callback data associated with the specified isolate group. This
  * data was passed to the isolate when it was created.
  * The embedder is responsible for ensuring the consistency of this data
@@ -1226,6 +1178,17 @@ DART_EXPORT void* Dart_IsolateGroupData(Dart_Isolate isolate);
  * debugging messages more comprehensible.
  */
 DART_EXPORT Dart_Handle Dart_DebugName(void);
+
+/**
+ * Returns the debugging name for the current isolate.
+ *
+ * This name is unique to each isolate and should only be used to make
+ * debugging messages more comprehensible.
+ *
+ * The returned string is scope allocated and is only valid until the next call
+ * to Dart_ExitScope.
+ */
+DART_EXPORT const char* Dart_DebugNameToCString(void);
 
 /**
  * Returns the ID for an isolate which is used to query the service protocol.
@@ -1258,18 +1221,6 @@ DART_EXPORT void Dart_EnterIsolate(Dart_Isolate isolate);
 DART_EXPORT void Dart_KillIsolate(Dart_Isolate isolate);
 
 /**
- * Notifies the VM that the embedder expects |size| bytes of memory have become
- * unreachable. The VM may use this hint to adjust the garbage collector's
- * growth policy.
- *
- * Multiple calls are interpreted as increasing, not replacing, the estimate of
- * unreachable memory.
- *
- * Requires there to be a current isolate.
- */
-DART_EXPORT void Dart_HintFreed(intptr_t size);
-
-/**
  * Notifies the VM that the embedder expects to be idle until |deadline|. The VM
  * may use this time to perform garbage collection or other tasks to avoid
  * delays during execution of Dart code in the future.
@@ -1281,12 +1232,127 @@ DART_EXPORT void Dart_HintFreed(intptr_t size);
  */
 DART_EXPORT void Dart_NotifyIdle(int64_t deadline);
 
+typedef void (*Dart_HeapSamplingReportCallback)(void* context, void* data);
+
+typedef void* (*Dart_HeapSamplingCreateCallback)(
+    Dart_Isolate isolate,
+    Dart_IsolateGroup isolate_group,
+    const char* cls_name,
+    intptr_t allocation_size);
+typedef void (*Dart_HeapSamplingDeleteCallback)(void* data);
+
+/**
+ * Starts the heap sampling profiler for each thread in the VM.
+ */
+DART_EXPORT void Dart_EnableHeapSampling(void);
+
+/*
+ * Stops the heap sampling profiler for each thread in the VM.
+ */
+DART_EXPORT void Dart_DisableHeapSampling(void);
+
+/* Registers callbacks are invoked once per sampled allocation upon object
+ * allocation and garbage collection.
+ *
+ * |create_callback| can be used to associate additional data with the sampled
+ * allocation, such as a stack trace. This data pointer will be passed to
+ * |delete_callback| to allow for proper disposal when the object associated
+ * with the allocation sample is collected.
+ *
+ * The provided callbacks must not call into the VM and should do as little
+ * work as possible to avoid performance penalities during object allocation and
+ * garbage collection.
+ *
+ * NOTE: It is a fatal error to set either callback to null once they have been
+ * initialized.
+ */
+DART_EXPORT void Dart_RegisterHeapSamplingCallback(
+    Dart_HeapSamplingCreateCallback create_callback,
+    Dart_HeapSamplingDeleteCallback delete_callback);
+
+/*
+ * Reports the surviving allocation samples for all live isolate groups in the
+ * VM.
+ *
+ * When the callback is invoked:
+ *  - |context| will be the context object provided when invoking
+ *    |Dart_ReportSurvivingAllocations|. This can be safely set to null if not
+ *    required.
+ *  - |heap_size| will be equal to the size of the allocated object associated
+ *    with the sample.
+ *  - |cls_name| will be a C String representing
+ *    the class name of the allocated object. This string is valid for the
+ *    duration of the call to Dart_ReportSurvivingAllocations and can be
+ *    freed by the VM at any point after the method returns.
+ *  - |data| will be set to the data associated with the sample by
+ *    |Dart_HeapSamplingCreateCallback|.
+ *
+ * If |force_gc| is true, a full GC will be performed before reporting the
+ * allocations.
+ */
+DART_EXPORT void Dart_ReportSurvivingAllocations(
+    Dart_HeapSamplingReportCallback callback,
+    void* context,
+    bool force_gc);
+
+/*
+ * Sets the average heap sampling rate based on a number of |bytes| for each
+ * thread.
+ *
+ * In other words, approximately every |bytes| allocated will create a sample.
+ * Defaults to 512 KiB.
+ */
+DART_EXPORT void Dart_SetHeapSamplingPeriod(intptr_t bytes);
+
+/**
+ * Notifies the VM that the embedder expects the application's working set has
+ * recently shrunk significantly and is not expected to rise in the near future.
+ * The VM may spend O(heap-size) time performing clean up work.
+ *
+ * Requires there to be a current isolate.
+ */
+DART_EXPORT void Dart_NotifyDestroyed(void);
+
 /**
  * Notifies the VM that the system is running low on memory.
  *
  * Does not require a current isolate. Only valid after calling Dart_Initialize.
  */
 DART_EXPORT void Dart_NotifyLowMemory(void);
+
+typedef enum {
+  /**
+   * Balanced
+   */
+  Dart_PerformanceMode_Default,
+  /**
+   * Optimize for low latency, at the expense of throughput and memory overhead
+   * by performing work in smaller batches (requiring more overhead) or by
+   * delaying work (requiring more memory). An embedder should not remain in
+   * this mode indefinitely.
+   */
+  Dart_PerformanceMode_Latency,
+  /**
+   * Optimize for high throughput, at the expense of latency and memory overhead
+   * by performing work in larger batches with more intervening growth.
+   */
+  Dart_PerformanceMode_Throughput,
+  /**
+   * Optimize for low memory, at the expensive of throughput and latency by more
+   * frequently performing work.
+   */
+  Dart_PerformanceMode_Memory,
+} Dart_PerformanceMode;
+
+/**
+ * Set the desired performance trade-off.
+ *
+ * Requires a current isolate.
+ *
+ * Returns the previous performance mode.
+ */
+DART_EXPORT Dart_PerformanceMode
+Dart_SetPerformanceMode(Dart_PerformanceMode mode);
 
 /**
  * Starts the CPU sampling profiler.
@@ -1296,7 +1362,7 @@ DART_EXPORT void Dart_StartProfiling(void);
 /**
  * Stops the CPU sampling profiler.
  *
- * Note that some profile samples might still be taken after this fucntion
+ * Note that some profile samples might still be taken after this function
  * returns due to the asynchronous nature of the implementation on some
  * platforms.
  */
@@ -1368,7 +1434,7 @@ DART_EXPORT void Dart_ExitIsolate(void);
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateSnapshot(uint8_t** vm_snapshot_data_buffer,
                     intptr_t* vm_snapshot_data_size,
                     uint8_t** isolate_snapshot_data_buffer,
@@ -1386,6 +1452,16 @@ Dart_CreateSnapshot(uint8_t** vm_snapshot_data_buffer,
 DART_EXPORT bool Dart_IsKernel(const uint8_t* buffer, intptr_t buffer_size);
 
 /**
+ * Returns whether the buffer contains a bytecode file.
+ *
+ * \param buffer Pointer to a buffer that might contain a bytecode binary.
+ * \param buffer_size Size of the buffer.
+ *
+ * \return Whether the buffer contains a bytecode binary.
+ */
+DART_EXPORT bool Dart_IsBytecode(const uint8_t* buffer, intptr_t buffer_size);
+
+/**
  * Make isolate runnable.
  *
  * When isolates are spawned, this function is used to indicate that
@@ -1398,7 +1474,7 @@ DART_EXPORT bool Dart_IsKernel(const uint8_t* buffer, intptr_t buffer_size);
  * \return NULL if successful. Returns an error message otherwise. The caller
  * is responsible for freeing the error message.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_IsolateMakeRunnable(
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_IsolateMakeRunnable(
     Dart_Isolate isolate);
 
 /*
@@ -1411,6 +1487,10 @@ DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_IsolateMakeRunnable(
  * A port is used to send or receive inter-isolate messages
  */
 typedef int64_t Dart_Port;
+typedef struct {
+  int64_t port_id;
+  int64_t origin_id;
+} Dart_PortEx;
 
 /**
  * ILLEGAL_PORT is a port number guaranteed never to be associated with a valid
@@ -1421,17 +1501,22 @@ typedef int64_t Dart_Port;
 /**
  * A message notification callback.
  *
- * This callback allows the embedder to provide an alternate wakeup
- * mechanism for the delivery of inter-isolate messages.  It is the
- * responsibility of the embedder to call Dart_HandleMessage to
- * process the message.
+ * This callback allows the embedder to provide a custom wakeup mechanism for
+ * the delivery of inter-isolate messages. This function is called once per
+ * message on an arbitrary thread. It is the responsibility of the embedder to
+ * eventually call Dart_HandleMessage once per callback received with the
+ * destination isolate set as the current isolate to process the message.
  */
-typedef void (*Dart_MessageNotifyCallback)(Dart_Isolate dest_isolate);
+typedef void (*Dart_MessageNotifyCallback)(Dart_Isolate destination_isolate);
 
 /**
- * Allows embedders to provide an alternative wakeup mechanism for the
- * delivery of inter-isolate messages. This setting only applies to
- * the current isolate.
+ * Allows embedders to provide a custom wakeup mechanism for the delivery of
+ * inter-isolate messages. This setting only applies to the current isolate.
+ *
+ * This mechanism is optional: if not provided, the isolate will be scheduled on
+ * a VM-managed thread pool. An embedder should provide this callback if it
+ * wants to run an isolate on a specific thread or to interleave handling of
+ * inter-isolate messages with other event sources.
  *
  * Most embedders will only call this function once, before isolate
  * execution begins. If this function is called after isolate
@@ -1559,18 +1644,7 @@ DART_EXPORT Dart_Handle Dart_GetStickyError(void);
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_HandleMessage(void);
-
-/**
- * Drains the microtask queue, then blocks the calling thread until the current
- * isolate receives a message, then handles all messages.
- *
- * \param timeout_millis When non-zero, the call returns after the indicated
-          number of milliseconds even if no message was received.
- * \return A valid handle if no error occurs, otherwise an error handle.
- */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
-Dart_WaitForEvent(int64_t timeout_millis);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_HandleMessage(void);
 
 /**
  * Handles any pending messages for the vm service for the current
@@ -1610,7 +1684,7 @@ DART_EXPORT bool Dart_HasServiceMessages(void);
  *   exception or other error occurs while processing messages, an
  *   error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop(void);
 
 /**
  * Lets the VM run message processing for the isolate.
@@ -1626,17 +1700,15 @@ DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_RunLoop(void);
  * \param error A non-NULL pointer which will hold an error message if the call
  *   fails. The error has to be free()ed by the caller.
  *
- * \return If successfull the VM takes owernship of the isolate and takes care
- *   of its message loop. If not successful the caller retains owernship of the
+ * \return If successful the VM takes ownership of the isolate and takes care
+ *   of its message loop. If not successful the caller retains ownership of the
  *   isolate.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT bool Dart_RunLoopAsync(
+DART_EXPORT DART_API_WARN_UNUSED_RESULT bool Dart_RunLoopAsync(
     bool errors_are_fatal,
     Dart_Port on_error_port,
     Dart_Port on_exit_port,
     char** error);
-
-/* TODO(turnidge): Should this be removed from the public api? */
 
 /**
  * Gets the main port id for the current isolate.
@@ -1656,6 +1728,8 @@ DART_EXPORT bool Dart_HasLivePorts(void);
  *
  * Requires there to be a current isolate.
  *
+ * For posting messages outside of an isolate see \ref Dart_PostCObject.
+ *
  * \param port_id The destination port.
  * \param object An object from the current isolate.
  *
@@ -1666,12 +1740,26 @@ DART_EXPORT bool Dart_Post(Dart_Port port_id, Dart_Handle object);
 /**
  * Returns a new SendPort with the provided port id.
  *
+ * If there is a possibility of a port closing since port_id was acquired
+ * for a SendPort, one should use Dart_NewSendPortEx and
+ * Dart_SendPortGetIdEx.
+ *
  * \param port_id The destination port.
  *
  * \return A new SendPort if no errors occurs. Otherwise returns
  *   an error handle.
  */
 DART_EXPORT Dart_Handle Dart_NewSendPort(Dart_Port port_id);
+
+/**
+ * Returns a new SendPort with the provided port id and origin id.
+ *
+ * \param portex_id The destination composte port id.
+ *
+ * \return A new SendPort if no errors occurs. Otherwise returns
+ *   an error handle.
+ */
+DART_EXPORT Dart_Handle Dart_NewSendPortEx(Dart_PortEx portex_id);
 
 /**
  * Gets the SendPort id for the provided SendPort.
@@ -1682,6 +1770,33 @@ DART_EXPORT Dart_Handle Dart_NewSendPort(Dart_Port port_id);
  */
 DART_EXPORT Dart_Handle Dart_SendPortGetId(Dart_Handle port,
                                            Dart_Port* port_id);
+
+/**
+ * Gets the SendPort and Origin ids for the provided SendPort.
+ * \param port A SendPort object whose id is desired.
+ * \param portex_id Returns composite id of the SendPort.
+ * \return Success if no error occurs. Otherwise returns
+ *   an error handle.
+ */
+DART_EXPORT Dart_Handle Dart_SendPortGetIdEx(Dart_Handle port,
+                                             Dart_PortEx* portex_id);
+
+/**
+ * Sets the owner thread of the current isolate to be the current thread.
+ *
+ * Requires there to be a current isolate, and that the isolate is unowned.
+ */
+DART_EXPORT void Dart_SetCurrentThreadOwnsIsolate(void);
+
+/**
+ * Returns whether the current thread owns the isolate that owns the given port.
+ *
+ * The port can be the isolate's main port, or any other port owned by the
+ * isolate.
+ *
+ * \param port The port to be checked.
+ */
+DART_EXPORT bool Dart_GetCurrentThreadOwnsIsolate(Dart_Port port);
 
 /*
  * ======
@@ -1769,6 +1884,17 @@ DART_EXPORT Dart_Handle Dart_TypeVoid(void);
 DART_EXPORT Dart_Handle Dart_TypeNever(void);
 
 /**
+ * Returns simple core types.
+ *
+ * \return A handle to type.
+ */
+DART_EXPORT Dart_Handle Dart_TypeString();
+DART_EXPORT Dart_Handle Dart_TypeDouble();
+DART_EXPORT Dart_Handle Dart_TypeInt();
+DART_EXPORT Dart_Handle Dart_TypeBoolean();
+DART_EXPORT Dart_Handle Dart_TypeObject();
+
+/**
  * Checks if the two objects are equal.
  *
  * The result of the comparison is returned through the 'equal'
@@ -1817,7 +1943,6 @@ DART_EXPORT bool Dart_IsDouble(Dart_Handle object);
 DART_EXPORT bool Dart_IsBoolean(Dart_Handle object);
 DART_EXPORT bool Dart_IsString(Dart_Handle object);
 DART_EXPORT bool Dart_IsStringLatin1(Dart_Handle object); /* (ISO-8859-1) */
-DART_EXPORT bool Dart_IsExternalString(Dart_Handle object);
 DART_EXPORT bool Dart_IsList(Dart_Handle object);
 DART_EXPORT bool Dart_IsMap(Dart_Handle object);
 DART_EXPORT bool Dart_IsLibrary(Dart_Handle object);
@@ -1885,7 +2010,7 @@ DART_EXPORT Dart_Handle Dart_FunctionName(Dart_Handle function);
 DART_EXPORT Dart_Handle Dart_FunctionOwner(Dart_Handle function);
 
 /**
- * Determines whether a function handle referes to a static function
+ * Determines whether a function handle refers to a static function
  * of method.
  *
  * For the purposes of the embedding API, a top-level function is
@@ -2123,6 +2248,17 @@ DART_EXPORT Dart_Handle Dart_BooleanValue(Dart_Handle boolean_obj, bool* value);
 DART_EXPORT Dart_Handle Dart_StringLength(Dart_Handle str, intptr_t* length);
 
 /**
+ * Gets the length of UTF-8 encoded representation for a string.
+ *
+ * \param str A String.
+ * \param length Returns the length of UTF-8 encoded representation for string.
+ *
+ * \return A valid handle if no error occurs during the operation.
+ */
+DART_EXPORT Dart_Handle Dart_StringUTF8Length(Dart_Handle str,
+                                              intptr_t* length);
+
+/**
  * Returns a String built from the provided C string
  * (There is an implicit assumption that the C string passed in contains
  *  UTF-8 encoded characters and '\0' is considered as a termination
@@ -2174,48 +2310,6 @@ DART_EXPORT Dart_Handle Dart_NewStringFromUTF32(const int32_t* utf32_array,
                                                 intptr_t length);
 
 /**
- * Returns a String which references an external array of
- * Latin-1 (ISO-8859-1) encoded characters.
- *
- * \param latin1_array Array of Latin-1 encoded characters. This must not move.
- * \param length The length of the characters array.
- * \param peer An external pointer to associate with this string.
- * \param external_allocation_size The number of externally allocated
- *   bytes for peer. Used to inform the garbage collector.
- * \param callback A callback to be called when this string is finalized.
- *
- * \return The String object if no error occurs. Otherwise returns
- *   an error handle.
- */
-DART_EXPORT Dart_Handle
-Dart_NewExternalLatin1String(const uint8_t* latin1_array,
-                             intptr_t length,
-                             void* peer,
-                             intptr_t external_allocation_size,
-                             Dart_HandleFinalizer callback);
-
-/**
- * Returns a String which references an external array of UTF-16 encoded
- * characters.
- *
- * \param utf16_array An array of UTF-16 encoded characters. This must not move.
- * \param length The length of the characters array.
- * \param peer An external pointer to associate with this string.
- * \param external_allocation_size The number of externally allocated
- *   bytes for peer. Used to inform the garbage collector.
- * \param callback A callback to be called when this string is finalized.
- *
- * \return The String object if no error occurs. Otherwise returns
- *   an error handle.
- */
-DART_EXPORT Dart_Handle
-Dart_NewExternalUTF16String(const uint16_t* utf16_array,
-                            intptr_t length,
-                            void* peer,
-                            intptr_t external_allocation_size,
-                            Dart_HandleFinalizer callback);
-
-/**
  * Gets the C string representation of a String.
  * (It is a sequence of UTF-8 encoded values with a '\0' termination.)
  *
@@ -2248,6 +2342,24 @@ DART_EXPORT Dart_Handle Dart_StringToCString(Dart_Handle str,
 DART_EXPORT Dart_Handle Dart_StringToUTF8(Dart_Handle str,
                                           uint8_t** utf8_array,
                                           intptr_t* length);
+
+/**
+ * Copies the UTF-8 encoded representation of a String into specified buffer.
+ *
+ * Any unpaired surrogate code points in the string will be converted as
+ * replacement characters (U+FFFD, 0xEF 0xBF 0xBD in UTF-8).
+ *
+ * \param str A string.
+ * \param utf8_array Buffer into which the UTF-8 encoded representation of
+ *   the string is copied into.
+ *   The buffer is allocated and managed by the caller.
+ * \param length Specifies the length of the buffer passed in.
+ *
+ * \return A valid handle if no error occurs during the operation.
+ */
+DART_EXPORT Dart_Handle Dart_CopyUTF8EncodingOfString(Dart_Handle str,
+                                                      uint8_t* utf8_array,
+                                                      intptr_t length);
 
 /**
  * Gets the data corresponding to the string object. This function returns
@@ -2326,25 +2438,6 @@ DART_EXPORT Dart_Handle Dart_StringGetProperties(Dart_Handle str,
  *   an error handle.
  */
 DART_EXPORT Dart_Handle Dart_NewList(intptr_t length);
-
-typedef enum {
-  Dart_CoreType_Dynamic,
-  Dart_CoreType_Int,
-  Dart_CoreType_String,
-} Dart_CoreType_Id;
-
-// TODO(bkonyi): convert this to use nullable types once NNBD is enabled.
-/**
- * Returns a List of the desired length with the desired legacy element type.
- *
- * \param element_type_id The type of elements of the list.
- * \param length The length of the list.
- *
- * \return The List object if no error occurs. Otherwise returns an error
- * handle.
- */
-DART_EXPORT Dart_Handle Dart_NewListOf(Dart_CoreType_Id element_type_id,
-                                       intptr_t length);
 
 /**
  * Returns a List of the desired length with the desired element type.
@@ -2501,6 +2594,26 @@ DART_EXPORT Dart_Handle Dart_MapContainsKey(Dart_Handle map, Dart_Handle key);
  */
 DART_EXPORT Dart_Handle Dart_MapKeys(Dart_Handle map);
 
+/**
+ * Returns a Map filled by key value pairs from the provided lists.
+ *
+ * \param keys_type Handle to a type of keys. E.g., from
+ *   Dart_Get<XXX>Type.
+ * \param keys_handle Handle to a list with keys. E.g., from
+ *   Dart_NewList<XXX>.
+ * \param values_type Handle to a type of values. E.g., from
+ *   Dart_Get<XXX>Type.
+ * \param values_handle Handle to a list with values. E.g., from
+ *   Dart_NewList<XXX>.
+ *
+ * \return The Map object if no error occurs. Otherwise returns
+ *   an error handle.
+ */
+DART_EXPORT Dart_Handle Dart_NewMap(Dart_Handle keys_type,
+                                    Dart_Handle keys_handle,
+                                    Dart_Handle values_type,
+                                    Dart_Handle values_handle);
+
 /*
  * ==========
  * Typed Data
@@ -2593,6 +2706,13 @@ Dart_NewExternalTypedDataWithFinalizer(Dart_TypedData_Type type,
                                        void* peer,
                                        intptr_t external_allocation_size,
                                        Dart_HandleFinalizer callback);
+DART_EXPORT Dart_Handle Dart_NewUnmodifiableExternalTypedDataWithFinalizer(
+    Dart_TypedData_Type type,
+    const void* data,
+    intptr_t length,
+    void* peer,
+    intptr_t external_allocation_size,
+    Dart_HandleFinalizer callback);
 
 /**
  * Returns a ByteBuffer object for the typed data.
@@ -2676,7 +2796,7 @@ DART_EXPORT Dart_Handle Dart_GetDataFromByteBuffer(Dart_Handle byte_buffer);
  *   then the new object. If an error occurs during execution, then an
  *   error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_New(Dart_Handle type,
          Dart_Handle constructor_name,
          int number_of_arguments,
@@ -2690,7 +2810,8 @@ Dart_New(Dart_Handle type,
  * \return The new object. If an error occurs during execution, then an
  *   error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_Allocate(Dart_Handle type);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_Allocate(Dart_Handle type);
 
 /**
  * Allocate a new object without invoking a constructor, and sets specified
@@ -2731,7 +2852,7 @@ Dart_AllocateWithNativeFields(Dart_Handle type,
  *   successfully, then the return value is returned. If an error
  *   occurs during execution, then an error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_Invoke(Dart_Handle target,
             Dart_Handle name,
             int number_of_arguments,
@@ -2747,7 +2868,7 @@ Dart_Invoke(Dart_Handle target,
  *   invoking the closure is returned. If an error occurs during
  *   execution, then an error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_InvokeClosure(Dart_Handle closure,
                    int number_of_arguments,
                    Dart_Handle* arguments);
@@ -2772,7 +2893,7 @@ Dart_InvokeClosure(Dart_Handle closure,
  *   successfully, then the object is returned. If an error
  *   occurs during execution, then an error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_InvokeConstructor(Dart_Handle object,
                        Dart_Handle name,
                        int number_of_arguments,
@@ -2798,7 +2919,7 @@ Dart_InvokeConstructor(Dart_Handle object,
  * \return If no error occurs, then the value of the field is
  *   returned. Otherwise an error handle is returned.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_GetField(Dart_Handle container, Dart_Handle name);
 
 /**
@@ -2821,7 +2942,7 @@ Dart_GetField(Dart_Handle container, Dart_Handle name);
  *
  * \return A valid handle if no error occurs.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_SetField(Dart_Handle container, Dart_Handle name, Dart_Handle value);
 
 /*
@@ -3217,7 +3338,7 @@ DART_EXPORT Dart_Handle Dart_GetNativeSymbol(Dart_Handle library,
 /**
  * Sets the callback used to resolve FFI native functions for a library.
  * The resolved functions are expected to be a C function pointer of the
- * correct signature (as specified in the `@FfiNative<NFT>()` function
+ * correct signature (as specified in the `@Native<NFT>()` function
  * annotation in Dart code).
  *
  * NOTE: This is an experimental feature and might change in the future.
@@ -3229,6 +3350,107 @@ DART_EXPORT Dart_Handle Dart_GetNativeSymbol(Dart_Handle library,
  */
 DART_EXPORT Dart_Handle
 Dart_SetFfiNativeResolver(Dart_Handle library, Dart_FfiNativeResolver resolver);
+
+/**
+ * Callback provided by the embedder that is used by the VM to resolve asset
+ * paths.
+ *
+ * The VM is responsible for looking up the asset path with the asset id in the
+ * kernel mapping. The embedder is responsible for providing the asset mapping
+ * during kernel compilation and using the asset path to return a library handle
+ * in this function.
+ *
+ * \param path The string in the asset path as passed in native_assets.yaml
+ *             during kernel compilation.
+ *
+ * \param error Returns NULL if successful, an error message otherwise. The
+ *   caller is responsible for calling free() on the error message.
+ *
+ * \return The library handle. If |error| is not-null, the return value is
+ *         undefined.
+ */
+typedef void* (*Dart_NativeAssetsDlopenCallback)(const char* path,
+                                                 char** error);
+typedef void* (*Dart_NativeAssetsDlopenCallbackNoPath)(char** error);
+
+/**
+ * Callback provided by the embedder that is used by the VM to resolve asset
+ * ids.
+ *
+ * The embedder can freely chose how to bundle asset id to asset path mappings
+ * and how to perform this lookup.
+ *
+ * If the embedder provides this callback, it must also provide
+ * `Dart_NativeAssetsAvailableAssets`.
+ *
+ * If provided, takes prescedence over `Dart_NativeAssetsDlopenCallback`.
+ *
+ * \param asset_id The asset id requested in the `@Native` external function.
+ *
+ * \param error Returns NULL if successful, an error message otherwise. The
+ *   caller is responsible for calling free() on the error message.
+ *
+ * \return The library handle. If |error| is not-null, the return value is
+ *         undefined.
+ */
+typedef void* (*Dart_NativeAssetsDlopenAssetId)(const char* asset_id,
+                                                char** error);
+
+/**
+ * Callback provided by the embedder that is used  by the VM to request a
+ * description of the available assets
+ *
+ * \return A malloced string containing all asset ids. The caller must free this
+ *   string.
+ */
+typedef char* (*Dart_NativeAssetsAvailableAssets)(void);
+
+/**
+ * Callback provided by the embedder that is used by the VM to lookup symbols
+ * in native code assets.
+ * If no callback is provided, using `@Native`s with `native_asset.yaml`s will
+ * fail.
+ *
+ * \param handle The library handle returned from a
+ *               `Dart_NativeAssetsDlopenCallback` or
+ *               `Dart_NativeAssetsDlopenCallbackNoPath`.
+ *
+ * \param symbol The symbol to look up. Is a string.
+ *
+ * \param error Returns NULL if creation is successful, an error message
+ *   otherwise. The caller is responsible for calling free() on the error
+ *   message.
+ *
+ * \return The symbol address. If |error| is not-null, the return value is
+ *         undefined.
+ */
+typedef void* (*Dart_NativeAssetsDlsymCallback)(void* handle,
+                                                const char* symbol,
+                                                char** error);
+
+typedef struct {
+  Dart_NativeAssetsDlopenCallback dlopen_absolute;
+  Dart_NativeAssetsDlopenCallback dlopen_relative;
+  Dart_NativeAssetsDlopenCallback dlopen_system;
+  Dart_NativeAssetsDlopenCallbackNoPath dlopen_process;
+  Dart_NativeAssetsDlopenCallbackNoPath dlopen_executable;
+  Dart_NativeAssetsDlsymCallback dlsym;
+  Dart_NativeAssetsDlopenAssetId dlopen;
+  Dart_NativeAssetsAvailableAssets available_assets;
+} NativeAssetsApi;
+
+/**
+ * Initializes native asset resolution for the current isolate group.
+ *
+ * The caller is responsible for ensuring this is called right after isolate
+ * group creation, and before running any dart code (or spawning isolates).
+ *
+ * @param native_assets_api The callbacks used by native assets resolution.
+ *                          The VM does not take ownership of the parameter,
+ *                          it can be freed immediately after the call.
+ */
+DART_EXPORT void Dart_InitializeNativeAssetsResolver(
+    NativeAssetsApi* native_assets_api);
 
 /*
  * =====================
@@ -3252,10 +3474,8 @@ typedef enum {
  * Dart_kCanonicalizeUrl
  *
  * This tag indicates that the embedder should canonicalize 'url' with
- * respect to 'library'.  For most embedders, the
- * Dart_DefaultCanonicalizeUrl function is a sufficient implementation
- * of this tag.  The return value should be a string holding the
- * canonicalized url.
+ * respect to 'library'.  For most embedders, this is resolving the `url`
+ * relative to the `library`s url (see `Dart_LibraryUrl`).
  *
  * Dart_kImportTag
  *
@@ -3304,9 +3524,9 @@ Dart_SetLibraryTagHandler(Dart_LibraryTagHandler handler);
  * call Dart_DeferredLoadComplete or Dart_DeferredLoadCompleteError before the
  * handler returns.
  *
- * If an error is returned, it will be propogated through
+ * If an error is returned, it will be propagated through
  * `prefix.loadLibrary()`. This is useful for synchronous
- * implementations, which must propogate any unwind errors from
+ * implementations, which must propagate any unwind errors from
  * Dart_DeferredLoadComplete or Dart_DeferredLoadComplete. Otherwise the handler
  * should return a non-error such as `Dart_Null()`.
  */
@@ -3327,7 +3547,7 @@ Dart_SetDeferredLoadHandler(Dart_DeferredLoadHandler handler);
  * Requires the current isolate to be the same current isolate during the
  * invocation of the Dart_DeferredLoadHandler.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_DeferredLoadComplete(intptr_t loading_unit_id,
                           const uint8_t* snapshot_data,
                           const uint8_t* snapshot_instructions);
@@ -3344,30 +3564,10 @@ Dart_DeferredLoadComplete(intptr_t loading_unit_id,
  * Requires the current isolate to be the same current isolate during the
  * invocation of the Dart_DeferredLoadHandler.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_DeferredLoadCompleteError(intptr_t loading_unit_id,
                                const char* error_message,
                                bool transient);
-
-/**
- * Canonicalizes a url with respect to some library.
- *
- * The url is resolved with respect to the library's url and some url
- * normalizations are performed.
- *
- * This canonicalization function should be sufficient for most
- * embedders to implement the Dart_kCanonicalizeUrl tag.
- *
- * \param base_url The base url relative to which the url is
- *                being resolved.
- * \param url The url being resolved and canonicalized.  This
- *            parameter is a string handle.
- *
- * \return If no error occurs, a String object is returned.  Otherwise
- *   an error handle is returned.
- */
-DART_EXPORT Dart_Handle Dart_DefaultCanonicalizeUrl(Dart_Handle base_url,
-                                                    Dart_Handle url);
 
 /**
  * Loads the root library for the current isolate.
@@ -3380,8 +3580,34 @@ DART_EXPORT Dart_Handle Dart_DefaultCanonicalizeUrl(Dart_Handle base_url,
  *
  * \return A handle to the root library, or an error.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_LoadScriptFromKernel(const uint8_t* kernel_buffer, intptr_t kernel_size);
+
+/**
+ * Loads the root library for the current isolate.
+ *
+ * Requires there to be no current root library.
+ *
+ * \param kernel_buffer A buffer which contains a bytecode binary.
+ *   Must remain valid until isolate group shutdown.
+ * \param kernel_size Length of the passed in buffer.
+ *
+ * \return A handle to the root library, or an error.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadScriptFromBytecode(const uint8_t* kernel_buffer, intptr_t kernel_size);
+
+/**
+ * Loads a module snapshot.
+ *
+ * \param snapshot_data Buffer containing the module snapshot data.
+ *   Must remain valid until isolate group shutdown.
+ * \param snapshot_instructions Buffer containing the module snapshot
+ *   instructions. Must remain valid until isolate group shutdown.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadModuleSnapshot(const uint8_t* snapshot_data,
+                        const uint8_t* snapshot_instructions);
 
 /**
  * Gets the library for the root script for the current isolate.
@@ -3410,7 +3636,7 @@ DART_EXPORT Dart_Handle Dart_SetRootLibrary(Dart_Handle library);
  * \param number_of_type_arguments Number of type arguments.
  *   For non parametric types the number of type arguments would be 0.
  * \param type_arguments Pointer to an array of type arguments.
- *   For non parameteric types a NULL would be passed in for this argument.
+ *   For non parametric types a NULL would be passed in for this argument.
  *
  * \return If no error occurs, the type is returned.
  *   Otherwise an error handle is returned.
@@ -3429,7 +3655,7 @@ DART_EXPORT Dart_Handle Dart_GetType(Dart_Handle library,
  * \param number_of_type_arguments Number of type arguments.
  *   For non parametric types the number of type arguments would be 0.
  * \param type_arguments Pointer to an array of type arguments.
- *   For non parameteric types a NULL would be passed in for this argument.
+ *   For non parametric types a NULL would be passed in for this argument.
  *
  * \return If no error occurs, the type is returned.
  *   Otherwise an error handle is returned.
@@ -3448,7 +3674,7 @@ DART_EXPORT Dart_Handle Dart_GetNullableType(Dart_Handle library,
  * \param number_of_type_arguments Number of type arguments.
  *   For non parametric types the number of type arguments would be 0.
  * \param type_arguments Pointer to an array of type arguments.
- *   For non parameteric types a NULL would be passed in for this argument.
+ *   For non parametric types a NULL would be passed in for this argument.
  *
  * \return If no error occurs, the type is returned.
  *   Otherwise an error handle is returned.
@@ -3490,7 +3716,6 @@ DART_EXPORT Dart_Handle Dart_TypeToNonNullableType(Dart_Handle type);
  */
 DART_EXPORT Dart_Handle Dart_IsNullableType(Dart_Handle type, bool* result);
 DART_EXPORT Dart_Handle Dart_IsNonNullableType(Dart_Handle type, bool* result);
-DART_EXPORT Dart_Handle Dart_IsLegacyType(Dart_Handle type, bool* result);
 
 /**
  * Lookup a class or interface by name from a Library.
@@ -3549,9 +3774,22 @@ DART_EXPORT Dart_Handle Dart_LibraryHandleError(Dart_Handle library,
  *
  * \return A handle to the main library of the compilation unit, or an error.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_LoadLibraryFromKernel(const uint8_t* kernel_buffer,
                            intptr_t kernel_buffer_size);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadLibrary(Dart_Handle kernel_buffer);
+
+/**
+ * Called by the embedder to load a partial program. Does not set the root
+ * library.
+ *
+ * \param bytecode_buffer An external typed data containing bytecode binary.
+ *
+ * \return A handle to the main library of the compilation unit, or an error.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_LoadLibraryFromBytecode(Dart_Handle bytecode_buffer);
 
 /**
  * Indicates that all outstanding load requests have been satisfied.
@@ -3566,7 +3804,7 @@ Dart_LoadLibraryFromKernel(const uint8_t* kernel_buffer,
  * \return Success if all classes have been finalized and deferred library
  *   futures are completed. Otherwise, returns an error.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_FinalizeLoading(bool complete_futures);
 
 /*
@@ -3631,7 +3869,6 @@ typedef enum {
 
 typedef struct {
   Dart_KernelCompilationStatus status;
-  bool null_safety;
   char* error;
   uint8_t* kernel;
   intptr_t kernel_size;
@@ -3652,13 +3889,16 @@ DART_EXPORT Dart_Port Dart_KernelPort(void);
  * Compiles the given `script_uri` to a kernel file.
  *
  * \param platform_kernel A buffer containing the kernel of the platform (e.g.
- * `vm_platform_strong.dill`). The VM does not take ownership of this memory.
+ * `vm_platform.dill`). The VM does not take ownership of this memory.
  *
  * \param platform_kernel_size The length of the platform_kernel buffer.
  *
  * \param snapshot_compile Set to `true` when the compilation is for a snapshot.
  * This is used by the frontend to determine if compilation related information
  * should be printed to console (e.g., null safety mode).
+ *
+ * \param embed_sources Set to `true` when sources should be embedded in the
+ * kernel file.
  *
  * \param verbosity Specifies the logging behavior of the kernel compilation
  * service.
@@ -3681,6 +3921,7 @@ Dart_CompileToKernel(const char* script_uri,
                      const intptr_t platform_kernel_size,
                      bool incremental_compile,
                      bool snapshot_compile,
+                     bool embed_sources,
                      const char* package_config,
                      Dart_KernelCompilationVerbosityLevel verbosity);
 
@@ -3705,41 +3946,7 @@ DART_EXPORT void Dart_SetDartLibrarySourcesKernel(
     const intptr_t platform_kernel_size);
 
 /**
- * Detect the null safety opt-in status.
- *
- * When running from source, it is based on the opt-in status of `script_uri`.
- * When running from a kernel buffer, it is based on the mode used when
- *   generating `kernel_buffer`.
- * When running from an appJIT or AOT snapshot, it is based on the mode used
- *   when generating `snapshot_data`.
- *
- * \param script_uri Uri of the script that contains the source code
- *
- * \param package_config Uri of the package configuration file (either in format
- *   of .packages or .dart_tool/package_config.json) for the null safety
- *   detection to resolve package imports against. If this parameter is not
- *   passed the package resolution of the parent isolate should be used.
- *
- * \param original_working_directory current working directory when the VM
- *   process was launched, this is used to correctly resolve the path specified
- *   for package_config.
- *
- * \param snapshot_data Buffer containing the snapshot data of the
- *   isolate or NULL if no snapshot is provided. If provided, the buffers must
- *   remain valid until the isolate shuts down.
- *
- * \param snapshot_instructions Buffer containing the snapshot instructions of
- *   the isolate or NULL if no snapshot is provided. If provided, the buffers
- *   must remain valid until the isolate shuts down.
- *
- * \param kernel_buffer A buffer which contains a kernel/DIL program. Must
- *   remain valid until isolate shutdown.
- *
- * \param kernel_buffer_size The size of `kernel_buffer`.
- *
- * \return Returns true if the null safety is opted in by the input being
- *   run `script_uri`, `snapshot_data` or `kernel_buffer`.
- *
+ * Always return true as the VM only supports strong null safety.
  */
 DART_EXPORT bool Dart_DetectNullSafety(const char* script_uri,
                                        const char* package_config,
@@ -3851,7 +4058,7 @@ DART_EXPORT Dart_Handle Dart_LoadingUnitLibraryUris(intptr_t loading_unit_id);
  *
  *  The assembly should be compiled as a static or shared library and linked or
  *  loaded by the embedder. Running this snapshot requires a VM compiled with
- *  DART_PRECOMPILED_SNAPSHOT. The kDartVmSnapshotData and
+ *  DART_PRECOMPILED_RUNTIME. The kDartVmSnapshotData and
  *  kDartVmSnapshotInstructions should be passed to Dart_Initialize. The
  *  kDartIsolateSnapshotData and kDartIsolateSnapshotInstructions should be
  *  passed to Dart_CreateIsolateGroup.
@@ -3862,16 +4069,17 @@ DART_EXPORT Dart_Handle Dart_LoadingUnitLibraryUris(intptr_t loading_unit_id);
  *  debugging sections.
  *
  *  If debug_callback_data is provided, debug_callback_data will be used with
- *  the callback to provide separate debugging information.
+ *  the callback to provide separate debugging information. Ignored when
+ *  targeting Windows.
  *
  *  \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppAOTSnapshotAsAssembly(Dart_StreamingWriteCallback callback,
                                     void* callback_data,
                                     bool stripped,
                                     void* debug_callback_data);
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppAOTSnapshotAsAssemblies(
     Dart_CreateLoadingUnitCallback next_callback,
     void* next_callback_data,
@@ -3891,7 +4099,7 @@ Dart_CreateAppAOTSnapshotAsAssemblies(
  *   - _kDartIsolateSnapshotInstructions
  *
  *  The shared library should be dynamically loaded by the embedder.
- *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_SNAPSHOT.
+ *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_RUNTIME.
  *  The kDartVmSnapshotData and kDartVmSnapshotInstructions should be passed to
  *  Dart_Initialize. The kDartIsolateSnapshotData and
  *  kDartIsolateSnapshotInstructions should be passed to Dart_CreateIsolate.
@@ -3906,17 +4114,121 @@ Dart_CreateAppAOTSnapshotAsAssemblies(
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppAOTSnapshotAsElf(Dart_StreamingWriteCallback callback,
                                void* callback_data,
                                bool stripped,
                                void* debug_callback_data);
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppAOTSnapshotAsElfs(Dart_CreateLoadingUnitCallback next_callback,
                                 void* next_callback_data,
                                 bool stripped,
                                 Dart_StreamingWriteCallback write_callback,
                                 Dart_StreamingCloseCallback close_callback);
+
+typedef enum {
+  Dart_AotBinaryFormat_Elf = 0,
+  Dart_AotBinaryFormat_Assembly = 1,
+  Dart_AotBinaryFormat_MachO_Dylib = 2,
+} Dart_AotBinaryFormat;
+
+/**
+ *  Creates a precompiled snapshot.
+ *   - A root library must have been loaded.
+ *   - Dart_Precompile must have been called.
+ *
+ *  Outputs a snapshot in the specified binary format defining the symbols
+ *   - _kDartVmSnapshotData
+ *   - _kDartVmSnapshotInstructions
+ *   - _kDartIsolateSnapshotData
+ *   - _kDartIsolateSnapshotInstructions
+ *
+ *  The shared library should be dynamically loaded by the embedder.
+ *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_RUNTIME.
+ *  The kDartVmSnapshotData and kDartVmSnapshotInstructions should be passed to
+ *  Dart_Initialize. The kDartIsolateSnapshotData and
+ *  kDartIsolateSnapshotInstructions should be passed to Dart_CreateIsolate.
+ *
+ *  The callback will be invoked one or more times to provide the binary output.
+ *
+ *  If stripped is true, then the binary output will not include DWARF
+ *  debugging sections.
+ *
+ *  If debug_callback_data is provided, debug_callback_data will be used with
+ *  the callback to provide separate debugging information.
+ *
+ *  The identifier should be an appropriate string for identifying the resulting
+ *  dynamic library. For example, the identifier is used in ID_DYLIB and
+ *  CODE_SIGNATURE load commands for Mach-O dynamic libraries and for DW_AT_name
+ *  in the Dart progam's root DWARF compilation unit.
+ *
+ *  The path should be the full path of the resulting dynamic library.
+ *  Currently, it is only used in unstripped Mach-O snapshots to create an
+ *  appropriate N_OSO symbolic debugging variable so dsymutil can be used.
+ *  The N_OSO symbol is not created if the path is nullptr.
+ *
+ * \return A valid handle if no error occurs during the operation.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_CreateAppAOTSnapshotAsBinary(Dart_AotBinaryFormat format,
+                                  Dart_StreamingWriteCallback callback,
+                                  void* callback_data,
+                                  bool stripped,
+                                  void* debug_callback_data,
+                                  const char* identifier,
+                                  const char* path);
+
+/**
+ *  Creates a precompiled snapshot along with a relocatable object file.
+ *   - A root library must have been loaded.
+ *   - Dart_Precompile must have been called.
+ *
+ *  Outputs both a snapshot and a relocatable object file in
+ *  the specified binary format defining the symbols
+ *   - _kDartVmSnapshotData
+ *   - _kDartVmSnapshotInstructions
+ *   - _kDartIsolateSnapshotData
+ *   - _kDartIsolateSnapshotInstructions
+ *  Whether or not the snapshot is stripped, the relocatable object file
+ *  contains all debugging information.
+ *
+ *  The shared library should be dynamically loaded by the embedder.
+ *  Running this snapshot requires a VM compiled with DART_PRECOMPILED_RUNTIME.
+ *  The kDartVmSnapshotData and kDartVmSnapshotInstructions should be passed to
+ *  Dart_Initialize. The kDartIsolateSnapshotData and
+ *  kDartIsolateSnapshotInstructions should be passed to Dart_CreateIsolate.
+ *
+ *  The callback will be invoked one or more times to provide the binary output.
+ *
+ *  If stripped is true, then the binary output will not include DWARF
+ *  debugging sections.
+ *
+ *  If debug_callback_data is provided, debug_callback_data will be used with
+ *  the callback to provide separate debugging information.
+ *
+ *  The identifier should be an appropriate string for identifying the resulting
+ *  dynamic library. For example, the identifier is used in ID_DYLIB and
+ *  CODE_SIGNATURE load commands for Mach-O dynamic libraries and for DW_AT_name
+ *  in the Dart progam's root DWARF compilation unit.
+ *
+ *  The path should be the full path of the resulting relocatable object file.
+ *  Currently, it is only used in Mach-O relocatable object files and snapshots
+ *  to create an appropriate N_OSO symbolic debugging variable
+ *  so dsymutil can be used. Note that an external strip utility is needed to
+ *  remove the N_OSO symbolic debugging variable after dsymutil usage.
+ *
+ * \return A valid handle if no error occurs during the operation.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_CreateAppAOTSnapshotAndRelocatableObject(
+    Dart_AotBinaryFormat format,
+    Dart_StreamingWriteCallback callback,
+    void* snapshot_callback_data,
+    void* object_callback_data,
+    bool stripped,
+    void* debug_callback_data,
+    const char* identifier,
+    const char* path);
 
 /**
  *  Like Dart_CreateAppAOTSnapshotAsAssembly, but only includes
@@ -3924,7 +4236,7 @@ Dart_CreateAppAOTSnapshotAsElfs(Dart_CreateLoadingUnitCallback next_callback,
  *  not strip DWARF information from the generated assembly or allow for
  *  separate debug information.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateVMAOTSnapshotAsAssembly(Dart_StreamingWriteCallback callback,
                                    void* callback_data);
 
@@ -3935,7 +4247,7 @@ Dart_CreateVMAOTSnapshotAsAssembly(Dart_StreamingWriteCallback callback,
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_SortClasses(void);
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_SortClasses(void);
 
 /**
  *  Creates a snapshot that caches compiled code and type feedback for faster
@@ -3958,25 +4270,11 @@ DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle Dart_SortClasses(void);
  *
  * \return A valid handle if no error occurs during the operation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_CreateAppJITSnapshotAsBlobs(uint8_t** isolate_snapshot_data_buffer,
                                  intptr_t* isolate_snapshot_data_size,
                                  uint8_t** isolate_snapshot_instructions_buffer,
                                  intptr_t* isolate_snapshot_instructions_size);
-
-/**
- * Like Dart_CreateAppJITSnapshotAsBlobs, but also creates a new VM snapshot.
- */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
-Dart_CreateCoreJITSnapshotAsBlobs(
-    uint8_t** vm_snapshot_data_buffer,
-    intptr_t* vm_snapshot_data_size,
-    uint8_t** vm_snapshot_instructions_buffer,
-    intptr_t* vm_snapshot_instructions_size,
-    uint8_t** isolate_snapshot_data_buffer,
-    intptr_t* isolate_snapshot_data_size,
-    uint8_t** isolate_snapshot_instructions_buffer,
-    intptr_t* isolate_snapshot_instructions_size);
 
 /**
  * Get obfuscation map for precompiled code.
@@ -3987,7 +4285,7 @@ Dart_CreateCoreJITSnapshotAsBlobs(
  * \return Returns an error handler if the VM was built in a mode that does not
  * support obfuscation.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT Dart_Handle
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
 Dart_GetObfuscationMap(uint8_t** buffer, intptr_t* buffer_length);
 
 /**
@@ -4011,5 +4309,30 @@ DART_EXPORT void Dart_DumpNativeStackTrace(void* context);
  *  attempt to cleanup resources.
  */
 DART_EXPORT void Dart_PrepareToAbort(void);
+
+/**
+ * Callback provided by the embedder that is used by the VM to
+ * produce footnotes appended to DWARF stack traces.
+ *
+ * Whenever VM formats a stack trace as a string it would call this callback
+ * passing raw program counters for each frame in the stack trace.
+ *
+ * Embedder can then return a string which if not-null will be appended to the
+ * formatted stack trace.
+ *
+ * Returned string is expected to be `malloc()` allocated. VM takes ownership
+ * of the returned string and will `free()` it.
+ *
+ * \param addresses raw program counter addresses for each frame
+ * \param count number of elements in the addresses array
+ */
+typedef char* (*Dart_DwarfStackTraceFootnoteCallback)(void* addresses[],
+                                                      intptr_t count);
+
+/**
+ *  Configure DWARF stack trace footnote callback.
+ */
+DART_EXPORT void Dart_SetDwarfStackTraceFootnoteCallback(
+    Dart_DwarfStackTraceFootnoteCallback callback);
 
 #endif /* INCLUDE_DART_API_H_ */ /* NOLINT */

--- a/third_party/flutter/third_party/dart/runtime/include/dart_api_dl.c
+++ b/third_party/flutter/third_party/dart/runtime/include/dart_api_dl.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+#include "dart_api_dl.h"               /* NOLINT */
+#include "dart_version.h"              /* NOLINT */
+#include "internal/dart_api_dl_impl.h" /* NOLINT */
+
+#include <stdio.h>
+#include <string.h>
+
+#define DART_API_DL_DEFINITIONS(name, R, A) name##_Type name##_DL = NULL;
+
+DART_API_ALL_DL_SYMBOLS(DART_API_DL_DEFINITIONS)
+DART_API_DEPRECATED_DL_SYMBOLS(DART_API_DL_DEFINITIONS)
+
+#undef DART_API_DL_DEFINITIONS
+
+typedef void* DartApiEntry_function;
+
+DartApiEntry_function FindFunctionPointer(const DartApiEntry* entries,
+                                          const char* name) {
+  while (entries->name != NULL) {
+    if (strcmp(entries->name, name) == 0) return entries->function;
+    entries++;
+  }
+  return NULL;
+}
+
+DART_EXPORT void Dart_UpdateExternalSize_Deprecated(
+    Dart_WeakPersistentHandle object, intptr_t external_size) {
+  printf("Dart_UpdateExternalSize is a nop, it has been deprecated\n");
+}
+
+DART_EXPORT void Dart_UpdateFinalizableExternalSize_Deprecated(
+    Dart_FinalizableHandle object,
+    Dart_Handle strong_ref_to_object,
+    intptr_t external_allocation_size) {
+  printf("Dart_UpdateFinalizableExternalSize is a nop, "
+         "it has been deprecated\n");
+}
+
+intptr_t Dart_InitializeApiDL(void* data) {
+  DartApi* dart_api_data = (DartApi*)data;
+
+  if (dart_api_data->major != DART_API_DL_MAJOR_VERSION) {
+    // If the DartVM we're running on does not have the same version as this
+    // file was compiled against, refuse to initialize. The symbols are not
+    // compatible.
+    return -1;
+  }
+  // Minor versions are allowed to be different.
+  // If the DartVM has a higher minor version, it will provide more symbols
+  // than we initialize here.
+  // If the DartVM has a lower minor version, it will not provide all symbols.
+  // In that case, we leave the missing symbols un-initialized. Those symbols
+  // should not be used by the Dart and native code. The client is responsible
+  // for checking the minor version number himself based on which symbols it
+  // is using.
+  // (If we would error out on this case, recompiling native code against a
+  // newer SDK would break all uses on older SDKs, which is too strict.)
+
+  const DartApiEntry* dart_api_function_pointers = dart_api_data->functions;
+
+#define DART_API_DL_INIT(name, R, A)                                           \
+  name##_DL =                                                                  \
+      (name##_Type)(FindFunctionPointer(dart_api_function_pointers, #name));
+  DART_API_ALL_DL_SYMBOLS(DART_API_DL_INIT)
+#undef DART_API_DL_INIT
+
+#define DART_API_DEPRECATED_DL_INIT(name, R, A)                                \
+  name##_DL = name##_Deprecated;
+  DART_API_DEPRECATED_DL_SYMBOLS(DART_API_DEPRECATED_DL_INIT)
+#undef DART_API_DEPRECATED_DL_INIT
+
+  return 0;
+}

--- a/third_party/flutter/third_party/dart/runtime/include/dart_api_dl.h
+++ b/third_party/flutter/third_party/dart/runtime/include/dart_api_dl.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+#ifndef RUNTIME_INCLUDE_DART_API_DL_H_
+#define RUNTIME_INCLUDE_DART_API_DL_H_
+
+#include "dart_api.h"        /* NOLINT */
+#include "dart_native_api.h" /* NOLINT */
+
+/** \mainpage Dynamically Linked Dart API
+ *
+ * This exposes a subset of symbols from dart_api.h and dart_native_api.h
+ * available in every Dart embedder through dynamic linking.
+ *
+ * All symbols are postfixed with _DL to indicate that they are dynamically
+ * linked and to prevent conflicts with the original symbol.
+ *
+ * Link `dart_api_dl.c` file into your library and invoke
+ * `Dart_InitializeApiDL` with `NativeApi.initializeApiDLData`.
+ *
+ * Returns 0 on success.
+ */
+
+DART_EXPORT intptr_t Dart_InitializeApiDL(void* data);
+
+// ============================================================================
+// IMPORTANT! Never update these signatures without properly updating
+// DART_API_DL_MAJOR_VERSION and DART_API_DL_MINOR_VERSION.
+//
+// Verbatim copy of `dart_native_api.h` and `dart_api.h` symbol names and types
+// to trigger compile-time errors if the symbols in those files are updated
+// without updating these.
+//
+// Function return and argument types, and typedefs are carbon copied. Structs
+// are typechecked nominally in C/C++, so they are not copied, instead a
+// comment is added to their definition.
+typedef int64_t Dart_Port_DL;
+typedef struct {
+  int64_t port_id;
+  int64_t origin_id;
+} Dart_PortEx_DL;
+
+typedef void (*Dart_NativeMessageHandler_DL)(Dart_Port_DL dest_port_id,
+                                             Dart_CObject* message);
+
+// dart_native_api.h symbols can be called on any thread.
+#define DART_NATIVE_API_DL_SYMBOLS(F)                                          \
+  /***** dart_native_api.h *****/                                              \
+  /* Dart_Port */                                                              \
+  F(Dart_PostCObject, bool, (Dart_Port_DL port_id, Dart_CObject * message))    \
+  F(Dart_PostInteger, bool, (Dart_Port_DL port_id, int64_t message))           \
+  F(Dart_NewNativePort, Dart_Port_DL,                                          \
+    (const char* name, Dart_NativeMessageHandler_DL handler,                   \
+     bool handle_concurrently))                                                \
+  F(Dart_CloseNativePort, bool, (Dart_Port_DL native_port_id))
+
+// dart_api.h symbols can only be called on Dart threads.
+#define DART_API_DL_SYMBOLS(F)                                                 \
+  /***** dart_api.h *****/                                                     \
+  /* Errors */                                                                 \
+  F(Dart_IsError, bool, (Dart_Handle handle))                                  \
+  F(Dart_IsApiError, bool, (Dart_Handle handle))                               \
+  F(Dart_IsUnhandledExceptionError, bool, (Dart_Handle handle))                \
+  F(Dart_IsCompilationError, bool, (Dart_Handle handle))                       \
+  F(Dart_IsFatalError, bool, (Dart_Handle handle))                             \
+  F(Dart_GetError, const char*, (Dart_Handle handle))                          \
+  F(Dart_ErrorHasException, bool, (Dart_Handle handle))                        \
+  F(Dart_ErrorGetException, Dart_Handle, (Dart_Handle handle))                 \
+  F(Dart_ErrorGetStackTrace, Dart_Handle, (Dart_Handle handle))                \
+  F(Dart_NewApiError, Dart_Handle, (const char* error))                        \
+  F(Dart_NewCompilationError, Dart_Handle, (const char* error))                \
+  F(Dart_NewUnhandledExceptionError, Dart_Handle, (Dart_Handle exception))     \
+  F(Dart_PropagateError, void, (Dart_Handle handle))                           \
+  /* Dart_Handle, Dart_PersistentHandle, Dart_WeakPersistentHandle */          \
+  F(Dart_HandleFromPersistent, Dart_Handle, (Dart_PersistentHandle object))    \
+  F(Dart_HandleFromWeakPersistent, Dart_Handle,                                \
+    (Dart_WeakPersistentHandle object))                                        \
+  F(Dart_NewPersistentHandle, Dart_PersistentHandle, (Dart_Handle object))     \
+  F(Dart_SetPersistentHandle, void,                                            \
+    (Dart_PersistentHandle obj1, Dart_Handle obj2))                            \
+  F(Dart_DeletePersistentHandle, void, (Dart_PersistentHandle object))         \
+  F(Dart_NewWeakPersistentHandle, Dart_WeakPersistentHandle,                   \
+    (Dart_Handle object, void* peer, intptr_t external_allocation_size,        \
+     Dart_HandleFinalizer callback))                                           \
+  F(Dart_DeleteWeakPersistentHandle, void, (Dart_WeakPersistentHandle object)) \
+  F(Dart_NewFinalizableHandle, Dart_FinalizableHandle,                         \
+    (Dart_Handle object, void* peer, intptr_t external_allocation_size,        \
+     Dart_HandleFinalizer callback))                                           \
+  F(Dart_DeleteFinalizableHandle, void,                                        \
+    (Dart_FinalizableHandle object, Dart_Handle strong_ref_to_object))         \
+  /* Isolates */                                                               \
+  F(Dart_CurrentIsolate, Dart_Isolate, (void))                                 \
+  F(Dart_ExitIsolate, void, (void))                                            \
+  F(Dart_EnterIsolate, void, (Dart_Isolate))                                   \
+  /* Dart_Port */                                                              \
+  F(Dart_GetMainPortId, Dart_Port, (void))                                     \
+  F(Dart_Post, bool, (Dart_Port_DL port_id, Dart_Handle object))               \
+  F(Dart_NewSendPort, Dart_Handle, (Dart_Port_DL port_id))                     \
+  F(Dart_NewSendPortEx, Dart_Handle, (Dart_PortEx_DL portex_id))               \
+  F(Dart_SendPortGetId, Dart_Handle,                                           \
+    (Dart_Handle port, Dart_Port_DL * port_id))                                \
+  F(Dart_SendPortGetIdEx, Dart_Handle,                                         \
+    (Dart_Handle port, Dart_PortEx_DL * portex_id))                            \
+  F(Dart_GetCurrentThreadOwnsIsolate, bool, (Dart_Port))                       \
+  /* Scopes */                                                                 \
+  F(Dart_EnterScope, void, (void))                                             \
+  F(Dart_ExitScope, void, (void))                                              \
+  /* Objects */                                                                \
+  F(Dart_IsNull, bool, (Dart_Handle))                                          \
+  F(Dart_Null, Dart_Handle, (void))
+
+// dart_api.h symbols that have been deprecated but are retained here
+// until we can make a breaking change bumping the major version number
+// (DART_API_DL_MAJOR_VERSION)
+#define DART_API_DEPRECATED_DL_SYMBOLS(F)                                      \
+  F(Dart_UpdateExternalSize, void,                                             \
+    (Dart_WeakPersistentHandle object, intptr_t external_allocation_size))     \
+  F(Dart_UpdateFinalizableExternalSize, void,                                  \
+    (Dart_FinalizableHandle object, Dart_Handle strong_ref_to_object,          \
+     intptr_t external_allocation_size))
+
+#define DART_API_ALL_DL_SYMBOLS(F)                                             \
+  DART_NATIVE_API_DL_SYMBOLS(F)                                                \
+  DART_API_DL_SYMBOLS(F)
+// IMPORTANT! Never update these signatures without properly updating
+// DART_API_DL_MAJOR_VERSION and DART_API_DL_MINOR_VERSION.
+//
+// End of verbatim copy.
+// ============================================================================
+
+// Copy of definition of DART_EXPORT without 'used' attribute.
+//
+// The 'used' attribute cannot be used with DART_API_ALL_DL_SYMBOLS because
+// they are not function declarations, but variable declarations with a
+// function pointer type.
+//
+// The function pointer variables are initialized with the addresses of the
+// functions in the VM. If we were to use function declarations instead, we
+// would need to forward the call to the VM adding indirection.
+#if defined(__CYGWIN__)
+#error Tool chain and platform not supported.
+#elif defined(_WIN32)
+#if defined(DART_SHARED_LIB)
+#define DART_EXPORT_DL DART_EXTERN_C __declspec(dllexport)
+#else
+#define DART_EXPORT_DL DART_EXTERN_C
+#endif
+#else
+#if __GNUC__ >= 4
+#if defined(DART_SHARED_LIB)
+#define DART_EXPORT_DL DART_EXTERN_C __attribute__((visibility("default")))
+#else
+#define DART_EXPORT_DL DART_EXTERN_C
+#endif
+#else
+#error Tool chain not supported.
+#endif
+#endif
+
+#define DART_API_DL_DECLARATIONS(name, R, A)                                   \
+  typedef R(*name##_Type) A;                                                   \
+  DART_EXPORT_DL name##_Type name##_DL;
+
+DART_API_ALL_DL_SYMBOLS(DART_API_DL_DECLARATIONS)
+DART_API_DEPRECATED_DL_SYMBOLS(DART_API_DL_DECLARATIONS)
+
+#undef DART_API_DL_DECLARATIONS
+
+#undef DART_EXPORT_DL
+
+#endif /* RUNTIME_INCLUDE_DART_API_DL_H_ */ /* NOLINT */

--- a/third_party/flutter/third_party/dart/runtime/include/dart_native_api.h
+++ b/third_party/flutter/third_party/dart/runtime/include/dart_native_api.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+#ifndef RUNTIME_INCLUDE_DART_NATIVE_API_H_
+#define RUNTIME_INCLUDE_DART_NATIVE_API_H_
+
+#include "dart_api.h" /* NOLINT */
+
+/*
+ * ==========================================
+ * Message sending/receiving from native code
+ * ==========================================
+ */
+
+/**
+ * A Dart_CObject is used for representing Dart objects as native C
+ * data outside the Dart heap. These objects are totally detached from
+ * the Dart heap. Only a subset of the Dart objects have a
+ * representation as a Dart_CObject.
+ *
+ * The string encoding in the 'value.as_string' is UTF-8.
+ *
+ * All the different types from dart:typed_data are exposed as type
+ * kTypedData. The specific type from dart:typed_data is in the type
+ * field of the as_typed_data structure. The length in the
+ * as_typed_data structure is always in bytes.
+ *
+ * The data for kTypedData is copied on message send and ownership remains with
+ * the caller. The ownership of data for kExternalTyped is passed to the VM on
+ * message send and returned when the VM invokes the
+ * Dart_HandleFinalizer callback; a non-NULL callback must be provided.
+ *
+ * Note that Dart_CObject_kNativePointer is intended for internal use by
+ * dart:io implementation and has no connection to dart:ffi Pointer class.
+ * It represents a pointer to a native resource of a known type.
+ * The receiving side will only see this pointer as an integer and will not
+ * see the specified finalizer.
+ * The specified finalizer will only be invoked if the message is not delivered.
+ */
+typedef enum {
+  Dart_CObject_kNull = 0,
+  Dart_CObject_kBool,
+  Dart_CObject_kInt32,
+  Dart_CObject_kInt64,
+  Dart_CObject_kDouble,
+  Dart_CObject_kString,
+  Dart_CObject_kArray,
+  Dart_CObject_kTypedData,
+  Dart_CObject_kExternalTypedData,
+  Dart_CObject_kSendPort,
+  Dart_CObject_kCapability,
+  Dart_CObject_kNativePointer,
+  Dart_CObject_kUnsupported,
+  Dart_CObject_kUnmodifiableExternalTypedData,
+  Dart_CObject_kNumberOfTypes
+} Dart_CObject_Type;
+// This enum is versioned by DART_API_DL_MAJOR_VERSION, only add at the end
+// and bump the DART_API_DL_MINOR_VERSION.
+
+typedef struct _Dart_CObject {
+  Dart_CObject_Type type;
+  union {
+    bool as_bool;
+    int32_t as_int32;
+    int64_t as_int64;
+    double as_double;
+    const char* as_string;
+    struct {
+      Dart_Port id;
+      Dart_Port origin_id;
+    } as_send_port;
+    struct {
+      int64_t id;
+    } as_capability;
+    struct {
+      intptr_t length;
+      struct _Dart_CObject** values;
+    } as_array;
+    struct {
+      Dart_TypedData_Type type;
+      intptr_t length; /* in elements, not bytes */
+      const uint8_t* values;
+    } as_typed_data;
+    struct {
+      Dart_TypedData_Type type;
+      intptr_t length; /* in elements, not bytes */
+      uint8_t* data;
+      void* peer;
+      Dart_HandleFinalizer callback;
+    } as_external_typed_data;
+    struct {
+      intptr_t ptr;
+      intptr_t size;
+      Dart_HandleFinalizer callback;
+    } as_native_pointer;
+  } value;
+} Dart_CObject;
+// This struct is versioned by DART_API_DL_MAJOR_VERSION, bump the version when
+// changing this struct.
+
+/**
+ * Posts a message on some port. The message will contain the Dart_CObject
+ * object graph rooted in 'message'.
+ *
+ * While the message is being sent the state of the graph of Dart_CObject
+ * structures rooted in 'message' should not be accessed, as the message
+ * generation will make temporary modifications to the data. When the message
+ * has been sent the graph will be fully restored.
+ *
+ * If true is returned, the message was enqueued, and finalizers for external
+ * typed data will eventually run, even if the receiving isolate shuts down
+ * before processing the message. If false is returned, the message was not
+ * enqueued and ownership of external typed data in the message remains with the
+ * caller.
+ *
+ * This function may be called on any thread when the VM is running (that is,
+ * after Dart_Initialize has returned and before Dart_Cleanup has been called).
+ *
+ * \param port_id The destination port.
+ * \param message The message to send.
+ *
+ * \return True if the message was posted.
+ */
+DART_EXPORT bool Dart_PostCObject(Dart_Port port_id, Dart_CObject* message);
+
+/**
+ * Posts a message on some port. The message will contain the integer 'message'.
+ *
+ * \param port_id The destination port.
+ * \param message The message to send.
+ *
+ * \return True if the message was posted.
+ */
+DART_EXPORT bool Dart_PostInteger(Dart_Port port_id, int64_t message);
+
+/**
+ * A native message handler.
+ *
+ * This handler is associated with a native port by calling
+ * Dart_NewNativePort.
+ *
+ * The message received is decoded into the message structure. The
+ * lifetime of the message data is controlled by the caller. All the
+ * data references from the message are allocated by the caller and
+ * will be reclaimed when returning to it.
+ */
+typedef void (*Dart_NativeMessageHandler)(Dart_Port dest_port_id,
+                                          Dart_CObject* message);
+
+/**
+ * Creates a new native port.  When messages are received on this
+ * native port, then they will be dispatched to the provided native
+ * message handler.
+ *
+ * \param name The name of this port in debugging messages.
+ * \param handler The C handler to run when messages arrive on the port.
+ * \param handle_concurrently Is it okay to process requests on this
+ *                            native port concurrently?
+ *
+ * \return If successful, returns the port id for the native port.  In
+ *   case of error, returns ILLEGAL_PORT.
+ */
+DART_EXPORT Dart_Port Dart_NewNativePort(const char* name,
+                                         Dart_NativeMessageHandler handler,
+                                         bool handle_concurrently);
+
+/**
+ * Creates a new native port.  When messages are received on this
+ * native port, then they will be dispatched to the provided native
+ * message handler using up to |max_concurrency| concurrent threads.
+ *
+ * \param name The name of this port in debugging messages.
+ * \param handler The C handler to run when messages arrive on the port.
+ * \param max_concurrency Size of the thread pool used by the native port.
+ *
+ * \return If successful, returns the port id for the native port.  In
+ *   case of error, returns ILLEGAL_PORT.
+ */
+DART_EXPORT Dart_Port
+Dart_NewConcurrentNativePort(const char* name,
+                             Dart_NativeMessageHandler handler,
+                             intptr_t max_concurrency);
+
+/**
+ * Closes the native port with the given id.
+ *
+ * The port must have been allocated by a call to Dart_NewNativePort.
+ *
+ * \param native_port_id The id of the native port to close.
+ *
+ * \return Returns true if the port was closed successfully.
+ */
+DART_EXPORT bool Dart_CloseNativePort(Dart_Port native_port_id);
+
+/*
+ * ==================
+ * Verification Tools
+ * ==================
+ */
+
+/**
+ * Forces all loaded classes and functions to be compiled eagerly in
+ * the current isolate..
+ *
+ * TODO(turnidge): Document.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle Dart_CompileAll(void);
+
+/**
+ * Finalizes all classes.
+ */
+DART_EXPORT DART_API_WARN_UNUSED_RESULT Dart_Handle
+Dart_FinalizeAllClasses(void);
+
+/*  This function is intentionally undocumented.
+ *
+ *  It should not be used outside internal tests.
+ */
+DART_EXPORT void* Dart_ExecuteInternalCommand(const char* command, void* arg);
+
+#endif /* INCLUDE_DART_NATIVE_API_H_ */ /* NOLINT */

--- a/third_party/flutter/third_party/dart/runtime/include/dart_tools_api.h
+++ b/third_party/flutter/third_party/dart/runtime/include/dart_tools_api.h
@@ -29,6 +29,11 @@
  */
 #define ILLEGAL_ISOLATE_ID ILLEGAL_PORT
 
+/**
+ * ILLEGAL_ISOLATE_GROUP_ID is a number guaranteed never to be associated with a
+ * valid isolate group.
+ */
+#define ILLEGAL_ISOLATE_GROUP_ID 0
 
 /*
  * =======
@@ -122,23 +127,23 @@ DART_EXPORT void Dart_RegisterRootServiceRequestCallback(
  * The pointers in this structure are not going to be cached or freed by the VM.
  */
 
- #define DART_EMBEDDER_INFORMATION_CURRENT_VERSION (0x00000001)
+#define DART_EMBEDDER_INFORMATION_CURRENT_VERSION (0x00000001)
 
 typedef struct {
   int32_t version;
-  const char* name;  // [optional] The name of the embedder
+  const char* name;     // [optional] The name of the embedder
   int64_t current_rss;  // [optional] the current RSS of the embedder
-  int64_t max_rss;  // [optional] the maximum RSS of the embedder
+  int64_t max_rss;      // [optional] the maximum RSS of the embedder
 } Dart_EmbedderInformation;
 
 /**
- * Callback provided by the embedder that is used by the vm to request
+ * Callback provided by the embedder that is used by the VM to request
  * information.
  *
  * \return Returns a pointer to a Dart_EmbedderInformation structure.
  * The embedder keeps the ownership of the structure and any field in it.
  * The embedder must ensure that the structure will remain valid until the
- * next invokation of the callback.
+ * next invocation of the callback.
  */
 typedef void (*Dart_EmbedderInformationCallback)(
     Dart_EmbedderInformation* info);
@@ -152,8 +157,8 @@ typedef void (*Dart_EmbedderInformationCallback)(
  * \param callback The callback to invoke.
  * \param user_data The user data passed to the callback.
  *
- * NOTE: If multiple callbacks with the same name are registered, only
- * the last callback registered will be remembered.
+ * NOTE: If multiple callbacks are registered, only the last callback registered
+ * will be remembered.
  */
 DART_EXPORT void Dart_SetEmbedderInformationCallback(
     Dart_EmbedderInformationCallback callback);
@@ -169,7 +174,7 @@ DART_EXPORT void Dart_SetEmbedderInformationCallback(
  * \param response_json_length The length of the returned json response.
  * \param error An optional error, must be free()ed by caller.
  *
- * \return Whether the call was sucessfully performed.
+ * \return Whether the call was successfully performed.
  *
  * NOTE: This method does not need a current isolate and must not have the
  * vm-isolate being the current isolate. It must be called after
@@ -249,69 +254,6 @@ DART_EXPORT char* Dart_ServiceSendDataEvent(const char* stream_id,
                                             const uint8_t* bytes,
                                             intptr_t bytes_length);
 
-/**
- * Usage statistics for a space/generation at a particular moment in time.
- *
- * \param used Amount of memory used, in bytes.
- *
- * \param capacity Memory capacity, in bytes.
- *
- * \param external External memory, in bytes.
- *
- * \param collections How many times the garbage collector has run in this
- *   space.
- *
- * \param time Cumulative time spent collecting garbage in this space, in
- *   seconds.
- *
- * \param avg_collection_period Average time between garbage collector running
- *   in this space, in milliseconds.
- */
-typedef struct {
-  intptr_t used;
-  intptr_t capacity;
-  intptr_t external;
-  intptr_t collections;
-  double time;
-  double avg_collection_period;
-} Dart_GCStats;
-
-/**
- * A Garbage Collection event with memory usage statistics.
- *
- * \param type The event type. Static lifetime.
- *
- * \param reason The reason for the GC event. Static lifetime.
- *
- * \param new_space Data for New Space.
- *
- * \param old_space Data for Old Space.
- */
-typedef struct {
-  const char* type;
-  const char* reason;
-  const char* isolate_id;
-
-  Dart_GCStats new_space;
-  Dart_GCStats old_space;
-} Dart_GCEvent;
-
-/**
- * A callback invoked when the VM emits a GC event.
- *
- * \param event The GC event data. Pointer only valid for the duration of the
- *   callback.
- */
-typedef void (*Dart_GCEventCallback)(Dart_GCEvent* event);
-
-/**
- * Sets the native GC event callback.
- *
- * \param callback A function pointer to an event handler callback function.
- *   A NULL value removes the existing listen callback function if any.
- */
-DART_EXPORT void Dart_SetGCEventCallback(Dart_GCEventCallback callback);
-
 /*
  * ========
  * Reload support
@@ -347,7 +289,7 @@ DART_EXPORT bool Dart_IsReloading();
  * Enable tracking of specified timeline category. This is operational
  * only when systrace timeline functionality is turned on.
  *
- * \param categories A comma seperated list of categories that need to
+ * \param categories A comma separated list of categories that need to
  *   be enabled, the categories are
  *   "all" : All categories
  *   "API" - Execution of Dart C API functions
@@ -358,12 +300,13 @@ DART_EXPORT bool Dart_IsReloading();
  *   "Embedder" - Execution of Dart embedder code
  *   "GC" - Execution of Dart Garbage Collector
  *   "Isolate" - Dart Isolate lifecycle execution
- *   "VM" - Excution in Dart VM runtime code
+ *   "Microtask" - Execution of Dart microtasks
+ *   "VM" - Execution in Dart VM runtime code
  *   "" - None
  *
  *  When "all" is specified all the categories are enabled.
- *  When a comma seperated list of categories is specified, the categories
- *   that are specified will be enabled and the rest will be disabled. 
+ *  When a comma separated list of categories is specified, the categories
+ *   that are specified will be enabled and the rest will be disabled.
  *  When "" is specified all the categories are disabled.
  *  The category names are case sensitive.
  *  eg:  Dart_EnableTimelineCategory("all");
@@ -414,11 +357,45 @@ typedef enum {
 /**
  * Add a timeline event to the embedder stream.
  *
+ * Note regarding flow events: events must be associated with flow IDs in two
+ * different ways to allow flow events to be serialized correctly in both
+ * Chrome's JSON trace event format and Perfetto's proto trace format. Events
+ * of type |Dart_Timeline_Event_Flow_Begin|, |Dart_Timeline_Event_Flow_Step|,
+ * and |Dart_Timeline_Event_Flow_End| must be reported to support serialization
+ * in Chrome's trace format. The |flow_ids| argument must be supplied when
+ * reporting events of type |Dart_Timeline_Event_Begin|,
+ * |Dart_Timeline_Event_Duration|, |Dart_Timeline_Event_Instant|,
+ * |Dart_Timeline_Event_Async_Begin|, and |Dart_Timeline_Event_Async_Instant| to
+ * support serialization in Perfetto's proto format.
+ *
+ * The Dart VM can use various underlying recorders depending on configuration
+ * and operating system. Many recorders do not support all event types;
+ * unsupported event types are siliently dropped. Some recorders do not accept
+ * timestamps as input, instead implicitly using the time the event is recorded.
+ * For maximum compatibility, record events with the Begin and End types as they
+ * occur instead of using the Duration type or buffering.
+ *
  * \param label The name of the event. Its lifetime must extend at least until
  *     Dart_Cleanup.
  * \param timestamp0 The first timestamp of the event.
- * \param timestamp1_or_async_id The second timestamp of the event or
- *     the async id.
+ * \param timestamp1_or_id When reporting an event of type
+ *     |Dart_Timeline_Event_Duration|, the second (end) timestamp of the event
+ *     should be passed through |timestamp1_or_id|. When reporting an event of
+ *     type |Dart_Timeline_Event_Async_Begin|, |Dart_Timeline_Event_Async_End|,
+ *     or |Dart_Timeline_Event_Async_Instant|, the async ID associated with the
+ *     event should be passed through |timestamp1_or_id|. When reporting an
+ *     event of type |Dart_Timeline_Event_Flow_Begin|,
+ *     |Dart_Timeline_Event_Flow_Step|, or |Dart_Timeline_Event_Flow_End|, the
+ *     flow ID associated with the event should be passed through
+ *     |timestamp1_or_id|. When reporting an event of type
+ *     |Dart_Timeline_Event_Begin| or |Dart_Timeline_Event_End|, the event ID
+ *     associated with the event should be passed through |timestamp1_or_id|.
+ *     Note that this event ID will only be used by the MacOS recorder. The
+ *     argument to |timestamp1_or_id| will not be used when reporting events of
+ *     other types.
+ * \param flow_id_count The number of flow IDs associated with this event.
+ * \param flow_ids An array of flow IDs associated with this event. The array
+ *     may be reclaimed when this call returns.
  * \param argument_count The number of argument names and values.
  * \param argument_names An array of names of the arguments. The lifetime of the
  *     names must extend at least until Dart_Cleanup. The array may be reclaimed
@@ -426,13 +403,15 @@ typedef enum {
  * \param argument_values An array of values of the arguments. The values and
  *     the array may be reclaimed when this call returns.
  */
-DART_EXPORT void Dart_TimelineEvent(const char* label,
-                                    int64_t timestamp0,
-                                    int64_t timestamp1_or_async_id,
-                                    Dart_Timeline_Event_Type type,
-                                    intptr_t argument_count,
-                                    const char** argument_names,
-                                    const char** argument_values);
+DART_EXPORT void Dart_RecordTimelineEvent(const char* label,
+                                          int64_t timestamp0,
+                                          int64_t timestamp1_or_id,
+                                          intptr_t flow_id_count,
+                                          const int64_t* flow_ids,
+                                          Dart_Timeline_Event_Type type,
+                                          intptr_t argument_count,
+                                          const char** argument_names,
+                                          const char** argument_values);
 
 /**
  * Associates a name with the current thread. This name will be used to name
@@ -442,6 +421,91 @@ DART_EXPORT void Dart_TimelineEvent(const char* label,
  */
 DART_EXPORT void Dart_SetThreadName(const char* name);
 
+typedef struct {
+  const char* name;
+  const char* value;
+} Dart_TimelineRecorderEvent_Argument;
+
+#define DART_TIMELINE_RECORDER_CURRENT_VERSION (0x00000002)
+
+typedef struct {
+  /* Set to DART_TIMELINE_RECORDER_CURRENT_VERSION */
+  int32_t version;
+
+  /* The event's type / phase. */
+  Dart_Timeline_Event_Type type;
+
+  /* The event's timestamp according to the same clock as
+   * Dart_TimelineGetMicros. For a duration event, this is the beginning time.
+   */
+  int64_t timestamp0;
+
+  /**
+   * For a duration event, this is the end time. For an async event, this is the
+   * async ID. For a flow event, this is the flow ID. For a begin or end event,
+   * this is the event ID (which is only referenced by the MacOS recorder).
+   */
+  int64_t timestamp1_or_id;
+
+  /* The current isolate of the event, as if by Dart_GetMainPortId, or
+   * ILLEGAL_PORT if the event had no current isolate. */
+  Dart_Port isolate;
+
+  /* The current isolate group of the event, as if by
+   * Dart_CurrentIsolateGroupId, or ILLEGAL_PORT if the event had no current
+   * isolate group. */
+  Dart_IsolateGroupId isolate_group;
+
+  /* The callback data associated with the isolate if any. */
+  void* isolate_data;
+
+  /* The callback data associated with the isolate group if any. */
+  void* isolate_group_data;
+
+  /* The name / label of the event. */
+  const char* label;
+
+  /* The stream / category of the event. */
+  const char* stream;
+
+  intptr_t argument_count;
+  Dart_TimelineRecorderEvent_Argument* arguments;
+} Dart_TimelineRecorderEvent;
+
+/**
+ * Callback provided by the embedder to handle the completion of timeline
+ * events.
+ *
+ * \param event A timeline event that has just been completed. The VM keeps
+ * ownership of the event and any field in it (i.e., the embedder should copy
+ * any values it needs after the callback returns).
+ */
+typedef void (*Dart_TimelineRecorderCallback)(
+    Dart_TimelineRecorderEvent* event);
+
+/**
+ * Register a `Dart_TimelineRecorderCallback` to be called as timeline events
+ * are completed.
+ *
+ * The callback will be invoked without a current isolate.
+ *
+ * The callback will be invoked on the thread completing the event. Because
+ * `Dart_RecordTimelineEvent` may be called by any thread, the callback may be
+ * called on any thread.
+ *
+ * The callback may be invoked at any time after `Dart_Initialize` is called and
+ * before `Dart_Cleanup` returns.
+ *
+ * If multiple callbacks are registered, only the last callback registered
+ * will be remembered. Providing a NULL callback will clear the registration
+ * (i.e., a NULL callback produced a no-op instead of a crash).
+ *
+ * Setting a callback is insufficient to receive events through the callback. The
+ * VM flag `timeline_recorder` must also be set to `callback`.
+ */
+DART_EXPORT void Dart_SetTimelineRecorderCallback(
+    Dart_TimelineRecorderCallback callback);
+
 /*
  * =======
  * Metrics
@@ -450,41 +514,19 @@ DART_EXPORT void Dart_SetThreadName(const char* name);
 
 /**
  * Return metrics gathered for the VM and individual isolates.
- *
- * NOTE: Non-heap metrics are not available in PRODUCT builds of Dart.
- * Calling the non-heap metric functions on a PRODUCT build might return invalid metrics.
  */
-DART_EXPORT int64_t Dart_VMIsolateCountMetric();  // Counter
-DART_EXPORT int64_t Dart_VMCurrentRSSMetric();    // Byte
-DART_EXPORT int64_t Dart_VMPeakRSSMetric();       // Byte
 DART_EXPORT int64_t
-Dart_IsolateHeapOldUsedMetric(Dart_Isolate isolate);  // Byte
+Dart_IsolateGroupHeapOldUsedMetric(Dart_IsolateGroup group);  // Byte
 DART_EXPORT int64_t
-Dart_IsolateHeapOldUsedMaxMetric(Dart_Isolate isolate);  // Byte
+Dart_IsolateGroupHeapOldCapacityMetric(Dart_IsolateGroup group);  // Byte
 DART_EXPORT int64_t
-Dart_IsolateHeapOldCapacityMetric(Dart_Isolate isolate);  // Byte
+Dart_IsolateGroupHeapOldExternalMetric(Dart_IsolateGroup group);  // Byte
 DART_EXPORT int64_t
-Dart_IsolateHeapOldCapacityMaxMetric(Dart_Isolate isolate);  // Byte
+Dart_IsolateGroupHeapNewUsedMetric(Dart_IsolateGroup group);  // Byte
 DART_EXPORT int64_t
-Dart_IsolateHeapOldExternalMetric(Dart_Isolate isolate);  // Byte
+Dart_IsolateGroupHeapNewCapacityMetric(Dart_IsolateGroup group);  // Byte
 DART_EXPORT int64_t
-Dart_IsolateHeapNewUsedMetric(Dart_Isolate isolate);  // Byte
-DART_EXPORT int64_t
-Dart_IsolateHeapNewUsedMaxMetric(Dart_Isolate isolate);  // Byte
-DART_EXPORT int64_t
-Dart_IsolateHeapNewCapacityMetric(Dart_Isolate isolate);  // Byte
-DART_EXPORT int64_t
-Dart_IsolateHeapNewCapacityMaxMetric(Dart_Isolate isolate);  // Byte
-DART_EXPORT int64_t
-Dart_IsolateHeapNewExternalMetric(Dart_Isolate isolate);  // Byte
-DART_EXPORT int64_t
-Dart_IsolateHeapGlobalUsedMetric(Dart_Isolate isolate);  // Byte
-DART_EXPORT int64_t
-Dart_IsolateHeapGlobalUsedMaxMetric(Dart_Isolate isolate);  // Byte
-DART_EXPORT int64_t
-Dart_IsolateRunnableLatencyMetric(Dart_Isolate isolate);  // Microsecond
-DART_EXPORT int64_t
-Dart_IsolateRunnableHeapSizeMetric(Dart_Isolate isolate);  // Byte
+Dart_IsolateGroupHeapNewExternalMetric(Dart_IsolateGroup group);  // Byte
 
 /*
  * ========
@@ -493,14 +535,14 @@ Dart_IsolateRunnableHeapSizeMetric(Dart_Isolate isolate);  // Byte
  */
 
 /*
- * Gets the current isolate's currently set UserTag instance.
+ * Gets the current Dart thread's currently set UserTag instance.
  *
  * \return The currently set UserTag instance.
  */
 DART_EXPORT Dart_Handle Dart_GetCurrentUserTag();
 
 /*
- * Gets the current isolate's default UserTag instance.
+ * Gets the current Dart thread's default UserTag instance.
  *
  * \return The default UserTag with label 'Default'
  */
@@ -516,7 +558,7 @@ DART_EXPORT Dart_Handle Dart_GetDefaultUserTag();
 DART_EXPORT Dart_Handle Dart_NewUserTag(const char* label);
 
 /*
- * Updates the current isolate's UserTag to a new value.
+ * Updates the current Dart thread's UserTag to a new value.
  *
  * \param user_tag The UserTag to be set as the current UserTag.
  *
@@ -532,7 +574,55 @@ DART_EXPORT Dart_Handle Dart_SetCurrentUserTag(Dart_Handle user_tag);
  * \return The UserTag's label. NULL if the user_tag is invalid. The caller is
  *   responsible for freeing the returned label.
  */
-DART_EXPORT DART_WARN_UNUSED_RESULT char* Dart_GetUserTagLabel(
+DART_EXPORT DART_API_WARN_UNUSED_RESULT char* Dart_GetUserTagLabel(
     Dart_Handle user_tag);
+
+/*
+ * =======
+ * Heap Snapshot
+ * =======
+ */
+
+/**
+ * Callback provided by the caller of `Dart_WriteHeapSnapshot` which is
+ * used to write out chunks of the requested heap snapshot.
+ *
+ * \param context An opaque context which was passed to `Dart_WriteHeapSnapshot`
+ *   together with this callback.
+ *
+ * \param buffer Pointer to the buffer containing a chunk of the snapshot.
+ *   The callback owns the buffer and needs to `free` it.
+ *
+ * \param size Number of bytes in the `buffer` to be written.
+ *
+ * \param is_last Set to `true` for the last chunk. The callback will not
+ *   be invoked again after it was invoked once with `is_last` set to `true`.
+ */
+typedef void (*Dart_HeapSnapshotWriteChunkCallback)(void* context,
+                                                    uint8_t* buffer,
+                                                    intptr_t size,
+                                                    bool is_last);
+
+/**
+ * Generate heap snapshot of the current isolate group and stream it into the
+ * given `callback`. VM would produce snapshot in chunks and send these chunks
+ * one by one back to the embedder by invoking the provided `callback`.
+ *
+ * This API enables embedder to stream snapshot into a file or socket without
+ * allocating a buffer to hold the whole snapshot in memory.
+ *
+ * The isolate group will be paused for the duration of this operation.
+ *
+ * \param write Callback used to write chunks of the heap snapshot.
+ *
+ * \param context Opaque context which would be passed on each invocation of
+ *   `write` callback.
+ *
+ * \returns `nullptr` if the operation is successful otherwise error message.
+ *   Caller owns error message string and needs to `free` it.
+ */
+DART_EXPORT char* Dart_WriteHeapSnapshot(
+    Dart_HeapSnapshotWriteChunkCallback write,
+    void* context);
 
 #endif  // RUNTIME_INCLUDE_DART_TOOLS_API_H_

--- a/third_party/flutter/third_party/dart/runtime/include/dart_version.h
+++ b/third_party/flutter/third_party/dart/runtime/include/dart_version.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+#ifndef RUNTIME_INCLUDE_DART_VERSION_H_
+#define RUNTIME_INCLUDE_DART_VERSION_H_
+
+// On breaking changes the major version is increased.
+// On backwards compatible changes the minor version is increased.
+// The versioning covers the symbols exposed in dart_api_dl.h
+#define DART_API_DL_MAJOR_VERSION 2
+#define DART_API_DL_MINOR_VERSION 6
+
+#endif /* RUNTIME_INCLUDE_DART_VERSION_H_ */ /* NOLINT */

--- a/third_party/flutter/third_party/dart/runtime/include/internal/dart_api_dl_impl.h
+++ b/third_party/flutter/third_party/dart/runtime/include/internal/dart_api_dl_impl.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+ * for details. All rights reserved. Use of this source code is governed by a
+ * BSD-style license that can be found in the LICENSE file.
+ */
+
+#ifndef RUNTIME_INCLUDE_INTERNAL_DART_API_DL_IMPL_H_
+#define RUNTIME_INCLUDE_INTERNAL_DART_API_DL_IMPL_H_
+
+typedef struct {
+  const char* name;
+  void (*function)(void);
+} DartApiEntry;
+
+typedef struct {
+  const int major;
+  const int minor;
+  const DartApiEntry* const functions;
+} DartApi;
+
+#endif /* RUNTIME_INCLUDE_INTERNAL_DART_API_DL_IMPL_H_ */ /* NOLINT */


### PR DESCRIPTION
First slice of the OSGi multi-bundle framework: the build gate, the vendored
Dart DL headers it depends on, and the configuration front end.

No runtime behavior yet — nothing calls the parser. This establishes the
schema and its validation so the bridge plugin and startup orchestrator have
something to build against.

## Additive by construction

With `ENABLE_OSGI=OFF` (the default) no OSGi translation unit is compiled, the
`dart_api_dl` target is not built, and the binary carries no `ihs::osgi`
symbols. Verified both ways:

| | OSGi objects built | `ihs::osgi` symbols |
|---|---|---|
| `ENABLE_OSGI=OFF` | none | 0 |
| `ENABLE_OSGI=ON` | 3 | 36 |

## Commits

**`third_party: vendor Dart dynamically-linked embedding API`**

Adds `dart_native_api.h`, `dart_api_dl.{h,c}`, `dart_version.h` and
`internal/dart_api_dl_impl.h`, supplying `Dart_PostCObject_DL` — the primitive
for handing a Dart isolate a message from another thread.

Pinned to Dart SDK `d684a576`, the revision `flutter/flutter` tag `3.44.2`
names in `DEPS` `dart_revision`, matching `.flutter-version`.

`dart_api.h` / `dart_tools_api.h` are refreshed to the same revision rather
than left alone: `dart_native_api.h` at this revision spells the macro
`DART_API_WARN_UNUSED_RESULT`, the old vendored header defined
`DART_WARN_UNUSED_RESULT`, and the mix does not compile. The refresh is
behavior-neutral — nothing consumed those headers (`fml/trace_event.h` is
their only includer, and nothing includes it). `PROVENANCE.md` records the pin
and a re-pin recipe.

**`osgi: add ENABLE_OSGI option and [osgi] config parsing`**

`[[osgi.bundles]]` entries delegate every `[view]` key — backend, DRM, args,
output pinning, shell/window — to `Configuration::get_view_parameters`, so a
bundle gets the full `[view]` surface with identical semantics instead of a
parallel implementation that would drift. Only the OSGi-specific keys
(`symbolic_name`, `priority`, `cpu_core`, `startup_timeout_ms`) are handled
here. A consequence: `[osgi.bundles.shell]` reaches `ivi_surface_id` through
the existing path, needing no new schema.

## Validation choices worth reviewing

**`cpu_core` is checked against the process affinity mask, not a core count.**
The two are not interchangeable. Confined to CPUs 2,3 on a 32-way host:

```
hardware_concurrency=32   affinity_count=2   highest_allowed_index=3
index 0 allowed? 0
```

`hardware_concurrency()` describes the machine, not the process. And a
`[0, count)` check admits indices 0 and 1 — exactly the two
`pthread_setaffinity_np` refuses. `sched_getaffinity` returns the same set the
pin is validated against, so it is the only bound under which a parse-time
error and a startup-time pin failure agree. Non-contiguous cpusets are normal
under containers, `systemd CPUAffinity=`, and IVI core partitioning.

Rejecting rather than warning is deliberate: a critical bundle that silently
runs unpinned has lost the guarantee its `cpu_core` was written to obtain, and
the symptom surfaces as jitter far from the cause. Happy to soften this to
warn-and-continue if one config.toml is expected to serve SoC variants with
differing core counts. A `sched_getaffinity` failure disables the check rather
than blocking startup.

**Other rejections:** duplicate `symbolic_name`; duplicate ivi-shell
`surface_id`, which would otherwise hand two bundles the same compositor
surface; and out-of-range integers — TOML integers are `int64_t`, so narrowing
via `value<int>()` yields an empty optional that `.value()` throws on, and a
config typo must be a diagnosed error rather than a crash.

**Relative `bundle` paths** resolve against the config file's directory, so one
spelling does not mean two different things across the `[[view]]` and
`[[osgi.bundles]]` halves of a single file. Matches
`Configuration::parse_config`.

## Build wiring

`dart_api_dl.c` is a separate static library rather than a shell source: it is
C, and `test/unit_test` harvests the shell target's `SOURCES` property and
prepends `shell/` to each entry, which an absolute `third_party/` path would
corrupt.

## Tests

24 cases covering the schema, the delegation, and each rejection path. The
affinity cases derive core numbers from the live mask instead of hardcoding
them, so the suite passes unchanged under confinement:

```
unrestricted     24 passed
taskset -c 2,3   24 passed   (mask-vs-count case runs for real here)
taskset -c 5     24 passed
```

## Follow-up noted, not included

`shell/configuration/configuration.h:100` reads "One process drives one backend
today, so the first bundle's value wins." That is contradicted by
`backend.h:82`, `register_backends.cc:1068` and `app.cc:136`, which already
resolve each view's backend independently. Left alone here to keep this PR
scoped; worth a one-line fix since it misleads anyone planning multi-backend
work.