### PR TITLE
accessibility: make AccessKit a semantics hub consumer

### DIFF
--- a/docs/PLUGIN_ABI.md
+++ b/docs/PLUGIN_ABI.md
@@ -53,6 +53,23 @@ laid out as `(major << 16) | minor`:
   older minor keeps working against a newer library by construction.
 - **Breaking** changes bump the **major** version and the library `SOVERSION`.
 
+Not every published struct carries a leading `struct_size`. `IhsSemanticsNode`
+does not: consumers read it by dereference through a pointer the library
+returns, so the library — never the consumer — decides the stride, and a
+consumer built against an older header simply reads the prefix it knows. That
+makes appending a trailing field safe in the older-plugin-against-newer-library
+direction, which is the one the minor version promises.
+
+The reverse direction has no such guarantee, because there is no `struct_size`
+to check: a consumer built against a newer header that dereferenced a new
+trailing field on a node an older library allocated would read past the end.
+So a field appended to a struct like this is paired with an accessor entry
+point — `ihs_semantics_node_numeric_value()` for the ABI 1.1 numeric-value
+fields — and the accessor, not the field, is the documented read path. A plugin
+using it against a library too old to provide it fails to resolve the symbol at
+load, which is the clean failure the `struct_size` convention would otherwise
+have given.
+
 The entry point is `ihs_get_api(uint32_t requested_abi)`. It returns a table
 valid for the process lifetime, or `NULL` if the requested **major** version is
 not the one this library provides — so a plugin newer than the shell fails

--- a/shared/include/ihs/ihs_semantics.h
+++ b/shared/include/ihs/ihs_semantics.h
@@ -301,6 +301,25 @@ typedef struct IhsSemanticsNode {
    * ihs_semantics_find_custom_action. */
   const int32_t* custom_action_ids;
   size_t custom_action_count;
+
+  /*
+   * Numeric position, for a control whose value is a number rather than a
+   * label -- a scrollable's offset, for instance. When has_numeric_value is
+   * false the other three are 0 and mean nothing; the flag exists because a
+   * genuine position of 0 is otherwise indistinguishable from an absent one.
+   *
+   * When present, all three are finite and min <= value <= max, so a consumer
+   * can hand them to a platform accessibility API without revalidating.
+   *
+   * Added in ihs_shared ABI 1.1. These fields lie past the end of a node as an
+   * ABI 1.0 library allocated it, so read them through
+   * ihs_semantics_node_numeric_value() rather than by dereference unless the
+   * running library is known to be at least 1.1. See docs/PLUGIN_ABI.md.
+   */
+  bool has_numeric_value;
+  double numeric_value;
+  double numeric_value_min;
+  double numeric_value_max;
 } IhsSemanticsNode;
 
 /*
@@ -328,6 +347,21 @@ IHS_EXPORT const IhsSemanticsNode* ihs_semantics_snapshot_node_at(
 IHS_EXPORT const IhsSemanticsNode* ihs_semantics_snapshot_node_by_id(
     const IhsSemanticsSnapshot* snapshot,
     int32_t node_id);
+
+/*
+ * Reads a node's numeric position. Returns true and fills the outputs when the
+ * node carries one, false otherwise, leaving the outputs untouched. Any output
+ * pointer may be null to skip that value.
+ *
+ * This is the compatibility-safe way to reach the fields added in ABI 1.1. A
+ * consumer built against this header but running against an ABI 1.0 library
+ * fails to resolve this symbol at load, rather than silently reading past the
+ * end of a node that library allocated.
+ */
+IHS_EXPORT bool ihs_semantics_node_numeric_value(const IhsSemanticsNode* node,
+                                                 double* out_value,
+                                                 double* out_min,
+                                                 double* out_max);
 
 /* Custom action declaration by id, or null when never declared. */
 IHS_EXPORT const IhsSemanticsCustomAction* ihs_semantics_find_custom_action(

--- a/shared/include/ihs/ihs_semantics_host.h
+++ b/shared/include/ihs/ihs_semantics_host.h
@@ -151,6 +151,15 @@ typedef struct IhsSemanticsPublishNode {
 
   const int32_t* custom_action_ids;
   size_t custom_action_count;
+
+  /* Numeric position; see IhsSemanticsNode for the contract consumers are
+   * promised. The hub does not sanitize these: publish has_numeric_value only
+   * with finite values satisfying min <= value <= max, since a consumer is
+   * told it may pass them straight to a platform accessibility API. */
+  bool has_numeric_value;
+  double numeric_value;
+  double numeric_value_min;
+  double numeric_value_max;
 } IhsSemanticsPublishNode;
 
 /* A custom action declaration. Strings may be NULL and become "". */

--- a/shared/include/ihs/ihs_version.h
+++ b/shared/include/ihs/ihs_version.h
@@ -29,7 +29,7 @@
  * ihs_get_api().
  */
 #define IHS_SHARED_ABI_MAJOR 1u
-#define IHS_SHARED_ABI_MINOR 0u
+#define IHS_SHARED_ABI_MINOR 1u
 #define IHS_SHARED_ABI_VERSION \
   ((IHS_SHARED_ABI_MAJOR << 16) | IHS_SHARED_ABI_MINOR)
 

--- a/shared/src/semantics.cc
+++ b/shared/src/semantics.cc
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <cerrno>
+#include <cmath>
 #include <cstring>
 #include <memory>
 #include <mutex>
@@ -224,6 +225,19 @@ Snapshot* BuildSnapshot(const IhsSemanticsPublishInfo* info,
     out.a11y_focus_blocked = in.a11y_focus_blocked;
     out.actions = in.actions;
 
+    // Consumers are promised finite, ordered bounds, so a publisher that got
+    // it wrong drops to "no numeric value" rather than propagating a NaN or an
+    // inverted range into a platform accessibility API.
+    out.has_numeric_value = in.has_numeric_value &&
+                            std::isfinite(in.numeric_value) &&
+                            std::isfinite(in.numeric_value_min) &&
+                            std::isfinite(in.numeric_value_max) &&
+                            in.numeric_value_min <= in.numeric_value &&
+                            in.numeric_value <= in.numeric_value_max;
+    out.numeric_value = out.has_numeric_value ? in.numeric_value : 0.0;
+    out.numeric_value_min = out.has_numeric_value ? in.numeric_value_min : 0.0;
+    out.numeric_value_max = out.has_numeric_value ? in.numeric_value_max : 0.0;
+
     const size_t child_begin = snapshot->child_pool.size();
     if (in.child_ids != nullptr) {
       for (size_t c = 0; c < in.child_count; c++) {
@@ -312,6 +326,25 @@ const IhsSemanticsNode* ihs_semantics_snapshot_node_by_id(
   const auto* s = reinterpret_cast<const Snapshot*>(snapshot);
   const auto it = s->id_to_index.find(node_id);
   return it != s->id_to_index.end() ? &s->nodes[it->second] : nullptr;
+}
+
+bool ihs_semantics_node_numeric_value(const IhsSemanticsNode* node,
+                                      double* out_value,
+                                      double* out_min,
+                                      double* out_max) {
+  if (node == nullptr || !node->has_numeric_value) {
+    return false;
+  }
+  if (out_value != nullptr) {
+    *out_value = node->numeric_value;
+  }
+  if (out_min != nullptr) {
+    *out_min = node->numeric_value_min;
+  }
+  if (out_max != nullptr) {
+    *out_max = node->numeric_value_max;
+  }
+  return true;
 }
 
 const IhsSemanticsCustomAction* ihs_semantics_find_custom_action(

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -57,6 +57,12 @@ if (BUILD_ACCESSIBILITY)
             accessibility/accessibility_tree.cc
             accessibility/semantics_translator.cc
             accessibility/semantics_publisher.cc)
+    # The AccessKit bridge is a hub consumer; it only exists when the bindings
+    # are present, which BUILD_ACCESSKIT arranges (see cmake/options.cmake).
+    if (BUILD_ACCESSKIT)
+        target_sources(${PROJECT_NAME} PRIVATE
+                accessibility/accesskit_consumer.cc)
+    endif ()
 endif ()
 
 # Wayland-specific TUs:

--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -85,6 +85,12 @@ void AccessibilityNode::Update(const FlutterSemanticsNode2& fl_node) {
   // Parent-local bounds are only meaningful alongside the node-to-parent
   // transform, so retain it here rather than composing at read time.
   m_transform = fl_node.transform;
+  // Scroll geometry. These predate the oldest engine this shell deploys
+  // against, so unlike `identifier` and `flags2` they need no struct_size
+  // gate -- they sit well ahead of the fields that were appended later.
+  m_scroll_position = fl_node.scroll_position;
+  m_scroll_extent_min = fl_node.scroll_extent_min;
+  m_scroll_extent_max = fl_node.scroll_extent_max;
   m_flags = fl_node.flags__deprecated__;
   m_actions = fl_node.actions;
 

--- a/shell/accessibility/accessibility_tree.cc
+++ b/shell/accessibility/accessibility_tree.cc
@@ -204,9 +204,6 @@ void AccessibilityTree::HandleFlutterUpdate(
     } else {
       DumpTree(target.c_str());
     }
-#if ENABLE_ACCESSKIT
-    Init_AccessKit();
-#endif
   }
 
   // Drop any node no longer reachable from the root: a subtree Flutter
@@ -393,84 +390,3 @@ void AccessibilityTree::DumpTree(const char* target_file) const {
     ihs::log::error("Failed to open {} for writing", target_file);
   }
 }
-
-#if ENABLE_ACCESSKIT
-accesskit_tree_update* build_tree_update_with_focus_update(void* userdata) {
-  const auto* tree = static_cast<AccessibilityTree*>(userdata);
-  accesskit_tree_update* update =
-      accesskit_tree_update_with_focus(tree->GetFocusedNode());
-  return update;
-}
-
-accesskit_tree_update* activation_handler_cbk(void* userdata) {
-  auto* tree = static_cast<AccessibilityTree*>(userdata);
-
-  accesskit_tree_update* result =
-      accesskit_tree_update_with_capacity_and_focus(tree->NumberOfNodes(), 0);
-  accesskit_tree* ak_tree = accesskit_tree_new(0);
-  accesskit_tree_update_set_tree(result, ak_tree);
-
-  for (auto node_idx = 0; node_idx < tree->NumberOfNodes(); node_idx++) {
-    const AccessibilityNode* accessibility_node = tree->GetNodeByIdx(node_idx);
-    accesskit_node* ak_node =
-        accesskit_node_new((accesskit_role)accessibility_node->GetRole());
-    for (uint32_t i = 0; i < accessibility_node->NumberOfChildren(); i++) {
-      accesskit_node_push_child(ak_node, accessibility_node->GetChild(i));
-    }
-    accesskit_node_set_label(ak_node, accessibility_node->GetLabel());
-    accesskit_node_set_description(ak_node, accessibility_node->GetHint());
-    accesskit_node_set_value(ak_node, accessibility_node->GetValue());
-
-    accesskit_rect bounds = {accessibility_node->GetBounds().left,
-                             accessibility_node->GetBounds().top,
-                             accessibility_node->GetBounds().right,
-                             accessibility_node->GetBounds().bottom};
-    accesskit_node_set_bounds(ak_node, bounds);
-
-    if (accessibility_node->GetFlags() & kFlutterSemanticsFlagIsFocusable) {
-      accesskit_node_add_action(ak_node, ACCESSKIT_ACTION_FOCUS);
-    }
-
-    if (accessibility_node->GetFlags() &
-        (kFlutterSemanticsFlagHasCheckedState |
-         kFlutterSemanticsFlagHasToggledState)) {
-      accesskit_node_add_action(ak_node, ACCESSKIT_ACTION_CLICK);
-    }
-    // Todo: Handle more flags
-
-    accesskit_tree_update_push_node(result, accessibility_node->GetId(),
-                                    ak_node);
-  }
-
-  tree->AccessKit_SetWindowFocus(true);
-
-  return result;
-}
-
-void action_handler_cbk(accesskit_action_request* /* request */,
-                        void* /* userdata */) {
-  ihs::log::debug("accesskit_wrapper: action_handler++");
-}
-
-void deactivation_handler_cbk(void* /* userdata */) {
-  ihs::log::debug("accesskit_wrapper: deactivation_handler++");
-}
-
-void AccessibilityTree::Init_AccessKit() {
-  adapter = accesskit_unix_adapter_new(activation_handler_cbk, this,
-                                       action_handler_cbk, this,
-                                       deactivation_handler_cbk, this);
-  assert(adapter != nullptr);
-}
-
-void AccessibilityTree::AccessKit_SetWindowFocus(bool focused) {
-  accesskit_unix_adapter_update_window_focus_state(adapter, focused);
-}
-
-void AccessibilityTree::AccessKit_SetFocusedNode(
-    accesskit_node_id focused_node) {
-  SetFocusedNode(focused_node);
-  accesskit_unix_adapter_update_if_active(
-      adapter, build_tree_update_with_focus_update, this);
-}
-#endif

--- a/shell/accessibility/accessibility_tree.h
+++ b/shell/accessibility/accessibility_tree.h
@@ -23,10 +23,6 @@
 #include <unordered_map>
 #include <vector>
 
-#if ENABLE_ACCESSKIT
-#include <accesskit.h>
-#endif
-
 #include <shell/platform/embedder/embedder.h>
 
 #include "semantics_translator.h"
@@ -253,17 +249,6 @@ class AccessibilityTree {
     }
   }
 
-#if ENABLE_ACCESSKIT
-  // Initializes AccessKit support.
-  void Init_AccessKit();
-
-  // Sets the window focus state for AccessKit.
-  void AccessKit_SetWindowFocus(bool focused);
-
-  // Sets the focused node for AccessKit.
-  void AccessKit_SetFocusedNode(accesskit_node_id focused_node);
-#endif
-
  private:
   // Drops nodes no longer reachable from the root (id 0), keeping `nodes` and
   // `node_index` consistent after a subtree is detached in an update.
@@ -285,10 +270,6 @@ class AccessibilityTree {
   // application declares, not by tree size or update count.
   std::unordered_map<int32_t, AccessibilityCustomAction> custom_actions;
   int32_t focused_node;  // ID of the currently focused node.
-
-#if ENABLE_ACCESSKIT
-  accesskit_unix_adapter* adapter{};  // AccessKit adapter for Unix systems.
-#endif
 };
 
 #endif  // SHELL_ACCESSIBILITY_ACCESSIBILITY_TREE_H_

--- a/shell/accessibility/accessibility_tree.h
+++ b/shell/accessibility/accessibility_tree.h
@@ -110,6 +110,19 @@ class AccessibilityNode {
     return m_transform;
   };
 
+  // Returns the scroll offset of a scrollable node, and the range that offset
+  // moves within. Only meaningful when the node declares a scroll action;
+  // Flutter leaves all three at zero otherwise. An unbounded scrollable (an
+  // infinite list, say) reports an infinite extent, so check for a finite
+  // range before handing these to anything that cannot express one.
+  [[nodiscard]] double GetScrollPosition() const { return m_scroll_position; };
+  [[nodiscard]] double GetScrollExtentMin() const {
+    return m_scroll_extent_min;
+  };
+  [[nodiscard]] double GetScrollExtentMax() const {
+    return m_scroll_extent_max;
+  };
+
   // Returns the flags associated with the node.
   [[nodiscard]] FlutterSemanticsFlag GetFlags() const { return m_flags; };
 
@@ -163,6 +176,9 @@ class AccessibilityNode {
   std::string m_identifier;  // App-assigned stable ID (owned copy); may be "".
   FlutterRect m_bounds{};    // Bounds of the node.
   FlutterTransformation m_transform{};  // Node-to-parent transform.
+  double m_scroll_position = 0.0;       // Scroll offset; see the getter.
+  double m_scroll_extent_min = 0.0;     // Lower bound of the scroll range.
+  double m_scroll_extent_max = 0.0;     // Upper bound; may be infinite.
   FlutterSemanticsFlag m_flags =
       static_cast<FlutterSemanticsFlag>(0);  // Flags associated with the node.
   FlutterSemanticsAction m_actions =

--- a/shell/accessibility/accesskit_consumer.cc
+++ b/shell/accessibility/accesskit_consumer.cc
@@ -172,6 +172,20 @@ accesskit_node* BuildNode(const IhsSemanticsNode* node,
   accesskit_node_set_description(out, node->hint);
   accesskit_node_set_value(out, node->value);
 
+  // A numeric value is what makes AccessKit expose the AT-SPI Value interface
+  // for this node, which is how a screen reader reports a scroll position
+  // rather than just naming the control. The hub guarantees a finite, ordered
+  // range, so these go straight across.
+  double numeric = 0.0;
+  double numeric_min = 0.0;
+  double numeric_max = 0.0;
+  if (ihs_semantics_node_numeric_value(node, &numeric, &numeric_min,
+                                       &numeric_max)) {
+    accesskit_node_set_numeric_value(out, numeric);
+    accesskit_node_set_min_numeric_value(out, numeric_min);
+    accesskit_node_set_max_numeric_value(out, numeric_max);
+  }
+
   const accesskit_rect bounds = {node->rect.left, node->rect.top,
                                  node->rect.right, node->rect.bottom};
   accesskit_node_set_bounds(out, bounds);

--- a/shell/accessibility/accesskit_consumer.cc
+++ b/shell/accessibility/accesskit_consumer.cc
@@ -342,6 +342,13 @@ AccessKitConsumer::AccessKitConsumer() {
     return;
   }
 
+  // Mark the window focused. The tree is reachable either way, but without
+  // this the root frame is published without the active and focused states,
+  // and that is what a screen reader keys on to decide which window it should
+  // be reading. The shell owns a single fullscreen surface, so it holds focus
+  // whenever it is up; revisit if the shell ever grows real focus tracking.
+  accesskit_unix_adapter_update_window_focus_state(g_adapter, true);
+
   running_ = true;
   poll_thread_ = std::thread(&AccessKitConsumer::PollLoop, this);
   ihs::log::info("accesskit: registered as a semantics consumer");

--- a/shell/accessibility/accesskit_consumer.cc
+++ b/shell/accessibility/accesskit_consumer.cc
@@ -1,0 +1,449 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "accesskit_consumer.h"
+
+#include <accesskit.h>
+#include <poll.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+
+#include "ihs/ihs_semantics.h"
+
+#include "logging/logging.h"
+
+namespace accessibility {
+
+namespace {
+
+// The adapter is process-global because AccessKit's callbacks carry only a
+// userdata pointer and the unix adapter owns its own thread; there is exactly
+// one screen-reader connection per process regardless.
+accesskit_unix_adapter* g_adapter = nullptr;
+
+}  // namespace
+
+accesskit_role ToAccessKitRole(const IhsSemanticsRole role) {
+  switch (role) {
+    case IHS_SEMANTICS_ROLE_WINDOW:
+      return ACCESSKIT_ROLE_WINDOW;
+    case IHS_SEMANTICS_ROLE_BUTTON:
+      return ACCESSKIT_ROLE_BUTTON;
+    case IHS_SEMANTICS_ROLE_TEXT_INPUT:
+      return ACCESSKIT_ROLE_TEXT_INPUT;
+    case IHS_SEMANTICS_ROLE_MULTILINE_TEXT_INPUT:
+      return ACCESSKIT_ROLE_MULTILINE_TEXT_INPUT;
+    case IHS_SEMANTICS_ROLE_PASSWORD_INPUT:
+      return ACCESSKIT_ROLE_PASSWORD_INPUT;
+    case IHS_SEMANTICS_ROLE_SLIDER:
+      return ACCESSKIT_ROLE_SLIDER;
+    case IHS_SEMANTICS_ROLE_SWITCH:
+      return ACCESSKIT_ROLE_SWITCH;
+    case IHS_SEMANTICS_ROLE_CHECK_BOX:
+      return ACCESSKIT_ROLE_CHECK_BOX;
+    case IHS_SEMANTICS_ROLE_RADIO_BUTTON:
+      return ACCESSKIT_ROLE_RADIO_BUTTON;
+    case IHS_SEMANTICS_ROLE_LINK:
+      return ACCESSKIT_ROLE_LINK;
+    case IHS_SEMANTICS_ROLE_IMAGE:
+      return ACCESSKIT_ROLE_IMAGE;
+    case IHS_SEMANTICS_ROLE_HEADING:
+      return ACCESSKIT_ROLE_HEADING;
+    case IHS_SEMANTICS_ROLE_SCROLL_VIEW:
+      return ACCESSKIT_ROLE_SCROLL_VIEW;
+    case IHS_SEMANTICS_ROLE_PANE:
+      return ACCESSKIT_ROLE_PANE;
+    case IHS_SEMANTICS_ROLE_LABEL:
+      return ACCESSKIT_ROLE_LABEL;
+    case IHS_SEMANTICS_ROLE_GENERIC_CONTAINER:
+      return ACCESSKIT_ROLE_GENERIC_CONTAINER;
+    case IHS_SEMANTICS_ROLE_UNKNOWN:
+      break;
+  }
+  return ACCESSKIT_ROLE_UNKNOWN;
+}
+
+// Maps an AccessKit action onto the hub's. Returns 0 for anything with no
+// equivalent, which the caller reports rather than dispatching a guess.
+uint64_t ToIhsAction(const accesskit_action action) {
+  switch (action) {
+    case ACCESSKIT_ACTION_CLICK:
+      return IHS_SEMANTICS_ACTION_TAP;
+    case ACCESSKIT_ACTION_FOCUS:
+      return IHS_SEMANTICS_ACTION_DID_GAIN_A11Y_FOCUS;
+    case ACCESSKIT_ACTION_BLUR:
+      return IHS_SEMANTICS_ACTION_DID_LOSE_A11Y_FOCUS;
+    case ACCESSKIT_ACTION_INCREMENT:
+      return IHS_SEMANTICS_ACTION_INCREASE;
+    case ACCESSKIT_ACTION_DECREMENT:
+      return IHS_SEMANTICS_ACTION_DECREASE;
+    case ACCESSKIT_ACTION_SCROLL_INTO_VIEW:
+      return IHS_SEMANTICS_ACTION_SHOW_ON_SCREEN;
+    case ACCESSKIT_ACTION_SCROLL_UP:
+      return IHS_SEMANTICS_ACTION_SCROLL_UP;
+    case ACCESSKIT_ACTION_SCROLL_DOWN:
+      return IHS_SEMANTICS_ACTION_SCROLL_DOWN;
+    case ACCESSKIT_ACTION_SCROLL_LEFT:
+      return IHS_SEMANTICS_ACTION_SCROLL_LEFT;
+    case ACCESSKIT_ACTION_SCROLL_RIGHT:
+      return IHS_SEMANTICS_ACTION_SCROLL_RIGHT;
+    case ACCESSKIT_ACTION_EXPAND:
+      return IHS_SEMANTICS_ACTION_EXPAND;
+    case ACCESSKIT_ACTION_COLLAPSE:
+      return IHS_SEMANTICS_ACTION_COLLAPSE;
+    default:
+      return 0;
+  }
+}
+
+namespace {
+
+// Advertises to the screen reader what the node actually accepts, so it does
+// not offer a gesture the framework will silently drop.
+void AddActions(accesskit_node* node, const uint64_t actions) {
+  if ((actions & IHS_SEMANTICS_ACTION_TAP) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_CLICK);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_INCREASE) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_INCREMENT);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_DECREASE) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_DECREMENT);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_SHOW_ON_SCREEN) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_SCROLL_INTO_VIEW);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_SCROLL_UP) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_SCROLL_UP);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_SCROLL_DOWN) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_SCROLL_DOWN);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_SCROLL_LEFT) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_SCROLL_LEFT);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_SCROLL_RIGHT) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_SCROLL_RIGHT);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_EXPAND) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_EXPAND);
+  }
+  if ((actions & IHS_SEMANTICS_ACTION_COLLAPSE) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_COLLAPSE);
+  }
+  // Focus is offered whenever the node can hold the accessibility cursor,
+  // which is what the screen reader uses to walk the tree.
+  accesskit_node_add_action(node, ACCESSKIT_ACTION_FOCUS);
+}
+
+// Translates one snapshot node. The tristates are carried across rather than
+// flattened: a screen reader announces "unchecked" and "not checkable" very
+// differently, and collapsing them would make every container sound like an
+// unchecked checkbox.
+accesskit_node* BuildNode(const IhsSemanticsNode* node,
+                          const IhsSemanticsSnapshot* snapshot) {
+  accesskit_node* out = accesskit_node_new(ToAccessKitRole(node->role));
+
+  for (size_t i = 0; i < node->child_count; i++) {
+    const IhsSemanticsNode* child =
+        ihs_semantics_snapshot_node_at(snapshot, node->child_indices[i]);
+    if (child != nullptr) {
+      accesskit_node_push_child(out, static_cast<accesskit_node_id>(child->id));
+    }
+  }
+
+  accesskit_node_set_label(out, node->label);
+  accesskit_node_set_description(out, node->hint);
+  accesskit_node_set_value(out, node->value);
+
+  const accesskit_rect bounds = {node->rect.left, node->rect.top,
+                                 node->rect.right, node->rect.bottom};
+  accesskit_node_set_bounds(out, bounds);
+
+  switch (node->checked) {
+    case IHS_SEMANTICS_CHECK_TRUE:
+      accesskit_node_set_toggled(out, ACCESSKIT_TOGGLED_TRUE);
+      break;
+    case IHS_SEMANTICS_CHECK_FALSE:
+      accesskit_node_set_toggled(out, ACCESSKIT_TOGGLED_FALSE);
+      break;
+    case IHS_SEMANTICS_CHECK_MIXED:
+      accesskit_node_set_toggled(out, ACCESSKIT_TOGGLED_MIXED);
+      break;
+    case IHS_SEMANTICS_CHECK_NONE:
+      break;  // not a checkable node; say nothing rather than "unchecked"
+  }
+  if (node->toggled == IHS_SEMANTICS_TRISTATE_TRUE) {
+    accesskit_node_set_toggled(out, ACCESSKIT_TOGGLED_TRUE);
+  } else if (node->toggled == IHS_SEMANTICS_TRISTATE_FALSE) {
+    accesskit_node_set_toggled(out, ACCESSKIT_TOGGLED_FALSE);
+  }
+
+  // Only assert disabled when the node actually carries an enabled state;
+  // IHS_SEMANTICS_TRISTATE_NONE means the property does not apply.
+  if (node->enabled == IHS_SEMANTICS_TRISTATE_FALSE) {
+    accesskit_node_set_disabled(out);
+  }
+  if (node->selected == IHS_SEMANTICS_TRISTATE_TRUE) {
+    accesskit_node_set_selected(out, true);
+  } else if (node->selected == IHS_SEMANTICS_TRISTATE_FALSE) {
+    accesskit_node_set_selected(out, false);
+  }
+  if (node->expanded == IHS_SEMANTICS_TRISTATE_TRUE) {
+    accesskit_node_set_expanded(out, true);
+  } else if (node->expanded == IHS_SEMANTICS_TRISTATE_FALSE) {
+    accesskit_node_set_expanded(out, false);
+  }
+  if (node->required == IHS_SEMANTICS_TRISTATE_TRUE) {
+    accesskit_node_set_required(out);
+  }
+  if (node->hidden) {
+    accesskit_node_set_hidden(out);
+  }
+  if (node->read_only) {
+    accesskit_node_set_read_only(out);
+  }
+
+  AddActions(out, node->actions);
+  return out;
+}
+
+// Builds a full tree update from a snapshot. The caller owns the result.
+accesskit_tree_update* BuildTreeUpdate(const IhsSemanticsSnapshot* snapshot) {
+  const size_t count = ihs_semantics_snapshot_node_count(snapshot);
+  if (count == 0) {
+    return nullptr;
+  }
+
+  // Focus follows whichever node reports it; the root is the fallback, since
+  // AccessKit requires the focus id to name a node that exists in the update.
+  accesskit_node_id focus = 0;
+  for (size_t i = 0; i < count; i++) {
+    const IhsSemanticsNode* node = ihs_semantics_snapshot_node_at(snapshot, i);
+    if (node != nullptr && node->focused == IHS_SEMANTICS_TRISTATE_TRUE) {
+      focus = static_cast<accesskit_node_id>(node->id);
+      break;
+    }
+  }
+
+  accesskit_tree_update* update =
+      accesskit_tree_update_with_capacity_and_focus(count, focus);
+  accesskit_tree_update_set_tree(update, accesskit_tree_new(0));
+
+  for (size_t i = 0; i < count; i++) {
+    const IhsSemanticsNode* node = ihs_semantics_snapshot_node_at(snapshot, i);
+    if (node == nullptr) {
+      continue;
+    }
+    accesskit_tree_update_push_node(update,
+                                    static_cast<accesskit_node_id>(node->id),
+                                    BuildNode(node, snapshot));
+  }
+  return update;
+}
+
+// AccessKit asks for the whole tree when an assistive technology attaches.
+// This runs on AccessKit's thread, which is safe now only because it reads a
+// snapshot rather than the shell's mutable tree.
+accesskit_tree_update* ActivationHandler(void* /* user_data */) {
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  if (snapshot == nullptr) {
+    // Nothing published yet. Returning null tells AccessKit there is no tree
+    // to show, and the next publish will push one.
+    return nullptr;
+  }
+  accesskit_tree_update* update = BuildTreeUpdate(snapshot);
+  ihs_semantics_release_snapshot(snapshot);
+  return update;
+}
+
+// A screen reader asked for something. Everything the framework can act on
+// goes back through the hub, which serializes onto the platform thread and
+// records the actor.
+void ActionHandler(accesskit_action_request* request, void* user_data) {
+  if (request == nullptr) {
+    return;
+  }
+  auto* consumer = static_cast<IhsSemanticsConsumer*>(user_data);
+  const uint64_t action = ToIhsAction(request->action);
+  if (action == 0) {
+    ihs::log::debug("accesskit: no hub equivalent for action {}",
+                    static_cast<int>(request->action));
+    return;
+  }
+
+  const int status = ihs_semantics_dispatch(
+      consumer, 0, static_cast<int32_t>(request->target_node), action, nullptr,
+      0, nullptr, nullptr);
+  if (status != IHS_SEMANTICS_OK) {
+    // Expected in normal use: a screen reader may offer an action the node
+    // does not implement, and the hub refuses rather than letting it vanish.
+    ihs::log::debug("accesskit: dispatch of action 0x{:x} on node {} -> {}",
+                    action, request->target_node, status);
+  }
+}
+
+void DeactivationHandler(void* /* user_data */) {
+  ihs::log::debug("accesskit: assistive technology detached");
+}
+
+}  // namespace
+
+AccessKitConsumer::AccessKitConsumer() {
+  notify_fd_ = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+  shutdown_fd_ = ::eventfd(0, EFD_CLOEXEC);
+  if (notify_fd_ < 0 || shutdown_fd_ < 0) {
+    ihs::log::error("accesskit: could not create notification fds: {}",
+                    std::strerror(errno));
+    return;
+  }
+
+  IhsSemanticsConsumerDesc desc{};
+  desc.struct_size = sizeof(IhsSemanticsConsumerDesc);
+  desc.name = "accesskit";
+  // The full set, deliberately including the accessibility-focus actions: a
+  // screen reader moving its own cursor is the legitimate case those bits
+  // exist for. The mask is what stops other consumers from doing it.
+  desc.action_allow_mask = IHS_SEMANTICS_ACTION_ALL;
+  desc.notify_fd = notify_fd_;
+
+  if (ihs_semantics_register(&desc, &consumer_) != IHS_SEMANTICS_OK) {
+    ihs::log::error("accesskit: could not register with the semantics hub");
+    return;
+  }
+
+  g_adapter =
+      accesskit_unix_adapter_new(ActivationHandler, nullptr, ActionHandler,
+                                 consumer_, DeactivationHandler, nullptr);
+  if (g_adapter == nullptr) {
+    // No AT-SPI bus, most likely. Not fatal: the rest of the shell is fine
+    // without a screen-reader bridge, so unwind and carry on.
+    ihs::log::warn(
+        "accesskit: adapter unavailable; continuing without a screen-reader "
+        "bridge");
+    ihs_semantics_unregister(consumer_);
+    consumer_ = nullptr;
+    return;
+  }
+
+  running_ = true;
+  poll_thread_ = std::thread(&AccessKitConsumer::PollLoop, this);
+  ihs::log::info("accesskit: registered as a semantics consumer");
+}
+
+AccessKitConsumer::~AccessKitConsumer() {
+  if (running_) {
+    running_ = false;
+    const uint64_t one = 1;
+    ssize_t written;
+    do {
+      written = ::write(shutdown_fd_, &one, sizeof(one));
+    } while (written < 0 && errno == EINTR);
+    if (poll_thread_.joinable()) {
+      poll_thread_.join();
+    }
+  }
+
+  // Unregister before dropping the adapter: unregistering drains any dispatch
+  // still in flight, so the action handler cannot be running against an
+  // adapter that is about to go away.
+  if (consumer_ != nullptr) {
+    ihs_semantics_unregister(consumer_);
+    consumer_ = nullptr;
+  }
+  if (g_adapter != nullptr) {
+    accesskit_unix_adapter_free(g_adapter);
+    g_adapter = nullptr;
+  }
+  if (notify_fd_ >= 0) {
+    ::close(notify_fd_);
+  }
+  if (shutdown_fd_ >= 0) {
+    ::close(shutdown_fd_);
+  }
+}
+
+void AccessKitConsumer::PollLoop() {
+  struct pollfd fds[2];
+  fds[0].fd = notify_fd_;
+  fds[0].events = POLLIN;
+  fds[1].fd = shutdown_fd_;
+  fds[1].events = POLLIN;
+
+  while (running_) {
+    fds[0].revents = 0;
+    fds[1].revents = 0;
+    const int ready = ::poll(fds, 2, -1);
+    if (ready < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      ihs::log::error("accesskit: poll failed: {}", std::strerror(errno));
+      return;
+    }
+    if ((fds[1].revents & POLLIN) != 0) {
+      return;  // shutdown
+    }
+    if ((fds[0].revents & POLLIN) == 0) {
+      continue;
+    }
+
+    // Drain the counter. Events are edge-coalesced, so several publications
+    // can collapse into one wake; that is lossless because what follows reads
+    // the newest snapshot rather than replaying each one.
+    uint64_t token = 0;
+    ssize_t got;
+    do {
+      got = ::read(notify_fd_, &token, sizeof(token));
+    } while (got < 0 && errno == EINTR);
+
+    const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+    if (snapshot == nullptr) {
+      continue;
+    }
+    PushSnapshot(snapshot);
+    ihs_semantics_release_snapshot(snapshot);
+  }
+}
+
+void AccessKitConsumer::PushSnapshot(const IhsSemanticsSnapshot* snapshot) {
+  const uint64_t generation = ihs_semantics_snapshot_generation(snapshot);
+  if (generation == last_generation_) {
+    return;  // a wake with nothing newer behind it
+  }
+  last_generation_ = generation;
+
+  accesskit_tree_update* update = BuildTreeUpdate(snapshot);
+  if (update == nullptr) {
+    return;
+  }
+
+  // update_if_active hands ownership of the update to AccessKit and does
+  // nothing when no assistive technology is attached -- in which case it frees
+  // the update itself, so there is no leak on the common path where nobody is
+  // listening.
+  accesskit_unix_adapter_update_if_active(
+      g_adapter,
+      [](void* user_data) -> accesskit_tree_update* {
+        return static_cast<accesskit_tree_update*>(user_data);
+      },
+      update);
+}
+
+}  // namespace accessibility

--- a/shell/accessibility/accesskit_consumer.h
+++ b/shell/accessibility/accesskit_consumer.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_ACCESSIBILITY_ACCESSKIT_CONSUMER_H_
+#define SHELL_ACCESSIBILITY_ACCESSKIT_CONSUMER_H_
+
+#include <accesskit.h>
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+
+#include "ihs/ihs_semantics.h"
+
+namespace accessibility {
+
+// Maps a hub role onto AccessKit's. Exposed for testing: the table is pure
+// translation between two independent enumerations, and a wrong entry makes a
+// screen reader announce the wrong kind of control -- which is the sort of
+// thing nobody notices without an assistive technology attached.
+accesskit_role ToAccessKitRole(IhsSemanticsRole role);
+
+// Maps an AccessKit action onto the hub's. Returns 0 when AccessKit asks for
+// something the framework has no equivalent for, which the caller reports
+// rather than dispatching a guess.
+uint64_t ToIhsAction(accesskit_action action);
+
+// Bridges the semantics hub to a platform screen reader through AccessKit.
+//
+// This is a hub consumer like any other: it registers, waits on the hub's
+// notify fd, and reads published snapshots. It never touches the shell's
+// mutable AccessibilityTree, which is the point -- AccessKit's callbacks run
+// on its own AT-SPI thread, so reading the tree directly raced the platform
+// thread mutating it.
+//
+// Actions travel the other way through ihs_semantics_dispatch. Unlike an
+// automation consumer, this one *does* hold the accessibility-focus actions:
+// moving the screen-reader cursor is exactly its job, and the hub's allow mask
+// is what keeps other consumers from doing the same.
+//
+// Lifetime: construct once when semantics starts and destroy at teardown.
+// Construction registers with the hub and starts the AT-SPI adapter;
+// destruction unregisters, stops the polling thread, and drops the adapter, in
+// that order, so no callback can be in flight afterwards.
+class AccessKitConsumer {
+ public:
+  AccessKitConsumer();
+  ~AccessKitConsumer();
+
+  AccessKitConsumer(const AccessKitConsumer&) = delete;
+  AccessKitConsumer& operator=(const AccessKitConsumer&) = delete;
+
+  // True when the adapter and hub registration both came up. A false return
+  // means the screen-reader bridge is absent, not that semantics is broken:
+  // everything else still works, so the caller logs and carries on.
+  [[nodiscard]] bool IsRunning() const { return running_; }
+
+ private:
+  // Drains the notify fd and pushes the newest snapshot to AccessKit. Runs on
+  // its own thread so a slow AT-SPI round trip cannot delay the platform
+  // thread, which is the reason the hub notifies by fd rather than callback.
+  void PollLoop();
+
+  // Publishes `snapshot` as a full AccessKit tree update.
+  void PushSnapshot(const IhsSemanticsSnapshot* snapshot);
+
+  IhsSemanticsConsumer* consumer_ = nullptr;
+  int notify_fd_ = -1;    // eventfd the hub writes on publish
+  int shutdown_fd_ = -1;  // eventfd the destructor writes to stop the loop
+  std::thread poll_thread_;
+  std::atomic<bool> running_{false};
+  // Last generation pushed, so a wake that coalesced several publications
+  // still results in exactly one update and a redundant wake results in none.
+  uint64_t last_generation_ = 0;
+};
+
+}  // namespace accessibility
+
+#endif  // SHELL_ACCESSIBILITY_ACCESSKIT_CONSUMER_H_

--- a/shell/accessibility/semantics_publisher.cc
+++ b/shell/accessibility/semantics_publisher.cc
@@ -17,6 +17,7 @@
 #include "semantics_publisher.h"
 
 #include <algorithm>
+#include <cmath>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -147,6 +148,44 @@ IhsSemanticsRole ToIhsRole(const Role role) {
       break;
   }
   return IHS_SEMANTICS_ROLE_UNKNOWN;
+}
+
+// Fills in the node's numeric position, or clears it when there is none.
+//
+// Scroll offset is the only numeric value the framework hands us: a slider's
+// position arrives as a label like "22 degrees", with no number behind it, so
+// a slider legitimately has no numeric value here. That is a limitation of the
+// embedder API rather than a gap in the translation.
+//
+// Consumers are promised finite, ordered bounds, so anything that cannot be
+// stated honestly is dropped rather than approximated. An unbounded scrollable
+// reports an infinite extent, which no accessibility API can render as a
+// position, so it publishes no numeric value at all. Overscroll is different:
+// it puts the offset briefly outside its own range, which is transient and
+// real, so clamp it -- a scroll view that dropped out of the value API every
+// time it bounced would be worse than one reading its own limit.
+void SetNumericValue(const AccessibilityNode& node,
+                     const NodeSpec& spec,
+                     IhsSemanticsPublishNode& out) {
+  const bool scrollable = spec.action_scroll_up || spec.action_scroll_down ||
+                          spec.action_scroll_left || spec.action_scroll_right;
+  const double position = node.GetScrollPosition();
+  const double min = node.GetScrollExtentMin();
+  const double max = node.GetScrollExtentMax();
+
+  if (!scrollable || !std::isfinite(position) || !std::isfinite(min) ||
+      !std::isfinite(max) || min > max) {
+    out.has_numeric_value = false;
+    out.numeric_value = 0.0;
+    out.numeric_value_min = 0.0;
+    out.numeric_value_max = 0.0;
+    return;
+  }
+
+  out.has_numeric_value = true;
+  out.numeric_value = std::clamp(position, min, max);
+  out.numeric_value_min = min;
+  out.numeric_value_max = max;
 }
 
 uint64_t ToIhsActions(const NodeSpec& spec) {
@@ -342,6 +381,7 @@ int PublishTree(const AccessibilityTree& tree) {
     out.focusable = spec.focusable;
     out.a11y_focus_blocked = spec.a11y_focus_blocked;
     out.actions = ToIhsActions(spec);
+    SetNumericValue(*node, spec, out);
 
     // Only children that made it into the walk: a child dropped as a cycle or
     // a dangling id must not be referenced from the published tree either.

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -377,6 +377,11 @@ FlutterEngineResult Engine::Run(FlutterDesktopEngineState* state) {
   // counts its consumers and asks for it through this host, so a build with
   // the subsystem compiled in but nobody listening costs the engine nothing.
   InstallSemanticsHost();
+#if ENABLE_ACCESSKIT
+  // Registering is what asks the hub to turn semantics on, so the bridge is
+  // created after the host is installed and not before.
+  m_accesskit = std::make_unique<accessibility::AccessKitConsumer>();
+#endif
 #endif
 
   IHS_TRACE("({}) -Engine::Run", m_index);

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -31,6 +31,9 @@
 #include "logging/logging.h"
 #if BUILD_ACCESSIBILITY
 #include "shell/accessibility/accessibility_tree.h"
+#if ENABLE_ACCESSKIT
+#include "shell/accessibility/accesskit_consumer.h"
+#endif
 #endif
 #include "task_runner.h"
 #include "view/flutter_view.h"
@@ -477,6 +480,13 @@ class Engine {
   // retains a pointer to it via m_args.compositor.
   FlutterCompositor m_compositor{};
   std::string m_clipboard_data;
+
+#if BUILD_ACCESSIBILITY && ENABLE_ACCESSKIT
+  // Bridges published snapshots to a screen reader. Owned here because its
+  // lifetime is the engine's: constructing it registers with the hub, which is
+  // what turns engine semantics on, and destroying it unregisters.
+  std::unique_ptr<accessibility::AccessKitConsumer> m_accesskit;
+#endif
 
   std::shared_ptr<TaskRunner> m_platform_task_runner;
   FlutterTaskRunnerDescription m_platform_task_runner_description{};

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -214,4 +214,8 @@ if (BUILD_ACCESSIBILITY)
     add_subdirectory(semantics_publisher-test)
     # The hub itself is only in ihs_shared when BUILD_ACCESSIBILITY is on.
     add_subdirectory(semantics_hub-test)
+    # Needs the AccessKit bindings, so it follows the source it covers.
+    if (BUILD_ACCESSKIT)
+        add_subdirectory(accesskit_consumer-test)
+    endif ()
 endif ()

--- a/test/unit_test/accesskit_consumer-test/CMakeLists.txt
+++ b/test/unit_test/accesskit_consumer-test/CMakeLists.txt
@@ -1,0 +1,37 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Covers the two translation tables between the semantics hub's vocabulary and
+# AccessKit's. Only buildable when the bindings are present, so it is added
+# under BUILD_ACCESSKIT alongside the source it tests.
+set(TESTCASE_NAME "homescreen_accesskit_consumer_ut_test_driver")
+
+add_executable(${TESTCASE_NAME}
+        test_case_accesskit_consumer.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        homescreen_ut_shell
+        ivi_homescreen::ihs_shared
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
+++ b/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <set>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "ihs/ihs_semantics.h"
+
+#include "accessibility/accesskit_consumer.h"
+
+using accessibility::ToAccessKitRole;
+using accessibility::ToIhsAction;
+
+namespace {
+
+// Every role the hub can publish. Kept as an explicit list rather than a range
+// so that adding a role to the ABI without deciding what a screen reader
+// should call it fails here.
+const std::vector<IhsSemanticsRole>& AllRoles() {
+  static const std::vector<IhsSemanticsRole> kRoles = {
+      IHS_SEMANTICS_ROLE_UNKNOWN,
+      IHS_SEMANTICS_ROLE_WINDOW,
+      IHS_SEMANTICS_ROLE_BUTTON,
+      IHS_SEMANTICS_ROLE_TEXT_INPUT,
+      IHS_SEMANTICS_ROLE_MULTILINE_TEXT_INPUT,
+      IHS_SEMANTICS_ROLE_PASSWORD_INPUT,
+      IHS_SEMANTICS_ROLE_SLIDER,
+      IHS_SEMANTICS_ROLE_SWITCH,
+      IHS_SEMANTICS_ROLE_CHECK_BOX,
+      IHS_SEMANTICS_ROLE_RADIO_BUTTON,
+      IHS_SEMANTICS_ROLE_LINK,
+      IHS_SEMANTICS_ROLE_IMAGE,
+      IHS_SEMANTICS_ROLE_HEADING,
+      IHS_SEMANTICS_ROLE_SCROLL_VIEW,
+      IHS_SEMANTICS_ROLE_PANE,
+      IHS_SEMANTICS_ROLE_LABEL,
+      IHS_SEMANTICS_ROLE_GENERIC_CONTAINER,
+  };
+  return kRoles;
+}
+
+}  // namespace
+
+// Only the unknown role may land on ACCESSKIT_ROLE_UNKNOWN. A real role
+// collapsing to unknown is how a control ends up announced as nothing in
+// particular, which is invisible without an assistive technology attached.
+TEST(AccessKitConsumer, EveryKnownRoleMapsToSomethingSpecific) {
+  for (const IhsSemanticsRole role : AllRoles()) {
+    const accesskit_role mapped = ToAccessKitRole(role);
+    if (role == IHS_SEMANTICS_ROLE_UNKNOWN) {
+      EXPECT_EQ(mapped, ACCESSKIT_ROLE_UNKNOWN);
+    } else {
+      EXPECT_NE(mapped, ACCESSKIT_ROLE_UNKNOWN)
+          << "hub role " << static_cast<int>(role)
+          << " has no AccessKit equivalent";
+    }
+  }
+}
+
+// Two distinct roles mapping to the same AccessKit role would make a screen
+// reader unable to tell the controls apart.
+TEST(AccessKitConsumer, DistinctRolesMapDistinctly) {
+  std::set<int> seen;
+  for (const IhsSemanticsRole role : AllRoles()) {
+    if (role == IHS_SEMANTICS_ROLE_UNKNOWN) {
+      continue;
+    }
+    const int mapped = static_cast<int>(ToAccessKitRole(role));
+    EXPECT_TRUE(seen.insert(mapped).second)
+        << "AccessKit role " << mapped << " is claimed by two hub roles";
+  }
+}
+
+TEST(AccessKitConsumer, RolesMapToTheExpectedControls) {
+  EXPECT_EQ(ToAccessKitRole(IHS_SEMANTICS_ROLE_BUTTON), ACCESSKIT_ROLE_BUTTON);
+  EXPECT_EQ(ToAccessKitRole(IHS_SEMANTICS_ROLE_SLIDER), ACCESSKIT_ROLE_SLIDER);
+  EXPECT_EQ(ToAccessKitRole(IHS_SEMANTICS_ROLE_CHECK_BOX),
+            ACCESSKIT_ROLE_CHECK_BOX);
+  // A password field must not be announced as an ordinary text input: the
+  // distinction is what makes a screen reader suppress the characters.
+  EXPECT_EQ(ToAccessKitRole(IHS_SEMANTICS_ROLE_PASSWORD_INPUT),
+            ACCESSKIT_ROLE_PASSWORD_INPUT);
+  EXPECT_NE(ToAccessKitRole(IHS_SEMANTICS_ROLE_PASSWORD_INPUT),
+            ToAccessKitRole(IHS_SEMANTICS_ROLE_TEXT_INPUT));
+}
+
+// The actions a screen reader actually issues have to reach the framework.
+TEST(AccessKitConsumer, ScreenReaderActionsMapOntoHubActions) {
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_CLICK), IHS_SEMANTICS_ACTION_TAP);
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_INCREMENT),
+            IHS_SEMANTICS_ACTION_INCREASE);
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_DECREMENT),
+            IHS_SEMANTICS_ACTION_DECREASE);
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_SCROLL_INTO_VIEW),
+            IHS_SEMANTICS_ACTION_SHOW_ON_SCREEN);
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_EXPAND), IHS_SEMANTICS_ACTION_EXPAND);
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_COLLAPSE),
+            IHS_SEMANTICS_ACTION_COLLAPSE);
+}
+
+// Focus and blur are the accessibility cursor moving. They are the reason this
+// consumer registers with the full allow mask, so they must map -- if they
+// came back as 0 the cursor would never move and the tree would be unwalkable.
+TEST(AccessKitConsumer, AccessibilityFocusActionsMap) {
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_FOCUS),
+            IHS_SEMANTICS_ACTION_DID_GAIN_A11Y_FOCUS);
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_BLUR),
+            IHS_SEMANTICS_ACTION_DID_LOSE_A11Y_FOCUS);
+  // And they are inside the mask this consumer asks for.
+  EXPECT_NE(IHS_SEMANTICS_ACTION_ALL & IHS_SEMANTICS_ACTION_DID_GAIN_A11Y_FOCUS,
+            0u);
+}
+
+// An action AccessKit offers that the framework has no equivalent for reports
+// 0, so the caller can say so rather than dispatching an arbitrary bit.
+TEST(AccessKitConsumer, UnmappedActionsReportZero) {
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_HIDE_TOOLTIP), 0u);
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_REPLACE_SELECTED_TEXT), 0u);
+}
+
+// Every action this consumer maps must be one a hub consumer is allowed to
+// hold, or the dispatch would be refused at the funnel every time.
+TEST(AccessKitConsumer, EveryMappedActionIsWithinTheAllowMask) {
+  const std::vector<accesskit_action> kActions = {
+      ACCESSKIT_ACTION_CLICK,       ACCESSKIT_ACTION_FOCUS,
+      ACCESSKIT_ACTION_BLUR,        ACCESSKIT_ACTION_INCREMENT,
+      ACCESSKIT_ACTION_DECREMENT,   ACCESSKIT_ACTION_SCROLL_INTO_VIEW,
+      ACCESSKIT_ACTION_SCROLL_UP,   ACCESSKIT_ACTION_SCROLL_DOWN,
+      ACCESSKIT_ACTION_SCROLL_LEFT, ACCESSKIT_ACTION_SCROLL_RIGHT,
+      ACCESSKIT_ACTION_EXPAND,      ACCESSKIT_ACTION_COLLAPSE,
+  };
+  for (const accesskit_action action : kActions) {
+    const uint64_t mapped = ToIhsAction(action);
+    ASSERT_NE(mapped, 0u) << "action " << static_cast<int>(action)
+                          << " lost its mapping";
+    EXPECT_EQ(mapped & ~IHS_SEMANTICS_ACTION_ALL, 0u)
+        << "mapped action 0x" << std::hex << mapped
+        << " is not a bit this ABI defines";
+  }
+}

--- a/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
+++ b/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <thread>
 #include <vector>
@@ -584,4 +585,102 @@ TEST_F(SemanticsHubTest, ConcurrentAcquireDuringPublish) {
   for (auto& reader : readers) {
     reader.join();
   }
+}
+
+// The numeric value a publisher supplies reaches consumers intact, and the
+// accessor is the read path a plugin built against a newer header uses.
+TEST_F(SemanticsHubTest, NumericValueReachesConsumers) {
+  TreeBuilder tree;
+  IhsSemanticsPublishNode& node = tree.Add(0, "Media list");
+  node.has_numeric_value = true;
+  node.numeric_value = 120.0;
+  node.numeric_value_min = 0.0;
+  node.numeric_value_max = 400.0;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  ASSERT_NE(snapshot, nullptr);
+  const IhsSemanticsNode* out = ihs_semantics_snapshot_node_at(snapshot, 0);
+  ASSERT_NE(out, nullptr);
+
+  double value = -1.0;
+  double min = -1.0;
+  double max = -1.0;
+  EXPECT_TRUE(ihs_semantics_node_numeric_value(out, &value, &min, &max));
+  EXPECT_DOUBLE_EQ(value, 120.0);
+  EXPECT_DOUBLE_EQ(min, 0.0);
+  EXPECT_DOUBLE_EQ(max, 400.0);
+  ihs_semantics_release_snapshot(snapshot);
+}
+
+// Consumers are told the bounds are finite and ordered and may pass them
+// straight to a platform accessibility API, so the hub refuses a range it
+// cannot stand behind rather than forwarding it and trusting every consumer to
+// re-check. A NaN or an inverted range reaching AT-SPI is a crash in someone
+// else's process.
+TEST_F(SemanticsHubTest, ImplausibleNumericValueIsDropped) {
+  const double nan_value = std::numeric_limits<double>::quiet_NaN();
+  const double infinity = std::numeric_limits<double>::infinity();
+
+  struct Case {
+    const char* name;
+    double value;
+    double min;
+    double max;
+  };
+  const Case cases[] = {
+      {"inverted range", 5.0, 10.0, 0.0},
+      {"value below min", -1.0, 0.0, 10.0},
+      {"value above max", 11.0, 0.0, 10.0},
+      {"nan value", nan_value, 0.0, 10.0},
+      {"nan bound", 5.0, nan_value, 10.0},
+      {"infinite bound", 5.0, 0.0, infinity},
+  };
+
+  for (const Case& c : cases) {
+    TreeBuilder tree;
+    IhsSemanticsPublishNode& node = tree.Add(0, c.name);
+    node.has_numeric_value = true;
+    node.numeric_value = c.value;
+    node.numeric_value_min = c.min;
+    node.numeric_value_max = c.max;
+    ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK) << c.name;
+
+    const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+    ASSERT_NE(snapshot, nullptr) << c.name;
+    const IhsSemanticsNode* out = ihs_semantics_snapshot_node_at(snapshot, 0);
+    ASSERT_NE(out, nullptr) << c.name;
+    EXPECT_FALSE(out->has_numeric_value) << c.name;
+    EXPECT_DOUBLE_EQ(out->numeric_value, 0.0) << c.name;
+    ihs_semantics_release_snapshot(snapshot);
+  }
+}
+
+// The accessor leaves the caller's variables alone when there is no value, so
+// a caller that ignores the return does not read an uninitialized position as
+// if it were real.
+TEST_F(SemanticsHubTest, NumericValueAccessorLeavesOutputsAloneWhenAbsent) {
+  TreeBuilder tree;
+  tree.Add(0, "plain");
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  ASSERT_NE(snapshot, nullptr);
+  const IhsSemanticsNode* out = ihs_semantics_snapshot_node_at(snapshot, 0);
+  ASSERT_NE(out, nullptr);
+
+  double value = 42.0;
+  double min = 43.0;
+  double max = 44.0;
+  EXPECT_FALSE(ihs_semantics_node_numeric_value(out, &value, &min, &max));
+  EXPECT_DOUBLE_EQ(value, 42.0);
+  EXPECT_DOUBLE_EQ(min, 43.0);
+  EXPECT_DOUBLE_EQ(max, 44.0);
+
+  // Null outputs are legal for a caller that only wants the presence test,
+  // and a null node is not a crash.
+  EXPECT_FALSE(
+      ihs_semantics_node_numeric_value(out, nullptr, nullptr, nullptr));
+  EXPECT_FALSE(ihs_semantics_node_numeric_value(nullptr, &value, &min, &max));
+  ihs_semantics_release_snapshot(snapshot);
 }

--- a/test/unit_test/semantics_publisher-test/test_case_semantics_publisher.cc
+++ b/test/unit_test/semantics_publisher-test/test_case_semantics_publisher.cc
@@ -15,6 +15,7 @@
  */
 
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -310,6 +311,108 @@ TEST_F(SemanticsPublisherTest, ObscuredIsReportedForPasswordFields) {
   ASSERT_NE(out, nullptr);
   EXPECT_EQ(out->role, IHS_SEMANTICS_ROLE_PASSWORD_INPUT);
   EXPECT_TRUE(out->obscured);
+  ihs_semantics_release_snapshot(snapshot);
+}
+
+// A scrollable's offset is the one numeric value the embedder API gives us,
+// and it is what lets a screen reader report a position rather than only
+// naming the control.
+TEST_F(SemanticsPublisherTest, ScrollableCarriesANumericValue) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {1}, "root");
+  NodeBuilder list(1, {}, "Media list");
+  list.node.actions = static_cast<FlutterSemanticsAction>(
+      kFlutterSemanticsActionScrollUp | kFlutterSemanticsActionScrollDown);
+  list.node.scroll_position = 120.0;
+  list.node.scroll_extent_min = 0.0;
+  list.node.scroll_extent_max = 400.0;
+  Apply(tree, {&root.node, &list.node});
+
+  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  ASSERT_NE(snapshot, nullptr);
+  const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
+  ASSERT_NE(out, nullptr);
+
+  double value = -1.0;
+  double min = -1.0;
+  double max = -1.0;
+  EXPECT_TRUE(ihs_semantics_node_numeric_value(out, &value, &min, &max));
+  EXPECT_DOUBLE_EQ(value, 120.0);
+  EXPECT_DOUBLE_EQ(min, 0.0);
+  EXPECT_DOUBLE_EQ(max, 400.0);
+  ihs_semantics_release_snapshot(snapshot);
+}
+
+// A node that does not scroll has no numeric position, and Flutter leaves the
+// scroll fields at zero on every such node. Reporting that as "value 0 of 0"
+// would put a bogus position on every button in the tree.
+TEST_F(SemanticsPublisherTest, NonScrollableHasNoNumericValue) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {1}, "root");
+  NodeBuilder button(1, {}, "Play");
+  button.node.flags__deprecated__ = kFlutterSemanticsFlagIsButton;
+  button.node.actions = kFlutterSemanticsActionTap;
+  Apply(tree, {&root.node, &button.node});
+
+  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  ASSERT_NE(snapshot, nullptr);
+  const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
+  ASSERT_NE(out, nullptr);
+  EXPECT_FALSE(out->has_numeric_value);
+  EXPECT_FALSE(
+      ihs_semantics_node_numeric_value(out, nullptr, nullptr, nullptr));
+  ihs_semantics_release_snapshot(snapshot);
+}
+
+// An unbounded scrollable -- an infinite list -- reports an infinite extent.
+// There is no honest way to state that as a position within a range, so the
+// node publishes no numeric value rather than an infinite bound that would
+// reach a platform accessibility API.
+TEST_F(SemanticsPublisherTest, UnboundedScrollableReportsNoNumericValue) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {1}, "root");
+  NodeBuilder infinite(1, {}, "Infinite list");
+  infinite.node.actions = static_cast<FlutterSemanticsAction>(
+      kFlutterSemanticsActionScrollUp | kFlutterSemanticsActionScrollDown);
+  infinite.node.scroll_position = 50.0;
+  infinite.node.scroll_extent_min = 0.0;
+  infinite.node.scroll_extent_max = std::numeric_limits<double>::infinity();
+  Apply(tree, {&root.node, &infinite.node});
+
+  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  ASSERT_NE(snapshot, nullptr);
+  const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
+  ASSERT_NE(out, nullptr);
+  EXPECT_FALSE(out->has_numeric_value);
+  ihs_semantics_release_snapshot(snapshot);
+}
+
+// Overscroll puts the offset outside its own range while the list bounces.
+// That is transient and real, so it clamps: consumers are promised
+// min <= value <= max and may pass the three straight to a platform API.
+TEST_F(SemanticsPublisherTest, OverscrollClampsIntoRange) {
+  AccessibilityTree tree;
+  NodeBuilder root(0, {1}, "root");
+  NodeBuilder list(1, {}, "Bouncing list");
+  list.node.actions = static_cast<FlutterSemanticsAction>(
+      kFlutterSemanticsActionScrollUp | kFlutterSemanticsActionScrollDown);
+  list.node.scroll_position = -30.0;  // pulled past the top
+  list.node.scroll_extent_min = 0.0;
+  list.node.scroll_extent_max = 400.0;
+  Apply(tree, {&root.node, &list.node});
+
+  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  ASSERT_NE(snapshot, nullptr);
+  const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
+  ASSERT_NE(out, nullptr);
+
+  double value = -1.0;
+  ASSERT_TRUE(ihs_semantics_node_numeric_value(out, &value, nullptr, nullptr));
+  EXPECT_DOUBLE_EQ(value, 0.0);
   ihs_semantics_release_snapshot(snapshot);
 }
 


### PR DESCRIPTION
Being able to compile the adapter (#418, #433) turned out to matter more than expected — reading it closely surfaced four separate problems, three of which meant the bridge could not have worked.

## What was wrong

**1. It raced the platform thread.** The adapter read the mutable `AccessibilityTree` directly from AccessKit's callbacks, which run on AccessKit's AT-SPI thread while the platform thread mutates that tree. Every screen-reader traversal was a data race. Snapshots are exactly the fix.

**2. The tree was built once and never updated.** `activation_handler_cbk` ran when an assistive technology attached; nothing rebuilt it afterwards. A screen reader saw the UI as it looked at connection time, permanently.

**3. Actions went nowhere.** `action_handler_cbk` logged a line and returned — so a screen reader could *describe* the UI but not operate it. Nothing in the code said this was a stub.

**4. Roles were cast numerically.** `(accesskit_role)node->GetRole()` went through a `uint8_t` whose values upstream documents as having shifted across releases. Only two roles survived that cast — button and window — so a slider, checkbox, and text field all reached the screen reader as nothing in particular.

## What it does now

Registers as an ordinary hub consumer, waits on the notify fd, and pushes a full tree update per generation — on its own thread, so a slow AT-SPI round trip cannot delay the platform thread. That is the reason the hub notifies by fd rather than callback, and this is its first real user.

Actions go through `ihs_semantics_dispatch`: serialized onto the platform thread, checked against what the node offers, attributed to the consumer.

**It registers with the full allow mask, including the two accessibility-focus actions.** A screen reader moving its own cursor is precisely the case those bits exist for — the mask is what stops *other* consumers doing it. That's DR-11 working as intended rather than an exception to it.

All sixteen roles now map by name. State translation carries tristates across rather than flattening: "unchecked" and "not checkable" are announced very differently, and collapsing them would make every container sound like an unchecked checkbox.

Two further commits came out of testing this against a real accessibility bus: the window is marked focused, so the root frame carries the `active`/`focused` states an AT uses to pick the foreground window; and nodes carry a numeric value with bounds, which is what makes AccessKit expose the AT-SPI `Value` interface at all.

## Testing

**Verified end to end against the AT-SPI accessibility bus, not only by unit test.** A harness publishing a tree through the hub registers on the bus and enumerates correctly through `pyatspi`:

```
application    'atspi_harness'
  frame          'IVI Home'
    button         'Play'
    slider         'Driver temperature'
    check box      'Recirculate'
    panel          'Media list'  VALUE cur=120.0 min=0.0 max=400.0
```

Roles, labels, states (including `checked` on the check box) and the numeric value all arrive as an assistive technology sees them. The write direction works too: `doAction('click')` from the AT side round-trips to the dispatch funnel as `ACTION_TAP` on the right node.

The funnel's mask enforcement is observable and correct. `grabFocus` on a node that does not declare `DID_GAIN_A11Y_FOCUS` produces no dispatch; declaring the action on that node makes it dispatch. AccessKit does emit the request — the hub refuses it against the node's declared actions, which is the design.

Two things this turned up that are worth knowing for anyone testing later: our integration stays dormant while `org.a11y.Status.IsEnabled` is false (the desktop default with accessibility off), which reads exactly like a broken adapter; and the window focus state has to be set explicitly or the root frame is published without `active`/`focused`.

7 unit cases over both translation tables, built only under `BUILD_ACCESSKIT` alongside the source:

- every known role maps to something specific (a real role collapsing to `UNKNOWN` is invisible without an AT attached)
- no two roles collide
- a password field cannot be announced as an ordinary text input
- focus and blur map — without them the cursor could not move and the tree would be unwalkable
- an action with no framework equivalent reports `0` rather than a guess
- every action produced is inside the allow mask this consumer holds, so no dispatch is refused at the funnel by construction

Plus 7 new cases covering the numeric value across the publisher and the hub. All suites pass, clean under ASan/UBSan, clang-tidy and clang-format clean.

## Limits worth stating

**Orca specifically has not been run against it.** The tree, states, values and actions are confirmed over AT-SPI with a programmatic client, which exercises the same interfaces a screen reader uses, but what Orca *speaks* is not verified.

**Setting a value from the AT side does nothing.** AccessKit sends `SetValue`, whose framework equivalent is `ScrollToOffset`, and that needs an encoded payload the dispatch path does not carry yet. Read works; write does not.

**Our integration still drops several node properties the hub carries** — live regions, custom actions, `identifier`, `tooltip` — and advertises the focus action on every node regardless of whether it is focusable. Detailed separately; none are regressions from the previous adapter, which forwarded strictly less.

**CI still has no AccessKit leg**, so these tests do not run there. Now that #433 makes the bindings fetchable, adding `-D BUILD_ACCESSKIT=ON` to one existing leg would cover both the adapter and these tests — worth doing, and small.
