### PR TITLE
build: fetch and cross-build AccessKit through an emb augment

### DIFF
--- a/.emb/base.emb.yaml
+++ b/.emb/base.emb.yaml
@@ -53,6 +53,40 @@ cross:
         SENTRY_BUILD_SHARED_LIBS: 'OFF'
         SENTRY_BUILD_TESTS: 'OFF'
         SENTRY_BUILD_EXAMPLES: 'OFF'
+    # AccessKit C bindings, for the platform accessibility adapter. Off by
+    # default; enable with `--define BUILD_ACCESSKIT=ON` (which also requires
+    # BUILD_ACCESSIBILITY, since the adapter reads the semantics tree).
+    #
+    # Built from source rather than unpacked: the release ships prebuilt
+    # libraries for linux/x86_64 and linux/x86 only, and accesskit.cmake maps
+    # aarch64 to a lib/linux/arm64 directory the archive does not contain, so a
+    # board build would configure and then fail to find the library. Building
+    # the crate gives every target a library for its own architecture, at the
+    # cost of a Rust toolchain -- the package pulls Corrosion and compiles with
+    # cargo, and the target's Rust std must be installed
+    # (`rustup target add aarch64-unknown-linux-gnu` for the boards here).
+    #
+    # The patch is what makes the package usable as an augment at all. Upstream
+    # installs back into its own source tree and never installs its CMake
+    # config, so an overlay build would leave the sysroot empty; the patch adds
+    # an opt-in conventional layout and a config find_package can resolve. It
+    # also gives Corrosion the cross triple, without which cargo builds host
+    # objects while the toolchain points at the cross compiler.
+    - pkg: accesskit-c
+      requires_define: BUILD_ACCESSKIT
+      min: "0.22.3"
+      url: https://github.com/AccessKit/accesskit-c/releases/download/0.22.3/accesskit-c-0.22.3.zip
+      build: cmake
+      static: true
+      patches:
+        - patches/accesskit-c-0001-prefix-install-and-cross-target.patch
+      defines:
+        ACCESSKIT_INSTALL_PREFIX_LAYOUT: 'ON'
+        # The archive carries pre-generated headers; regenerating them needs a
+        # pinned nightly Rust plus cbindgen and clang-format, which is not a
+        # dependency worth taking on for a header that is already correct.
+        ACCESSKIT_BUILD_HEADERS: 'OFF'
+        ACCESSKIT_BUILD_LIBRARIES: 'ON'
   defines:
     DISABLE_PLUGINS: 'ON'              # shared by the native build and the boards
   # Native host backend matrix: `emb cross . --build` (no --target) compiles

--- a/.emb/patches/accesskit-c-0001-prefix-install-and-cross-target.patch
+++ b/.emb/patches/accesskit-c-0001-prefix-install-and-cross-target.patch
@@ -1,0 +1,164 @@
+Subject: [PATCH] install into CMAKE_INSTALL_PREFIX and honor the CMake cross target
+
+accesskit-c is built to be consumed in place: accesskit.cmake resolves
+ACCESSKIT_INCLUDE_DIR and ACCESSKIT_LIBRARIES_DIR relative to the source
+directory, the install() rules copy the freshly built libraries back into that
+same tree, and accesskit-config.cmake sits at the archive root and is never
+installed at all. Pointing CMAKE_PREFIX_PATH at an unpacked release therefore
+works, but installing into a prefix produces nothing a consumer can find.
+
+An emb augment builds into a sysroot overlay and expects the package to install
+there, so add an opt-in conventional layout: header into <prefix>/include,
+static library into <prefix>/lib, and a generated ACCESSKITConfig.cmake that
+find_package(ACCESSKIT) resolves from the overlay. Off by default, so the
+upstream in-place flow is untouched.
+
+Separately, tell Corrosion which Rust target to build. Without Rust_CARGO_TARGET
+it builds for the host while the CMake toolchain still points every compiler at
+the cross gcc, so cargo links host artifacts with a compiler that rejects -m64.
+Deriving the triple from CMAKE_SYSTEM_PROCESSOR when CMAKE_CROSSCOMPILING is set
+makes a cross build produce objects for the architecture the rest of the build
+is targeting.
+
+Finally, forward the C compiler's flags to rustc as link arguments. rustc drives
+the final link through that compiler, and a Debian multiarch sysroot keeps
+crti.o and libc under lib/<triple>/ where plain --sysroot does not reach them, so
+without the -B/-L set the toolchain already passes in CMAKE_C_FLAGS the cdylib
+link fails with `cannot find crti.o`.
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 930e626..2732ce1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,8 +5,35 @@ project(accesskit-c)
+ option(ACCESSKIT_BUILD_HEADERS "Whether to build header files" OFF)
+ option(ACCESSKIT_BUILD_LIBRARIES "Whether to build libraries" ON)
+ option(ACCESSKIT_ANDROID_EMBEDDED_DEX "Whether to embed the classes.dex file in the library (Android only)" OFF)
++option(ACCESSKIT_INSTALL_PREFIX_LAYOUT "Install into CMAKE_INSTALL_PREFIX (include/, lib/, lib/cmake/) instead of back into the source tree" OFF)
+ 
+ if (ACCESSKIT_BUILD_LIBRARIES)
++    # Corrosion defaults to the host triple. Under a CMake cross build that
++    # leaves cargo producing host objects while every compiler variable points
++    # at the cross toolchain, so host artifacts get linked with a compiler that
++    # rejects their flags. Derive the triple from what the toolchain file
++    # already declares.
++    if (CMAKE_CROSSCOMPILING AND NOT Rust_CARGO_TARGET)
++        if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
++            if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
++                set(Rust_CARGO_TARGET "aarch64-unknown-linux-gnu" CACHE STRING "")
++            elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
++                set(Rust_CARGO_TARGET "x86_64-unknown-linux-gnu" CACHE STRING "")
++            elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|armv7|armv7l)$")
++                set(Rust_CARGO_TARGET "armv7-unknown-linux-gnueabihf" CACHE STRING "")
++            elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv64)$")
++                set(Rust_CARGO_TARGET "riscv64gc-unknown-linux-gnu" CACHE STRING "")
++            endif()
++        endif()
++        if (Rust_CARGO_TARGET)
++            message(STATUS "accesskit-c: cross target ${Rust_CARGO_TARGET}")
++        else()
++            message(WARNING
++                "accesskit-c: cross-compiling for ${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR} "
++                "but no Rust triple is known for it; set Rust_CARGO_TARGET explicitly.")
++        endif()
++    endif()
++
+     include(FetchContent)
+ 
+     FetchContent_Declare(
+@@ -20,6 +47,29 @@ if (ACCESSKIT_BUILD_LIBRARIES)
+     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+     set(CMAKE_PDB_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+     corrosion_import_crate(MANIFEST_PATH Cargo.toml)
++
++    # rustc drives the final link through the C compiler, so it needs the same
++    # search paths that compiler is given for everything else. A Debian
++    # multiarch sysroot keeps crti.o and libc under lib/<triple>/, which plain
++    # --sysroot does not reach; the toolchain file passes the -B/-L/-rpath-link
++    # set in CMAKE_C_FLAGS, and without forwarding them the cdylib link fails
++    # with `cannot find crti.o`. Forward the C flags as link arguments.
++    if (CMAKE_CROSSCOMPILING AND Rust_CARGO_TARGET)
++        set(_accesskit_link_args "")
++        if (CMAKE_SYSROOT)
++            list(APPEND _accesskit_link_args "--sysroot=${CMAKE_SYSROOT}")
++        endif()
++        separate_arguments(_accesskit_cflags NATIVE_COMMAND "${CMAKE_C_FLAGS}")
++        list(APPEND _accesskit_link_args ${_accesskit_cflags})
++
++        set(_accesskit_rustflags "")
++        foreach (_accesskit_arg IN LISTS _accesskit_link_args)
++            list(APPEND _accesskit_rustflags "-Clink-arg=${_accesskit_arg}")
++        endforeach()
++        if (_accesskit_rustflags)
++            corrosion_add_target_local_rustflags(accesskit ${_accesskit_rustflags})
++        endif()
++    endif()
+     if (ACCESSKIT_ANDROID_EMBEDDED_DEX)
+         corrosion_set_features(accesskit FEATURES android-embedded-dex)
+     endif()
+@@ -44,14 +94,17 @@ endif()
+ 
+ include("accesskit.cmake")
+ 
+-if (ACCESSKIT_BUILD_HEADERS)
++# The upstream destinations are absolute paths back into the source tree. Under
++# a DESTDIR install that produces a nested copy of the whole path inside the
++# staging root, so skip them when the prefix layout below is what was asked for.
++if (ACCESSKIT_BUILD_HEADERS AND NOT ACCESSKIT_INSTALL_PREFIX_LAYOUT)
+     install(FILES
+         "${CMAKE_CURRENT_BINARY_DIR}/accesskit.h"
+         DESTINATION "${ACCESSKIT_INCLUDE_DIR}"
+     )
+ endif()
+ 
+-if (ACCESSKIT_BUILD_LIBRARIES)
++if (ACCESSKIT_BUILD_LIBRARIES AND NOT ACCESSKIT_INSTALL_PREFIX_LAYOUT)
+     install(FILES
+         "$<TARGET_PROPERTY:accesskit-static,IMPORTED_LOCATION>"
+         DESTINATION "${ACCESSKIT_LIBRARIES_DIR}/static"
+@@ -68,3 +121,45 @@ if (ACCESSKIT_BUILD_LIBRARIES)
+         DESTINATION "${ACCESSKIT_LIBRARIES_DIR}/shared"
+     )
+ endif()
++
++# Conventional prefix layout, for consumers that install rather than point at an
++# unpacked release. The upstream rules above stay in place; this only adds a
++# second set of destinations plus the package config that makes them findable,
++# since upstream ships its config in the archive rather than installing one.
++if (ACCESSKIT_INSTALL_PREFIX_LAYOUT AND ACCESSKIT_BUILD_LIBRARIES)
++    include(GNUInstallDirs)
++
++    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/accesskit.h"
++            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
++
++    install(FILES "$<TARGET_PROPERTY:accesskit-static,IMPORTED_LOCATION>"
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}")
++
++    # Written out rather than configure_file'd so the installed config carries
++    # no build-machine paths: it resolves everything from its own location,
++    # which is what lets the overlay be consumed from a different prefix.
++    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/ACCESSKITConfig.cmake"
++"get_filename_component(_accesskit_prefix \"\${CMAKE_CURRENT_LIST_DIR}/../../..\" ABSOLUTE)
++set(ACCESSKIT_INCLUDE_DIR \"\${_accesskit_prefix}/${CMAKE_INSTALL_INCLUDEDIR}\")
++set(ACCESSKIT_INCLUDE_DIRS \"\${ACCESSKIT_INCLUDE_DIR}\")
++set(ACCESSKIT_LIBRARY \"\${_accesskit_prefix}/${CMAKE_INSTALL_LIBDIR}/libaccesskit.a\")
++set(ACCESSKIT_LIBRARIES \"\${ACCESSKIT_LIBRARY}\")
++
++if (NOT TARGET accesskit)
++  add_library(accesskit STATIC IMPORTED GLOBAL)
++  set_target_properties(accesskit PROPERTIES
++      IMPORTED_LOCATION \"\${ACCESSKIT_LIBRARY}\"
++      INTERFACE_INCLUDE_DIRECTORIES \"\${ACCESSKIT_INCLUDE_DIR}\")
++  # Mirrors what the upstream config links on linux -- the Rust staticlib needs
++  # libm, and -static-libgcc keeps the unwinder out of the shared dependency
++  # set. dl/pthread/rt are what the Rust standard library itself pulls in.
++  set_property(TARGET accesskit PROPERTY INTERFACE_LINK_LIBRARIES
++      -static-libgcc m dl pthread rt)
++endif()
++
++set(ACCESSKIT_FOUND TRUE)
++")
++
++    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ACCESSKITConfig.cmake"
++            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ACCESSKIT")
++endif()


### PR DESCRIPTION
Follow-up to #418, which made the adapter buildable but left the bindings to be supplied by hand. This wires them into the augment list beside sentry-native, gated on the same `BUILD_ACCESSKIT`.

**This is the approach I reported as not fitting.** It doesn't, unpatched — so the patch is the substance of this PR. All three blockers are now fixed and verified on both native and cross.

## Built from source, not unpacked

The release ships prebuilt libraries for `linux/x86_64` and `linux/x86` only, and `accesskit.cmake` maps aarch64 to a `lib/linux/arm64` directory the archive doesn't contain — a board build would configure and then fail to find the library. Building the crate gives every target a library for its own architecture from one entry.

Cost: a Rust toolchain (Corrosion + cargo), and the target's std must be installed — `rustup target add aarch64-unknown-linux-gnu` for the boards here. I've noted that in the manifest comment.

## What the patch fixes

**1. It installs into its own source tree, not a prefix.** `accesskit.cmake` resolves destinations relative to the source dir, and the CMake config consumers need sits at the archive root and is never installed. An augment would build it and leave the sysroot empty — exactly what a native run did before: augment reports success, configuration then fails to find ACCESSKIT. The patch adds an opt-in conventional layout plus a generated `ACCESSKITConfig.cmake`.

It also **suppresses the upstream rules** when that layout is used. Their destinations are absolute paths, so under DESTDIR they reproduce the entire path inside the staging root — a second 41 MB copy of the library at `sysroot/mnt/dev/.../overlay-src/...`. I hit that, which is why the option replaces rather than supplements.

**2. Corrosion defaulted to the host triple**, so cargo built host objects while every compiler variable pointed at the cross toolchain, and host build scripts were linked with a compiler that rejects their flags:

```
aarch64-none-linux-gnu-gcc: error: unrecognized command-line option '-m64'
```

The patch derives the Rust triple from `CMAKE_SYSTEM_PROCESSOR` when cross-compiling.

**3. That moved the failure to linking the library itself** — `cannot find crti.o`. rustc drives the final link through the C compiler, and a Debian multiarch sysroot keeps startup objects under `lib/<triple>/` where plain `--sysroot` doesn't reach. The toolchain file already passes the `-B`/`-L` set in `CMAKE_C_FLAGS`, so the patch forwards those to rustc as link arguments — the same thing emb's own `cargoEnv()` does for cargo modules, and its doc comment describes this exact failure.

## Verified both ways

| | native (`--target local`) | cross (`--target rpi5-trixie`) |
|---|---|---|
| augment build | ✅ 28.5 s | ✅ 27.8 s |
| installs into | overlay `usr/{include,lib64}` + `lib64/cmake/ACCESSKIT` | sysroot `usr/{include,lib}` + `lib/cmake/ACCESSKIT` |
| library arch | x86_64 | **`ELF 64-bit ARM aarch64`, 41 MB** |
| `find_package(ACCESSKIT)` | ✅ resolves | ✅ resolves |
| `ENABLE_ACCESSKIT` reaches sources | ✅ | ✅ |
| accesskit symbols in shell binary | 498 | 497 |
| duplicate install tree | none | none |

## Note on the patch itself

It's carried as `.emb/patches/` and applied by `git apply`, which the augment schema supports. I'd rather upstream the prefix-layout and cross-target parts to accesskit-c eventually — both are general fixes, not local hacks — but that's a slower path and this unblocks the adapter now.