### PR TITLE
osgi: connect the bridge to the orchestrator

### DIFF
--- a/shell/main.cc
+++ b/shell/main.cc
@@ -30,6 +30,7 @@
 #include "configuration/configuration.h"
 #if ENABLE_OSGI
 #include "osgi/app_bundle_host.h"
+#include "osgi/bridge_registry.h"
 #include "osgi/osgi_config.h"
 #include "osgi/startup_orchestrator.h"
 #endif
@@ -374,6 +375,13 @@ int main(const int argc, char** argv) {
     if (!osgi_config.empty()) {
       orchestrator = std::make_unique<ihs::osgi::BundleStartupOrchestrator>(
           bundle_host, osgi_config.bundles);
+      // Connect the bridge to the orchestrator. Without this a bundle can call
+      // init, register its port, run its activator to completion and report
+      // ACTIVE -- and the critical wait would still time out, because nothing
+      // would be listening. Set before any bundle starts so a fast activator
+      // cannot report into a null observer.
+      ihs::osgi::BridgeRegistry::Instance().SetLifecycleObserver(
+          orchestrator.get());
       for (const auto& outcome : orchestrator->StartCriticalPhase()) {
         if (!outcome.ok()) {
           // Reported, not fatal: one broken cluster must not stop the rest of

--- a/shell/osgi/bridge_registry.cc
+++ b/shell/osgi/bridge_registry.cc
@@ -202,10 +202,52 @@ std::vector<std::string> BridgeRegistry::PendingBundles() const {
   return pending;
 }
 
+void BridgeRegistry::SetLifecycleObserver(IBundleLifecycleObserver* observer) {
+  std::lock_guard lock(mutex_);
+  observer_ = observer;
+}
+
+bool BridgeRegistry::ReportActive(const std::string& symbolic_name) {
+  IBundleLifecycleObserver* observer = nullptr;
+  {
+    std::lock_guard lock(mutex_);
+    if (bundles_.find(symbolic_name) == bundles_.end()) {
+      // A report from a bundle that never called init: either a stale message
+      // from a previous incarnation, or a symbolic_name that does not match the
+      // config. Either way there is nothing to advance.
+      ihs::log::warn("[osgi] bridge: ACTIVE from unregistered bundle '{}'",
+                     symbolic_name);
+      return false;
+    }
+    observer = observer_;
+  }
+  // Dispatched outside the lock: the observer is the orchestrator, whose
+  // NotifyActive takes its own lock and signals a condition variable. Holding
+  // this one across that call would couple two unrelated locks on the startup
+  // path for no reason.
+  if (observer != nullptr) {
+    observer->OnBundleActive(symbolic_name);
+  }
+  return true;
+}
+
+bool BridgeRegistry::ReportStopped(const std::string& symbolic_name) {
+  IBundleLifecycleObserver* observer = nullptr;
+  {
+    std::lock_guard lock(mutex_);
+    observer = observer_;
+  }
+  if (observer != nullptr) {
+    observer->OnBundleStopped(symbolic_name);
+  }
+  return true;
+}
+
 void BridgeRegistry::ResetForTesting() {
   std::lock_guard lock(mutex_);
   bundles_.clear();
   framework_port_.reset();
+  observer_ = nullptr;
 }
 
 }  // namespace ihs::osgi

--- a/shell/osgi/bridge_registry.h
+++ b/shell/osgi/bridge_registry.h
@@ -44,6 +44,26 @@ struct DartPortApi {
 // The real Dart DL calls.
 const DartPortApi& RealDartPortApi();
 
+// Receives bundle lifecycle reports that arrive from Dart over the bridge.
+//
+// The bridge is per-engine and knows nothing about startup sequencing; the
+// orchestrator owns the sequencing and knows nothing about channels. This is
+// the seam between them -- without it a bundle can register its port and still
+// never be seen to reach ACTIVE, so every critical bundle times out no matter
+// how correctly its activator behaves.
+class IBundleLifecycleObserver {
+ public:
+  virtual ~IBundleLifecycleObserver() = default;
+
+  // The bundle's activator finished start(). This is what ACTIVE means in the
+  // OSGi lifecycle -- not that the engine is up, which the shell already knows,
+  // but that the bundle's own code declared itself ready.
+  virtual void OnBundleActive(const std::string& symbolic_name) = 0;
+
+  // The bundle's activator finished stop(), or it is going away.
+  virtual void OnBundleStopped(const std::string& symbolic_name) = 0;
+};
+
 // Tracks which isolate ports the OSGi bridge knows about and hands each bundle
 // the framework isolate's port.
 //
@@ -99,6 +119,18 @@ class BridgeRegistry {
   // order. Empty once the framework port is known.
   [[nodiscard]] std::vector<std::string> PendingBundles() const;
 
+  // Route lifecycle reports to @observer. Null detaches. The observer must
+  // outlive the registry's use of it; in practice it is the orchestrator, which
+  // lives for the whole run.
+  void SetLifecycleObserver(IBundleLifecycleObserver* observer);
+
+  // A bundle reported that its activator completed. Returns false when the
+  // bundle is unknown to the bridge, which means it never called init.
+  bool ReportActive(const std::string& symbolic_name);
+
+  // A bundle reported that it stopped.
+  bool ReportStopped(const std::string& symbolic_name);
+
   // Test seam: drop all state (not the DL binding, which is a VM-global).
   void ResetForTesting();
 
@@ -111,6 +143,7 @@ class BridgeRegistry {
   mutable std::mutex mutex_;
   bool dart_api_ready_{false};
   std::optional<int64_t> framework_port_;
+  IBundleLifecycleObserver* observer_{nullptr};
 
   struct Bundle {
     int64_t port{0};

--- a/shell/osgi/osgi_bridge_plugin.cc
+++ b/shell/osgi/osgi_bridge_plugin.cc
@@ -153,6 +153,27 @@ void OsgiBridgePlugin::HandleMethodCall(
     return;
   }
 
+  if (method_call.method_name() == kMethodActive ||
+      method_call.method_name() == kMethodStopped) {
+    std::string symbolic_name;
+    if (const auto* v = Find(*args, "symbolic_name");
+        v == nullptr || !ReadString(*v, symbolic_name)) {
+      result->Error(kErrorBadArgs, "'symbolic_name' must be a string");
+      return;
+    }
+    const bool is_active = method_call.method_name() == kMethodActive;
+    const bool ok = is_active ? registry.ReportActive(symbolic_name)
+                              : registry.ReportStopped(symbolic_name);
+    if (!ok) {
+      result->Error(kErrorRejected, "bundle is not registered");
+      return;
+    }
+    ihs::log::debug("[osgi] bridge: bundle '{}' reported {}", symbolic_name,
+                    is_active ? "ACTIVE" : "STOPPED");
+    result->Success(flutter::EncodableValue(true));
+    return;
+  }
+
   if (method_call.method_name() == kMethodShutdown) {
     std::string symbolic_name;
     if (const auto* v = Find(*args, "symbolic_name");

--- a/shell/osgi/osgi_bridge_plugin.h
+++ b/shell/osgi/osgi_bridge_plugin.h
@@ -48,6 +48,14 @@ class OsgiBridgePlugin {
   // Replies true, or an error code below.
   static constexpr char kMethodInit[] = "init";
 
+  // The bundle's activator finished start(). This -- not the engine coming up,
+  // which the shell already knows -- is what ACTIVE means, and it is what
+  // releases a critical bundle's startup wait. Args: symbolic_name (string).
+  static constexpr char kMethodActive[] = "active";
+
+  // The bundle's activator finished stop(). Args: symbolic_name (string).
+  static constexpr char kMethodStopped[] = "stopped";
+
   // Release a bundle's registration so the same symbolic name can re-register
   // after a restart. Args: symbolic_name (string). Replies true if it was
   // known.

--- a/shell/osgi/startup_orchestrator.h
+++ b/shell/osgi/startup_orchestrator.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "bridge_registry.h"
 #include "bundle_host.h"
 #include "bundle_state.h"
 #include "startup_plan.h"
@@ -61,7 +62,7 @@ struct BundleOutcome {
 // Dart activator reports it over the bridge, which calls NotifyActive. The wait
 // is therefore a condition variable with a deadline rather than a poll, and the
 // deadline is per bundle from its manifest.
-class BundleStartupOrchestrator {
+class BundleStartupOrchestrator final : public IBundleLifecycleObserver {
  public:
   BundleStartupOrchestrator(IBundleHost& host,
                             std::vector<BundleManifest> manifests,
@@ -92,6 +93,15 @@ class BundleStartupOrchestrator {
   // The bundle stopped or died. Moves it out of the live states so the same
   // symbolic name can be started again.
   void NotifyStopped(const std::string& symbolic_name);
+
+  // IBundleLifecycleObserver. The bridge reports in these terms; the
+  // orchestrator already had the operations, so they simply forward.
+  void OnBundleActive(const std::string& symbolic_name) override {
+    NotifyActive(symbolic_name);
+  }
+  void OnBundleStopped(const std::string& symbolic_name) override {
+    NotifyStopped(symbolic_name);
+  }
 
   [[nodiscard]] BundleState StateOf(const std::string& symbolic_name) const;
 

--- a/test/unit_test/osgi_bridge-test/test_case_osgi_bridge.cc
+++ b/test/unit_test/osgi_bridge-test/test_case_osgi_bridge.cc
@@ -239,6 +239,85 @@ TEST_F(BridgeRegistryTest, FailedPostLeavesBundlePending) {
   EXPECT_TRUE(registry_->PendingBundles().empty());
 }
 
+// --- Lifecycle observer ---------------------------------------------------
+//
+// The seam between the bridge (which knows channels) and the orchestrator
+// (which knows startup sequencing). Without it a bundle can register, run its
+// activator and report ACTIVE while the critical wait times out anyway.
+
+namespace {
+class RecordingObserver final : public ihs::osgi::IBundleLifecycleObserver {
+ public:
+  void OnBundleActive(const std::string& name) override {
+    active.push_back(name);
+  }
+  void OnBundleStopped(const std::string& name) override {
+    stopped.push_back(name);
+  }
+  std::vector<std::string> active;
+  std::vector<std::string> stopped;
+};
+}  // namespace
+
+TEST_F(BridgeRegistryTest, ForwardsActiveAndStoppedToTheObserver) {
+  RecordingObserver observer;
+  registry_->SetLifecycleObserver(&observer);
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+
+  EXPECT_TRUE(registry_->ReportActive("com.ivi.cluster"));
+  EXPECT_EQ(observer.active, std::vector<std::string>{"com.ivi.cluster"});
+
+  EXPECT_TRUE(registry_->ReportStopped("com.ivi.cluster"));
+  EXPECT_EQ(observer.stopped, std::vector<std::string>{"com.ivi.cluster"});
+}
+
+// A report from a bundle that never called init cannot advance anything, and
+// silently accepting it would hide a symbolic_name that does not match config.
+TEST_F(BridgeRegistryTest, RejectsActiveFromAnUnregisteredBundle) {
+  RecordingObserver observer;
+  registry_->SetLifecycleObserver(&observer);
+  EXPECT_FALSE(registry_->ReportActive("com.ivi.ghost"));
+  EXPECT_TRUE(observer.active.empty());
+}
+
+// With no observer attached the registry must not crash -- the shell may run
+// bundles with no orchestrator (every bundle deferred, nothing awaited).
+TEST_F(BridgeRegistryTest, ActiveWithoutAnObserverIsHarmless) {
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  EXPECT_TRUE(registry_->ReportActive("com.ivi.cluster"));
+}
+
+TEST_F(BridgeRegistryTest, DetachingTheObserverStopsDelivery) {
+  RecordingObserver observer;
+  registry_->SetLifecycleObserver(&observer);
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  registry_->SetLifecycleObserver(nullptr);
+  EXPECT_TRUE(registry_->ReportActive("com.ivi.cluster"));
+  EXPECT_TRUE(observer.active.empty());
+}
+
+// The observer is dispatched outside the registry lock, so an observer that
+// calls back into the registry must not deadlock. The orchestrator does
+// exactly this shape of thing under its own lock.
+TEST_F(BridgeRegistryTest, ObserverMayCallBackIntoTheRegistry) {
+  class Reentrant final : public ihs::osgi::IBundleLifecycleObserver {
+   public:
+    explicit Reentrant(ihs::osgi::BridgeRegistry* r) : registry_(r) {}
+    void OnBundleActive(const std::string&) override {
+      (void)registry_->PendingBundles();
+      (void)registry_->framework_port();
+    }
+    void OnBundleStopped(const std::string&) override {}
+
+   private:
+    ihs::osgi::BridgeRegistry* registry_;
+  };
+  Reentrant observer(registry_.get());
+  registry_->SetLifecycleObserver(&observer);
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  EXPECT_TRUE(registry_->ReportActive("com.ivi.cluster"));
+}
+
 // --- Concurrency ------------------------------------------------------------
 
 // Bundle engines register from their own threads while the framework may land

--- a/test/unit_test/osgi_orchestrator-test/test_case_osgi_orchestrator.cc
+++ b/test/unit_test/osgi_orchestrator-test/test_case_osgi_orchestrator.cc
@@ -23,6 +23,7 @@
 #include <thread>
 #include <vector>
 
+#include "osgi/bridge_registry.h"
 #include "osgi/startup_orchestrator.h"
 
 namespace {
@@ -163,6 +164,103 @@ ihs::osgi::StartupPolicy NoStagger() {
 }
 
 }  // namespace
+
+// --- The bridge/orchestrator join -------------------------------------------
+//
+// Every other test here calls NotifyActive directly, and every test in the
+// bridge suite drives the registry directly. Both pass whether or not anything
+// connects them -- which is exactly how the two shipped fully built and fully
+// disconnected. These cases wire the real BridgeRegistry to the real
+// orchestrator and let a bundle report ACTIVE the way production does.
+
+namespace {
+
+// A host whose spawned bundle behaves like a real Dart activator: it registers
+// over the bridge and then reports ACTIVE, rather than calling the orchestrator
+// directly the way FakeHost does.
+class BridgeReportingHost final : public ihs::osgi::IBundleHost {
+ public:
+  BridgeReportingHost(ihs::osgi::BridgeRegistry* registry, bool report_active)
+      : registry_(registry), report_active_(report_active) {}
+
+  BundleHandle Spawn(const ihs::osgi::BundleManifest& manifest) override {
+    const BundleHandle handle = ++next_handle_;
+    // What the Dart side does over dev.osgi/bridge: init, then active.
+    registry_->RegisterBundle(manifest.symbolic_name,
+                              static_cast<int64_t>(handle));
+    if (report_active_) {
+      registry_->ReportActive(manifest.symbolic_name);
+    }
+    return handle;
+  }
+  bool PinThread(BundleHandle, int) override { return true; }
+  void Shutdown(BundleHandle) override {}
+
+ private:
+  ihs::osgi::BridgeRegistry* registry_;
+  bool report_active_;
+  BundleHandle next_handle_{0};
+};
+
+ihs::osgi::DartPortApi NoopDartApi() {
+  return {[](void*) -> intptr_t { return 0; },
+          [](int64_t, int64_t) { return true; }};
+}
+
+}  // namespace
+
+// The join, end to end: a bundle reports ACTIVE over the bridge and the
+// critical wait is released by it. Before the observer existed this timed out.
+TEST(OrchestratorBridgeJoin, ActiveOverTheBridgeReleasesTheCriticalWait) {
+  auto api = NoopDartApi();
+  ihs::osgi::BridgeRegistry registry(api);
+  ASSERT_TRUE(registry.InitializeDartApi(0xDEADBEEF));
+
+  BridgeReportingHost host(&registry, /*report_active=*/true);
+  BundleStartupOrchestrator orchestrator(
+      host, {Manifest("com.ivi.cluster", Priority::kCritical)}, NoStagger());
+  registry.SetLifecycleObserver(&orchestrator);
+
+  const auto outcomes = orchestrator.StartCriticalPhase();
+  ASSERT_EQ(outcomes.size(), 1u);
+  EXPECT_EQ(outcomes[0].failure, StartupFailure::kNone)
+      << "ACTIVE reported over the bridge did not reach the orchestrator";
+  EXPECT_EQ(outcomes[0].state, BundleState::kActive);
+}
+
+// The control: same wiring, but the bundle never reports. Confirms the pass
+// above comes from the report and not from something else releasing the wait.
+TEST(OrchestratorBridgeJoin, WithoutTheReportTheCriticalWaitStillTimesOut) {
+  auto api = NoopDartApi();
+  ihs::osgi::BridgeRegistry registry(api);
+  ASSERT_TRUE(registry.InitializeDartApi(0xDEADBEEF));
+
+  BridgeReportingHost host(&registry, /*report_active=*/false);
+  BundleStartupOrchestrator orchestrator(
+      host, {Manifest("com.ivi.cluster", Priority::kCritical)}, NoStagger());
+  registry.SetLifecycleObserver(&orchestrator);
+
+  const auto outcomes = orchestrator.StartCriticalPhase();
+  ASSERT_EQ(outcomes.size(), 1u);
+  EXPECT_EQ(outcomes[0].failure, StartupFailure::kTimedOut);
+}
+
+// Detaching the observer must reopen the gap rather than leave a stale pointer
+// delivering into a destroyed orchestrator.
+TEST(OrchestratorBridgeJoin, DetachedObserverStopsReleasingTheWait) {
+  auto api = NoopDartApi();
+  ihs::osgi::BridgeRegistry registry(api);
+  ASSERT_TRUE(registry.InitializeDartApi(0xDEADBEEF));
+
+  BridgeReportingHost host(&registry, /*report_active=*/true);
+  BundleStartupOrchestrator orchestrator(
+      host, {Manifest("com.ivi.cluster", Priority::kCritical)}, NoStagger());
+  registry.SetLifecycleObserver(&orchestrator);
+  registry.SetLifecycleObserver(nullptr);
+
+  const auto outcomes = orchestrator.StartCriticalPhase();
+  EXPECT_EQ(outcomes[0].failure, StartupFailure::kTimedOut);
+}
 
 // --- Critical phase ---------------------------------------------------------
 


### PR DESCRIPTION
**Nothing called `NotifyActive` outside the unit tests.**

The bridge (#422) and the orchestrator (#425) were both complete, both tested,
and entirely disconnected. A bundle could call `init`, register its port, run
its activator to completion and report ACTIVE — and the critical wait would
still burn its full deadline and tear the bundle down.

## Why no test caught it

The bridge's tests drive the registry directly. The orchestrator's tests call
`NotifyActive` directly. **Each suite passes whether or not anything connects
them**, which is exactly how the two shipped fully built and fully
disconnected.

It only surfaces when something outside both tries to bring a bundle up — which
is what the vkms harness does, and why its `B3` could never have passed
*however correct a Dart activator was*. I had previously said the remaining work
was Dart rather than C++; that was wrong, and writing the Dart side first would
have produced a bundle that did everything right and still timed out, with the
failure looking like a Dart bug.

## The seam

`IBundleLifecycleObserver`. The bridge knows channels and nothing about startup
sequencing; the orchestrator knows sequencing and nothing about channels. The
orchestrator implements the interface — it already had `NotifyActive` /
`NotifyStopped` with exactly these semantics, so the methods forward — and
`main.cc` attaches it **before any bundle starts**, so a fast activator cannot
report into a null observer.

The channel gains `active` and `stopped`. **ACTIVE deliberately means the
bundle's activator finished `start()`**, not that its engine came up: the shell
already knows the latter, and it is not what the OSGi lifecycle means. A report
from a bundle that never called `init` is refused rather than ignored, because
the likeliest cause is a `symbolic_name` that does not match the config, and
that should be loud.

The observer is dispatched **outside** the registry lock — it is the
orchestrator, which takes its own lock and signals a condition variable, and
holding both across that call would couple two unrelated locks on the startup
path. A test drives an observer that calls back into the registry to hold that
property.

## Testing the join, not just the parts

Adding a fifth isolated unit test would have repeated the original mistake. So
alongside the observer tests there are three cases that wire a **real**
`BridgeRegistry` to a **real** `BundleStartupOrchestrator`, with the host
reporting the way a Dart activator will — register over the bridge, then report
ACTIVE. That is the production path minus channel marshalling.

**Two of the three are controls**, because one positive would prove very little:

| | |
|---|---|
| ACTIVE over the bridge releases the critical wait | fails before this PR |
| Same wiring, no report → still times out | so the pass comes from the report |
| Detached observer → gap reopens | no stale pointer into a destroyed orchestrator |

## Verified

- **rpi4 / trixie / vc4**, two bundles on `DSI-1` + `HDMI-A-1`: **5 pass, 0 fail**, 916 page-flip ioctls — no regression from touching `main.cc`, the registry, the plugin and the orchestrator header.
- **91 unit tests** (18 orchestrator + 20 bridge + 18 startup + 23 config + 12 vsync)
- `ENABLE_OSGI=OFF`: builds clean, zero `ihs::osgi` symbols
- clang-format-19 clean (via `scripts/format.sh`), clang-tidy 0 findings

> The hardware run is a **regression check only**. B3 still skips there because
> no bundle reports ACTIVE, so the observer is never exercised on the pi. The
> join is demonstrated by the three cases above, which is the strongest
> available until a bundle speaks the protocol.

## What this unblocks

Everything the C++ side owes `B3` is now in place and shown to work. One Dart
activator calling `init` and then `active` closes the last open assertion — and
unlike before this PR, it would actually work.