### PR TITLE
shell: start the MCP provider from config

### DIFF
--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -108,6 +108,12 @@ static constexpr char kCrashpadBinaryPath[] = "@CRASHPAD_RUNTIME_PATH@";
 
 #cmakedefine01 BUILD_ACCESSIBILITY
 
+/* The MCP surface. ihs_shared also exports IHS_WITH_MCP from its own PUBLIC
+ * interface, but that is the library telling its consumers what it contains;
+ * shell code guards on this, alongside BUILD_ACCESSIBILITY, so the build's
+ * own answer does not depend on what a linked target happens to leak. */
+#cmakedefine01 BUILD_MCP
+
 #cmakedefine01 DEBUG_PLATFORM_MESSAGES
 
 #cmakedefine01 ENABLE_LTO

--- a/docs/config-examples/reference.toml
+++ b/docs/config-examples/reference.toml
@@ -22,6 +22,10 @@
   # type=bool default=false values=true|false applies=all
   disable_cursor =
 
+  # Serve the MCP surface, letting an external agent read and drive the UI. Requires a build configured with BUILD_MCP; off unless both the build and this key ask for it.
+  # type=bool default=false values=true|false applies=all
+  enable_mcp =
+
   # Wayland input events to mask (e.g. 'keyboard pointer').
   # type=string default=— values=comma/space list applies=wayland
   wayland_event_mask =

--- a/scripts/gen_config_reference.py
+++ b/scripts/gen_config_reference.py
@@ -51,6 +51,7 @@ META = {
     "global.disable_cursor": ("false", "true|false", "all", "Hide the pointer cursor."),
     "global.wayland_event_mask": ("—", "comma/space list", "wayland", "Wayland input events to mask (e.g. 'keyboard pointer')."),
     "global.debug_backend": ("false", "true|false", "all", "Enable backend debug logging."),
+    "global.enable_mcp": ("false", "true|false", "all", "Serve the MCP surface, letting an external agent read and drive the UI. Requires a build configured with BUILD_MCP; off unless both the build and this key ask for it."),
     # [sentry] — process-level (optional; DSN from $SENTRY_DSN)
     "sentry.release": ("—", "string", "all", "Sentry release tag."),
     "sentry.env": ("(built-in)", "string", "all", "Sentry environment."),

--- a/shell/configuration/README.md
+++ b/shell/configuration/README.md
@@ -283,6 +283,7 @@ file see
 | `[global]` | `cursor_theme` | `string` | `—` | `string` | all |
 | `[global]` | `debug_backend` | `bool` | `false` | `true\|false` | all |
 | `[global]` | `disable_cursor` | `bool` | `false` | `true\|false` | all |
+| `[global]` | `enable_mcp` | `bool` | `false` | `true\|false` | all |
 | `[global]` | `wayland_event_mask` | `string` | `—` | `comma/space list` | wayland |
 | `[sentry]` | `attachments` | `string` | `[]` | `array<path>` | all |
 | `[sentry]` | `env` | `string` | `(built-in)` | `string` | all |

--- a/shell/configuration/configuration.cc
+++ b/shell/configuration/configuration.cc
@@ -70,6 +70,10 @@ void Configuration::get_global_parameters(toml::table* root, Config& instance) {
     instance.debug_backend =
         root->at_path("global.debug_backend").value<bool>().value();
   }
+  if (root->at_path("global.enable_mcp").is_boolean()) {
+    instance.enable_mcp =
+        root->at_path("global.enable_mcp").value<bool>().value();
+  }
 }
 
 namespace {
@@ -416,6 +420,9 @@ void Configuration::get_cli_override(const std::string& bundle_path,
   if (cli.debug_backend.has_value()) {
     instance.debug_backend = cli.debug_backend.value();
   }
+  if (cli.enable_mcp.has_value()) {
+    instance.enable_mcp = cli.enable_mcp.value();
+  }
   if (!cli.view.engine_args.empty()) {
     for (auto const& arg : cli.view.engine_args) {
       instance.view.engine_args.emplace_back(arg);
@@ -639,6 +646,8 @@ void Configuration::PrintConfig(const Config& config) {
   }
   ihs::log::info("Debug Shell: ........... {}",
                  (config.debug_backend.value_or(false) ? "true" : "false"));
+  ihs::log::info("MCP Surface: ........... {}",
+                 (config.enable_mcp.value_or(false) ? "true" : "false"));
   ihs::log::info("********");
   ihs::log::info("* View *");
   ihs::log::info("********");
@@ -741,7 +750,11 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
         cxxopts::value<bool>()->implicit_value("true"))(
         "wayland-event-mask",
         "Wayland input events to mask (e.g. pointer-axis,keyboard)",
-        cxxopts::value<std::string>(config.wayland_event_mask));
+        cxxopts::value<std::string>(config.wayland_event_mask))(
+        "enable-mcp",
+        "Serve the MCP surface, letting an external agent read and drive the "
+        "UI (requires a build configured with BUILD_MCP)",
+        cxxopts::value<bool>()->implicit_value("true"));
 
     // [[view]] (geometry / Flutter)
     allocated->add_options("View")("w,width", "View width in px",
@@ -976,6 +989,9 @@ std::vector<Configuration::Config> Configuration::ParseArgcArgv(
     }
     if (result.count("debug-backend")) {
       config.debug_backend = result["debug-backend"].as<bool>();
+    }
+    if (result.count("enable-mcp")) {
+      config.enable_mcp = result["enable-mcp"].as<bool>();
     }
     if (result.count("fullscreen")) {
       config.view.fullscreen = result["fullscreen"].as<bool>();

--- a/shell/configuration/configuration.h
+++ b/shell/configuration/configuration.h
@@ -34,6 +34,17 @@ class Configuration {
     std::optional<bool> debug_backend;
     std::vector<std::string> bundle_paths;
 
+    // [global] enable_mcp: serve the MCP surface, which lets an external agent
+    // read the UI and drive it. Off unless asked for, and asking takes both a
+    // build that included the surface (BUILD_MCP) and this key -- the double
+    // opt-in cmake/options.cmake describes, so neither a stray config on a
+    // stock image nor an MCP-capable build on its own exposes anything.
+    //
+    // It also decides whether the engine produces semantics at all: starting
+    // the provider registers a hub consumer, and the hub reference-counts
+    // those to switch semantics on. Left off, the surface costs nothing.
+    std::optional<bool> enable_mcp;
+
     struct {
       std::string bundle_path;
       // Engine / Dart VM switches -> FlutterProjectArgs.command_line_argv

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -31,6 +31,11 @@
 
 #include "config/common.h"
 #include "engine.h"
+#if BUILD_ACCESSIBILITY && BUILD_MCP
+#include "ihs/ihs_mcp_host.h"
+#include "ihs/ihs_mcp_semantics.h"
+#endif
+
 #if BUILD_ACCESSIBILITY
 #include "ihs/ihs_semantics_host.h"
 #include "shell/accessibility/semantics_publisher.h"
@@ -125,7 +130,8 @@ Engine::Engine(FlutterView* view,
                const std::vector<const char*>& dart_entrypoint_args_c,
                const std::string& bundle_path,
                const int32_t accessibility_features,
-               const bool merge_render_platform)
+               const bool merge_render_platform,
+               const bool enable_mcp)
     : m_index(index),
       m_running(false),
       m_backend(view->GetBackend()),
@@ -135,6 +141,7 @@ Engine::Engine(FlutterView* view,
       m_prev_width(0),
       m_prev_pixel_ratio(1.0),
       m_accessibility_features(accessibility_features),
+      m_enable_mcp(enable_mcp),
       m_flutter_engine(nullptr) {
   IHS_TRACE("({}) +Engine::Engine", m_index);
 
@@ -314,6 +321,15 @@ void Engine::Shutdown() {
     return;  // never started, or already stopped — idempotent
   }
   m_running = false;
+
+#if BUILD_ACCESSIBILITY && BUILD_MCP
+  // Before the engine threads go: stop() guarantees no provider callback is in
+  // flight when it returns, and releases the hub registration that was keeping
+  // semantics on. Safe when start never ran.
+  if (m_enable_mcp) {
+    ihs_mcp_semantics_provider_stop();
+  }
+#endif
   // Deinitialize stops new frame work; Shutdown joins the platform, UI and
   // rasterizer threads. After this returns nothing in the engine touches the
   // backend (no more VsyncTrampoline / PresentLayers), so the caller may
@@ -381,6 +397,23 @@ FlutterEngineResult Engine::Run(FlutterDesktopEngineState* state) {
   // Registering is what asks the hub to turn semantics on, so the bridge is
   // created after the host is installed and not before.
   m_accesskit = std::make_unique<accessibility::AccessKitConsumer>();
+#endif
+#if BUILD_MCP
+  // The second half of the double opt-in: the surface is compiled in, and the
+  // image asked for it. Starting registers a hub consumer, which is what turns
+  // semantics on, so leaving it off really does cost nothing rather than
+  // merely hiding the tools.
+  if (m_enable_mcp) {
+    const int status = ihs_mcp_semantics_provider_start();
+    if (status == IHS_MCP_OK) {
+      ihs::log::info("({}) MCP semantics provider started", m_index);
+    } else {
+      // Not fatal: the UI is the product and it runs without an agent
+      // attached. Loud, though, because the image explicitly asked for this.
+      ihs::log::error("({}) MCP semantics provider failed to start: {}",
+                      m_index, status);
+    }
+  }
 #endif
 #endif
 

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -66,7 +66,8 @@ class Engine {
          const std::vector<const char*>& dart_entrypoint_args_c,
          const std::string& bundle_path,
          int32_t accessibility_features,
-         bool merge_render_platform);
+         bool merge_render_platform,
+         bool enable_mcp);
 
   ~Engine();
 
@@ -480,6 +481,10 @@ class Engine {
   // retains a pointer to it via m_args.compositor.
   FlutterCompositor m_compositor{};
   std::string m_clipboard_data;
+
+  // [global] enable_mcp. Held rather than read at teardown so stop pairs with
+  // exactly the start that ran, whatever config does afterwards.
+  bool m_enable_mcp = false;
 
 #if BUILD_ACCESSIBILITY && ENABLE_ACCESSKIT
   // Bridges published snapshots to a screen reader. Owned here because its

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -551,7 +551,8 @@ bool FlutterView::Initialize() {
       this, m_index, m_command_line_args_c, m_dart_entrypoint_args_c,
       m_config.view.bundle_path,
       m_config.view.accessibility_features.value_or(0),
-      m_config.view.merge_render_platform.value_or(false));
+      m_config.view.merge_render_platform.value_or(false),
+      m_config.enable_mcp.value_or(false));
 
   m_state->engine = m_flutter_engine.get();
 

--- a/test/unit_test/configuration-test-case/test_case_configuration.cc
+++ b/test/unit_test/configuration-test-case/test_case_configuration.cc
@@ -25,12 +25,14 @@ TEST(HomescreenConfigurationParseConfig, Lv1Normal001) {
       Configuration::parse_config(config);
 
   const auto& [app_id, cursor_theme, disable_cursor, wayland_event_mask,
-               debug_backend, bundle_paths, view, hud, config_file] =
-      configs.back();
+               debug_backend, bundle_paths, enable_mcp, view, hud,
+               config_file] = configs.back();
 
   EXPECT_EQ("com.toyotaconnected.homescreen", app_id);
   EXPECT_EQ(false, disable_cursor.value_or(false));
   EXPECT_EQ(false, debug_backend.value_or(false));
+  // The MCP surface is opt-in: absent from config means off, never inherited.
+  EXPECT_EQ(false, enable_mcp.value_or(false));
   EXPECT_EQ(kBundlePath, view.bundle_path);
   EXPECT_EQ("NORMAL", view.window_type);
   EXPECT_EQ(0, view.wl_output_index.value_or(0));
@@ -85,8 +87,8 @@ TEST(HomescreenConfigurationParseArgcArgv, Lv1Normal001) {
   const auto configs = Configuration::ParseArgcArgv(argc, argv_p);
 
   const auto& [app_id, cursor_theme, disable_cursor, wayland_event_mask,
-               debug_backend, bundle_paths, view, hud, config_file] =
-      configs.back();
+               debug_backend, bundle_paths, enable_mcp, view, hud,
+               config_file] = configs.back();
   // check result
 
   EXPECT_EQ(kSourceRoot, view.bundle_path);


### PR DESCRIPTION
The semantics provider merged in #435 was never started outside its own tests. An MCP build shipped the surface and never registered it, so every `ui_*` tool was dead code in a real process.

## What this adds

The runtime half of the double opt-in that `cmake/options.cmake` already describes: *"an image has to opt in at build time here and again at runtime through config before any of it is reachable."* The build half existed; this is the config half.

`[global] enable_mcp` (also `--enable-mcp`), off by default, following the `debug_backend` precedent through TOML parse, CLI override, and the startup config dump.

## Why the default matters beyond the tool surface

Starting the provider **registers a hub consumer**, and the hub reference-counts consumers to decide whether the engine produces semantics at all. Wiring this unconditionally at bring-up would have switched semantics on for every MCP-capable image, defeating the refcounted-enable design that `engine.cc` describes in its own comment — *"a build with the subsystem compiled in but nobody listening costs the engine nothing."*

So left off, this genuinely costs nothing. It does not merely hide the tools.

Stop runs in `Shutdown()`, where the provider's contract guarantees no callback is in flight when it returns and releases the hub registration — which, if it was the last consumer, is what turns semantics back off.

## One thing worth reviewing closely

`BUILD_MCP` joins `BUILD_ACCESSIBILITY` in `config_common.h.in`, and that was not cosmetic.

`ihs_shared` already exports `IHS_WITH_MCP=1` from its PUBLIC interface, so guarding shell code on that would have worked — but it is the *library* describing itself to consumers, and it would make the build's own answer depend on what a linked target happens to leak. Meanwhile the obvious-looking guard, `#if BUILD_MCP`, was undefined for shell code: it would have expanded to `0` and compiled the whole feature to nothing, silently, in a build that reported `MCP ... Enabled`. That is the failure this repo has already been bitten by once with the `QUIET` AccessKit probe (#418).

## Testing

Both legs of the gate, since the value of this change is that the surface stays off unless asked for:

- **MCP on:** generated header carries `#define BUILD_MCP 1`, shell links, 26/26 tests pass.
- **MCP off:** shell builds and references **no `ihs_mcp` symbol at all** (`nm -u` count is 0).

The `Configuration::Config` structured-binding test caught the new field, as designed; it now also asserts `enable_mcp` defaults to false, since an opt-in that could be inherited would not be one.

clang-tidy reports nothing on the added lines (the warnings in these files are pre-existing, at constructors and unrelated methods), clang-format clean.

## Not in scope

There is still no transport. This registers the provider in-process; nothing external can reach it until the UDS/Streamable-HTTP work lands, at which point the socket permissions and token questions in P6 apply. Starting the provider is a prerequisite for that work, not a substitute for it.
