### PR TITLE
build: fail when a requested sanitizer cannot be delivered

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -614,6 +614,54 @@ MESSAGE(STATUS "Generate Golden Images.. ${UNIT_TEST_SAVE_GOLDENS}")
 #
 find_package(Sanitizers)
 
+# Fail when a sanitizer was asked for and cannot be delivered.
+#
+# sanitizers-cmake probes each sanitizer's flags and, when the probe fails,
+# emits a *warning* and leaves the flags empty -- so the build proceeds and
+# every target compiles with no instrumentation at all. A run then passes
+# clean, and nothing about it says the sanitizer was never there. That is the
+# worst outcome available: a green result that means nothing, for a check
+# somebody enabled precisely because they did not trust the code.
+#
+# The probe's own message compounds it by blaming the compiler ("not available
+# for GNU compiler"), which reads as "GCC cannot do this". Usually GCC can, and
+# the real cause is a missing runtime: on Fedora the ThreadSanitizer devel
+# symlink ships with gcc while libtsan.so.N lives in libtsan, so the flag
+# compiles and only the link fails.
+#
+# So: if the option is ON and the probe produced no flags for this compiler,
+# stop. Turning the option off, or installing the runtime, are both fine
+# answers -- silently getting nothing is not.
+function(_ihs_require_sanitizer option_name prefix pretty runtime_hint)
+    if (NOT ${option_name})
+        return()
+    endif ()
+    # The module keys its flags cache on the CMake compiler id (GNU, Clang).
+    if (NOT ${prefix}_${CMAKE_CXX_COMPILER_ID}_FLAGS)
+        message(FATAL_ERROR
+                "${option_name}=ON but no working ${pretty} flags were found "
+                "for ${CMAKE_CXX_COMPILER_ID} "
+                "${CMAKE_CXX_COMPILER_VERSION}.\n"
+                "The build would otherwise continue with NO instrumentation, "
+                "and the resulting clean run would prove nothing.\n"
+                "${runtime_hint}\n"
+                "Otherwise configure with -D${option_name}=OFF, or use a "
+                "toolchain that has the runtime (clang ships its own).")
+    endif ()
+endfunction()
+
+# Each hint says what is actually wrong for that sanitizer: three of them are
+# normally a missing runtime package, and MemorySanitizer simply does not exist
+# for GCC. A generic "probably a missing runtime" would be wrong for MSan.
+_ihs_require_sanitizer(SANITIZE_THREAD TSan "ThreadSanitizer"
+        "Usually a missing runtime rather than a compiler that cannot do it: the flag compiles and only the link fails. Install it (Fedora: libtsan; Debian/Ubuntu: libtsan0).")
+_ihs_require_sanitizer(SANITIZE_ADDRESS ASan "AddressSanitizer"
+        "Usually a missing runtime rather than a compiler that cannot do it: the flag compiles and only the link fails. Install it (Fedora: libasan; Debian/Ubuntu: libasan8).")
+_ihs_require_sanitizer(SANITIZE_MEMORY MSan "MemorySanitizer"
+        "MemorySanitizer is clang-only; GCC does not implement it, so no runtime will help.")
+_ihs_require_sanitizer(SANITIZE_UNDEFINED UBSan "UndefinedBehaviorSanitizer"
+        "Usually a missing runtime rather than a compiler that cannot do it: the flag compiles and only the link fails. Install it (Fedora: libubsan; Debian/Ubuntu: libubsan1).")
+
 #
 # Executable Name
 #


### PR DESCRIPTION
`-DSANITIZE_THREAD=ON` produces a build with **no instrumentation at all**.

`sanitizers-cmake` probes the flags, and when the probe fails it emits a
warning and leaves them empty — so configure succeeds, every target compiles
clean, the suite runs green, and nothing about the result says the sanitizer
was never there.

That is the worst available outcome: a meaningless pass, for a check somebody
enabled precisely because they did not trust the code.

## I had the cause wrong, and the probe's message is why

The probe says:

```
ThreadSanitizer is not available for GNU compiler.
```

**GCC is fine.** On Fedora the devel symlink `/usr/lib/gcc/*/libtsan.so` ships
with gcc while `libtsan.so.2.0.0` lives in a separate package, so
`-fsanitize=thread` **compiles and only the link fails**. The compiler was
never the problem; a missing runtime was.

This cost real time on this tree. Believing the option did nothing on GCC, I
built the OSGi concurrency suites under clang by hand to get coverage I had
already asked for — and reported in #422, #423 and #425 that the option
"silently skips instrumentation on GCC". That claim was wrong in its
attribution, and it came straight from this message.

## The change

If a `SANITIZE_*` option is ON and the probe produced no flags for the compiler
in use, configure stops with what is actually wrong and how to fix it.

Each hint is specific rather than generic: three of the four are normally a
missing runtime package, and **MemorySanitizer genuinely does not exist for
GCC**, so "probably a missing runtime" would be actively misleading for it.

The check lives in this repo's `options.cmake` rather than in the vendored
module. The module's permissive behaviour is defensible for a project that
treats sanitizers as best-effort; this one does not.

## Verified

| | |
|---|---|
| GCC `-DSANITIZE_THREAD=ON` | configure fails, names `libtsan` |
| GCC `-DSANITIZE_MEMORY=ON` | configure fails, says clang-only |
| clang `-DSANITIZE_THREAD=ON` | configures; built test driver carries **644 `__tsan` symbols** and runs instrumented |
| no sanitizer requested | unchanged — and no warning either |

The clang row is the one that matters: it shows the option now *means*
something, rather than merely failing more loudly.

**No CI job sets `SANITIZE_*`**, so nothing in the matrix changes.

## Follow-on

With this in, installing `libtsan` makes GCC ThreadSanitizer runs work
directly, and the by-hand clang builds I used for the OSGi concurrency suites
become unnecessary. Worth considering for the `unit-tests` job, which currently
has no sanitizer coverage at all — though that is a separate change and a
separate cost discussion.