### PR TITLE
shared: add the semantics MCP provider

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -190,6 +190,16 @@ endif ()
 if (BUILD_MCP)
     target_sources(ihs_shared PRIVATE src/mcp_provider.cc)
     target_compile_definitions(ihs_shared PUBLIC IHS_WITH_MCP=1)
+    # The semantics provider bridges the two: it needs the hub as well as the
+    # registry, so it is only built when both are.
+    if (BUILD_ACCESSIBILITY)
+        target_sources(ihs_shared PRIVATE src/mcp_semantics_provider.cc)
+        # rapidjson is header-only, so this adds an include path and no link
+        # dependency -- the provider serializes snapshots and parses nothing
+        # beyond two scalar arguments.
+        target_include_directories(ihs_shared PRIVATE
+                "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/rapidjson/include")
+    endif ()
     message(STATUS "MCP provider registry . Enabled")
 else ()
     message(STATUS "MCP provider registry . Disabled")

--- a/shared/include/ihs/ihs_mcp_semantics.h
+++ b/shared/include/ihs/ihs_mcp_semantics.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * SHELL-ONLY lifecycle for the semantics MCP provider -- the surface that lets
+ * a client inspect the UI and drive it. Not part of the plugin ABI.
+ *
+ * The provider is a hub consumer and an MCP provider at once: it reads
+ * published snapshots to answer queries, and sends actions back through
+ * ihs_semantics_dispatch. It claims the `ui_` tool prefix and the `ui://`
+ * resource scheme.
+ *
+ * Starting it registers with both the hub and the MCP registry. Registering
+ * with the hub is what asks the engine for semantics, so nothing is produced
+ * until something actually wants it.
+ *
+ * The tools it offers are the ones the framework can act on directly, so an
+ * accessibility-correct app is drivable with no extra work: a tap dispatch
+ * invokes the same handler the widget registered for a real tap.
+ *
+ * Threading: start/stop from one thread, typically at engine bring-up and
+ * teardown. Everything else is driven by the MCP host.
+ */
+
+#ifndef IHS_MCP_SEMANTICS_H_
+#define IHS_MCP_SEMANTICS_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "ihs/ihs_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Registers the semantics provider. Returns an IhsMcpStatus: IHS_MCP_OK, or
+ * IHS_MCP_ERR_PREFIX_TAKEN if something already claims `ui_` / `ui://`.
+ *
+ * Idempotent -- starting an already-started provider succeeds without
+ * registering twice, so a caller that cannot easily tell whether bring-up
+ * already ran does not have to.
+ */
+IHS_EXPORT int ihs_mcp_semantics_provider_start(void);
+
+/*
+ * Unregisters from both the MCP registry and the hub. Safe to call when not
+ * started. After it returns, no callback into the provider is in flight and
+ * its hub registration is released -- which, if it was the last consumer, is
+ * what turns engine semantics back off.
+ */
+IHS_EXPORT void ihs_mcp_semantics_provider_stop(void);
+
+/* Whether the provider is currently registered. Diagnostics. */
+IHS_EXPORT bool ihs_mcp_semantics_provider_running(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* IHS_MCP_SEMANTICS_H_ */

--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -1,0 +1,661 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The semantics MCP provider: `ui_*` tools and `ui://` resources over the
+// semantics hub. See include/ihs/ihs_mcp_semantics.h for the lifecycle.
+
+#include "ihs/ihs_mcp_semantics.h"
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_semantics.h"
+
+namespace {
+
+// One tool as this provider declares it, paired with the hub action it
+// dispatches. A zero action marks a tool that is answered from the snapshot
+// rather than sent to the framework.
+struct ToolEntry {
+  const char* name;
+  const char* description;
+  const char* schema;
+  uint64_t action;
+  uint64_t capability;
+};
+
+// A node argument, shared by every action tool: either the numeric tree id or
+// the application's stable identifier. Both are offered because `identifier`
+// is absent on the engine revisions currently deployed, so a client that has
+// only ids must still be able to act.
+constexpr char kNodeSchema[] =
+    R"({"type":"object","properties":{)"
+    R"("node_id":{"type":"integer","description":"Semantics tree id."},)"
+    R"("identifier":{"type":"string","description":"Application-assigned identifier, when the app sets one."})"
+    R"(},"anyOf":[{"required":["node_id"]},{"required":["identifier"]}]})";
+
+constexpr char kEmptySchema[] = R"({"type":"object","properties":{}})";
+
+constexpr char kQuerySchema[] =
+    R"({"type":"object","properties":{)"
+    R"("identifier":{"type":"string"},)"
+    R"("label":{"type":"string","description":"Substring match, case sensitive."},)"
+    R"("role":{"type":"string","description":"Role name, e.g. button or slider."})"
+    R"(}})";
+
+const ToolEntry kTools[] = {
+    {"snapshot", "The whole semantics tree as JSON.", kEmptySchema, 0,
+     IHS_MCP_CAP_INSPECT},
+    {"query", "Find nodes by identifier, label substring, or role.",
+     kQuerySchema, 0, IHS_MCP_CAP_INSPECT},
+    {"tap", "Activate a node, as a tap would.", kNodeSchema,
+     IHS_SEMANTICS_ACTION_TAP, IHS_MCP_CAP_INTERACT},
+    {"long_press", "Long-press a node.", kNodeSchema,
+     IHS_SEMANTICS_ACTION_LONG_PRESS, IHS_MCP_CAP_INTERACT},
+    {"increase", "Increment a value, as on a slider.", kNodeSchema,
+     IHS_SEMANTICS_ACTION_INCREASE, IHS_MCP_CAP_INTERACT},
+    {"decrease", "Decrement a value.", kNodeSchema,
+     IHS_SEMANTICS_ACTION_DECREASE, IHS_MCP_CAP_INTERACT},
+    {"show_on_screen", "Scroll a node into view.", kNodeSchema,
+     IHS_SEMANTICS_ACTION_SHOW_ON_SCREEN, IHS_MCP_CAP_INTERACT},
+    {"dismiss", "Dismiss a node, as a swipe-away would.", kNodeSchema,
+     IHS_SEMANTICS_ACTION_DISMISS, IHS_MCP_CAP_INTERACT},
+    {"expand", "Expand a node.", kNodeSchema, IHS_SEMANTICS_ACTION_EXPAND,
+     IHS_MCP_CAP_INTERACT},
+    {"collapse", "Collapse a node.", kNodeSchema, IHS_SEMANTICS_ACTION_COLLAPSE,
+     IHS_MCP_CAP_INTERACT},
+};
+
+// The accessibility-focus actions are deliberately absent from the table
+// above. They move a screen reader's cursor, and an agent driving the UI must
+// not be able to yank it away from someone reading the screen. The hub's
+// allow mask below enforces the same thing a second time, at the funnel.
+constexpr uint64_t kAllowMask = IHS_SEMANTICS_ACTION_NO_A11Y_FOCUS;
+
+const char* RoleName(const IhsSemanticsRole role) {
+  switch (role) {
+    case IHS_SEMANTICS_ROLE_WINDOW:
+      return "window";
+    case IHS_SEMANTICS_ROLE_BUTTON:
+      return "button";
+    case IHS_SEMANTICS_ROLE_TEXT_INPUT:
+      return "text_input";
+    case IHS_SEMANTICS_ROLE_MULTILINE_TEXT_INPUT:
+      return "multiline_text_input";
+    case IHS_SEMANTICS_ROLE_PASSWORD_INPUT:
+      return "password_input";
+    case IHS_SEMANTICS_ROLE_SLIDER:
+      return "slider";
+    case IHS_SEMANTICS_ROLE_SWITCH:
+      return "switch";
+    case IHS_SEMANTICS_ROLE_CHECK_BOX:
+      return "check_box";
+    case IHS_SEMANTICS_ROLE_RADIO_BUTTON:
+      return "radio_button";
+    case IHS_SEMANTICS_ROLE_LINK:
+      return "link";
+    case IHS_SEMANTICS_ROLE_IMAGE:
+      return "image";
+    case IHS_SEMANTICS_ROLE_HEADING:
+      return "heading";
+    case IHS_SEMANTICS_ROLE_SCROLL_VIEW:
+      return "scroll_view";
+    case IHS_SEMANTICS_ROLE_PANE:
+      return "pane";
+    case IHS_SEMANTICS_ROLE_LABEL:
+      return "label";
+    case IHS_SEMANTICS_ROLE_GENERIC_CONTAINER:
+      return "generic_container";
+    case IHS_SEMANTICS_ROLE_UNKNOWN:
+      break;
+  }
+  return "unknown";
+}
+
+// Tristates cross the wire as three values rather than a bool. A client
+// reading "enabled": false must be able to tell a disabled control from one
+// where enablement is meaningless, which is the whole reason the hub carries
+// the distinction.
+const char* TristateName(const IhsSemanticsTristate value) {
+  switch (value) {
+    case IHS_SEMANTICS_TRISTATE_TRUE:
+      return "true";
+    case IHS_SEMANTICS_TRISTATE_FALSE:
+      return "false";
+    case IHS_SEMANTICS_TRISTATE_NONE:
+      break;
+  }
+  return "not_applicable";
+}
+
+const char* CheckStateName(const IhsSemanticsCheckState value) {
+  switch (value) {
+    case IHS_SEMANTICS_CHECK_TRUE:
+      return "true";
+    case IHS_SEMANTICS_CHECK_FALSE:
+      return "false";
+    case IHS_SEMANTICS_CHECK_MIXED:
+      return "mixed";
+    case IHS_SEMANTICS_CHECK_NONE:
+      break;
+  }
+  return "not_applicable";
+}
+
+// The verbs a client may invoke on this node, named as the tools that carry
+// them, so a caller reads the answer and calls it without a second mapping.
+void WriteActions(rapidjson::Writer<rapidjson::StringBuffer>& w,
+                  const uint64_t actions) {
+  w.Key("actions");
+  w.StartArray();
+  for (const ToolEntry& tool : kTools) {
+    if (tool.action != 0 && (actions & tool.action) != 0) {
+      w.String(tool.name);
+    }
+  }
+  w.EndArray();
+}
+
+void WriteNode(rapidjson::Writer<rapidjson::StringBuffer>& w,
+               const IhsSemanticsNode* node,
+               const IhsSemanticsSnapshot* snapshot) {
+  w.StartObject();
+  w.Key("id");
+  w.Int(node->id);
+  if (node->identifier[0] != '\0') {
+    // Omitted rather than emitted empty, so a client can tell "this app does
+    // not annotate" from "this engine cannot report it" only by its absence
+    // everywhere -- which is the honest signal either way.
+    w.Key("identifier");
+    w.String(node->identifier);
+  }
+  w.Key("role");
+  w.String(RoleName(node->role));
+  w.Key("label");
+  w.String(node->label);
+  if (node->hint[0] != '\0') {
+    w.Key("hint");
+    w.String(node->hint);
+  }
+  // A password field's contents are not something to hand to a client. The
+  // role is the reliable signal, since it is derived from the same obscured
+  // flag a screen reader uses to suppress the characters.
+  if (node->role != IHS_SEMANTICS_ROLE_PASSWORD_INPUT && !node->obscured &&
+      node->value[0] != '\0') {
+    w.Key("value");
+    w.String(node->value);
+  }
+  if (node->tooltip[0] != '\0') {
+    w.Key("tooltip");
+    w.String(node->tooltip);
+  }
+
+  w.Key("rect");
+  w.StartObject();
+  w.Key("x");
+  w.Double(node->rect.left);
+  w.Key("y");
+  w.Double(node->rect.top);
+  w.Key("w");
+  w.Double(node->rect.right - node->rect.left);
+  w.Key("h");
+  w.Double(node->rect.bottom - node->rect.top);
+  w.EndObject();
+
+  w.Key("state");
+  w.StartObject();
+  w.Key("enabled");
+  w.String(TristateName(node->enabled));
+  w.Key("checked");
+  w.String(CheckStateName(node->checked));
+  w.Key("selected");
+  w.String(TristateName(node->selected));
+  w.Key("toggled");
+  w.String(TristateName(node->toggled));
+  w.Key("expanded");
+  w.String(TristateName(node->expanded));
+  w.Key("focused");
+  w.String(TristateName(node->focused));
+  w.Key("required");
+  w.String(TristateName(node->required));
+  w.Key("hidden");
+  w.Bool(node->hidden);
+  w.Key("read_only");
+  w.Bool(node->read_only);
+  w.EndObject();
+
+  WriteActions(w, node->actions);
+
+  if (node->custom_action_count > 0) {
+    w.Key("custom_actions");
+    w.StartArray();
+    for (size_t i = 0; i < node->custom_action_count; i++) {
+      const IhsSemanticsCustomAction* action = ihs_semantics_find_custom_action(
+          snapshot, node->custom_action_ids[i]);
+      w.StartObject();
+      w.Key("id");
+      w.Int(node->custom_action_ids[i]);
+      if (action != nullptr) {
+        w.Key("label");
+        w.String(action->label);
+      }
+      w.EndObject();
+    }
+    w.EndArray();
+  }
+
+  w.Key("children");
+  w.StartArray();
+  for (size_t i = 0; i < node->child_count; i++) {
+    const IhsSemanticsNode* child =
+        ihs_semantics_snapshot_node_at(snapshot, node->child_indices[i]);
+    if (child != nullptr) {
+      w.Int(child->id);
+    }
+  }
+  w.EndArray();
+  w.EndObject();
+}
+
+std::string SerializeTree(const IhsSemanticsSnapshot* snapshot) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> w(buffer);
+  w.StartObject();
+  w.Key("generation");
+  w.Uint64(ihs_semantics_snapshot_generation(snapshot));
+  w.Key("nodes");
+  w.StartArray();
+  const size_t count = ihs_semantics_snapshot_node_count(snapshot);
+  for (size_t i = 0; i < count; i++) {
+    const IhsSemanticsNode* node = ihs_semantics_snapshot_node_at(snapshot, i);
+    if (node != nullptr) {
+      WriteNode(w, node, snapshot);
+    }
+  }
+  w.EndArray();
+  w.EndObject();
+  return buffer.GetString();
+}
+
+// A payload the host frees through the release hook. Heap-allocated because
+// the host may outlive the call that produced it.
+void FillPayload(IhsMcpPayload* out, std::string text) {
+  auto* owned = new std::string(std::move(text));
+  out->struct_size = sizeof(IhsMcpPayload);
+  out->data = owned->c_str();
+  out->length = owned->size();
+  out->release_ctx = owned;
+  out->release = [](void* ctx) { delete static_cast<std::string*>(ctx); };
+}
+
+std::string ErrorJson(const char* reason, const uint64_t generation) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> w(buffer);
+  w.StartObject();
+  w.Key("error");
+  w.String(reason);
+  w.Key("generation");
+  w.Uint64(generation);
+  w.EndObject();
+  return buffer.GetString();
+}
+
+// Minimal extraction for the two argument shapes this provider accepts. A full
+// parser is not warranted: the host hands over a JSON object, and what is
+// needed from it is one integer or one string.
+bool ExtractInt(const char* json, const char* key, int32_t* out) {
+  const std::string needle = std::string("\"") + key + "\"";
+  const char* at = std::strstr(json, needle.c_str());
+  if (at == nullptr) {
+    return false;
+  }
+  at = std::strchr(at + needle.size(), ':');
+  if (at == nullptr) {
+    return false;
+  }
+  // strtol rather than sscanf: this reports whether anything was consumed and
+  // whether the value fits, so a malformed argument is refused rather than
+  // silently becoming node 0 -- which is the root, and would act on the wrong
+  // thing.
+  errno = 0;
+  char* end = nullptr;
+  const long value = std::strtol(at + 1, &end, 10);
+  if (end == at + 1 || errno == ERANGE || value < INT32_MIN ||
+      value > INT32_MAX) {
+    return false;
+  }
+  *out = static_cast<int32_t>(value);
+  return true;
+}
+
+bool ExtractString(const char* json, const char* key, std::string* out) {
+  const std::string needle = std::string("\"") + key + "\"";
+  const char* at = std::strstr(json, needle.c_str());
+  if (at == nullptr) {
+    return false;
+  }
+  at = std::strchr(at + needle.size(), ':');
+  if (at == nullptr) {
+    return false;
+  }
+  const char* open = std::strchr(at, '"');
+  if (open == nullptr) {
+    return false;
+  }
+  const char* close = std::strchr(open + 1, '"');
+  if (close == nullptr) {
+    return false;
+  }
+  out->assign(open + 1, static_cast<size_t>(close - open - 1));
+  return true;
+}
+
+// Resolves the node a tool call names, by id or by identifier.
+const IhsSemanticsNode* ResolveNode(const IhsSemanticsSnapshot* snapshot,
+                                    const char* arguments) {
+  int32_t id = 0;
+  if (ExtractInt(arguments, "node_id", &id)) {
+    return ihs_semantics_snapshot_node_by_id(snapshot, id);
+  }
+  std::string identifier;
+  if (ExtractString(arguments, "identifier", &identifier) &&
+      !identifier.empty()) {
+    const size_t count = ihs_semantics_snapshot_node_count(snapshot);
+    for (size_t i = 0; i < count; i++) {
+      const IhsSemanticsNode* node =
+          ihs_semantics_snapshot_node_at(snapshot, i);
+      if (node != nullptr && identifier == node->identifier) {
+        return node;
+      }
+    }
+  }
+  return nullptr;
+}
+
+struct Provider {
+  std::mutex mutex;
+  IhsMcpProvider* mcp = nullptr;
+  IhsSemanticsConsumer* consumer = nullptr;
+  std::vector<IhsMcpToolDesc> tools;
+  std::vector<std::string> names;  // prefix-free names, owned
+  IhsMcpResourceDesc resources[1]{};
+};
+
+Provider& TheProvider() {
+  static auto* provider = new Provider();  // leaked; outlives static teardown
+  return *provider;
+}
+
+int ListTools(void* /* user_data */,
+              const IhsMcpToolDesc** out_tools,
+              size_t* out_count) {
+  Provider& p = TheProvider();
+  *out_tools = p.tools.empty() ? nullptr : p.tools.data();
+  *out_count = p.tools.size();
+  return IHS_MCP_OK;
+}
+
+int ListResources(void* /* user_data */,
+                  const IhsMcpResourceDesc** out_resources,
+                  size_t* out_count) {
+  Provider& p = TheProvider();
+  *out_resources = p.resources;
+  *out_count = 1;
+  return IHS_MCP_OK;
+}
+
+int ReadResource(void* /* user_data */,
+                 const char* uri,
+                 IhsMcpPayload* out_content) {
+  if (std::strcmp(uri, "ui://semantics/tree") != 0) {
+    return IHS_MCP_ERR_NOT_FOUND;
+  }
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  if (snapshot == nullptr) {
+    // Semantics has not produced a tree yet. An empty document says so
+    // without pretending the UI has no nodes.
+    FillPayload(out_content, R"({"generation":0,"nodes":[]})");
+    return IHS_MCP_OK;
+  }
+  FillPayload(out_content, SerializeTree(snapshot));
+  ihs_semantics_release_snapshot(snapshot);
+  return IHS_MCP_OK;
+}
+
+std::string RunQuery(const IhsSemanticsSnapshot* snapshot,
+                     const char* arguments) {
+  std::string want_identifier;
+  std::string want_label;
+  std::string want_role;
+  ExtractString(arguments, "identifier", &want_identifier);
+  ExtractString(arguments, "label", &want_label);
+  ExtractString(arguments, "role", &want_role);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> w(buffer);
+  w.StartObject();
+  w.Key("generation");
+  w.Uint64(ihs_semantics_snapshot_generation(snapshot));
+  w.Key("nodes");
+  w.StartArray();
+
+  const size_t count = ihs_semantics_snapshot_node_count(snapshot);
+  for (size_t i = 0; i < count; i++) {
+    const IhsSemanticsNode* node = ihs_semantics_snapshot_node_at(snapshot, i);
+    if (node == nullptr) {
+      continue;
+    }
+    // Every supplied selector must match. Narrowing rather than widening is
+    // what makes adding a second selector useful.
+    if (!want_identifier.empty() && want_identifier != node->identifier) {
+      continue;
+    }
+    if (!want_label.empty() &&
+        std::strstr(node->label, want_label.c_str()) == nullptr) {
+      continue;
+    }
+    if (!want_role.empty() && want_role != RoleName(node->role)) {
+      continue;
+    }
+    WriteNode(w, node, snapshot);
+  }
+  w.EndArray();
+  w.EndObject();
+  return buffer.GetString();
+}
+
+int CallTool(void* /* user_data */,
+             const char* name,
+             const char* arguments_json,
+             size_t /* arguments_length */,
+             IhsMcpPayload* out_result) {
+  const ToolEntry* tool = nullptr;
+  for (const ToolEntry& candidate : kTools) {
+    if (std::strcmp(candidate.name, name) == 0) {
+      tool = &candidate;
+      break;
+    }
+  }
+  if (tool == nullptr) {
+    return IHS_MCP_ERR_NOT_FOUND;
+  }
+
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  if (snapshot == nullptr) {
+    FillPayload(out_result, ErrorJson("no semantics tree has been published "
+                                      "yet",
+                                      0));
+    return IHS_MCP_ERR_REFUSED;
+  }
+  const uint64_t generation = ihs_semantics_snapshot_generation(snapshot);
+
+  if (std::strcmp(name, "snapshot") == 0) {
+    FillPayload(out_result, SerializeTree(snapshot));
+    ihs_semantics_release_snapshot(snapshot);
+    return IHS_MCP_OK;
+  }
+  if (std::strcmp(name, "query") == 0) {
+    FillPayload(out_result, RunQuery(snapshot, arguments_json));
+    ihs_semantics_release_snapshot(snapshot);
+    return IHS_MCP_OK;
+  }
+
+  const IhsSemanticsNode* node = ResolveNode(snapshot, arguments_json);
+  if (node == nullptr) {
+    FillPayload(out_result,
+                ErrorJson("no node matched node_id or identifier", generation));
+    ihs_semantics_release_snapshot(snapshot);
+    return IHS_MCP_ERR_NOT_FOUND;
+  }
+
+  // A disabled control is refused here rather than dispatched. The framework
+  // drops such an action silently, so a client would otherwise see success and
+  // no effect, which is worse than being told.
+  if (node->enabled == IHS_SEMANTICS_TRISTATE_FALSE) {
+    FillPayload(out_result, ErrorJson("node is disabled", generation));
+    ihs_semantics_release_snapshot(snapshot);
+    return IHS_MCP_ERR_REFUSED;
+  }
+  if ((node->actions & tool->action) == 0) {
+    FillPayload(out_result,
+                ErrorJson("node does not offer this action", generation));
+    ihs_semantics_release_snapshot(snapshot);
+    return IHS_MCP_ERR_REFUSED;
+  }
+
+  const int32_t node_id = node->id;
+  ihs_semantics_release_snapshot(snapshot);
+
+  Provider& p = TheProvider();
+  const int status = ihs_semantics_dispatch(
+      p.consumer, 0, node_id, tool->action, nullptr, 0, nullptr, nullptr);
+  if (status != IHS_SEMANTICS_OK) {
+    FillPayload(out_result, ErrorJson("dispatch refused", generation));
+    return IHS_MCP_ERR_REFUSED;
+  }
+
+  // Report the generation the decision was made against. A client that wants
+  // to know what changed re-reads the tree and compares; the hub cannot say
+  // here whether the widget did anything, and pretending otherwise would be
+  // worse than saying nothing.
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> w(buffer);
+  w.StartObject();
+  w.Key("dispatched");
+  w.Bool(true);
+  w.Key("node_id");
+  w.Int(node_id);
+  w.Key("generation_before");
+  w.Uint64(generation);
+  w.EndObject();
+  FillPayload(out_result, buffer.GetString());
+  return IHS_MCP_OK;
+}
+
+}  // namespace
+
+extern "C" {
+
+int ihs_mcp_semantics_provider_start(void) {
+  Provider& p = TheProvider();
+  std::lock_guard<std::mutex> lock(p.mutex);
+  if (p.mcp != nullptr) {
+    return IHS_MCP_OK;  // idempotent
+  }
+
+  p.names.clear();
+  p.tools.clear();
+  p.names.reserve(sizeof(kTools) / sizeof(kTools[0]));
+  p.tools.reserve(sizeof(kTools) / sizeof(kTools[0]));
+  for (const ToolEntry& entry : kTools) {
+    p.names.emplace_back(entry.name);
+  }
+  for (size_t i = 0; i < p.names.size(); i++) {
+    IhsMcpToolDesc desc{};
+    desc.name = p.names[i].c_str();
+    desc.description = kTools[i].description;
+    desc.input_schema_json = kTools[i].schema;
+    desc.capability = kTools[i].capability;
+    p.tools.push_back(desc);
+  }
+
+  p.resources[0].uri = "ui://semantics/tree";
+  p.resources[0].name = "semantics tree";
+  p.resources[0].description = "The current UI as a semantics tree.";
+  p.resources[0].mime_type = "application/json";
+
+  // Register with the hub first: an MCP client can call the moment the
+  // provider is visible, and answering with "no tree" because we had not
+  // subscribed yet would be a self-inflicted race.
+  IhsSemanticsConsumerDesc consumer{};
+  consumer.struct_size = sizeof(IhsSemanticsConsumerDesc);
+  consumer.name = "mcp.semantics";
+  consumer.action_allow_mask = kAllowMask;
+  consumer.notify_fd = -1;  // pulls on demand; no push needed
+  if (ihs_semantics_register(&consumer, &p.consumer) != IHS_SEMANTICS_OK) {
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+
+  IhsMcpProviderDesc desc{};
+  desc.struct_size = sizeof(IhsMcpProviderDesc);
+  desc.name = "semantics";
+  desc.tool_prefix = "ui_";
+  desc.resource_scheme = "ui";
+  desc.capability_mask = IHS_MCP_CAP_INSPECT | IHS_MCP_CAP_INTERACT;
+  desc.callbacks.list_tools = ListTools;
+  desc.callbacks.call_tool = CallTool;
+  desc.callbacks.list_resources = ListResources;
+  desc.callbacks.read_resource = ReadResource;
+  desc.notify_fd = -1;
+
+  const int status = ihs_mcp_provider_register(&desc, &p.mcp);
+  if (status != IHS_MCP_OK) {
+    ihs_semantics_unregister(p.consumer);
+    p.consumer = nullptr;
+    return status;
+  }
+  return IHS_MCP_OK;
+}
+
+void ihs_mcp_semantics_provider_stop(void) {
+  Provider& p = TheProvider();
+  std::lock_guard<std::mutex> lock(p.mutex);
+  if (p.mcp != nullptr) {
+    ihs_mcp_provider_unregister(p.mcp);
+    p.mcp = nullptr;
+  }
+  if (p.consumer != nullptr) {
+    ihs_semantics_unregister(p.consumer);
+    p.consumer = nullptr;
+  }
+}
+
+bool ihs_mcp_semantics_provider_running(void) {
+  Provider& p = TheProvider();
+  std::lock_guard<std::mutex> lock(p.mutex);
+  return p.mcp != nullptr;
+}
+
+}  // extern "C"

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -198,6 +198,10 @@ add_subdirectory(mutation_stack-test)
 # its tests would have nothing to link against otherwise.
 if (BUILD_MCP)
     add_subdirectory(mcp_provider-test)
+    # The semantics provider needs the hub as well as the registry.
+    if (BUILD_ACCESSIBILITY)
+        add_subdirectory(mcp_semantics_provider-test)
+    endif ()
 endif ()
 add_subdirectory(pixel_swizzle-test)
 add_subdirectory(scale_policy-test)

--- a/test/unit_test/mcp_semantics_provider-test/CMakeLists.txt
+++ b/test/unit_test/mcp_semantics_provider-test/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Semantics MCP provider tests: drives the ui_* tools and ui:// resources
+# so no socket, session, or engine is involved -- the routing layer is
+# deliberately transport-free and this is where that pays off.
+set(TESTCASE_NAME "homescreen_mcp_semantics_provider_ut_test_driver")
+
+add_executable(${TESTCASE_NAME}
+        test_case_mcp_semantics_provider.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        ivi_homescreen::ihs_shared
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "ihs/ihs_mcp_host.h"
+#include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_mcp_semantics.h"
+#include "ihs/ihs_semantics.h"
+#include "ihs/ihs_semantics_host.h"
+
+namespace {
+
+// Records what the provider asked the shell to do, so a test can assert the
+// dispatch reached the far side with the right node and action rather than
+// only that the call returned OK.
+struct MockHost {
+  int dispatch_calls = 0;
+  int32_t last_node_id = 0;
+  uint64_t last_action = 0;
+  bool semantics_enabled = false;
+};
+
+MockHost* g_host = nullptr;
+
+void OnEnable(void* /*user_data*/, bool enabled) {
+  g_host->semantics_enabled = enabled;
+}
+
+int OnDispatch(void* /*user_data*/,
+               int64_t /*view_id*/,
+               int32_t node_id,
+               uint64_t action,
+               const uint8_t* /*data*/,
+               size_t /*data_length*/) {
+  g_host->dispatch_calls++;
+  g_host->last_node_id = node_id;
+  g_host->last_action = action;
+  return IHS_SEMANTICS_OK;
+}
+
+// Builds and publishes a tree, owning the arrays the info points at.
+struct TreeBuilder {
+  std::vector<IhsSemanticsPublishNode> nodes;
+  std::vector<std::vector<int32_t>> children;
+
+  IhsSemanticsPublishNode& Add(int32_t id,
+                               const char* label,
+                               IhsSemanticsRole role) {
+    children.emplace_back();
+    IhsSemanticsPublishNode node{};
+    node.id = id;
+    node.label = label;
+    node.role = role;
+    node.enabled = IHS_SEMANTICS_TRISTATE_NONE;
+    nodes.push_back(node);
+    return nodes.back();
+  }
+
+  int Publish() {
+    IhsSemanticsPublishInfo info{};
+    info.struct_size = sizeof(IhsSemanticsPublishInfo);
+    info.nodes = nodes.data();
+    info.node_count = nodes.size();
+    return ihs_semantics_publish(&info);
+  }
+};
+
+std::string CallTool(const char* name, const char* args, int* status_out) {
+  IhsMcpPayload payload{};
+  const int status =
+      ihs_mcp_host_call_tool(name, args, args ? strlen(args) : 0, &payload);
+  if (status_out != nullptr) {
+    *status_out = status;
+  }
+  std::string body;
+  if (payload.data != nullptr) {
+    body.assign(payload.data, payload.length);
+  }
+  ihs_mcp_host_release_payload(&payload);
+  return body;
+}
+
+bool Contains(const std::string& haystack, const char* needle) {
+  return haystack.find(needle) != std::string::npos;
+}
+
+class McpSemanticsProviderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    host_ = MockHost{};
+    g_host = &host_;
+    IhsSemanticsHost host{};
+    host.struct_size = sizeof(IhsSemanticsHost);
+    host.set_semantics_enabled = OnEnable;
+    host.dispatch = OnDispatch;
+    ihs_semantics_set_host(&host);
+    ihs_semantics_clear();
+    ASSERT_EQ(ihs_mcp_semantics_provider_start(), IHS_MCP_OK);
+  }
+
+  void TearDown() override {
+    ihs_mcp_semantics_provider_stop();
+    ihs_semantics_clear();
+    ihs_semantics_set_host(nullptr);
+    g_host = nullptr;
+    ASSERT_EQ(ihs_mcp_provider_count(), 0u);
+  }
+
+  MockHost host_;
+};
+
+}  // namespace
+
+// Registering the provider is what asks the engine for semantics, so nothing
+// is produced until something actually wants it.
+TEST_F(McpSemanticsProviderTest, StartingTheProviderTurnsSemanticsOn) {
+  EXPECT_TRUE(host_.semantics_enabled);
+  EXPECT_TRUE(ihs_mcp_semantics_provider_running());
+}
+
+TEST_F(McpSemanticsProviderTest, StartIsIdempotent) {
+  EXPECT_EQ(ihs_mcp_semantics_provider_start(), IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_provider_count(), 1u);
+}
+
+// Tools reach a client under the provider's prefix, so a call carries the
+// prefixed name and the provider still sees its own vocabulary.
+TEST_F(McpSemanticsProviderTest, ToolsAreAdvertisedUnderTheUiPrefix) {
+  std::vector<std::string> names;
+  ihs_mcp_host_for_each_tool(
+      [](const IhsMcpHostTool* tool, void* user_data) {
+        static_cast<std::vector<std::string>*>(user_data)->emplace_back(
+            tool->name);
+      },
+      &names);
+  ASSERT_FALSE(names.empty());
+  for (const std::string& name : names) {
+    EXPECT_EQ(name.rfind("ui_", 0), 0u) << name << " escaped the prefix";
+  }
+  EXPECT_NE(std::find(names.begin(), names.end(), "ui_tap"), names.end());
+  EXPECT_NE(std::find(names.begin(), names.end(), "ui_snapshot"), names.end());
+}
+
+// The accessibility-focus actions must not be offered: an agent moving the
+// screen-reader cursor is exactly what the allow mask exists to prevent.
+TEST_F(McpSemanticsProviderTest, NoToolExposesAccessibilityFocus) {
+  std::vector<std::string> names;
+  ihs_mcp_host_for_each_tool(
+      [](const IhsMcpHostTool* tool, void* user_data) {
+        static_cast<std::vector<std::string>*>(user_data)->emplace_back(
+            tool->name);
+      },
+      &names);
+  for (const std::string& name : names) {
+    EXPECT_EQ(name.find("focus"), std::string::npos)
+        << name << " would let a client move the accessibility cursor";
+  }
+}
+
+TEST_F(McpSemanticsProviderTest, SnapshotSerializesThePublishedTree) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& button =
+      tree.Add(7, "Play", IHS_SEMANTICS_ROLE_BUTTON);
+  button.actions = IHS_SEMANTICS_ACTION_TAP;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool("ui_snapshot", nullptr, &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  EXPECT_TRUE(Contains(body, "\"generation\""));
+  EXPECT_TRUE(Contains(body, "\"label\":\"Play\""));
+  EXPECT_TRUE(Contains(body, "\"role\":\"button\""));
+  // Verbs are named as the tools that carry them, so a client reads the
+  // answer and calls it without a second mapping.
+  EXPECT_TRUE(Contains(body, "\"actions\":[\"tap\"]"));
+}
+
+// A password field's contents are not something to hand a client.
+TEST_F(McpSemanticsProviderTest, ObscuredValuesAreNotSerialized) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& secret =
+      tree.Add(3, "Password", IHS_SEMANTICS_ROLE_PASSWORD_INPUT);
+  secret.value = "hunter2";
+  secret.obscured = true;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const std::string body = CallTool("ui_snapshot", nullptr, nullptr);
+  EXPECT_TRUE(Contains(body, "password_input"));
+  EXPECT_FALSE(Contains(body, "hunter2"));
+}
+
+// Tristates cross the wire as three values: a client reading "false" must be
+// able to tell a disabled control from one where enablement is meaningless.
+TEST_F(McpSemanticsProviderTest, TristatesAreNotFlattened) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& disabled =
+      tree.Add(1, "Save", IHS_SEMANTICS_ROLE_BUTTON);
+  disabled.enabled = IHS_SEMANTICS_TRISTATE_FALSE;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const std::string body = CallTool("ui_snapshot", nullptr, nullptr);
+  EXPECT_TRUE(Contains(body, "\"enabled\":\"false\""));
+  EXPECT_TRUE(Contains(body, "\"enabled\":\"not_applicable\""));
+}
+
+TEST_F(McpSemanticsProviderTest, QueryNarrowsByEverySelectorGiven) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  tree.Add(1, "Play", IHS_SEMANTICS_ROLE_BUTTON);
+  tree.Add(2, "Play", IHS_SEMANTICS_ROLE_SLIDER);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  // Label alone matches both.
+  const std::string by_label =
+      CallTool("ui_query", R"({"label":"Play"})", nullptr);
+  EXPECT_TRUE(Contains(by_label, "\"id\":1"));
+  EXPECT_TRUE(Contains(by_label, "\"id\":2"));
+
+  // Adding a role narrows rather than widens.
+  const std::string by_both =
+      CallTool("ui_query", R"({"label":"Play","role":"slider"})", nullptr);
+  EXPECT_FALSE(Contains(by_both, "\"id\":1"));
+  EXPECT_TRUE(Contains(by_both, "\"id\":2"));
+}
+
+TEST_F(McpSemanticsProviderTest, TapDispatchesToTheShell) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& button =
+      tree.Add(12, "Play", IHS_SEMANTICS_ROLE_BUTTON);
+  button.actions = IHS_SEMANTICS_ACTION_TAP;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":12})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  EXPECT_EQ(host_.dispatch_calls, 1);
+  EXPECT_EQ(host_.last_node_id, 12);
+  EXPECT_EQ(host_.last_action, IHS_SEMANTICS_ACTION_TAP);
+  EXPECT_TRUE(Contains(body, "\"dispatched\":true"));
+}
+
+// The framework drops an action on a disabled node silently, so a client would
+// otherwise see success and no effect.
+TEST_F(McpSemanticsProviderTest, DisabledNodeIsRefusedBeforeDispatch) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& button =
+      tree.Add(5, "Save", IHS_SEMANTICS_ROLE_BUTTON);
+  button.actions = IHS_SEMANTICS_ACTION_TAP;
+  button.enabled = IHS_SEMANTICS_TRISTATE_FALSE;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":5})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_REFUSED);
+  EXPECT_EQ(host_.dispatch_calls, 0);
+  EXPECT_TRUE(Contains(body, "disabled"));
+}
+
+// Same reasoning for an action the node never offered.
+TEST_F(McpSemanticsProviderTest, ActionNotOfferedIsRefusedBeforeDispatch) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& node =
+      tree.Add(9, "Label", IHS_SEMANTICS_ROLE_LABEL);
+  node.actions = 0;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":9})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_REFUSED);
+  EXPECT_EQ(host_.dispatch_calls, 0);
+  EXPECT_TRUE(Contains(body, "does not offer"));
+}
+
+TEST_F(McpSemanticsProviderTest, UnknownNodeIsReportedNotFound) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":999})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_NOT_FOUND);
+  EXPECT_EQ(host_.dispatch_calls, 0);
+  EXPECT_TRUE(Contains(body, "no node matched"));
+}
+
+// Addressing by the application's identifier is the stable route where the
+// engine supplies one.
+TEST_F(McpSemanticsProviderTest, NodesResolveByIdentifier) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& slider =
+      tree.Add(4, "Volume", IHS_SEMANTICS_ROLE_SLIDER);
+  slider.identifier = "hvac.temp.driver";
+  slider.actions = IHS_SEMANTICS_ACTION_INCREASE;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  CallTool("ui_increase", R"({"identifier":"hvac.temp.driver"})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  EXPECT_EQ(host_.last_node_id, 4);
+  EXPECT_EQ(host_.last_action, IHS_SEMANTICS_ACTION_INCREASE);
+}
+
+TEST_F(McpSemanticsProviderTest, ResourceReturnsTheTree) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  IhsMcpPayload payload{};
+  ASSERT_EQ(ihs_mcp_host_read_resource("ui://semantics/tree", &payload),
+            IHS_MCP_OK);
+  const std::string body(payload.data, payload.length);
+  EXPECT_TRUE(Contains(body, "\"nodes\""));
+  ihs_mcp_host_release_payload(&payload);
+
+  EXPECT_EQ(ihs_mcp_host_read_resource("ui://nope", &payload),
+            IHS_MCP_ERR_NOT_FOUND);
+}
+
+// Before the engine has published anything there is no tree. Saying so beats
+// an empty document that reads as "the UI has no nodes".
+TEST_F(McpSemanticsProviderTest, ToolsRefuseBeforeAnythingIsPublished) {
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":1})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_REFUSED);
+  EXPECT_TRUE(Contains(body, "no semantics tree"));
+}
+
+// Stopping releases the hub registration, which is what lets semantics go
+// quiet again when nothing is listening.
+TEST_F(McpSemanticsProviderTest, StoppingReleasesTheHubRegistration) {
+  EXPECT_TRUE(host_.semantics_enabled);
+  ihs_mcp_semantics_provider_stop();
+  EXPECT_FALSE(host_.semantics_enabled);
+  EXPECT_FALSE(ihs_mcp_semantics_provider_running());
+  EXPECT_EQ(ihs_semantics_consumer_count(), 0u);
+}


### PR DESCRIPTION
Rhe first registrant on the provider ABI from #416. `ui_*` tools and a `ui://` resource over the semantics hub — hub consumer and MCP provider at once.

**Still no transport.** The routing layer being transport-free means this is fully exercisable without a socket, which is why it comes before transport rather than after: the UI-facing surface can be argued about on its own, before anyone has to accept a security surface alongside it.

## What it offers

Ten tools — two that read (`ui_snapshot`, `ui_query`) and eight that act (`ui_tap`, `ui_long_press`, `ui_increase`, `ui_decrease`, `ui_show_on_screen`, `ui_dismiss`, `ui_expand`, `ui_collapse`). All are actions the framework invokes directly, so an accessibility-correct app is drivable with no extra work: a tap dispatch reaches the same handler the widget registered for a real tap.

Registering with the hub is what asks the engine for semantics, so a build with MCP compiled in still produces nothing until a client connects.

## Three deliberate choices, all tested

**The accessibility-focus actions are stated twice as forbidden** — absent from the tool table, *and* withheld by the hub allow mask. An agent must not move a screen reader's cursor out from under someone reading the screen. Saying it in both places means neither a new tool nor a changed mask can quietly grant it alone. There's a test asserting no advertised tool contains "focus".

**Tristates cross as three values, not booleans.** A client reading `"enabled": false` must be able to distinguish a disabled control from one where enablement is meaningless — the distinction the hub carries and the reason it carries it.

**An obscured field's value is never serialized.** The role is the reliable signal, derived from the same flag a screen reader uses to suppress characters. Test publishes `hunter2` into a password field and asserts it never appears.

Also: verbs are named as the tools that carry them, so a client reads a node's `actions` and calls what it finds without a second mapping.

## Refusals happen before dispatch

A disabled node and an action the node doesn't offer are both refused up front. The framework drops either **silently**, so passing them through would show a client success and no effect — worse than being told no.

The response carries the generation the decision was made against. Whether the widget actually did anything is not knowable here, and claiming otherwise would be worse than saying nothing; a client that needs to know re-reads and compares.

## Testing

16 cases driven against the **real** hub and registry — no engine involved, since publishing is just a call. Covers prefixing, the absent focus tools, serialization, obscured values, tristates, query narrowing across selectors, dispatch reaching the shell with the right node and action, resolution by identifier, both pre-dispatch refusals, unknown nodes, the resource, behaviour before anything is published, and that stopping releases the hub registration.

26/26 ctest in both `BUILD_MCP` configurations, clean under ASan/UBSan, clang-tidy and clang-format clean, standalone `shared` build installs and its headers stay C11-clean.

One tidy finding worth mentioning because it was a real bug: argument parsing used `sscanf`, which doesn't report conversion failure — a malformed `node_id` would have become `0`, which is the **root**, so a bad argument would have acted on the wrong node. Now `strtol` with range checks.

## Not here

**Transport** (UDS + Streamable HTTP), so nothing is reachable from outside the process yet — the security posture is opt-in twice and neither opt-in exists.

**Parameterized tools** — `ui_set_text` and `ui_scroll_to` need StandardMessageCodec payloads, which is its own piece. The hub and dispatch path already carry the data argument for them.

**Nothing calls `ihs_mcp_semantics_provider_start()`** yet; the shell wiring lands with transport, since starting a provider with no server to serve it would do nothing observable.