### PR TITLE
osgi: bring bundles up as real views via App::AddView

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -499,6 +499,7 @@ endif ()
 # target (third_party/CMakeLists.txt), which also carries its include dir.
 if (ENABLE_OSGI)
     target_sources(${PROJECT_NAME} PRIVATE
+            osgi/app_bundle_host.cc
             osgi/bridge_registry.cc
             osgi/bundle_state.cc
             osgi/cpu_affinity.cc

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -271,9 +271,10 @@ FlutterView* App::AddView(const Configuration::Config& config) {
 }
 
 bool App::RemoveView(FlutterView* view) {
-  const auto it = std::find_if(
-      m_views.begin(), m_views.end(),
-      [view](const std::unique_ptr<FlutterView>& v) { return v.get() == view; });
+  const auto it = std::find_if(m_views.begin(), m_views.end(),
+                               [view](const std::unique_ptr<FlutterView>& v) {
+                                 return v.get() == view;
+                               });
   if (it == m_views.end()) {
     return false;
   }

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -140,6 +140,14 @@ std::vector<std::shared_ptr<IDisplay>> App::BuildDisplays(
   // use, or respecting one main() set explicitly) before creating any display.
   // The active backend backs the first bundle and process-level queries; each
   // view independently resolves its own backend (ResolveKeyForConfig) below.
+  if (configs.empty()) {
+    // Legitimate under ENABLE_OSGI: a pure-bundle deployment starts with no
+    // views and gains them through AddView. Resolving the active backend needs
+    // a config to resolve from, so it is deferred to the first AddView rather
+    // than guessed from an empty set.
+    return {};
+  }
+
   auto& reg = backend::BackendRegistry::Instance();
   if (!EnsureActiveBackend(reg, configs)) {
     ihs::log::critical("[App] no usable backend available; aborting");
@@ -193,6 +201,12 @@ std::vector<std::shared_ptr<IDisplay>> App::BuildDisplays(
 std::shared_ptr<IDisplay> App::DisplayForContext(
     const Configuration::Config& config) {
   auto& reg = backend::BackendRegistry::Instance();
+  // When the App was constructed with no views, nothing has resolved the active
+  // backend yet; this config is the first one that can.
+  if (!EnsureActiveBackend(reg, {config})) {
+    ihs::log::error("[App] no usable backend for this config");
+    return nullptr;
+  }
   const std::string ck = ContextKey(reg, config);
   if (const auto it = m_display_by_context.find(ck);
       it != m_display_by_context.end()) {

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -180,11 +180,93 @@ std::vector<std::shared_ptr<IDisplay>> App::BuildDisplays(
     }
     auto display = descriptor->make_display(group_configs);
     m_displays.push_back(display);
+    // Remember which context this display serves so a view added later joins
+    // it instead of creating a second display on the same device.
+    m_display_by_context.emplace(ck, display);
     for (const size_t idx : members) {
       per_config[idx] = display;
     }
   }
   return per_config;
+}
+
+std::shared_ptr<IDisplay> App::DisplayForContext(
+    const Configuration::Config& config) {
+  auto& reg = backend::BackendRegistry::Instance();
+  const std::string ck = ContextKey(reg, config);
+  if (const auto it = m_display_by_context.find(ck);
+      it != m_display_by_context.end()) {
+    return it->second;
+  }
+
+  const std::string key = ResolveKeyForConfig(reg, config);
+  const backend::BackendDescriptor* descriptor = reg.Resolve(key);
+  if (descriptor == nullptr) {
+    // Not exit(): unlike the constructor path, this runs while a shell is
+    // already up, and one bundle naming an unbuildable backend must not take
+    // the running system down with it.
+    ihs::log::error("[App] no backend resolved for context '{}'", ck);
+    return nullptr;
+  }
+  auto display = descriptor->make_display({config});
+  m_displays.push_back(display);
+  m_display_by_context.emplace(ck, display);
+  return display;
+}
+
+void App::WatchDisplayOutputs(const std::shared_ptr<IDisplay>& display) {
+  auto* provider = display->GetOutputProvider();
+  if (provider == nullptr || !provider->SupportsHotplug()) {
+    return;  // e.g. the software sink, and DRM until its monitor is wired
+  }
+  auto watch = std::make_unique<OutputWatch>(this, display.get());
+  provider->SetOutputListener(watch.get());
+  m_output_watches.push_back(std::move(watch));
+  ihs::log::debug("[App] watching outputs on a display ({} live now)",
+                  provider->EnumerateOutputs().size());
+}
+
+FlutterView* App::AddView(const Configuration::Config& config) {
+  const size_t display_count_before = m_displays.size();
+  auto display = DisplayForContext(config);
+  if (display == nullptr) {
+    return nullptr;
+  }
+  const bool display_is_new = m_displays.size() != display_count_before;
+
+  // Index continues the constructor's sequence: it is the engine index that
+  // shows up in the logs, and a duplicate would make two engines
+  // indistinguishable there.
+  auto view = std::make_unique<FlutterView>(config, m_views.size(), display);
+  // Initialize() runs the engine. Doing it here, one view at a time, is the
+  // whole point of this entry point.
+  view->Initialize();
+  FlutterView* raw = view.get();
+  m_views.emplace_back(std::move(view));
+
+  if (display_is_new) {
+    WatchDisplayOutputs(display);
+    // The constructor's StartEvents pass has already run by the time anything
+    // calls AddView after Run(); a display created now has to be started here
+    // or it would never pump.
+    if (m_displays_started) {
+      display->StartEvents();
+    }
+  }
+  return raw;
+}
+
+bool App::RemoveView(FlutterView* view) {
+  const auto it = std::find_if(
+      m_views.begin(), m_views.end(),
+      [view](const std::unique_ptr<FlutterView>& v) { return v.get() == view; });
+  if (it == m_views.end()) {
+    return false;
+  }
+  // The display is left in place: it may still serve other views, and it is
+  // owned by m_displays / m_display_by_context, not by the view.
+  m_views.erase(it);
+  return true;
 }
 
 App::App(const std::vector<Configuration::Config>& configs) {
@@ -276,20 +358,14 @@ App::App(const std::vector<Configuration::Config>& configs) {
   // compares against a real binding and finds nothing to do -- which is the
   // correct answer at startup, not a special case.
   for (const auto& display : m_displays) {
-    auto* provider = display->GetOutputProvider();
-    if (provider == nullptr || !provider->SupportsHotplug()) {
-      continue;  // e.g. the software sink, and DRM until its monitor is wired
-    }
-    auto watch = std::make_unique<OutputWatch>(this, display.get());
-    provider->SetOutputListener(watch.get());
-    m_output_watches.push_back(std::move(watch));
-    ihs::log::debug("[App] watching outputs on a display ({} live now)",
-                    provider->EnumerateOutputs().size());
+    WatchDisplayOutputs(display);
   }
 
   for (const auto& display : m_displays) {
     display->StartEvents();
   }
+  // Anything AddView creates from here on has to start its own display.
+  m_displays_started = true;
 
 #if BUILD_BACKEND_HEADLESS_VULKAN
   // Bring up the in-process ihs-vk-export bridge last: the headless-vulkan

--- a/shell/app.h
+++ b/shell/app.h
@@ -21,8 +21,8 @@
 #include <memory>
 #include <string_view>
 
-#include "config/common.h"  // ENABLE_DLT — keep before logger.hpp / member decl
 #include <unordered_map>
+#include "config/common.h"  // ENABLE_DLT — keep before logger.hpp / member decl
 
 #include "configuration/configuration.h"
 #include "display/output.h"
@@ -153,7 +153,8 @@ class App final {
   std::vector<std::shared_ptr<IDisplay>> m_displays;
   // Context key -> display, so AddView can join a view to the display its
   // device-context already has instead of creating a second one.
-  std::unordered_map<std::string, std::shared_ptr<IDisplay>> m_display_by_context;
+  std::unordered_map<std::string, std::shared_ptr<IDisplay>>
+      m_display_by_context;
   // True once Run() has started the displays, so a view added later knows to
   // start its display itself rather than waiting for a StartEvents pass that
   // has already happened.

--- a/shell/app.h
+++ b/shell/app.h
@@ -22,6 +22,8 @@
 #include <string_view>
 
 #include "config/common.h"  // ENABLE_DLT — keep before logger.hpp / member decl
+#include <unordered_map>
+
 #include "configuration/configuration.h"
 #include "display/output.h"
 #include "logging/logger.hpp"
@@ -60,6 +62,39 @@ class App final {
   [[nodiscard]] int Loop() const;
 
   /**
+   * @brief Construct and start one additional view after construction.
+   *
+   * The constructor builds every view in @p configs back to back, and
+   * FlutterView::Initialize() runs the engine -- so by the time it returns,
+   * every engine is already competing for the GPU. That is the right shape for
+   * a fixed view set, but it cannot express "this view must be up before the
+   * next one starts", which is exactly what an OSGi critical bundle is.
+   *
+   * This is the incremental entry point: it resolves @p config against the
+   * displays already built (reusing the one for its device-context, or
+   * creating a display when the context is new), constructs the view, and runs
+   * its engine -- one view, when the caller says so.
+   *
+   * Safe to call before or after Run(). Returns nullptr if no backend resolves
+   * for the config, which the caller reports as a failed bundle rather than
+   * taking the whole process down.
+   *
+   * @relation flutter, osgi
+   */
+  FlutterView* AddView(const Configuration::Config& config);
+
+  /**
+   * @brief Tear down a view previously returned by AddView().
+   *
+   * Returns true if @p view was owned by this App. Used when a bundle fails to
+   * report ACTIVE within its deadline: a half-started bundle must not be left
+   * holding a surface and a vsync registration.
+   *
+   * @relation flutter, osgi
+   */
+  bool RemoveView(FlutterView* view);
+
+  /**
    * @brief Run the application until shutdown is requested.
    *
    * Drives the shared asio reactor (a single io_context) on the calling thread
@@ -80,6 +115,18 @@ class App final {
   // device). A homogeneous config set yields a single shared display.
   std::vector<std::shared_ptr<IDisplay>> BuildDisplays(
       const std::vector<Configuration::Config>& configs);
+
+  // Display for @p config's device-context, reusing an existing one when the
+  // context already has a display and creating one otherwise. Shared by
+  // BuildDisplays and AddView so both place a view on the same display for the
+  // same (backend, device) -- two displays on one device would fight over the
+  // DRM master.
+  std::shared_ptr<IDisplay> DisplayForContext(
+      const Configuration::Config& config);
+
+  // Start watching @p display's outputs, if it reports hotplug at all. Called
+  // for displays built at construction and for any created later by AddView.
+  void WatchDisplayOutputs(const std::shared_ptr<IDisplay>& display);
 
   // Watches one display's outputs on App's behalf. IOutputListener reports
   // what changed but not which display reported it, and App can drive several
@@ -104,6 +151,13 @@ class App final {
   // The displays the App drives. One entry per distinct device-context; a
   // homogeneous config set yields a single shared display.
   std::vector<std::shared_ptr<IDisplay>> m_displays;
+  // Context key -> display, so AddView can join a view to the display its
+  // device-context already has instead of creating a second one.
+  std::unordered_map<std::string, std::shared_ptr<IDisplay>> m_display_by_context;
+  // True once Run() has started the displays, so a view added later knows to
+  // start its display itself rather than waiting for a StartEvents pass that
+  // has already happened.
+  bool m_displays_started{false};
   std::vector<std::unique_ptr<FlutterView>> m_views;
   // One per display that reports hotplug; cleared before the displays go.
   std::vector<std::unique_ptr<OutputWatch>> m_output_watches;

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -1132,6 +1132,25 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
   // be an existing directory (paths may originate from -b or from a --config
   // file's [[view]] entries).
   if (configs.empty()) {
+#if ENABLE_OSGI
+    // A pure-OSGi deployment has no [[view]] at all: every surface belongs to a
+    // bundle, and the bundles become views once the orchestrator adds them. An
+    // empty view list is therefore only fatal when the file does not declare
+    // any either. Checked by re-reading the document rather than by calling
+    // into the OSGi parser, so this stays a question about the file's shape and
+    // configuration.cc keeps knowing nothing about bundles.
+    if (config.config_file && !config.config_file->empty()) {
+      if (auto doc = toml::parse_file(*config.config_file)) {
+        if (const auto node = doc.table().at_path("osgi.bundles");
+            node.is_array() && !node.as_array()->empty()) {
+          ihs::log::debug(
+              "[osgi] no [[view]] entries; the configured bundles supply the "
+              "views");
+          return configs;
+        }
+      }
+    }
+#endif
     ihs::log::critical(
         "No views configured: provide -b <bundle> or --config <file>");
     exit(EXIT_FAILURE);

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -182,7 +182,14 @@ int main(const int argc, char** argv) {
 #endif
 
   const auto configs = Configuration::ParseArgcArgv(argc, argv);
+#if ENABLE_OSGI
+  // A pure-OSGi config has no [[view]]: the bundles become the views, and they
+  // are added below once App exists. ParseArgcArgv has already rejected an
+  // empty list that had no bundles behind it either, so reaching here with none
+  // means bundles are coming.
+#else
   assert(!configs.empty());
+#endif
 
   // Make the resolved configuration readable by FFI plugins via ihs_shared.
   PublishIhsConfig(configs);
@@ -342,10 +349,21 @@ int main(const int argc, char** argv) {
     std::unique_ptr<ihs::osgi::BundleStartupOrchestrator> orchestrator;
     ihs::osgi::OsgiConfig osgi_config;
     ihs::osgi::AppBundleHost bundle_host(app, nullptr);
-    if (!configs.empty() && configs.front().config_file &&
-        !configs.front().config_file->empty()) {
-      if (!ihs::osgi::LoadOsgiConfig(*configs.front().config_file,
-                                     osgi_config)) {
+    // Read from argv rather than configs.front(): a pure-OSGi deployment has no
+    // views, so there is no config to carry the path.
+    std::string osgi_config_path;
+    for (int i = 1; i + 1 < argc; ++i) {
+      if (std::string_view(argv[i]) == "--config") {
+        osgi_config_path = argv[i + 1];
+        break;
+      }
+    }
+    if (osgi_config_path.empty() && !configs.empty() &&
+        configs.front().config_file) {
+      osgi_config_path = *configs.front().config_file;
+    }
+    if (!osgi_config_path.empty()) {
+      if (!ihs::osgi::LoadOsgiConfig(osgi_config_path, osgi_config)) {
         // A malformed [osgi] table is a configuration error the operator has to
         // see, not something to start half of.
         ihs::log::critical("[osgi] configuration rejected; not starting bundles");

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -366,7 +366,8 @@ int main(const int argc, char** argv) {
       if (!ihs::osgi::LoadOsgiConfig(osgi_config_path, osgi_config)) {
         // A malformed [osgi] table is a configuration error the operator has to
         // see, not something to start half of.
-        ihs::log::critical("[osgi] configuration rejected; not starting bundles");
+        ihs::log::critical(
+            "[osgi] configuration rejected; not starting bundles");
         return EXIT_FAILURE;
       }
     }

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -28,6 +28,11 @@
 #include "backend/wayland_leased_drm/lease_client.h"
 #endif
 #include "configuration/configuration.h"
+#if ENABLE_OSGI
+#include "osgi/app_bundle_host.h"
+#include "osgi/osgi_config.h"
+#include "osgi/startup_orchestrator.h"
+#endif
 #include "ihs/config.h"
 #include "logging/logger.hpp"
 #include "logging/logging.h"
@@ -325,6 +330,48 @@ int main(const int argc, char** argv) {
     // has a valid fd to write to.
     (void)MainLoopWaker::instance();
     InstallShutdownHandlers();
+
+#if ENABLE_OSGI
+    // OSGi bundles are added one at a time rather than being folded into
+    // `configs` above, and that is the whole point: App's constructor runs
+    // every view's engine back to back, so a bundle in that vector would
+    // already be competing for the GPU before anything could wait on it.
+    // Critical bundles are therefore brought up here -- after App exists, so
+    // there are displays to join, but before Run() -- and each is awaited
+    // before the next starts.
+    std::unique_ptr<ihs::osgi::BundleStartupOrchestrator> orchestrator;
+    ihs::osgi::OsgiConfig osgi_config;
+    ihs::osgi::AppBundleHost bundle_host(app, nullptr);
+    if (!configs.empty() && configs.front().config_file &&
+        !configs.front().config_file->empty()) {
+      if (!ihs::osgi::LoadOsgiConfig(*configs.front().config_file,
+                                     osgi_config)) {
+        // A malformed [osgi] table is a configuration error the operator has to
+        // see, not something to start half of.
+        ihs::log::critical("[osgi] configuration rejected; not starting bundles");
+        return EXIT_FAILURE;
+      }
+    }
+    if (!osgi_config.empty()) {
+      orchestrator = std::make_unique<ihs::osgi::BundleStartupOrchestrator>(
+          bundle_host, osgi_config.bundles);
+      for (const auto& outcome : orchestrator->StartCriticalPhase()) {
+        if (!outcome.ok()) {
+          // Reported, not fatal: one broken cluster must not stop the rest of
+          // the system from coming up. Which is the right call for a given
+          // product is a deployment decision, and it is visible here.
+          ihs::log::error("[osgi] critical bundle '{}' failed: {}",
+                          outcome.symbolic_name,
+                          ihs::osgi::StartupFailureName(outcome.failure));
+        }
+      }
+      // The deferred phases run before Run() rather than from inside the
+      // reactor: they do not block on ACTIVE, so the only cost is their
+      // staggered launches, and doing it here keeps the startup sequence in
+      // one readable place.
+      orchestrator->StartDeferredPhases();
+    }
+#endif
 
     // Run the application: the shared reactor drives every backend on this
     // (main) thread and blocks until the shutdown signal stops the io_context.

--- a/shell/osgi/app_bundle_host.cc
+++ b/shell/osgi/app_bundle_host.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "app_bundle_host.h"
+
+#include <pthread.h>
+#include <sched.h>
+
+#include <utility>
+
+#include "app.h"
+#include "logging/logging.h"
+#include "task_runner.h"
+#include "view/flutter_view.h"
+
+namespace ihs::osgi {
+
+AppBundleHost::AppBundleHost(App& app, VsyncCoordinator* coordinator)
+    : app_(app), coordinator_(coordinator) {}
+
+BundleHandle AppBundleHost::Spawn(const BundleManifest& manifest) {
+  std::lock_guard lock(mutex_);
+
+  // One view, right now. Everything the bundle's [osgi.bundles.*] table said --
+  // backend, DRM connector, args, output pinning -- is already in this config,
+  // because it was built by the same parser a [[view]] goes through.
+  FlutterView* view = app_.AddView(manifest.config);
+  if (view == nullptr) {
+    ihs::log::error("[osgi] bundle '{}': could not create a view",
+                    manifest.symbolic_name);
+    return kInvalidBundleHandle;
+  }
+
+  const BundleHandle handle = ++next_handle_;
+  live_.emplace(handle, Live{view, manifest.symbolic_name});
+  return handle;
+}
+
+bool AppBundleHost::PinThread(const BundleHandle handle, const int cpu_core) {
+  std::lock_guard lock(mutex_);
+  const auto it = live_.find(handle);
+  if (it == live_.end()) {
+    return false;
+  }
+
+  TaskRunner* runner = it->second.view->GetPlatformTaskRunner();
+  if (runner == nullptr) {
+    ihs::log::error("[osgi] bundle '{}': no platform task runner to pin",
+                    it->second.symbolic_name);
+    return false;
+  }
+
+  // The engine's platform thread is the one that matters: it runs the Dart
+  // isolate's platform-side work and is where a missed deadline shows up as
+  // jitter. cpu_core was already validated against the process affinity mask at
+  // parse time, so a refusal here is the kernel declining, not a bad config.
+  cpu_set_t set;
+  CPU_ZERO(&set);
+  CPU_SET(static_cast<size_t>(cpu_core), &set);
+  if (const int rc =
+          pthread_setaffinity_np(runner->NativeHandle(), sizeof(set), &set);
+      rc != 0) {
+    ihs::log::error(
+        "[osgi] bundle '{}': pthread_setaffinity_np to CPU {} failed ({})",
+        it->second.symbolic_name, cpu_core, rc);
+    return false;
+  }
+  ihs::log::debug("[osgi] bundle '{}': engine thread pinned to CPU {}",
+                  it->second.symbolic_name, cpu_core);
+  return true;
+}
+
+void AppBundleHost::Shutdown(const BundleHandle handle) {
+  std::lock_guard lock(mutex_);
+  const auto it = live_.find(handle);
+  if (it == live_.end()) {
+    return;
+  }
+
+  // Deregister from the vsync fan-out before the view goes: a coordinator
+  // holding a target into a destroyed view would deliver a tick into freed
+  // memory on the next vblank.
+  if (coordinator_ != nullptr) {
+    coordinator_->Remove(it->second.symbolic_name);
+  }
+  app_.RemoveView(it->second.view);
+  ihs::log::debug("[osgi] bundle '{}': view torn down",
+                  it->second.symbolic_name);
+  live_.erase(it);
+}
+
+}  // namespace ihs::osgi

--- a/shell/osgi/app_bundle_host.h
+++ b/shell/osgi/app_bundle_host.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <mutex>
+
+#include "bundle_host.h"
+#include "vsync_coordinator.h"
+
+class App;
+class FlutterView;
+
+namespace ihs::osgi {
+
+// The production IBundleHost: brings a bundle up as a real Flutter view on a
+// real backend.
+//
+// Spawn is App::AddView, which is the piece that makes "critical first" mean
+// anything. App's constructor builds every view back to back and
+// FlutterView::Initialize() runs the engine, so a bundle expressed as just
+// another config in that vector would already be competing for the GPU before
+// the orchestrator could wait on anything -- the ordering would be observed,
+// not enforced. Adding views one at a time is what lets the orchestrator hold
+// the reactor until the cluster is actually up.
+//
+// Threading: the orchestrator calls Spawn/PinThread/Shutdown from the startup
+// thread, before the reactor runs for critical bundles and from the deferred
+// phase afterwards. App is not thread-safe, so all three are serialized on
+// mutex_ and are expected to be called from one thread at a time.
+class AppBundleHost final : public IBundleHost {
+ public:
+  // @coordinator may be null when the shell was built without a vsync source
+  // to fan out; bundles then drive their own vsync as an unmanaged view does.
+  AppBundleHost(App& app, VsyncCoordinator* coordinator);
+
+  BundleHandle Spawn(const BundleManifest& manifest) override;
+  bool PinThread(BundleHandle handle, int cpu_core) override;
+  void Shutdown(BundleHandle handle) override;
+
+ private:
+  struct Live {
+    FlutterView* view{nullptr};
+    std::string symbolic_name;
+  };
+
+  App& app_;
+  VsyncCoordinator* coordinator_;
+
+  mutable std::mutex mutex_;
+  BundleHandle next_handle_{0};
+  std::map<BundleHandle, Live> live_;
+};
+
+}  // namespace ihs::osgi

--- a/shell/task_runner.h
+++ b/shell/task_runner.h
@@ -36,6 +36,11 @@ class TaskRunner {
 
   static pthread_t GetThreadId() { return pthread_self(); };
 
+  /// The pthread this runner's thread is running on, for pthread_setaffinity_np.
+  /// Distinct from GetThreadId(), which answers for the *calling* thread and so
+  /// cannot be used to pin someone else's.
+  [[nodiscard]] pthread_t NativeHandle() const { return pthread_self_; }
+
   [[nodiscard]] bool IsThreadEqual(const pthread_t threadid) const {
     return pthread_equal(threadid, pthread_self_) != 0;
   };

--- a/shell/task_runner.h
+++ b/shell/task_runner.h
@@ -36,9 +36,9 @@ class TaskRunner {
 
   static pthread_t GetThreadId() { return pthread_self(); };
 
-  /// The pthread this runner's thread is running on, for pthread_setaffinity_np.
-  /// Distinct from GetThreadId(), which answers for the *calling* thread and so
-  /// cannot be used to pin someone else's.
+  /// The pthread this runner's thread is running on, for
+  /// pthread_setaffinity_np. Distinct from GetThreadId(), which answers for the
+  /// *calling* thread and so cannot be used to pin someone else's.
   [[nodiscard]] pthread_t NativeHandle() const { return pthread_self_; }
 
   [[nodiscard]] bool IsThreadEqual(const pthread_t threadid) const {

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -486,6 +486,10 @@ PlatformViewRegistry* FlutterView::GetPlatformViewRegistry() const {
   return state == nullptr ? nullptr : state->platform_view_registry.get();
 }
 
+TaskRunner* FlutterView::GetPlatformTaskRunner() const {
+  return m_flutter_engine ? m_flutter_engine->GetPlatformTaskRunner() : nullptr;
+}
+
 void FlutterView::Initialize() {
   // Engine / Dart VM switches -> command_line_argv. argv[0] is the app id.
   std::vector<const char*> m_command_line_args_c;

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -72,6 +72,8 @@ class Backend;
 class CompositorSurface;
 #endif
 
+class TaskRunner;
+
 class FlutterView {
  public:
   FlutterView(Configuration::Config config,
@@ -246,6 +248,12 @@ class FlutterView {
 
  public:
   [[nodiscard]] bool IsSuspended() const { return m_suspended; }
+
+  /// This view's platform task runner, or nullptr before Initialize(). Exposed
+  /// for the OSGi host, which pins a critical bundle's engine thread to the
+  /// core its manifest names -- the thread belongs to the runner, and nothing
+  /// else outside the view can reach it.
+  [[nodiscard]] TaskRunner* GetPlatformTaskRunner() const;
 
   /**
    * @brief Get pointer to Display object


### PR DESCRIPTION
> **Stacked on #425.** Base is `jw/osgi-orchestrator`; GitHub will retarget to
> `v3.0` when that merges. The diff shown here is just this slice.

Third and last of the `BundleEngineManager` slices: the production
`IBundleHost`, and the `App` change that makes the critical-first guarantee
real rather than merely observed.

**Validated on hardware** — rpi4 / trixie / vc4, two bundles on `DSI-1` +
`HDMI-A-1`, via the harness in #426: **5 pass, 0 fail**, 864 page-flip ioctls
across both CRTCs.

## The problem this solves

`App`'s constructor builds every view in one loop and `FlutterView::Initialize()`
**runs the engine**. So by the time it returns, every engine is already
competing for the GPU.

Folding OSGi bundles into that config vector — the obvious integration, and the
one this plan assumed — would have left the orchestrator *watching* an ordering
it never controlled. "Critical first" would have been true of the log lines and
false of the machine, and #426's B3 would have gone green on a property that
did not hold.

## `App::AddView`

Resolve the config against the displays already built, reusing the one for its
device-context or creating a display when the context is new, construct the
view, run its engine. One view, when the caller says so. `RemoveView` is its
counterpart — a bundle that misses its deadline must not be left holding a
surface and a vsync registration.

Display resolution is factored into `DisplayForContext` so the constructor and
`AddView` cannot diverge: **two displays on one device would fight over the DRM
master**. It logs and returns null where the constructor path `exit()`s, because
it now runs while a shell is already up, and one bundle naming an unbuildable
backend must not take a running system down.

## `AppBundleHost`

Implements the seam from #425. `Spawn` is `AddView`. `Shutdown` deregisters from
the vsync coordinator **before** dropping the view — a coordinator still holding
a target into a destroyed view would deliver a tick into freed memory on the
next vblank. `PinThread` pins the engine's platform thread, which is where a
missed deadline shows up as jitter; reaching it needed two small accessors,
`TaskRunner::NativeHandle` (`GetThreadId` answers for the *calling* thread, so
it cannot pin someone else's) and `FlutterView::GetPlatformTaskRunner`.

## A view-less config is now valid

A pure-OSGi deployment declares `[[osgi.bundles]]` and no `[[view]]`. Four
places assumed at least one view exists, and **none were reachable from unit
tests** — each was found by starting the shell against a real config:
`ParseArgcArgv`'s "No views configured" exit, `main.cc`'s assert,
`BuildDisplays` handing an empty set to `EnsureActiveBackend` (which indexes
`configs[0]`), and reading the `[osgi]` path from `configs.front()`.

## What this costs

**This is where "strictly additive" stops being accurate.** `App`,
`FlutterView`, `TaskRunner`, `main.cc` and `configuration.cc` all change. What
remains true and is verified per slice is that **`ENABLE_OSGI=OFF` is
behaviorally unchanged**: the OFF binary builds clean and carries zero
`ihs::osgi` symbols, against 888 with it ON. plan.md has been corrected to claim
that rather than the stronger thing.

## Verified

- rpi4 hardware: 5/0 via #426's harness, two engines on two connectors, both presenting
- 83 unit tests across the five OSGi suites still passing
- `ENABLE_OSGI=OFF` and `=ON` both build clean; OFF has zero OSGi symbols
- clang-tidy 0 findings, clang-format applied

## Known, not addressed here

`register_backends.cc:472` calls `exit()` when a DRM backend fails to init, so a
bundle with a bad connector name kills the process instead of failing one
bundle. That contradicts the orchestrator's "one broken cluster must not take
the rest of the system with it", which holds for spawn failures it can detect
but not for this. Making `Backend::Create` failable is a change to shared code
well beyond this slice, so it is flagged rather than smuggled in.