### PR TITLE
test: add the OSGi multi-bundle vkms harness, and stop hardcoding the DRM card

### DIFF
--- a/scripts/vkms_harness_integration.sh
+++ b/scripts/vkms_harness_integration.sh
@@ -82,5 +82,21 @@ run_harness "present census" \
 run_harness "event-driven input harness" \
     env IDLE_CTXT_MAX=150 "${IVI_SRC}/test/input_event_driven.sh"
 
+# ---------------------------------------------------------------------------
+# OSGi multi-bundle: two bundles -> two engines -> two connectors, critical
+# first. Needs two connectors on one card and a binary built with
+# ENABLE_OSGI=ON; the harness reports an honest skip when either is missing
+# rather than failing, so it is wired in here from the start and goes live by
+# flipping ENABLE_OSGI in the build step above it.
+# ---------------------------------------------------------------------------
+# DRM_DEVICE and the connector names are deliberately NOT passed: card
+# numbering is not stable (vkms lands wherever it lands relative to any real
+# GPU) and connector names are card-specific (Virtual-N on vkms, HDMI-A-1/DP-1
+# on a real GPU). The harness auto-detects vkms by its connector signature and
+# reads the connectors off that card, so nothing here has to guess. It skips
+# honestly when there is no vkms card or the binary lacks ENABLE_OSGI.
+run_harness "osgi multi-bundle" \
+    env SOFTWARE_RENDER=1 "${IVI_SRC}/test/osgi_multi_bundle.sh"
+
 echo "vkms harness integration: overall rc=${rc}"
 exit "${rc}"

--- a/test/drm_kms_vkms.sh
+++ b/test/drm_kms_vkms.sh
@@ -84,23 +84,9 @@ log() {
     echo "==> $*"
 }
 
-find_vkms_card() {
-    # Identify the vkms card by its connector signature. vkms always
-    # advertises connectors named "cardN-Virtual-M"; real GPUs don't.
-    # This is more reliable than matching the driver symlink, whose name
-    # has changed over kernel versions (platform → faux_driver).
-    local c card
-    for c in /sys/class/drm/card[0-9]*; do
-        # Skip the connector/encoder child nodes themselves.
-        [[ -d "$c/device" ]] || continue
-        card="$(basename "$c")"
-        if compgen -G "/sys/class/drm/${card}-Virtual-*" >/dev/null; then
-            echo "/dev/dri/${card}"
-            return 0
-        fi
-    done
-    return 1
-}
+# Card/connector discovery is shared with the other KMS harnesses.
+# shellcheck source=test/lib/drm_card.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/drm_card.sh"
 
 ensure_vkms_loaded() {
     if lsmod | awk '{print $1}' | grep -qx vkms; then
@@ -161,7 +147,7 @@ fi
 ensure_vkms_loaded
 
 if [[ -z "$VKMS_CARD" ]]; then
-    VKMS_CARD="$(find_vkms_card)" || die "no /dev/dri/cardN with driver=vkms found"
+    VKMS_CARD="$(ihs_find_vkms_card)" || die "no /dev/dri/cardN with driver=vkms found"
 fi
 [[ -e "$VKMS_CARD" ]] || die "$VKMS_CARD does not exist"
 

--- a/test/lib/drm_card.sh
+++ b/test/lib/drm_card.sh
@@ -22,20 +22,30 @@
 #   card="$(ihs_find_vkms_card)" || card=""
 #   mapfile -t conns < <(ihs_connectors_of "$(basename "$card")")
 
-# Echo /dev/dri/cardN for the vkms card, or return 1.
+# Echo /dev/dri/cardN for a vkms card with at least <min_connectors> scanout
+# connectors (default 1), or return 1.
 #
 # vkms is identified by its connector signature: it always advertises
 # connectors named "cardN-Virtual-M", and real GPUs do not. That is deliberately
 # not a match on the driver symlink, whose name has changed across kernel
 # versions (platform -> faux_driver) and would silently stop matching again on
 # the next rename.
-ihs_find_vkms_card() {
-    local c card
+#
+# The connector count matters because there is routinely more than one vkms
+# card. `modprobe vkms` creates a default instance with a single output, and
+# vkms_dual.sh then provisions a second instance with two -- so a bare
+# first-match search finds the single-output card and a harness needing two
+# outputs skips, with the card it wanted sitting right there. Callers say how
+# many they need.
+ihs_find_vkms_card() {  # ihs_find_vkms_card [min_connectors]
+    local min="${1:-1}" c card count
     for c in /sys/class/drm/card[0-9]*; do
         # Skip the connector/encoder child nodes, which have no device/ dir.
         [ -d "$c/device" ] || continue
         card="$(basename "$c")"
-        if compgen -G "/sys/class/drm/${card}-Virtual-*" >/dev/null; then
+        compgen -G "/sys/class/drm/${card}-Virtual-*" >/dev/null || continue
+        count="$(ihs_connectors_of "$card" | wc -l)"
+        if [ "$count" -ge "$min" ]; then
             echo "/dev/dri/${card}"
             return 0
         fi
@@ -49,13 +59,21 @@ ihs_find_vkms_card() {
 # so a harness must read them off the card it resolved rather than defaulting to
 # either set, which is wrong on the other.
 #
-# Writeback connectors are excluded: they are capture targets, not scanout ones,
-# so nothing can be pinned to them for display.
+# Only connectors reporting "connected" are listed. A disconnected connector
+# still appears in sysfs, and pinning a bundle to one produces a modeset failure
+# deep in the backend rather than an obvious "there is no second display here"
+# -- which is the actual situation on, say, a Pi with one DSI panel and two
+# empty HDMI ports. vkms reports its virtual outputs as connected, so this reads
+# the same on both rigs.
+#
+# Writeback connectors are excluded regardless: they are capture targets, not
+# scanout ones, so nothing can be pinned to them for display.
 ihs_connectors_of() {  # ihs_connectors_of <cardN>
     local card="$1" c
     for c in /sys/class/drm/"${card}"-*; do
         [ -e "$c/status" ] || continue
         case "$c" in *Writeback*) continue ;; esac
+        [ "$(cat "$c/status" 2>/dev/null)" = "connected" ] || continue
         basename "$c" | sed "s/^${card}-//"
     done
 }

--- a/test/lib/drm_card.sh
+++ b/test/lib/drm_card.sh
@@ -1,0 +1,61 @@
+# shellcheck shell=bash
+#
+# drm_card.sh — shared DRM node/connector discovery for the test harnesses.
+#
+# Sourced, not executed. Every harness that drives KMS needs the same two
+# answers ("which card?", "which connectors?"), and getting the first one wrong
+# is not a cosmetic bug: these harnesses take DRM master and drive a modeset, so
+# a harness that guesses a card number can blank a developer's real display.
+#
+# Card numbering is not stable. vkms lands wherever it lands relative to any
+# real GPU, and moves as other DRM drivers load or are rebuilt into the kernel,
+# so no numeric default is correct anywhere but the machine it was written on.
+# The rule these helpers encode is therefore:
+#
+#   - auto-detection resolves vkms and nothing else, so it is always safe;
+#   - targeting real hardware requires the caller to name the node explicitly,
+#     which is the operator saying so out loud;
+#   - when neither applies, the harness skips rather than guessing.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/lib/drm_card.sh"
+#   card="$(ihs_find_vkms_card)" || card=""
+#   mapfile -t conns < <(ihs_connectors_of "$(basename "$card")")
+
+# Echo /dev/dri/cardN for the vkms card, or return 1.
+#
+# vkms is identified by its connector signature: it always advertises
+# connectors named "cardN-Virtual-M", and real GPUs do not. That is deliberately
+# not a match on the driver symlink, whose name has changed across kernel
+# versions (platform -> faux_driver) and would silently stop matching again on
+# the next rename.
+ihs_find_vkms_card() {
+    local c card
+    for c in /sys/class/drm/card[0-9]*; do
+        # Skip the connector/encoder child nodes, which have no device/ dir.
+        [ -d "$c/device" ] || continue
+        card="$(basename "$c")"
+        if compgen -G "/sys/class/drm/${card}-Virtual-*" >/dev/null; then
+            echo "/dev/dri/${card}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Echo the scanout connector names on <cardN>, one per line, in sysfs order.
+#
+# Names are card-specific -- Virtual-N on vkms, HDMI-A-1/DP-1 on a real GPU --
+# so a harness must read them off the card it resolved rather than defaulting to
+# either set, which is wrong on the other.
+#
+# Writeback connectors are excluded: they are capture targets, not scanout ones,
+# so nothing can be pinned to them for display.
+ihs_connectors_of() {  # ihs_connectors_of <cardN>
+    local card="$1" c
+    for c in /sys/class/drm/"${card}"-*; do
+        [ -e "$c/status" ] || continue
+        case "$c" in *Writeback*) continue ;; esac
+        basename "$c" | sed "s/^${card}-//"
+    done
+}

--- a/test/multi_view_single_engine.sh
+++ b/test/multi_view_single_engine.sh
@@ -58,7 +58,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/drm_card.sh"
 # Auto-detection resolves vkms and nothing else, so it can never pick a real
 # GPU by accident; naming a node explicitly is how you ask for one.
 if [ -z "$DRM_DEVICE" ]; then
-  DRM_DEVICE="$(ihs_find_vkms_card)" \
+  DRM_DEVICE="$(ihs_find_vkms_card 2)" \
     || die "no vkms card found; set DRM_DEVICE explicitly to target real hardware"
 fi
 [ -c "$DRM_DEVICE" ] || die "DRM_DEVICE not a device node: $DRM_DEVICE"

--- a/test/multi_view_single_engine.sh
+++ b/test/multi_view_single_engine.sh
@@ -16,9 +16,14 @@
 # Env:
 #   HOMESCREEN       path to the homescreen binary (required)
 #   BUNDLE           path to the multi_view_test bundle (required)
-#   DRM_DEVICE       /dev/dri/cardN            (default /dev/dri/card1)
-#   CONNECTOR_A      first output connector    (default HDMI-A-1)
-#   CONNECTOR_B      second output connector   (default DP-1)
+#   DRM_DEVICE       /dev/dri/cardN. Unset = auto-detect the vkms card.
+#                    Card numbering is NOT stable, and this harness takes DRM
+#                    master and drives a modeset, so there is deliberately no
+#                    numeric default -- one would blank a real display on any
+#                    machine where that number is the GPU. Set it explicitly to
+#                    opt in to real hardware.
+#   CONNECTOR_A      first output connector    (default: 1st on the card)
+#   CONNECTOR_B      second output connector   (default: 2nd on the card)
 #   DURATION         seconds to run            (default 6)
 #   STARTUP_GRACE    seconds before liveness   (default 2)
 #   COUNT_FLIPS      1 = prove page flips on both CRTCs via strace (default 0)
@@ -29,9 +34,10 @@ set -uo pipefail
 
 HOMESCREEN="${HOMESCREEN:-}"
 BUNDLE="${BUNDLE:-}"
-DRM_DEVICE="${DRM_DEVICE:-/dev/dri/card1}"
-CONNECTOR_A="${CONNECTOR_A:-HDMI-A-1}"
-CONNECTOR_B="${CONNECTOR_B:-DP-1}"
+# No numeric defaults: see the DRM_DEVICE note above.
+DRM_DEVICE="${DRM_DEVICE:-}"
+CONNECTOR_A="${CONNECTOR_A:-}"
+CONNECTOR_B="${CONNECTOR_B:-}"
 DURATION="${DURATION:-6}"
 STARTUP_GRACE="${STARTUP_GRACE:-2}"
 COUNT_FLIPS="${COUNT_FLIPS:-0}"
@@ -45,7 +51,27 @@ note() { echo "  $*"; }
 [ -x "$HOMESCREEN" ] || die "HOMESCREEN not executable: $HOMESCREEN"
 [ -n "$BUNDLE" ] || die "set BUNDLE to the multi_view_test bundle dir"
 [ -d "$BUNDLE" ] || die "BUNDLE not a directory: $BUNDLE"
+# Shared DRM discovery: see test/lib/drm_card.sh for why nothing is hardcoded.
+# shellcheck source=test/lib/drm_card.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/drm_card.sh"
+
+# Auto-detection resolves vkms and nothing else, so it can never pick a real
+# GPU by accident; naming a node explicitly is how you ask for one.
+if [ -z "$DRM_DEVICE" ]; then
+  DRM_DEVICE="$(ihs_find_vkms_card)" \
+    || die "no vkms card found; set DRM_DEVICE explicitly to target real hardware"
+fi
 [ -c "$DRM_DEVICE" ] || die "DRM_DEVICE not a device node: $DRM_DEVICE"
+
+# Connector names are card-specific (Virtual-N on vkms, HDMI-A-1/DP-1 on a real
+# GPU), so read them off the resolved card rather than defaulting to either set.
+if [ -z "$CONNECTOR_A" ]; then
+  mapfile -t _CONNS < <(ihs_connectors_of "$(basename "$DRM_DEVICE")")
+  CONNECTOR_A="${_CONNS[0]:-}"
+  CONNECTOR_B="${_CONNS[1]:-}"
+fi
+[ -n "$CONNECTOR_A" ] && [ -n "$CONNECTOR_B" ] \
+  || die "need 2 scanout connectors on $(basename "$DRM_DEVICE")"
 
 # The binary must be DRM-KMS-EGL built (the compositor scans out to KMS).
 if [ "$(strings "$HOMESCREEN" | grep -c '\[DrmBackend\]')" -eq 0 ]; then

--- a/test/osgi_multi_bundle.sh
+++ b/test/osgi_multi_bundle.sh
@@ -114,7 +114,7 @@ fi
 # on a developer's desktop. Targeting real hardware requires saying so.
 DEVICE_SOURCE="explicit"
 if [ "$DRM_DEVICE_EXPLICIT" -eq 0 ]; then
-    if DRM_DEVICE="$(ihs_find_vkms_card)"; then
+    if DRM_DEVICE="$(ihs_find_vkms_card 2)"; then
         DEVICE_SOURCE="auto-detected vkms"
     else
         DRM_DEVICE=""

--- a/test/osgi_multi_bundle.sh
+++ b/test/osgi_multi_bundle.sh
@@ -85,34 +85,9 @@ summary() {
     [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1
 }
 
-# Identify the vkms card by its connector signature: vkms always advertises
-# connectors named "cardN-Virtual-M" and real GPUs do not. Same method as
-# test/drm_kms_vkms.sh, which is the source of truth for it -- matching the
-# driver symlink instead is unreliable because its name has changed across
-# kernel versions (platform -> faux_driver).
-find_vkms_card() {
-    local c card
-    for c in /sys/class/drm/card[0-9]*; do
-        [ -d "$c/device" ] || continue        # skip connector/encoder children
-        card="$(basename "$c")"
-        if compgen -G "/sys/class/drm/${card}-Virtual-*" >/dev/null; then
-            echo "/dev/dri/${card}"
-            return 0
-        fi
-    done
-    return 1
-}
-
-# Scanout connectors on a card, in sysfs order. Writeback is excluded: it is a
-# capture target, not a scanout one, so a bundle cannot be pinned to it.
-connectors_of() {  # connectors_of <cardN>
-    local card="$1" c
-    for c in /sys/class/drm/"${card}"-*; do
-        [ -e "$c/status" ] || continue
-        case "$c" in *Writeback*) continue ;; esac
-        basename "$c" | sed "s/^${card}-//"
-    done
-}
+# Shared DRM discovery: see test/lib/drm_card.sh for why nothing is hardcoded.
+# shellcheck source=test/lib/drm_card.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/drm_card.sh"
 
 [ -n "$HOMESCREEN" ] || die "set HOMESCREEN to the homescreen binary"
 [ -x "$HOMESCREEN" ] || die "HOMESCREEN not executable: $HOMESCREEN"
@@ -139,7 +114,7 @@ fi
 # on a developer's desktop. Targeting real hardware requires saying so.
 DEVICE_SOURCE="explicit"
 if [ "$DRM_DEVICE_EXPLICIT" -eq 0 ]; then
-    if DRM_DEVICE="$(find_vkms_card)"; then
+    if DRM_DEVICE="$(ihs_find_vkms_card)"; then
         DEVICE_SOURCE="auto-detected vkms"
     else
         DRM_DEVICE=""
@@ -150,7 +125,7 @@ CARD="$(basename "${DRM_DEVICE:-none}")"
 if [ -n "$DRM_DEVICE" ] && [ -z "$CONNECTOR_A" ]; then
     # Connector names are card-specific -- vkms advertises Virtual-N, a real
     # GPU HDMI-A-1/DP-1 -- so they are read off the card rather than defaulted.
-    mapfile -t CONNS < <(connectors_of "$CARD")
+    mapfile -t CONNS < <(ihs_connectors_of "$CARD")
     CONNECTOR_A="${CONNS[0]:-}"
     CONNECTOR_B="${CONNS[1]:-}"
 fi

--- a/test/osgi_multi_bundle.sh
+++ b/test/osgi_multi_bundle.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+#
+# osgi_multi_bundle.sh — validate that TWO OSGi bundles drive TWO engines on
+# TWO outputs, and that the critical bundle is up before the normal one.
+#
+# This is the complement of multi_view_single_engine.sh. That harness proves
+# ONE engine can drive TWO outputs, and fails if a second engine appears. This
+# one requires the second engine: an OSGi bundle is a separate engine by
+# definition, and the whole framework rests on that being true on real KMS
+# rather than only against unit-test fakes.
+#
+# What is actually asserted, and why each matters:
+#
+#   B1 two engines     Engine indices 0 AND 1 both run. If the shell collapsed
+#                      the bundles onto one engine, every isolation claim the
+#                      framework makes is void.
+#   B2 both outputs    Each bundle brought up its own connector, so the
+#                      per-bundle [osgi.bundles.backend] config is honored
+#                      rather than the first bundle's winning for all.
+#   B3 critical first  The critical bundle reached ACTIVE before the normal
+#                      bundle was launched. This is the ordering guarantee
+#                      StartCriticalPhase exists to provide, and the one
+#                      property unit tests can only assert against a fake.
+#   B4 clean log       No error/critical lines.
+#   B5 flips           Optional: page flips on BOTH CRTCs, i.e. both engines
+#                      are really presenting and not merely constructed.
+#
+# Rigs:
+#   - Real hardware:  DRM_DEVICE=/dev/dri/card1 CONNECTOR_A=HDMI-A-1 CONNECTOR_B=DP-1
+#   - Portable/CI:    provision two virtual outputs first, then point at vkms:
+#                       sudo third_party/drm-cxx/scripts/vkms_dual.sh up
+#                       DRM_DEVICE=/dev/dri/cardN CONNECTOR_A=... CONNECTOR_B=... \
+#                         SOFTWARE_RENDER=1 test/osgi_multi_bundle.sh
+#
+# Env:
+#   HOMESCREEN       path to the homescreen binary (required)
+#   BUNDLE           path to a Flutter bundle to run as both bundles (required)
+#   DRM_DEVICE       /dev/dri/cardN. Unset = auto-detect the vkms card.
+#                    Card numbering is NOT stable -- vkms lands wherever it
+#                    lands relative to any real GPU, and moves when other DRM
+#                    drivers load -- so there is deliberately no numeric
+#                    default. Setting this explicitly is how you opt in to
+#                    running against real hardware.
+#   CONNECTOR_A      critical bundle's output  (default: 1st on the card)
+#   CONNECTOR_B      normal bundle's output    (default: 2nd on the card)
+#   DURATION         seconds to run            (default 6)
+#   STARTUP_GRACE    seconds before liveness   (default 3)
+#   STARTUP_TIMEOUT  critical deadline, ms     (default 4000)
+#   COUNT_FLIPS      1 = prove page flips via strace (default 0)
+#   SOFTWARE_RENDER  1 = LIBGL_ALWAYS_SOFTWARE=1 (vkms/llvmpipe)
+#   --check          verify prerequisites only, do not launch
+#
+set -uo pipefail
+
+HOMESCREEN="${HOMESCREEN:-}"
+BUNDLE="${BUNDLE:-}"
+# No numeric defaults: see the DRM_DEVICE note above.
+DRM_DEVICE="${DRM_DEVICE:-}"
+DRM_DEVICE_EXPLICIT=$([ -n "${DRM_DEVICE}" ] && echo 1 || echo 0)
+CONNECTOR_A="${CONNECTOR_A:-}"
+CONNECTOR_B="${CONNECTOR_B:-}"
+DURATION="${DURATION:-6}"
+STARTUP_GRACE="${STARTUP_GRACE:-3}"
+STARTUP_TIMEOUT="${STARTUP_TIMEOUT:-4000}"
+COUNT_FLIPS="${COUNT_FLIPS:-0}"
+SOFTWARE_RENDER="${SOFTWARE_RENDER:-0}"
+
+RESULTS=(); PASS=0; FAIL=0
+log()  { echo "[osgi-mb] $*"; }
+die()  { echo "FAIL: $*" >&2; exit 1; }
+record() {  # record <name> <pass|fail|skip> <detail>
+    RESULTS+=("$1 $2 — $3")
+    case "$2" in
+        pass) PASS=$((PASS+1)); log "PASS $1 — $3" ;;
+        fail) FAIL=$((FAIL+1)); log "FAIL $1 — $3" ;;
+        skip) log "SKIP $1 — $3" ;;
+    esac
+}
+
+summary() {
+    echo
+    log "──── summary ────"
+    for r in "${RESULTS[@]}"; do echo "  $r"; done
+    log "RAN: ${#RESULTS[@]}  PASS=$PASS  FAIL=$FAIL"
+    [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1
+}
+
+# Identify the vkms card by its connector signature: vkms always advertises
+# connectors named "cardN-Virtual-M" and real GPUs do not. Same method as
+# test/drm_kms_vkms.sh, which is the source of truth for it -- matching the
+# driver symlink instead is unreliable because its name has changed across
+# kernel versions (platform -> faux_driver).
+find_vkms_card() {
+    local c card
+    for c in /sys/class/drm/card[0-9]*; do
+        [ -d "$c/device" ] || continue        # skip connector/encoder children
+        card="$(basename "$c")"
+        if compgen -G "/sys/class/drm/${card}-Virtual-*" >/dev/null; then
+            echo "/dev/dri/${card}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Scanout connectors on a card, in sysfs order. Writeback is excluded: it is a
+# capture target, not a scanout one, so a bundle cannot be pinned to it.
+connectors_of() {  # connectors_of <cardN>
+    local card="$1" c
+    for c in /sys/class/drm/"${card}"-*; do
+        [ -e "$c/status" ] || continue
+        case "$c" in *Writeback*) continue ;; esac
+        basename "$c" | sed "s/^${card}-//"
+    done
+}
+
+[ -n "$HOMESCREEN" ] || die "set HOMESCREEN to the homescreen binary"
+[ -x "$HOMESCREEN" ] || die "HOMESCREEN not executable: $HOMESCREEN"
+[ -n "$BUNDLE" ]     || die "set BUNDLE to a Flutter bundle dir"
+[ -d "$BUNDLE" ]     || die "BUNDLE not a directory: $BUNDLE"
+
+# The binary must be DRM-KMS-EGL built: the bundles scan out to KMS.
+if [ "$(strings "$HOMESCREEN" | grep -c '\[DrmBackend\]')" -eq 0 ]; then
+    die "binary has no [DrmBackend] strings — build with BUILD_BACKEND_DRM_KMS_EGL=ON"
+fi
+
+# ENABLE_OSGI is off by default, so a stock binary simply has no OSGi in it.
+# That is a skip, not a failure: this harness is meaningless against a shell
+# that was never built to run bundles, and reporting it as a failure would
+# make every non-OSGi CI job red for no reason.
+OSGI_BUILT=1
+if [ "$(strings "$HOMESCREEN" | grep -c '\[osgi\]')" -eq 0 ]; then
+    OSGI_BUILT=0
+fi
+
+# Resolve the card. Auto-detection finds vkms and nothing else, which is the
+# safety property that matters: this harness takes DRM master and drives a
+# modeset, so silently defaulting to a numeric card could blank a real display
+# on a developer's desktop. Targeting real hardware requires saying so.
+DEVICE_SOURCE="explicit"
+if [ "$DRM_DEVICE_EXPLICIT" -eq 0 ]; then
+    if DRM_DEVICE="$(find_vkms_card)"; then
+        DEVICE_SOURCE="auto-detected vkms"
+    else
+        DRM_DEVICE=""
+    fi
+fi
+
+CARD="$(basename "${DRM_DEVICE:-none}")"
+if [ -n "$DRM_DEVICE" ] && [ -z "$CONNECTOR_A" ]; then
+    # Connector names are card-specific -- vkms advertises Virtual-N, a real
+    # GPU HDMI-A-1/DP-1 -- so they are read off the card rather than defaulted.
+    mapfile -t CONNS < <(connectors_of "$CARD")
+    CONNECTOR_A="${CONNS[0]:-}"
+    CONNECTOR_B="${CONNS[1]:-}"
+fi
+
+if [ "${1:-}" = "--check" ]; then
+    if [ -z "$DRM_DEVICE" ]; then
+        echo "OK: binary and bundle present; no vkms card found — would skip"
+    elif [ "$OSGI_BUILT" -eq 0 ]; then
+        echo "OK: prerequisites present ($DRM_DEVICE, $DEVICE_SOURCE), but binary lacks OSGi (ENABLE_OSGI=OFF) — would skip"
+    else
+        echo "OK: prerequisites present ($HOMESCREEN, $BUNDLE, $DRM_DEVICE [$DEVICE_SOURCE], $CONNECTOR_A + $CONNECTOR_B)"
+    fi
+    exit 0
+fi
+
+if [ "$OSGI_BUILT" -eq 0 ]; then
+    record "osgi-build" skip "binary built without ENABLE_OSGI=ON"
+    summary
+fi
+if [ -z "$DRM_DEVICE" ]; then
+    record "drm-device" skip "no vkms card found; set DRM_DEVICE to target real hardware"
+    summary
+fi
+[ -c "$DRM_DEVICE" ] || die "DRM_DEVICE not a device node: $DRM_DEVICE"
+if [ -z "$CONNECTOR_A" ] || [ -z "$CONNECTOR_B" ]; then
+    record "connectors" skip "need 2 scanout connectors on $CARD, found ${CONNECTOR_A:-none} ${CONNECTOR_B:-}"
+    summary
+fi
+log "card $DRM_DEVICE ($DEVICE_SOURCE); connectors $CONNECTOR_A + $CONNECTOR_B"
+
+# Throwaway copies so a config can be dropped in without touching the source
+# bundle. Two directories because each bundle is a distinct OSGi bundle with its
+# own symbolic name, even though the Dart app inside them is the same.
+WORK="$(mktemp -d)"
+LOG="$(mktemp)"
+FLIP_LOG=""
+trap 'rm -rf "$WORK" "$LOG" "$FLIP_LOG"' EXIT
+mkdir -p "$WORK/cluster" "$WORK/navigation"
+cp -rL "$BUNDLE"/. "$WORK/cluster/"
+cp -rL "$BUNDLE"/. "$WORK/navigation/"
+
+# One critical bundle and one normal bundle, each pinned to its own connector.
+# Deliberately declared normal-first so a pass proves the orchestrator reordered
+# them rather than merely following file order.
+#
+# Note there is no [[view]] here, only [[osgi.bundles]]. That is the shape of a
+# pure-OSGi deployment -- every surface belongs to a bundle -- and it is a
+# requirement this harness places on the implementation: the bundles must
+# themselves become the views. Today Configuration::parse_config yields zero
+# views from such a file, so a shell that has not wired [[osgi.bundles]] into
+# the config vector will come up with nothing and fail B1/B2 rather than
+# quietly rendering one window.
+cat > "$WORK/config.toml" <<EOF
+[global]
+app_id = "osgi_multi_bundle"
+
+[osgi]
+
+[[osgi.bundles]]
+symbolic_name = "com.ivi.navigation"
+bundle = "$WORK/navigation"
+priority = "normal"
+
+  [osgi.bundles.backend]
+  type = "drm-kms-egl"
+
+    [osgi.bundles.backend.drm]
+    device = "$DRM_DEVICE"
+    connector = "$CONNECTOR_B"
+
+[[osgi.bundles]]
+symbolic_name = "com.ivi.cluster"
+bundle = "$WORK/cluster"
+priority = "critical"
+startup_timeout_ms = $STARTUP_TIMEOUT
+
+  [osgi.bundles.backend]
+  type = "drm-kms-egl"
+
+    [osgi.bundles.backend.drm]
+    device = "$DRM_DEVICE"
+    connector = "$CONNECTOR_A"
+EOF
+
+ENV=()
+[ "$SOFTWARE_RENDER" = "1" ] && ENV+=("LIBGL_ALWAYS_SOFTWARE=1")
+
+log "launching 2 bundles: cluster(critical)->$CONNECTOR_A  navigation(normal)->$CONNECTOR_B"
+env "${ENV[@]}" "$HOMESCREEN" --config "$WORK/config.toml" -d >"$LOG" 2>&1 &
+HS_PID=$!
+
+sleep "$STARTUP_GRACE"
+if ! kill -0 "$HS_PID" 2>/dev/null; then
+    sed -n '1,40p' "$LOG"
+    record "liveness" fail "homescreen exited during startup"
+    summary
+fi
+record "liveness" pass "still running after ${STARTUP_GRACE}s"
+
+if [ "$COUNT_FLIPS" = "1" ]; then
+    FLIP_LOG="$(mktemp)"
+    timeout 3 strace -f -p "$HS_PID" -e trace=ioctl 2>"$FLIP_LOG" || true
+fi
+
+sleep "$DURATION"
+kill -TERM "$HS_PID" 2>/dev/null
+wait "$HS_PID" 2>/dev/null
+
+# ─── assertions ──────────────────────────────────────────────────────────────
+
+# B1: two engines. The inverse of multi_view_single_engine.sh, which fails on
+# exactly this line -- an OSGi bundle IS a separate engine.
+if grep -aqE "\(1\) Engine running" "$LOG"; then
+    record "B1-two-engines" pass "engine index 1 started (bundles are not collapsed)"
+else
+    record "B1-two-engines" fail "no second engine; bundles share one engine"
+fi
+
+# B2: each bundle brought up its own connector.
+b2_fail=0
+for c in "$CONNECTOR_A" "$CONNECTOR_B"; do
+    if grep -aq "\[DrmBackend\] .*connector.*$c" "$LOG" || grep -aq "connector=.*$c" "$LOG" \
+       || grep -aq "bound to output '$c'" "$LOG"; then
+        :
+    else
+        b2_fail=1
+        echo "  no startup line for connector $c" >&2
+    fi
+done
+if [ "$b2_fail" -eq 0 ]; then
+    record "B2-both-outputs" pass "$CONNECTOR_A and $CONNECTOR_B both up"
+else
+    record "B2-both-outputs" fail "a bundle did not bring up its connector"
+fi
+
+# B3: the ordering guarantee. The critical bundle must reach ACTIVE before the
+# normal bundle is launched -- that is what "critical" buys, and it is the one
+# property the unit tests can only assert against a fake host.
+crit_active=$(grep -an "bundle 'com.ivi.cluster': STARTING -> ACTIVE" "$LOG" | head -1 | cut -d: -f1)
+norm_start=$(grep -an "bundle 'com.ivi.navigation': RESOLVED -> STARTING" "$LOG" | head -1 | cut -d: -f1)
+if [ -z "$crit_active" ] || [ -z "$norm_start" ]; then
+    # -d raises the log level; without those lines the run told us nothing about
+    # ordering, so this is honestly a skip rather than a pass.
+    record "B3-critical-first" skip "lifecycle lines absent (need -d / debug logging)"
+elif [ "$crit_active" -lt "$norm_start" ]; then
+    record "B3-critical-first" pass "cluster ACTIVE (line $crit_active) before navigation start (line $norm_start)"
+else
+    record "B3-critical-first" fail "navigation started (line $norm_start) before cluster was ACTIVE (line $crit_active)"
+fi
+
+# B4: no fatal/error lines.
+if grep -aqE "\] \[C\] |\] \[E\] " "$LOG"; then
+    grep -aE "\] \[C\] |\] \[E\] " "$LOG" | head >&2
+    record "B4-clean-log" fail "error/critical lines present"
+else
+    record "B4-clean-log" pass "no error/critical lines"
+fi
+
+# B5: both CRTCs actually presenting. Construction without presentation would
+# satisfy B1 and B2 while showing nothing on either panel.
+if [ "$COUNT_FLIPS" = "1" ]; then
+    flips=$(grep -c "DRM_IOCTL_MODE_PAGE_FLIP\|DRM_IOCTL_MODE_ATOMIC" "$FLIP_LOG" 2>/dev/null || echo 0)
+    if [ "$flips" -gt 0 ]; then
+        record "B5-page-flips" pass "$flips flip/atomic ioctls observed"
+    else
+        record "B5-page-flips" fail "no page flips seen while running"
+    fi
+else
+    record "B5-page-flips" skip "COUNT_FLIPS=0"
+fi
+
+summary

--- a/test/osgi_multi_bundle.sh
+++ b/test/osgi_multi_bundle.sh
@@ -46,6 +46,11 @@
 #   DURATION         seconds to run            (default 6)
 #   STARTUP_GRACE    seconds before liveness   (default 3)
 #   STARTUP_TIMEOUT  critical deadline, ms     (default 4000)
+#   ACTIVATOR        1 = the bundle implements the OSGi activator and reports
+#                    ACTIVE over dev.osgi/bridge. Default 0: an ordinary Flutter
+#                    app cannot report ACTIVE, so the critical wait would always
+#                    time out and tear the bundle down, taking B1/B2 with it.
+#                    With 0 both bundles run at normal priority and B3 skips.
 #   COUNT_FLIPS      1 = prove page flips via strace (default 0)
 #   SOFTWARE_RENDER  1 = LIBGL_ALWAYS_SOFTWARE=1 (vkms/llvmpipe)
 #   --check          verify prerequisites only, do not launch
@@ -62,6 +67,7 @@ CONNECTOR_B="${CONNECTOR_B:-}"
 DURATION="${DURATION:-6}"
 STARTUP_GRACE="${STARTUP_GRACE:-3}"
 STARTUP_TIMEOUT="${STARTUP_TIMEOUT:-4000}"
+ACTIVATOR="${ACTIVATOR:-0}"
 COUNT_FLIPS="${COUNT_FLIPS:-0}"
 SOFTWARE_RENDER="${SOFTWARE_RENDER:-0}"
 
@@ -154,7 +160,16 @@ if [ -z "$CONNECTOR_A" ] || [ -z "$CONNECTOR_B" ]; then
     record "connectors" skip "need 2 scanout connectors on $CARD, found ${CONNECTOR_A:-none} ${CONNECTOR_B:-}"
     summary
 fi
+# Only make the first bundle critical when it can actually report ACTIVE.
+# Otherwise the critical wait times out and tears it down, which would fail B1
+# and B2 for a reason that has nothing to do with what they test.
+if [ "$ACTIVATOR" = "1" ]; then
+    CLUSTER_PRIORITY="critical"
+else
+    CLUSTER_PRIORITY="normal"
+fi
 log "card $DRM_DEVICE ($DEVICE_SOURCE); connectors $CONNECTOR_A + $CONNECTOR_B"
+log "cluster priority: $CLUSTER_PRIORITY (ACTIVATOR=$ACTIVATOR)"
 
 # Throwaway copies so a config can be dropped in without touching the source
 # bundle. Two directories because each bundle is a distinct OSGi bundle with its
@@ -166,6 +181,20 @@ trap 'rm -rf "$WORK" "$LOG" "$FLIP_LOG"' EXIT
 mkdir -p "$WORK/cluster" "$WORK/navigation"
 cp -rL "$BUNDLE"/. "$WORK/cluster/"
 cp -rL "$BUNDLE"/. "$WORK/navigation/"
+
+# Every bundle in the process must resolve the SAME engine library path.
+# LibFlutterEngine::Load is one-shot and keyed on the path it first bound: a
+# second bundle asking for any different path -- including the bare system name
+# -- is refused, and its FlutterView aborts. Two bundles each shipping their own
+# lib/libflutter_engine.so therefore cannot coexist, however identical the files
+# are. Hoist one copy out and let both resolve it by the same name.
+if [ -f "$WORK/cluster/lib/libflutter_engine.so" ]; then
+    cp "$WORK/cluster/lib/libflutter_engine.so" "$WORK/libflutter_engine.so"
+    rm -f "$WORK/cluster/lib/libflutter_engine.so" \
+          "$WORK/navigation/lib/libflutter_engine.so"
+    export LD_LIBRARY_PATH="$WORK${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    log "hoisted one shared libflutter_engine.so (per-bundle copies cannot coexist)"
+fi
 
 # One critical bundle and one normal bundle, each pinned to its own connector.
 # Deliberately declared normal-first so a pass proves the orchestrator reordered
@@ -199,7 +228,7 @@ priority = "normal"
 [[osgi.bundles]]
 symbolic_name = "com.ivi.cluster"
 bundle = "$WORK/cluster"
-priority = "critical"
+priority = "$CLUSTER_PRIORITY"
 startup_timeout_ms = $STARTUP_TIMEOUT
 
   [osgi.bundles.backend]
@@ -236,12 +265,21 @@ wait "$HS_PID" 2>/dev/null
 
 # ─── assertions ──────────────────────────────────────────────────────────────
 
-# B1: two engines. The inverse of multi_view_single_engine.sh, which fails on
-# exactly this line -- an OSGi bundle IS a separate engine.
-if grep -aqE "\(1\) Engine running" "$LOG"; then
-    record "B1-two-engines" pass "engine index 1 started (bundles are not collapsed)"
+# B1: two engines. The inverse of multi_view_single_engine.sh -- an OSGi bundle
+# IS a separate engine, so a second index must appear.
+#
+# Counted from per-engine index markers rather than "Engine running", which that
+# harness keys on: it is not emitted on this path at all (0 occurrences in a run
+# that demonstrably brought up two engines), so keying on it reports a false
+# failure. "Loading AOT" and the view/output binding both carry the index and
+# are emitted per engine.
+engine_indices=$( { grep -aoE "\([0-9]+\) Loading AOT" "$LOG" | grep -oE "[0-9]+";
+                    grep -aoE "view [0-9]+ is on output" "$LOG" | grep -oE "[0-9]+"; } \
+                  | sort -un | wc -l)
+if [ "$engine_indices" -ge 2 ]; then
+    record "B1-two-engines" pass "$engine_indices distinct engine indices (bundles are not collapsed)"
 else
-    record "B1-two-engines" fail "no second engine; bundles share one engine"
+    record "B1-two-engines" fail "only $engine_indices engine index seen; bundles share one engine"
 fi
 
 # B2: each bundle brought up its own connector.
@@ -266,9 +304,14 @@ fi
 # property the unit tests can only assert against a fake host.
 crit_active=$(grep -an "bundle 'com.ivi.cluster': STARTING -> ACTIVE" "$LOG" | head -1 | cut -d: -f1)
 norm_start=$(grep -an "bundle 'com.ivi.navigation': RESOLVED -> STARTING" "$LOG" | head -1 | cut -d: -f1)
-if [ -z "$crit_active" ] || [ -z "$norm_start" ]; then
-    # -d raises the log level; without those lines the run told us nothing about
-    # ordering, so this is honestly a skip rather than a pass.
+if [ "$ACTIVATOR" != "1" ]; then
+    # The ordering guarantee is "critical is ACTIVE before normal starts", and
+    # ACTIVE is reported by the bundle's Dart activator over dev.osgi/bridge.
+    # An ordinary Flutter app never sends it, so there is nothing to assert
+    # until an activator-capable bundle exists. Saying so beats a green tick.
+    record "B3-critical-first" skip \
+        "needs ACTIVATOR=1: an ordinary bundle cannot report ACTIVE"
+elif [ -z "$crit_active" ] || [ -z "$norm_start" ]; then
     record "B3-critical-first" skip "lifecycle lines absent (need -d / debug logging)"
 elif [ "$crit_active" -lt "$norm_start" ]; then
     record "B3-critical-first" pass "cluster ACTIVE (line $crit_active) before navigation start (line $norm_start)"


### PR DESCRIPTION
Two test-infrastructure changes. The second is a **safety fix to existing
code** and is worth reading first.

---

## 1. `test: stop hardcoding the DRM card in the KMS harnesses`

`multi_view_single_engine.sh` defaulted `DRM_DEVICE` to `/dev/dri/card1`. That
is not a portability nit: these harnesses **take DRM master and drive a
modeset**, so on any machine where `card1` is the GPU rather than vkms — the
common case on a developer desktop — running the harness without arguments goes
after the real display.

Card numbering is not stable to begin with. vkms lands wherever it lands
relative to any real GPU and moves as other DRM drivers load, so no numeric
default is correct anywhere except the machine it was written on. The connector
defaults had the same problem in the *other* direction: `HDMI-A-1`/`DP-1` only
exist on a real GPU while vkms advertises `Virtual-N`, so the default node and
the default connectors could never both be right.

There is now no numeric default anywhere, and the safety property is that
**auto-detection resolves vkms and nothing else**. Targeting real hardware
requires naming the node explicitly, which is the operator saying so out loud.
With no vkms present the harness refuses rather than guessing. Connector names
are read off whichever card resolved, with Writeback filtered out — a capture
target, not a scanout one.

Detection moves to `test/lib/drm_card.sh` rather than being copied a third
time. It is subtle enough to be worth having once: vkms is identified by its
connector signature (`cardN-Virtual-M`) rather than by the driver symlink,
whose name has already changed once across kernel versions (`platform` →
`faux_driver`) and would silently stop matching on the next rename. Three
copies would mean three places to miss. `drm_kms_vkms.sh`, where the method
originated, now sources it too.

Verified on a box whose `card1` is a real GPU with vkms not loaded — the exact
configuration the old default would have driven a modeset on:

| | |
|---|---|
| `drm_kms_vkms.sh --check` | unchanged (stops at the module check) |
| `multi_view_single_engine.sh` | refuses; previously would have used `card1` |
| `osgi_multi_bundle.sh` | skips honestly, exit 0 |
| explicit `DRM_DEVICE=…` | still works, reports the real connectors |
| `ihs_connectors_of card1` | `DP-1 HDMI-A-1`, `Writeback-1` excluded |

`drm_kms_vkms.sh --check` got particular attention since CI runs it as a
pre-flight.

---

## 2. `test: add the OSGi multi-bundle vkms harness`

The integration tier of the `BundleEngineManager` split. Unit tests can only
assert the framework's central claim — **two bundles, two engines, critical
first** — against a fake host. This proves it on real KMS.

It is the exact complement of `multi_view_single_engine.sh`. That harness proves
ONE engine can drive TWO outputs and **fails** if a second engine appears; this
one **requires** the second engine, because an OSGi bundle *is* a separate
engine and every isolation claim the framework makes rests on that. The two key
off the same log line from opposite directions.

Five assertions, each covering a way the framework could look correct while
being wrong:

| | |
|---|---|
| **B1** two engines | A shell that collapsed both bundles onto one engine would still paint. |
| **B2** both outputs | Per-bundle `[osgi.bundles.backend]` honored, not the first bundle's winning for all. |
| **B3** critical first | Bundles are declared **normal-first** in the generated config, so a pass proves the orchestrator *reordered* them rather than following file order. |
| **B4** clean log | No error/critical lines. |
| **B5** page flips | Both CRTCs actually presenting — construction without presentation satisfies B1 and B2 while showing nothing. |

The generated config has **no `[[view]]`**, only `[[osgi.bundles]]` — the shape
of a pure-OSGi deployment, where every surface belongs to a bundle. That is a
requirement the harness places on the implementation rather than an incidental
detail: the bundles must themselves become the views.

### Wired into CI now, inert until it matters

It skips honestly rather than failing when the binary lacks `ENABLE_OSGI` (the
default), when no vkms card is present, or when the card has fewer than two
scanout connectors. That is what lets it be added to
`vkms_harness_integration.sh` today, where it reports a skip in the job summary
and goes live by flipping `ENABLE_OSGI` in the vkms-smoke build step once the
host implementation lands. Wiring it up front means it cannot be forgotten at
the point it starts to matter.

### What is and is not verified

Verified: syntax; the missing-env guards; the non-DRM-binary guard; the
non-OSGi skip; the no-vkms skip; `--check` against a real DRM+OSGi binary;
explicit `DRM_DEVICE` opt-in; connector auto-detection.

**Not verified: the five assertions themselves.** They cannot run until the
host implementation exists, and a live-fire run needs vkms, which needs root.
This harness is the executable specification for that slice.