### PR TITLE
Tell platform-view plugins where the bundle's assets are

### DIFF
--- a/shared/include/ihs/platform_view.h
+++ b/shared/include/ihs/platform_view.h
@@ -214,6 +214,19 @@ typedef struct IhsPvCapabilities {
 IHS_EXPORT int ihs_pv_query_capabilities(IhsPvCapabilities* out);
 
 /*
+ * Absolute path to the running bundle's flutter_assets directory, or NULL if
+ * the shell is older than this entry point, has no host installed, or has not
+ * resolved a bundle. Borrowed: owned by the shell and valid for the engine's
+ * lifetime; copy it if you need to outlive the call.
+ *
+ * A plugin that resolves its own assets by relative path needs this. The
+ * compositor-surface path receives the directory as an initialize() argument;
+ * the platform-view path had no equivalent, so such a plugin had nothing to
+ * resolve against.
+ */
+IHS_EXPORT const char* ihs_pv_assets_path(void);
+
+/*
  * The backend's Vulkan objects, offered to a plugin that renders on a Vulkan
  * backend. Handles are void* so this header stays free of vulkan.h; cast to the
  * matching Vk* type.
@@ -544,6 +557,9 @@ typedef struct IhsPlatformViewApi {
                 const IhsFrame* frame,
                 int acquire_fence_fd,
                 int* out_release_fence_fd);
+
+  /* Appended after the initial layout; check struct_size before calling. */
+  const char* (*assets_path)(void);
 } IhsPlatformViewApi;
 
 #ifdef __cplusplus

--- a/shared/include/ihs/platform_view_host.h
+++ b/shared/include/ihs/platform_view_host.h
@@ -75,6 +75,13 @@ extern "C" {
  *                 read back the cached grant payload for @view.
  *   submit        hand a produced frame for @view to the compositor present
  *                 path.
+ *   assets_path   absolute path to the running bundle's flutter_assets
+ *                 directory, or NULL if the engine has not resolved one.
+ *                 Borrowed and owned by the shell; valid for the engine's
+ *                 lifetime. A plugin that loads its own assets by relative
+ *                 path needs this: unlike the compositor-surface entry point,
+ *                 which is handed the directory at initialize(), nothing in
+ *                 the platform-view path told a plugin where the bundle is.
  */
 typedef struct IhsPvHost {
   size_t struct_size;
@@ -108,6 +115,9 @@ typedef struct IhsPvHost {
                 const IhsFrame* frame,
                 int acquire_fence_fd,
                 int* out_release_fence_fd);
+
+  /* Appended after the initial layout; read only when struct_size covers it. */
+  const char* (*assets_path)(void* user_data);
 } IhsPvHost;
 
 /*

--- a/shared/src/platform_view.cc
+++ b/shared/src/platform_view.cc
@@ -28,6 +28,8 @@
  * thread. The mutex guards only the installed host pointer.
  */
 
+#include <cstddef>
+
 #include "ihs/platform_view.h"
 #include "ihs/platform_view_host.h"
 
@@ -139,6 +141,22 @@ extern "C" int ihs_pv_query_capabilities(IhsPvCapabilities* out) {
     return IHS_PV_ERR_NO_REGISTRY;
   }
   return h->query_capabilities(h->user_data, out);
+}
+
+extern "C" const char* ihs_pv_assets_path(void) {
+  const IhsPvHost* h = host();
+  if (h == nullptr) {
+    return nullptr;
+  }
+  // Appended to IhsPvHost after its initial layout. A shell built against the
+  // older header reports a smaller struct_size and has no member here, so the
+  // bounds check is what makes reading it safe rather than a guess.
+  constexpr size_t kNeeded =
+      offsetof(IhsPvHost, assets_path) + sizeof(h->assets_path);
+  if (h->struct_size < kNeeded || h->assets_path == nullptr) {
+    return nullptr;
+  }
+  return h->assets_path(h->user_data);
 }
 
 extern "C" int ihs_pv_vulkan_context(IhsVulkanContext* out) {
@@ -268,6 +286,7 @@ const IhsPlatformViewApi* platform_view_api() noexcept {
       &ihs_pv_register_factory,   &ihs_pv_unregister_factory,
       &ihs_pv_negotiate,          &ihs_pv_grant_drm_plane_id,
       &ihs_pv_grant_shm_fd,       &ihs_pv_submit,
+      &ihs_pv_assets_path,
   };
   return &api;
 }

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -1335,6 +1335,15 @@ int HostSubmit(void* user_data,
 
 // Process-global host; user_data re-points at the most recently installed
 // engine (single-engine today).
+const char* HostAssetsPath(void* user_data) {
+  const auto* state = static_cast<FlutterDesktopEngineState*>(user_data);
+  if (state == nullptr || state->flutter_asset_directory.empty()) {
+    return nullptr;
+  }
+  // Borrowed: owned by the engine state, which outlives every platform view.
+  return state->flutter_asset_directory.c_str();
+}
+
 IhsPvHost g_host{};
 
 }  // namespace
@@ -1349,6 +1358,7 @@ void InstallPlatformViewHost(FlutterDesktopEngineState* engine_state) {
   g_host.register_factory = HostRegisterFactory;
   g_host.unregister_factory = HostUnregisterFactory;
   g_host.query_capabilities = HostQueryCapabilities;
+  g_host.assets_path = HostAssetsPath;
   g_host.vulkan_context = HostVulkanContext;
   g_host.egl_context = HostEglContext;
   g_host.grant = HostGrant;


### PR DESCRIPTION
A plugin on the platform-view path has no way to find `flutter_assets`. The compositor-surface path is handed the directory as an `initialize()` argument (`compositor_surface.cc:182`); nothing equivalent exists here, so a plugin that resolves its own assets by relative path has nothing to resolve against.

## What it looks like when it bites

Fluorite is such a plugin: glb through `ModelSystem`, `.filamat` through the material loader, HDR through the indirect-light and skybox loaders all join onto an asset root it never receives. The join returns the relative path unchanged, and then:

```
[E] fluorite/core: [readAsset] invalid path: assets/models/ground.glb
[V] fluorite/core: [updateAsyncAssetLoading] Model async loading progress: 0%   (x5413)
```

An app with a custom material fails harder, at startup, before a frame:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Material instance has no data
```

Neither message names a missing asset root. That is what made this expensive to find — the shell is entirely healthy at that point (`zero-copy dma-buf present ENABLED`, `platform-view host installed`, `Platform view created with id: 0`), so the fault reads as the plugin's.

## The change

| | |
| --- | --- |
| `IhsPvHost` | gains `const char* (*assets_path)(void* user_data)` |
| `libihs_shared` | forwards it as `ihs_pv_assets_path()` |
| shell | answers from `FlutterDesktopEngineState::flutter_asset_directory`, which `flutter_view.cc:255` already resolves |

The pointer is borrowed and owned by the engine state, which outlives every platform view.

## Compatibility

Appended to `IhsPvHost` and `IhsPlatformViewApi` rather than inserted, and the forwarder bounds-checks `struct_size` before reading the member:

```cpp
constexpr size_t kNeeded = offsetof(IhsPvHost, assets_path) + sizeof(h->assets_path);
if (h->struct_size < kNeeded || h->assets_path == nullptr) return nullptr;
```

So a plugin built against this header keeps working against a shell built against the older one — it gets `NULL` and can report that rather than reading past the end of the struct. No existing member moves, and the `ihs_*` wildcard in `ihs_shared.map` already exports the new symbol.

## Testing

Verified against a Fluorite app that until now needed an environment variable and a *debug* FFI entry point (`fluorite_set_asset_path_for_test`) to load anything at all. With this change and no workaround of any kind:

```
[I] fluorite/ihs_pv: asset root: <bundle>/data/flutter_assets
readAsset failures: 0
models added: 33
```

Built `wayland-vulkan` with `BUILD_COMPOSITOR=ON`; the app renders its scene, and the same app against an unpatched shell still starts and reports the missing root rather than crashing.

## Note for the plugin side

Fluorite needs a matching change to call `ihs_pv_assets_path()` and seed its ECS asset root. That is written and tested but cannot be submitted until this lands: fluorite pins `ivi-homescreen-shared` to a source tarball at a fixed commit, so its augment has to be repointed at a commit containing this before the consumer will compile.
