### PR TITLE
test: fix both broken assertions in multi_view_single_engine

### DIFF
--- a/test/multi_view_single_engine.sh
+++ b/test/multi_view_single_engine.sh
@@ -141,22 +141,55 @@ wait "$HS_PID" 2>/dev/null
 fail=0
 
 # 1. The single engine must have brought up BOTH connectors.
+#
+# The two outputs announce themselves differently, and only the primary matched
+# the patterns this used to look for:
+#
+#   primary      [DrmBackend] picked connector DSI-1 via user pin (--drm-connector)
+#                [OutputManager] view bound to output 'DSI-1'
+#   additional   [DrmBackend] additional output 'HDMI-A-1': connector=35 crtc=104 ...
+#
+# The additional form puts the connector name before "connector=", so
+# "connector=.*$c" cannot match it, and it never gets a "bound to output" line.
+# The check therefore failed for the second output -- the one this harness
+# exists to verify -- however well it came up.
 for c in "$CONNECTOR_A" "$CONNECTOR_B"; do
-  if grep -aq "\[DrmBackend\] .*connector.*$c" "$LOG" || grep -aq "connector=.*$c" "$LOG" \
-     || grep -aq "bound to output '$c'" "$LOG"; then
+  if grep -aq "\[DrmBackend\] .*connector.*$c" "$LOG" \
+     || grep -aq "connector=.*$c" "$LOG" \
+     || grep -aq "bound to output '$c'" "$LOG" \
+     || grep -aq "additional output '$c'" "$LOG"; then
     note "output up: $c"
   else
     echo "FAIL: no startup line for connector $c" >&2; fail=1
   fi
 done
 
-# 2. Exactly one engine: expect a single 'Engine running' / '(0) Engine'
-#    and NOT a second discrete engine index.
-if grep -aqE "\(1\) Engine running" "$LOG"; then
-  echo "FAIL: a second engine (index 1) started" >&2
+# 2. Exactly one engine drives both outputs.
+#
+# This used to look for "(1) Engine running", which is IHS_DEBUG -- and
+# IHS_DEBUG compiles to ((void)0) under NDEBUG. In a release build the string
+# does not exist, the grep never matches, and the check reports "single engine"
+# no matter how many engines started. It could only ever fail in a Debug build,
+# which is not the binary that ships.
+#
+# Count distinct engine indices instead, from markers that survive release.
+# Engine::Engine logs exactly one of these at info level per engine: "Loading
+# AOT" for an AOT bundle, "Runtime=debug" for a JIT one.
+engine_indices=$(grep -aoE "\([0-9]+\) (Loading AOT|Runtime=debug)" "$LOG" \
+                 | grep -oE "^\(?[0-9]+" | tr -d '(' | sort -un)
+engine_count=$(printf '%s' "$engine_indices" | grep -c . || true)
+
+if [ "$engine_count" -eq 0 ]; then
+  # Neither marker appeared, so no engine got as far as choosing a runtime.
+  # Reporting "single engine" here is what the old check did, and it is the
+  # failure mode worth avoiding: absence of evidence read as evidence.
+  echo "FAIL: no engine start markers in the log; the run proves nothing" >&2
+  fail=1
+elif [ "$engine_count" -gt 1 ]; then
+  echo "FAIL: $engine_count engines started (indices: $(echo $engine_indices | tr '\n' ' ')); expected exactly one" >&2
   fail=1
 else
-  note "single engine (no discrete second engine)"
+  note "single engine (one index, both outputs)"
 fi
 
 # 3. No fatal/error spdlog lines.


### PR DESCRIPTION
The harness exists to prove ONE engine drives TWO outputs. **Both of its
substantive assertions were broken, in opposite directions** — and between them
they cancelled into a harness that could report neither the thing it was
checking for nor the thing it was checking against.

Found by running it end to end on an rpi4 (trixie, vc4, `DSI-1` + `HDMI-A-1`).

## 1. The engine check could not fail

```bash
grep -aqE "\(1\) Engine running"
```

`Engine running` is `IHS_DEBUG`, and `IHS_DEBUG` compiles to `((void)0)` under
`NDEBUG`:

```c
#ifndef NDEBUG
#define IHS_DEBUG(...) ihs::log::debug(__VA_ARGS__)
#else
#define IHS_DEBUG(...) ((void)0)
#endif
```

So in a release build the string does not exist, the grep never matches, and
the check reports "single engine" however many engines started. It could only
ever fail in a **Debug** build — not the binary that ships, and not what the
emb/pios path produces.

Demonstrated rather than argued. Run over release logs captured on hardware
that provably brought up two engines on two connectors:

| log | reality | old check |
|---|---|---|
| `two3.log` | 2 engines | **PASS** |
| `two_act.log` | 2 engines | **PASS** |

It now counts distinct engine indices from markers that survive release —
`Engine::Engine` logs exactly one per engine at info level, `Loading AOT` for an
AOT bundle or `Runtime=debug` for a JIT one. Against the same logs, 1-bundle
runs yield one index and 2-bundle runs yield two.

**Zero markers is now a failure rather than a pass.** That case is the bug in
miniature: the old check read *"the string I looked for is absent"* as *"the
thing I was worried about did not happen"*, when it equally meant the run proved
nothing.

## 2. The connector check could not pass for the second output

The two outputs announce themselves differently:

```
primary      [DrmBackend] picked connector DSI-1 via user pin (--drm-connector)
             [OutputManager] view bound to output 'DSI-1'
additional   [DrmBackend] additional output 'HDMI-A-1': connector=35 crtc=104 mode=1280x1440@60
```

The additional form puts the connector name **before** `connector=`, so
`connector=.*$c` cannot match it, and it never gets a `bound to output` line.
The check therefore failed for the second output — the one the whole harness
exists to verify — however well it came up. Added that pattern.

## Verified end to end, exit 0

```
output up: DSI-1
output up: HDMI-A-1
single engine (one index, both outputs)
page-flip/atomic ioctls observed: 240
```

`multi_view_test` cross-built for arm64 and run against `DSI-1` + `HDMI-A-1` on
vc4. That also exercises the **positive** case — one engine *should* pass —
where log-based checking only covered the negative.

## Why both survived

**This harness is not run by CI.** Nothing in `.github/` or `scripts/` invokes
it. Worth adding, since `vkms_dual.sh` already provisions exactly the two
outputs it needs — but that is a separate change with its own runtime cost, so I
have not bundled it here.

> I originally intended to fix only the first assertion, on the strength of
> verifying the logic against captured logs. That would have shipped the second
> bug. The end-to-end run is what found it.