### PR TITLE
ci: retry ghcr.io logins in the pios workflow

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -93,10 +93,32 @@ jobs:
           restore-keys: |
             emb-store-${{ matrix.pios }}-
 
+      # Retried: ghcr.io intermittently answers a valid credential with
+      # "denied", and a bare login turns that into a red build that never
+      # compiled anything. POSIX sh so the same idiom works here (bash) and in
+      # the container job below (dash). The token is re-fed on every attempt --
+      # --password-stdin consumes it, so the pipeline must live inside the loop.
       - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          i=1
+          while :; do
+            if printf '%s' "$GHCR_TOKEN" \
+                 | docker login ghcr.io -u "$GHCR_USER" --password-stdin; then
+              break
+            fi
+            if [ "$i" -ge 5 ]; then
+              echo "::error::docker login ghcr.io failed after $i attempts"
+              exit 1
+            fi
+            # Surfaced, not swallowed: a rising retry count is the early signal
+            # that the registry is degrading rather than blipping.
+            echo "::warning::docker login ghcr.io failed (attempt $i/5); retrying"
+            sleep $(( i * 3 ))
+            i=$(( i + 1 ))
+          done
 
       # oras uploads the resolved store entries to the OCI cache in the publish
       # step below (EMB_CACHE_REGISTRY). Cache the binary keyed on the version so
@@ -113,6 +135,9 @@ jobs:
           path: ~/oras-bin
           key: oras-${{ env.ORAS_VERSION }}-linux-amd64
       - name: Install + log in oras
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
           # Fetch from GitHub releases only on a cache miss (version bump or
           # eviction); the cache restores ~/oras-bin/oras otherwise.
@@ -123,8 +148,22 @@ jobs:
               | tar -xzf - -C "$HOME/oras-bin" oras
           fi
           sudo install -m 0755 "$HOME/oras-bin/oras" /usr/local/bin/oras
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          # Retried for the same reason as the docker login above: the download
+          # was already hardened, the authentication never was.
+          i=1
+          while :; do
+            if printf '%s' "$GHCR_TOKEN" \
+                 | oras login ghcr.io -u "$GHCR_USER" --password-stdin; then
+              break
+            fi
+            if [ "$i" -ge 5 ]; then
+              echo "::error::oras login ghcr.io failed after $i attempts"
+              exit 1
+            fi
+            echo "::warning::oras login ghcr.io failed (attempt $i/5); retrying"
+            sleep $(( i * 3 ))
+            i=$(( i + 1 ))
+          done
 
       # rpi5-<os> is the canonical publish target: the sysroot (and thus the
       # image) is model-independent, so one image per OS serves rpi4/zero-2w
@@ -200,6 +239,9 @@ jobs:
           path: /usr/local/bin/oras
           key: oras-${{ env.ORAS_VERSION }}-linux-amd64
       - name: Install + log in oras
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USER: ${{ github.actor }}
         run: |
           # Only fetch from GitHub releases on a cache miss (version bump); the
           # cache restores /usr/local/bin/oras otherwise.
@@ -208,8 +250,24 @@ jobs:
               "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
               | tar -xzf - -C /usr/local/bin oras
           fi
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          # This is the login that has actually failed in CI: ~25 matrix jobs
+          # authenticate to ghcr.io at once, which is exactly the concentration
+          # that provokes a spurious "denied". No shell: bash here on purpose --
+          # the loop is POSIX so it runs under the container's dash unchanged.
+          i=1
+          while :; do
+            if printf '%s' "$GHCR_TOKEN" \
+                 | oras login ghcr.io -u "$GHCR_USER" --password-stdin; then
+              break
+            fi
+            if [ "$i" -ge 5 ]; then
+              echo "::error::oras login ghcr.io failed after $i attempts"
+              exit 1
+            fi
+            echo "::warning::oras login ghcr.io failed (attempt $i/5); retrying"
+            sleep $(( i * 3 ))
+            i=$(( i + 1 ))
+          done
 
       # The image bakes the toolchain + sysroot at /emb, so -w /emb resolves as
       # a pure cache hit (no download/extract). Host build tools (cmake, ninja,


### PR DESCRIPTION
## What happened

A build matrix job on #419 failed with:

```
Error response from registry: failed to validate the credentials for ghcr.io:
GET "https://ghcr.io/v2/": denied: denied
```

The credentials were fine — the same login succeeded in sibling jobs of the
same run, with the same token and the same `github.actor`. ghcr.io
intermittently rejects a good credential, and the login had no retry, so a
transient registry blip became a red build.

The step runs **before** the compile step, so the job skipped the build
entirely: it reported failure having verified nothing. Clearing it needs a
manual re-run by someone with write access.

## The asymmetry this fixes

The oras *download* was already hardened:

```yaml
curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors ...
```

The *authentication* immediately after it was a single bare attempt. Both are
network calls to the same class of endpoint.

The flakiness of this dependency was already known — the comment above the
cache step records an earlier incident: *"the publish job had no cache and a
run hit a 504 window that outlasted the curl retries and failed."* The logins
just never got the same treatment.

## Scope: three sites, not one

| Line | Job | Shell | Call |
|---|---|---|---|
| `:96` | `publish` | bash | `docker login ghcr.io` |
| `:127` | `publish` | bash | `oras login ghcr.io` |
| `:212` | `build` | **dash** | `oras login ghcr.io` ← the one that fired |

All three now retry five times with linear backoff.

## Two details the shape depends on

**The loop is POSIX sh, not bash.** The `build` job runs in a container, where
the default shell is dash — only its `Build` step opts into `shell: bash`, and
the file already warns about this ("Container jobs default to dash (sh);
pipefail/SECONDS need bash"). Keeping the idiom POSIX lets the same code serve
all three sites with no `shell:` key.

**The token is re-fed inside the loop.** `--password-stdin` consumes stdin, so
piping it once *around* the loop would retry with an empty password — turning a
transient failure into an authentication failure that reports the wrong cause.

Both were verified rather than assumed. The test harness's fake `oras` asserts
the token arrives on every attempt, and a negative control on the
tempting-but-wrong shape (token piped once, loop inside) confirms the assertion
is not vacuous:

```
[dash] fail_times=0 rc=0 :: LOGIN OK after 1 attempt(s)
[dash] fail_times=2 rc=0 :: LOGIN OK after 3 attempt(s)
[dash] fail_times=5 rc=1 :: ::error::oras login failed after 5 attempts
[bash]  ... identical ...
[negative control] FAIL: stdin token was '' (not re-fed!)
```

## Retries are visible, not silent

Each retry emits `::warning::`. A rising retry count is the early signal that
the registry is degrading rather than blipping; a silent retry would hide
exactly the trend worth seeing.

## Also

The token moves from inline `${{ }}` interpolation in the script body to an
`env:` block at each site, so it is no longer expanded into shell text.

## Not addressed

`container.credentials` (`:189-193`) is a fourth ghcr.io authentication,
performed by the runner before any step runs. If that blips the job dies with
no step to wrap, so it cannot be hardened from inside the workflow.

## On frequency

Observed once across the 15 most recent `pios` runs. This is a low-rate flake,
not a constant problem — the case for fixing it is the blast radius (a red CI
that compiled nothing, needing a manual re-run) and that the risk is not
per-job independent: ~25 matrix jobs authenticate to ghcr.io near-simultaneously,
which is the concentration that provokes a spurious `denied`.