### PR TITLE
shell: a view that cannot start must not take the process down

### DIFF
--- a/shell/app.cc
+++ b/shell/app.cc
@@ -187,6 +187,13 @@ std::vector<std::shared_ptr<IDisplay>> App::BuildDisplays(
       std::exit(EXIT_FAILURE);
     }
     auto display = descriptor->make_display(group_configs);
+    if (display == nullptr) {
+      // Still fatal here: this runs before anything is up, so there is nothing
+      // to keep alive by continuing. AddView's copy of this recovers instead.
+      ihs::log::critical("[App] could not create a display for context '{}'",
+                         ck);
+      std::exit(EXIT_FAILURE);
+    }
     m_displays.push_back(display);
     // Remember which context this display serves so a view added later joins
     // it instead of creating a second display on the same device.
@@ -223,6 +230,10 @@ std::shared_ptr<IDisplay> App::DisplayForContext(
     return nullptr;
   }
   auto display = descriptor->make_display({config});
+  if (display == nullptr) {
+    ihs::log::error("[App] could not create a display for context '{}'", ck);
+    return nullptr;
+  }
   m_displays.push_back(display);
   m_display_by_context.emplace(ck, display);
   return display;
@@ -246,19 +257,13 @@ FlutterView* App::AddView(const Configuration::Config& config) {
   if (display == nullptr) {
     return nullptr;
   }
-  const bool display_is_new = m_displays.size() != display_count_before;
-
-  // Index continues the constructor's sequence: it is the engine index that
-  // shows up in the logs, and a duplicate would make two engines
-  // indistinguishable there.
-  auto view = std::make_unique<FlutterView>(config, m_views.size(), display);
-  // Initialize() runs the engine. Doing it here, one view at a time, is the
-  // whole point of this entry point.
-  view->Initialize();
-  FlutterView* raw = view.get();
-  m_views.emplace_back(std::move(view));
-
-  if (display_is_new) {
+  // Wire a newly created display up before building the view on it, not after.
+  // The view may fail to initialize, and the display outlives that failure --
+  // it stays in m_display_by_context for the next view on the same
+  // device-context. Watching and starting it only on the success path would
+  // leave it registered but never pumping, and the next view would reuse it
+  // seeing display_is_new == false and never start it either.
+  if (m_displays.size() != display_count_before) {
     WatchDisplayOutputs(display);
     // The constructor's StartEvents pass has already run by the time anything
     // calls AddView after Run(); a display created now has to be started here
@@ -267,7 +272,23 @@ FlutterView* App::AddView(const Configuration::Config& config) {
       display->StartEvents();
     }
   }
-  return raw;
+
+  // Index continues the constructor's sequence: it is the engine index that
+  // shows up in the logs, and a duplicate would make two engines
+  // indistinguishable there.
+  auto view = std::make_unique<FlutterView>(config, m_views.size(), display);
+  // Initialize() runs the engine. Doing it here, one view at a time, is the
+  // whole point of this entry point.
+  //
+  // A failure is this view's alone. Dropping the unique_ptr tears it back down
+  // and leaves every other view untouched -- which is what lets a bundle name a
+  // connector that is not plugged in without taking the cluster beside it down.
+  if (!view->Initialize()) {
+    ihs::log::error("[App] view {} failed to initialize", m_views.size());
+    return nullptr;
+  }
+  m_views.emplace_back(std::move(view));
+  return m_views.back().get();
 }
 
 bool App::RemoveView(FlutterView* view) {
@@ -303,7 +324,12 @@ App::App(const std::vector<Configuration::Config>& configs) {
   m_views.reserve(configs.size());
   for (auto const& cfg : configs) {
     auto view = std::make_unique<FlutterView>(cfg, index, view_display[index]);
-    view->Initialize();
+    if (!view->Initialize()) {
+      // Fatal on this path only: the constructor runs before anything is up, so
+      // there is no running system for a failed view to spare.
+      ihs::log::critical("[App] view {} failed to initialize; aborting", index);
+      std::exit(EXIT_FAILURE);
+    }
     m_views.emplace_back(std::move(view));
     index++;
 

--- a/shell/backend/register_backends.cc
+++ b/shell/backend/register_backends.cc
@@ -133,7 +133,12 @@ std::shared_ptr<IDisplay> MakeDrmDisplay(
   // reason it could not pick one.
   auto device = homescreen::ResolveDrmDevice(configs[0].view.drm_device);
   if (!device) {
-    std::exit(EXIT_FAILURE);
+    // Propagated, not fatal, for the same reason as the backend factories: a
+    // view naming a card that cannot be resolved must not take down the views
+    // already running beside it. App::DisplayForContext turns this into a
+    // failed view; App's constructor still treats it as fatal, because at that
+    // point there is nothing else to keep alive.
+    return nullptr;
   }
   return std::make_shared<DrmDisplay>(static_cast<int32_t>(w),
                                       static_cast<int32_t>(h), 60.0,
@@ -465,12 +470,18 @@ std::shared_ptr<Backend> MakeDrmEglBackend(const Configuration::Config& config,
                                  drm_display->SharedDevice(), drm_display);
 
   // DrmBackend::Create returns nullptr on any init failure (libseat
-  // take_device, drmSetMaster, no usable connector, GBM/EGL setup,
-  // …). Continuing would dereference a null backend in Engine::Run
-  // and SEGV; fail-fast with the same exit path as a missing bundle.
+  // take_device, drmSetMaster, no usable connector, GBM/EGL setup, …).
+  //
+  // Propagated rather than fatal. Continuing with a null backend would
+  // dereference it in Engine::Run and SEGV, so the caller has to handle it --
+  // but killing the process here makes one view's failure everyone's. With
+  // several views in a process that is wrong: a bundle naming a connector that
+  // is not plugged in takes down the cluster next to it.
+  // FlutterView::Initialize reports the failure and App decides, which is the
+  // only place that knows whether anything else is running.
   if (!m_backend) {
-    ihs::log::critical("[FlutterView] DRM backend init failed; aborting");
-    exit(EXIT_FAILURE);
+    ihs::log::error("[FlutterView] DRM backend init failed");
+    return nullptr;
   }
 
   // Start the card's single PAGE_FLIP_EVENT reader (owned by the device-context
@@ -578,13 +589,11 @@ std::shared_ptr<Backend> MakeDrmVulkanBackend(
                 ParseTriState(config.view.drm_explicit_sync));
 
   // Create returns nullptr on any init failure (unsupported device, no
-  // zero-copy scanout path). Continuing would dereference a null backend in
-  // Engine::Run and SEGV; fail-fast with the same exit path the EGL DRM
-  // backend uses.
+  // zero-copy scanout path). Propagated rather than fatal, for the same reason
+  // as the EGL DRM backend above.
   if (!vk_backend) {
-    ihs::log::critical(
-        "[FlutterView] DRM Vulkan backend init failed; aborting");
-    exit(EXIT_FAILURE);
+    ihs::log::error("[FlutterView] DRM Vulkan backend init failed");
+    return nullptr;
   }
 
   // Wire the self-committing HW cursor (if Create opened one) to the seat

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -490,7 +490,15 @@ TaskRunner* FlutterView::GetPlatformTaskRunner() const {
   return m_flutter_engine ? m_flutter_engine->GetPlatformTaskRunner() : nullptr;
 }
 
-void FlutterView::Initialize() {
+bool FlutterView::Initialize() {
+  // Backend::Create returns null when the backend could not be built at all
+  // (no descriptor for the key) or its factory failed to initialize the device.
+  // Everything below dereferences it.
+  if (!m_backend) {
+    ihs::log::error("({}) no usable backend; view cannot start", m_index);
+    return false;
+  }
+
   // Engine / Dart VM switches -> command_line_argv. argv[0] is the app id.
   std::vector<const char*> m_command_line_args_c;
   m_command_line_args_c.reserve(m_config.view.engine_args.size() + 2);
@@ -555,8 +563,8 @@ void FlutterView::Initialize() {
   m_flutter_engine->Run(m_state->engine_state);
 
   if (!m_flutter_engine->IsRunning()) {
-    ihs::log::critical("Failed to Run Engine");
-    exit(EXIT_FAILURE);
+    ihs::log::error("({}) failed to run engine", m_index);
+    return false;
   }
 
   // Hand the engine handle + platform task runner to the backend so
@@ -709,6 +717,7 @@ void FlutterView::Initialize() {
 #endif
 
   IHS_DEBUG("({}) Engine running...", m_index);
+  return true;
 }
 
 void FlutterView::UpdateDisplayMetadata() const {

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -107,7 +107,14 @@ class FlutterView {
    * @relation
    * wayland, flutter
    */
-  void Initialize();
+  /// Bring the engine up. Returns false when the view cannot run -- its backend
+  /// failed to initialize, or the engine refused to start.
+  ///
+  /// A failure here used to exit the process. With several views in one process
+  /// that is the wrong call: one bundle naming a connector that is not plugged
+  /// in would take the cluster down with it. The caller decides, because only
+  /// it knows whether anything else is already running.
+  [[nodiscard]] bool Initialize();
 
   /**
    * @brief Get the WaylandWindow associated with this view.


### PR DESCRIPTION
A DRM backend that failed to initialize called `exit(EXIT_FAILURE)`. With one
view per process that was defensible. With several it is not: **a bundle naming
a connector that is not plugged in killed the instrument cluster running beside
it**, before that cluster had even been asked to start.

## It also made the orchestrator's contract a fiction

`StartCriticalPhase` (#425) is written so a failed bundle is recorded and
startup continues — *"one broken cluster must not take the rest of the system
with it"* — and its unit tests pass, because a fake host can return a failure
handle.

The real one could not. The process died inside `App::AddView` before `Spawn`
ever returned. **The seam that made the orchestrator testable is exactly what
hid this** — the same shape as the bridge/orchestrator disconnection in #428:
both sides correct in isolation, the join broken.

## The change

Failure propagates instead of terminating:

- The DRM EGL and Vulkan factories return `nullptr`. `DrmBackend::Create` and
  `VulkanDrmBackend::Create` **already** reported failure that way; only the
  factory bodies turned it into an exit.
- `MakeDrmDisplay` returns `nullptr` when the card cannot be resolved.
- `FlutterView::Initialize` returns `bool` rather than exiting on a null backend
  or an engine that would not run.

`App` decides, because only `App` knows whether anything else is running:

| | |
|---|---|
| constructor | still fatal — it runs before anything is up, so there is no running system for a failed view to spare. It now names the failed view instead of dying inside the backend. |
| `AddView` | returns `nullptr`. The `unique_ptr` goes out of scope, the view tears back down, every other view is untouched. |

## One ordering detail that matters

A newly created display is now watched and started **before** the view is built
on it, not after.

The display outlives a view that fails — it stays in `m_display_by_context` for
the next view on the same device-context. Wiring it only on the success path
would leave it registered but never pumping, and the next view would reuse it,
see `display_is_new == false`, and never start it either. I hit this in my own
first version of the change.

## Verified on rpi4 (trixie, vc4)

Two bundles, one pinned to `HDMI-A-2` with nothing plugged into it:

```
[DrmBackend] --drm-connector=HDMI-A-2 not found among eligible connectors
[osgi] bundle 'com.ivi.broken': could not create a view
[osgi] bundle 'com.ivi.cluster': STARTING -> ACTIVE
[DrmCompositor] pipe-check: vblank advanced ... — pipe is live
```

The process survived the whole run. **Before this change it exited during the
first bundle and the second never started.**

No regressions: `osgi_multi_bundle` **6/0** on hardware, `multi_view_single_engine`
exit 0, **91** unit tests, and `ENABLE_OSGI=OFF` still builds clean.

## Two exits left deliberately

The leased-DRM acquisition failure, and a page-flip handler whose own comment
explains it must not run `atexit` handlers from the monitor thread. Neither is
on the `AddView` path — I checked rather than assumed.