### PR TITLE
accessibility: forward node properties AccessKit was dropping

### DIFF
--- a/shell/accessibility/accesskit_consumer.cc
+++ b/shell/accessibility/accesskit_consumer.cc
@@ -179,18 +179,30 @@ accesskit_node* BuildNode(const IhsSemanticsNode* node,
     }
   }
 
-  accesskit_node_set_label(out, node->label);
-  accesskit_node_set_description(out, node->hint);
-  accesskit_node_set_value(out, node->value);
+  // Every string is set only when it has content. The hub normalizes an absent
+  // string to "" so its own consumers need no null checks, but AccessKit's
+  // model is optional -- Some("") is not None -- so that normalization has to
+  // be undone here rather than carried across. Forwarding "" would give a node
+  // an empty label that AccessKit counts as having one, and a live region with
+  // an empty name emits an announcement of nothing at all.
+  if (node->label[0] != '\0') {
+    accesskit_node_set_label(out, node->label);
+  }
+  if (node->hint[0] != '\0') {
+    accesskit_node_set_description(out, node->hint);
+  }
 
   // AccessKit derives a Label node's accessible name from its *value*, not its
   // label -- label_comes_from_value() is exactly role == Label. Flutter puts
   // the text in label, so without this every piece of static text in the UI
   // reaches a screen reader with no name at all, which is most of what there
-  // is to read. Only fill an empty value, so a node carrying both keeps its
-  // own.
-  if (role == ACCESSKIT_ROLE_LABEL && node->value[0] == '\0') {
-    accesskit_node_set_value(out, node->label);
+  // is to read. A Label carrying its own value keeps it.
+  const char* value = node->value;
+  if (role == ACCESSKIT_ROLE_LABEL && value[0] == '\0') {
+    value = node->label;
+  }
+  if (value[0] != '\0') {
+    accesskit_node_set_value(out, value);
   }
 
   // The application's own stable id, which is what an automation client keys

--- a/shell/accessibility/accesskit_consumer.cc
+++ b/shell/accessibility/accesskit_consumer.cc
@@ -116,7 +116,9 @@ namespace {
 
 // Advertises to the screen reader what the node actually accepts, so it does
 // not offer a gesture the framework will silently drop.
-void AddActions(accesskit_node* node, const uint64_t actions) {
+void AddActions(accesskit_node* node,
+                const uint64_t actions,
+                const bool focusable) {
   if ((actions & IHS_SEMANTICS_ACTION_TAP) != 0) {
     accesskit_node_add_action(node, ACCESSKIT_ACTION_CLICK);
   }
@@ -147,10 +149,18 @@ void AddActions(accesskit_node* node, const uint64_t actions) {
   if ((actions & IHS_SEMANTICS_ACTION_COLLAPSE) != 0) {
     accesskit_node_add_action(node, ACCESSKIT_ACTION_COLLAPSE);
   }
-  // Focus is offered whenever the node can hold the accessibility cursor,
-  // which is what the screen reader uses to walk the tree.
-  accesskit_node_add_action(node, ACCESSKIT_ACTION_FOCUS);
+  // Focus is offered only where the node can actually hold the accessibility
+  // cursor. Advertising it everywhere -- as this did -- makes every static
+  // label and layout container look like a focus target, which is what a
+  // screen reader user experiences as a tree full of nothing. Walking the
+  // tree does not depend on this: traversal follows children, and only an
+  // explicit grabFocus needs the action.
+  if (focusable) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_FOCUS);
+  }
 }
+
+}  // namespace
 
 // Translates one snapshot node. The tristates are carried across rather than
 // flattened: a screen reader announces "unchecked" and "not checkable" very
@@ -158,7 +168,8 @@ void AddActions(accesskit_node* node, const uint64_t actions) {
 // unchecked checkbox.
 accesskit_node* BuildNode(const IhsSemanticsNode* node,
                           const IhsSemanticsSnapshot* snapshot) {
-  accesskit_node* out = accesskit_node_new(ToAccessKitRole(node->role));
+  const accesskit_role role = ToAccessKitRole(node->role);
+  accesskit_node* out = accesskit_node_new(role);
 
   for (size_t i = 0; i < node->child_count; i++) {
     const IhsSemanticsNode* child =
@@ -171,6 +182,28 @@ accesskit_node* BuildNode(const IhsSemanticsNode* node,
   accesskit_node_set_label(out, node->label);
   accesskit_node_set_description(out, node->hint);
   accesskit_node_set_value(out, node->value);
+
+  // AccessKit derives a Label node's accessible name from its *value*, not its
+  // label -- label_comes_from_value() is exactly role == Label. Flutter puts
+  // the text in label, so without this every piece of static text in the UI
+  // reaches a screen reader with no name at all, which is most of what there
+  // is to read. Only fill an empty value, so a node carrying both keeps its
+  // own.
+  if (role == ACCESSKIT_ROLE_LABEL && node->value[0] == '\0') {
+    accesskit_node_set_value(out, node->label);
+  }
+
+  // The application's own stable id, which is what an automation client keys
+  // on when a label is localized or ambiguous. Empty on every node at the
+  // 3.38.3 deployment floor, since that engine never writes identifier -- so
+  // this does nothing today and starts working on an engine bump, rather than
+  // being quietly forgotten at the point where it would matter.
+  if (node->identifier[0] != '\0') {
+    accesskit_node_set_author_id(out, node->identifier);
+  }
+  if (node->tooltip[0] != '\0') {
+    accesskit_node_set_tooltip(out, node->tooltip);
+  }
 
   // A numeric value is what makes AccessKit expose the AT-SPI Value interface
   // for this node, which is how a screen reader reports a scroll position
@@ -234,9 +267,45 @@ accesskit_node* BuildNode(const IhsSemanticsNode* node,
     accesskit_node_set_read_only(out);
   }
 
-  AddActions(out, node->actions);
+  // A live region is announced without the accessibility cursor moving to it,
+  // which is the only way a toast or a snackbar reaches a screen reader at
+  // all: by the time a user could navigate to one it has usually gone. Flutter
+  // carries a single liveRegion boolean with no urgency distinction, so this
+  // maps to polite -- assertive interrupts whatever is being spoken, and
+  // claiming that for every transient message would make the UI hostile.
+  if (node->live_region) {
+    accesskit_node_set_live(out, ACCESSKIT_LIVE_POLITE);
+  }
+
+  // An application's own verbs -- "Add to favorites", "Dismiss route" -- exist
+  // only as custom actions, so without these a screen reader user can reach
+  // every control the app declares and still not invoke anything specific to
+  // it. The label lives once in the snapshot's declaration table rather than
+  // on each referencing node, so resolve it here; a node referencing an
+  // undeclared id is skipped, since an action announced with no name is worse
+  // than one that is absent.
+  for (size_t i = 0; i < node->custom_action_count; i++) {
+    const int32_t action_id = node->custom_action_ids[i];
+    const IhsSemanticsCustomAction* declared =
+        ihs_semantics_find_custom_action(snapshot, action_id);
+    if (declared == nullptr || declared->label[0] == '\0') {
+      continue;
+    }
+    accesskit_custom_action* custom = accesskit_custom_action_new(action_id);
+    accesskit_custom_action_set_description(custom, declared->label);
+    // Takes ownership, so there is nothing to free here.
+    accesskit_node_push_custom_action(out, custom);
+  }
+
+  // a11y_focus_blocked is the framework saying this node must not take the
+  // accessibility cursor even though it otherwise could -- a node behind a
+  // modal barrier, typically. Offering focus anyway would let a screen reader
+  // move onto content the app has deliberately sealed off.
+  AddActions(out, node->actions, node->focusable && !node->a11y_focus_blocked);
   return out;
 }
+
+namespace {
 
 // Builds a full tree update from a snapshot. The caller owns the result.
 accesskit_tree_update* BuildTreeUpdate(const IhsSemanticsSnapshot* snapshot) {

--- a/shell/accessibility/accesskit_consumer.h
+++ b/shell/accessibility/accesskit_consumer.h
@@ -38,6 +38,17 @@ accesskit_role ToAccessKitRole(IhsSemanticsRole role);
 // rather than dispatching a guess.
 uint64_t ToIhsAction(accesskit_action action);
 
+// Translates one hub node into an AccessKit node. Exposed for testing: several
+// of the rules here are invisible without an assistive technology attached and
+// fail silently when wrong -- a Label's accessible name comes from its value
+// rather than its label, and the focus action must be offered only where the
+// node can actually hold the accessibility cursor.
+//
+// `snapshot` resolves the node's children and custom-action declarations, so
+// it must be the snapshot the node came from. Caller owns the result.
+accesskit_node* BuildNode(const IhsSemanticsNode* node,
+                          const IhsSemanticsSnapshot* snapshot);
+
 // Bridges the semantics hub to a platform screen reader through AccessKit.
 //
 // This is a hub consumer like any other: it registers, waits on the hub's

--- a/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
+++ b/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
@@ -341,3 +341,24 @@ TEST(AccessKitConsumer, CustomActionsResolveTheirDeclaredLabels) {
             "Add to favorites");
   accesskit_custom_actions_free(actions);
 }
+
+// The hub normalizes an absent string to "" so its consumers need no null
+// checks. AccessKit's model is optional, where Some("") is not None, so that
+// normalization has to be undone at this boundary: an empty label would be
+// counted as a label the node does not have, and a live region whose name is
+// empty emits an announcement of nothing.
+TEST(AccessKitConsumer, EmptyStringsAreNotForwardedAsContent) {
+  const IhsSemanticsPublishNode node =
+      PlainNode("", IHS_SEMANTICS_ROLE_BUTTON);  // no label, hint, or value
+  const BuiltNode built(node);
+  EXPECT_EQ(accesskit_node_label(built.get()), nullptr);
+  EXPECT_EQ(accesskit_node_description(built.get()), nullptr);
+  EXPECT_EQ(accesskit_node_value(built.get()), nullptr);
+}
+
+// The Label fixup must not manufacture a value out of an absent label either.
+TEST(AccessKitConsumer, LabelNodeWithNoTextCarriesNoValue) {
+  const IhsSemanticsPublishNode node = PlainNode("", IHS_SEMANTICS_ROLE_LABEL);
+  const BuiltNode built(node);
+  EXPECT_EQ(accesskit_node_value(built.get()), nullptr);
+}

--- a/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
+++ b/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
@@ -16,11 +16,13 @@
 
 #include <cstdint>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "gtest/gtest.h"
 
 #include "ihs/ihs_semantics.h"
+#include "ihs/ihs_semantics_host.h"
 
 #include "accessibility/accesskit_consumer.h"
 
@@ -153,4 +155,189 @@ TEST(AccessKitConsumer, EveryMappedActionIsWithinTheAllowMask) {
         << "mapped action 0x" << std::hex << mapped
         << " is not a bit this ABI defines";
   }
+}
+
+namespace {
+
+// Publishes a one-node tree and hands back the built AccessKit node. The
+// snapshot is real rather than a stub, since BuildNode resolves children and
+// custom-action declarations through it.
+class BuiltNode {
+ public:
+  BuiltNode(const IhsSemanticsPublishNode& node,
+            std::vector<IhsSemanticsPublishCustomAction> customs = {}) {
+    IhsSemanticsPublishInfo info{};
+    info.struct_size = sizeof(info);
+    info.nodes = &node;
+    info.node_count = 1;
+    info.custom_actions = customs.empty() ? nullptr : customs.data();
+    info.custom_action_count = customs.size();
+    ihs_semantics_publish(&info);
+    snapshot_ = ihs_semantics_acquire_snapshot();
+    built_ = accessibility::BuildNode(
+        ihs_semantics_snapshot_node_at(snapshot_, 0), snapshot_);
+  }
+  ~BuiltNode() {
+    accesskit_node_free(built_);
+    ihs_semantics_release_snapshot(snapshot_);
+    ihs_semantics_clear();
+  }
+  BuiltNode(const BuiltNode&) = delete;
+  BuiltNode& operator=(const BuiltNode&) = delete;
+
+  accesskit_node* get() const { return built_; }
+
+ private:
+  const IhsSemanticsSnapshot* snapshot_ = nullptr;
+  accesskit_node* built_ = nullptr;
+};
+
+// Reads a string getter that hands back an owned copy.
+std::string Owned(char* value) {
+  if (value == nullptr) {
+    return {};
+  }
+  std::string out(value);
+  accesskit_string_free(value);
+  return out;
+}
+
+IhsSemanticsPublishNode PlainNode(const char* label, IhsSemanticsRole role) {
+  IhsSemanticsPublishNode node{};
+  node.id = 0;
+  node.label = label;
+  node.hint = "";
+  node.value = "";
+  node.tooltip = "";
+  node.identifier = "";
+  node.role = role;
+  return node;
+}
+
+}  // namespace
+
+// AccessKit derives a Label node's accessible name from its value, not its
+// label. Flutter puts the text in the label, so without the fixup every piece
+// of static text in the UI reaches a screen reader nameless -- and since a
+// live region's announcement is built from that same name, an unnamed toast is
+// never announced at all.
+TEST(AccessKitConsumer, LabelNodeCarriesItsTextInTheValue) {
+  const IhsSemanticsPublishNode node =
+      PlainNode("Now playing", IHS_SEMANTICS_ROLE_LABEL);
+  const BuiltNode built(node);
+  EXPECT_EQ(Owned(accesskit_node_value(built.get())), "Now playing");
+}
+
+// Only a Label takes its name from the value; anything else keeps whatever
+// value it was given, so a slider reading "21.5" is not overwritten.
+TEST(AccessKitConsumer, NonLabelRolesKeepTheirOwnValue) {
+  IhsSemanticsPublishNode node =
+      PlainNode("Driver temperature", IHS_SEMANTICS_ROLE_SLIDER);
+  node.value = "21.5";
+  const BuiltNode built(node);
+  EXPECT_EQ(Owned(accesskit_node_value(built.get())), "21.5");
+
+  // And a Label that already has a value keeps it rather than being clobbered.
+  IhsSemanticsPublishNode labelled =
+      PlainNode("ignored", IHS_SEMANTICS_ROLE_LABEL);
+  labelled.value = "explicit";
+  const BuiltNode built_label(labelled);
+  EXPECT_EQ(Owned(accesskit_node_value(built_label.get())), "explicit");
+}
+
+// Focus is what a screen reader uses to place its cursor. Offering it on every
+// node -- as this did before -- makes static text and layout containers look
+// like focus targets, which reads as a tree full of nothing.
+TEST(AccessKitConsumer, FocusIsOfferedOnlyWhereTheNodeCanHoldTheCursor) {
+  IhsSemanticsPublishNode focusable =
+      PlainNode("Play", IHS_SEMANTICS_ROLE_BUTTON);
+  focusable.focusable = true;
+  const BuiltNode built_focusable(focusable);
+  EXPECT_TRUE(accesskit_node_supports_action(built_focusable.get(),
+                                             ACCESSKIT_ACTION_FOCUS));
+
+  const IhsSemanticsPublishNode plain =
+      PlainNode("Now playing", IHS_SEMANTICS_ROLE_LABEL);
+  const BuiltNode built_plain(plain);
+  EXPECT_FALSE(accesskit_node_supports_action(built_plain.get(),
+                                              ACCESSKIT_ACTION_FOCUS));
+}
+
+// The framework can mark a node as unable to take the accessibility cursor
+// even though it is otherwise focusable -- content behind a modal barrier.
+// Offering focus anyway would walk a screen reader into sealed-off content.
+TEST(AccessKitConsumer, BlockedNodesDoNotOfferFocus) {
+  IhsSemanticsPublishNode blocked =
+      PlainNode("Behind a dialog", IHS_SEMANTICS_ROLE_BUTTON);
+  blocked.focusable = true;
+  blocked.a11y_focus_blocked = true;
+  const BuiltNode built(blocked);
+  EXPECT_FALSE(
+      accesskit_node_supports_action(built.get(), ACCESSKIT_ACTION_FOCUS));
+}
+
+// A live region is announced without the cursor moving to it, which is the
+// only way a toast reaches a screen reader before it disappears.
+TEST(AccessKitConsumer, LiveRegionsArePolite) {
+  IhsSemanticsPublishNode toast =
+      PlainNode("Bluetooth connected", IHS_SEMANTICS_ROLE_LABEL);
+  toast.live_region = true;
+  const BuiltNode built(toast);
+  const accesskit_opt_live live = accesskit_node_live(built.get());
+  ASSERT_TRUE(live.has_value);
+  EXPECT_EQ(live.value, ACCESSKIT_LIVE_POLITE);
+
+  // An ordinary node says nothing about liveness at all, which is distinct
+  // from saying "off": AccessKit inherits liveness from an ancestor when the
+  // node itself is silent, and asserting off would suppress that.
+  const IhsSemanticsPublishNode quiet =
+      PlainNode("Now playing", IHS_SEMANTICS_ROLE_LABEL);
+  const BuiltNode built_quiet(quiet);
+  EXPECT_FALSE(accesskit_node_live(built_quiet.get()).has_value);
+}
+
+// The app's stable id is what an automation client keys on when a label is
+// localized or ambiguous. Empty at the 3.38.3 deployment floor, so this pins
+// the wiring rather than anything observable on a shipping target today.
+TEST(AccessKitConsumer, IdentifierAndTooltipAreForwarded) {
+  IhsSemanticsPublishNode node = PlainNode("Play", IHS_SEMANTICS_ROLE_BUTTON);
+  node.identifier = "media.play";
+  node.tooltip = "Start playback";
+  const BuiltNode built(node);
+  EXPECT_EQ(Owned(accesskit_node_author_id(built.get())), "media.play");
+  EXPECT_EQ(Owned(accesskit_node_tooltip(built.get())), "Start playback");
+}
+
+// An unannotated node must not claim an empty identifier: an author id of ""
+// is a different statement from having none, and automation clients key on it.
+TEST(AccessKitConsumer, UnannotatedNodesCarryNoIdentifier) {
+  const IhsSemanticsPublishNode node =
+      PlainNode("Play", IHS_SEMANTICS_ROLE_BUTTON);
+  const BuiltNode built(node);
+  EXPECT_EQ(accesskit_node_author_id(built.get()), nullptr);
+  EXPECT_EQ(accesskit_node_tooltip(built.get()), nullptr);
+}
+
+// Custom actions are the application's own verbs. A node referencing an
+// undeclared id is skipped rather than announced with no name.
+TEST(AccessKitConsumer, CustomActionsResolveTheirDeclaredLabels) {
+  std::vector<int32_t> ids = {100, 999};  // 999 is never declared
+  IhsSemanticsPublishNode node = PlainNode("Play", IHS_SEMANTICS_ROLE_BUTTON);
+  node.custom_action_ids = ids.data();
+  node.custom_action_count = ids.size();
+
+  std::vector<IhsSemanticsPublishCustomAction> customs(1);
+  customs[0].id = 100;
+  customs[0].label = "Add to favorites";
+  customs[0].hint = "";
+
+  const BuiltNode built(node, customs);
+  accesskit_custom_actions* actions =
+      accesskit_node_custom_actions(built.get());
+  ASSERT_NE(actions, nullptr);
+  EXPECT_EQ(actions->length, 1u);
+  EXPECT_EQ(accesskit_custom_action_id(actions->values[0]), 100);
+  EXPECT_EQ(Owned(accesskit_custom_action_description(actions->values[0])),
+            "Add to favorites");
+  accesskit_custom_actions_free(actions);
 }


### PR DESCRIPTION
Follow-up to #434. Now that the bridge is a hub consumer, a field-by-field comparison of what the hub publishes against what reached AccessKit turned up five properties being dropped and a sixth set wrong.

## The one that matters most

**A Label's accessible name comes from its value, not its label.** AccessKit's `label_comes_from_value()` is exactly `role == Label`, and Flutter puts the text in the label — so every piece of static text in the UI reached a screen reader with no name at all. That is most of what there is to read.

It also silently disabled live regions: the announcement is built from that same name, so an unnamed toast was never announced.

## The rest

**Live regions** are forwarded as polite. This is how a toast or snackbar reaches a screen reader at all — by the time a user could navigate to one it has usually gone. Flutter carries a single `liveRegion` boolean with no urgency distinction, and assertive interrupts whatever is currently being spoken, so polite is the honest mapping. This is the mitigation the plan's R-6 already assumed existed.

**Focus was advertised on every node.** The old code added `ACCESSKIT_ACTION_FOCUS` unconditionally while its own comment claimed it was offered "whenever the node can hold the accessibility cursor" — `focusable` was never even passed in. Static text and layout containers all looked like focus targets. It now also honours `a11y_focus_blocked`, so a screen reader cannot walk onto content behind a modal barrier.

**Custom actions** — the application's own verbs — are resolved against the snapshot's declaration table. A node referencing an undeclared id is skipped, since an action announced with no name is worse than one that is absent.

**`identifier`** is forwarded as the author id, and **`tooltip`** as the tooltip. The identifier is empty on every node at the 3.38.3 deployment floor, so it does nothing today; wiring it now means it starts working on an engine bump instead of staying quietly dropped at the point where it would matter.

## Testing

**Verified over the AT-SPI accessibility bus**, not only by unit test:

```
button 'Play'  FOCUSABLE | id=media.play | actions=click
label  'Now playing'
label  'Bluetooth connected'
```

Labels carry their text, the author id arrives as `AccessibleId`, and only the focusable node reports `FOCUSABLE` — the slider, check box and panel no longer claim to be focus targets. Publishing a tree without a toast and then republishing with one emits `object:announcement from 'Bluetooth connected'`, which is the live-region path working end to end.

8 new unit cases (15 total in this suite) pin the rules that fail silently: a Label's text lands in the value, a non-Label keeps its own value, focus is offered only where the cursor can land, a blocked node offers none, liveness is polite when set and *absent* rather than "off" when not (AccessKit inherits liveness from an ancestor, so asserting off would suppress that), an unannotated node carries no author id, and an undeclared custom action is skipped.

`BuildNode` is exposed for testing alongside the two translation tables, for the same reason they are.

All suites pass, clang-tidy and clang-format clean.

## Limits

**Custom actions and tooltips are not observable on Linux.** `accesskit_atspi_common` surfaces neither over AT-SPI — there is no custom-action handling in that backend at all. Both are set correctly on the AccessKit node, which is what the other AccessKit backends consume, but nothing on this platform will show them today.

**CI still has no AccessKit leg**, so none of these 15 tests run there.
