### PR TITLE
shared: serve MCP over a Unix domain socket

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -192,6 +192,12 @@ if (BUILD_MCP)
     target_compile_definitions(ihs_shared PUBLIC IHS_WITH_MCP=1)
     # The semantics provider bridges the two: it needs the hub as well as the
     # registry, so it is only built when both are.
+    # The transport is framing over a socket: it routes onto ihs_mcp_host and
+    # knows nothing about tools, so it builds with the registry rather than
+    # with the semantics provider.
+    target_sources(ihs_shared PRIVATE src/mcp_transport.cc)
+    target_include_directories(ihs_shared PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/rapidjson/include")
     if (BUILD_ACCESSIBILITY)
         target_sources(ihs_shared PRIVATE src/mcp_semantics_provider.cc)
         # rapidjson is header-only, so this adds an include path and no link
@@ -280,7 +286,8 @@ endif ()
 if (NOT BUILD_MCP)
     list(APPEND _ihs_header_excludes
             PATTERN "ihs_mcp_provider.h" EXCLUDE
-            PATTERN "ihs_mcp_host.h" EXCLUDE)
+            PATTERN "ihs_mcp_host.h" EXCLUDE
+            PATTERN "ihs_mcp_transport.h" EXCLUDE)
 endif ()
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ihs
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/shared/include/ihs/ihs_mcp_transport.h
+++ b/shared/include/ihs/ihs_mcp_transport.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The MCP transport: a Unix domain socket carrying JSON-RPC 2.0 over HTTP,
+ * which is what the MCP Streamable HTTP transport is once the network is taken
+ * out of it. Everything it serves comes from ihs_mcp_host.h; it adds framing
+ * and a socket, and knows nothing about tools or the semantics tree.
+ *
+ * Unix domain only, deliberately. A TCP listener would make the UI drivable
+ * from off-box, which is a product-security decision rather than a transport
+ * one, so there is no address family to configure and no token to get wrong.
+ * A filesystem socket puts the decision where the operating system can enforce
+ * it: the socket is created 0600, and every connection's peer credentials are
+ * checked against the shell's own uid before a byte is read.
+ */
+
+#ifndef IHS_MCP_TRANSPORT_H_
+#define IHS_MCP_TRANSPORT_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "ihs/ihs_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct IhsMcpTransportConfig {
+  size_t struct_size; /* sizeof(IhsMcpTransportConfig) */
+
+  /*
+   * Where to listen. NULL or "" selects
+   * $XDG_RUNTIME_DIR/ivi-homescreen/mcp.sock, falling back to
+   * /run/user/<uid>/ivi-homescreen/mcp.sock. The parent directory is created
+   * 0700 if missing.
+   *
+   * An existing socket at the path is replaced only when nothing is listening
+   * on it, so a second shell cannot silently steal the first one's endpoint.
+   */
+  const char* socket_path;
+
+  /*
+   * Largest request body accepted, in bytes. 0 selects 1 MiB. A request that
+   * declares more is refused before anything is read, so an oversized
+   * Content-Length costs nothing to reject.
+   */
+  size_t max_request_bytes;
+} IhsMcpTransportConfig;
+
+/*
+ * Binds the socket and serves on a thread of its own. Returns IHS_MCP_OK, or
+ * IHS_MCP_ERR_INVALID for a malformed config, IHS_MCP_ERR_REFUSED when the
+ * path is already being served by a live listener, and
+ * IHS_MCP_ERR_UNAVAILABLE when the socket cannot be created or bound.
+ *
+ * Idempotent: starting an already-started transport succeeds and keeps the
+ * original socket, so a caller that cannot easily tell whether bring-up
+ * already ran does not have to.
+ */
+IHS_EXPORT int ihs_mcp_transport_start(const IhsMcpTransportConfig* config);
+
+/*
+ * Stops serving, closes every connection, joins the thread and unlinks the
+ * socket. Safe to call when not started. After it returns no request is in
+ * flight, so a caller may tear down the host it routes to.
+ */
+IHS_EXPORT void ihs_mcp_transport_stop(void);
+
+/* Whether the transport is currently serving. Diagnostics. */
+IHS_EXPORT bool ihs_mcp_transport_running(void);
+
+/*
+ * The path actually bound, or "" when not started. Callers log this rather
+ * than recomputing the default. Valid until the next stop.
+ */
+IHS_EXPORT const char* ihs_mcp_transport_socket_path(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* IHS_MCP_TRANSPORT_H_ */

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -1,0 +1,732 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// MCP transport: JSON-RPC 2.0 over HTTP on a Unix domain socket. Framing and
+// dispatch only -- every method here is a thin translation onto
+// ihs_mcp_host.h, which is where tools and resources actually live.
+
+#include "ihs/ihs_mcp_transport.h"
+
+#include "ihs/ihs_mcp_host.h"
+#include "ihs/ihs_mcp_provider.h"
+
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+#include "ihs/logging.h"
+
+namespace {
+
+// Logging goes through the C API for the same reason the rest of ihs_shared
+// does: the library sits below the shell's C++ logging wrapper.
+int32_t TraceContext() {
+  static const int32_t ctx = ihs_log_context_open("MCPT", nullptr);
+  return ctx;
+}
+
+void Log(const int32_t level, const std::string& text) {
+  const int32_t ctx = TraceContext();
+  if (ctx < 0 || ihs_log_enabled(ctx, level) == 0) {
+    return;
+  }
+  ihs_log(ctx, level, text.c_str(), text.size());
+}
+
+constexpr size_t kDefaultMaxRequestBytes = 1024 * 1024;
+
+// Bounds the header section independently of the body: headers are read
+// before any Content-Length is known, so without this a peer could stream
+// header bytes forever and never be refused.
+constexpr size_t kMaxHeaderBytes = 16 * 1024;
+
+// The MCP revision this speaks. Sent back from initialize; a client asking for
+// something else still gets this, which is what the specification calls for --
+// the server states what it supports and the client decides whether to go on.
+constexpr const char* kProtocolVersion = "2025-06-18";
+
+// JSON-RPC 2.0 error codes.
+constexpr int kParseError = -32700;
+constexpr int kInvalidRequest = -32600;
+constexpr int kMethodNotFound = -32601;
+constexpr int kInvalidParams = -32602;
+constexpr int kInternalError = -32603;
+
+struct Transport {
+  std::mutex mutex;
+  bool running = false;
+  int listen_fd = -1;
+  int wake_fd = -1;  // eventfd-free: a self-pipe, so stop() interrupts accept
+  int wake_write_fd = -1;
+  std::string socket_path{};
+  size_t max_request_bytes = kDefaultMaxRequestBytes;
+  std::thread thread;
+};
+
+Transport& TheTransport() {
+  static auto* t = new Transport();  // leaked: outlives static teardown
+  return *t;
+}
+
+// ---------------------------------------------------------------------------
+// JSON helpers
+// ---------------------------------------------------------------------------
+
+std::string Escape(const std::string& in) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  writer.String(in.c_str(), static_cast<rapidjson::SizeType>(in.size()));
+  return buffer.GetString();
+}
+
+// The id is echoed verbatim so a client's own numbering survives, including
+// the null the specification requires when a request could not be parsed well
+// enough to have one.
+std::string ResultEnvelope(const std::string& id, const std::string& result) {
+  return R"({"jsonrpc":"2.0","id":)" + id + R"(,"result":)" + result + "}";
+}
+
+std::string ErrorEnvelope(const std::string& id,
+                          const int code,
+                          const std::string& message) {
+  return R"({"jsonrpc":"2.0","id":)" + id + R"(,"error":{"code":)" +
+         std::to_string(code) + R"(,"message":)" + Escape(message) + "}}";
+}
+
+// Maps a host status onto the JSON-RPC code that describes it. A denied
+// capability is deliberately not folded into "not found": the host keeps them
+// distinct so a masked tool asked for by name is visible as a refusal rather
+// than a typo, and flattening that here would throw the distinction away at
+// the last step.
+int JsonRpcCodeFor(const int status) {
+  if (status == IHS_MCP_ERR_NOT_FOUND) {
+    return kMethodNotFound;
+  }
+  if (status == IHS_MCP_ERR_INVALID) {
+    return kInvalidParams;
+  }
+  // A denied capability, a refusal and an unavailable provider are all the
+  // server declining rather than the request being malformed, which is what
+  // JSON-RPC's internal error covers. The distinction between them survives
+  // in the message, which StatusText keeps specific.
+  return kInternalError;
+}
+
+const char* StatusText(const int status) {
+  switch (status) {
+    case IHS_MCP_ERR_NOT_FOUND:
+      return "no such tool or resource";
+    case IHS_MCP_ERR_INVALID:
+      return "invalid arguments";
+    case IHS_MCP_ERR_CAPABILITY_DENIED:
+      return "capability denied";
+    case IHS_MCP_ERR_REFUSED:
+      return "refused";
+    case IHS_MCP_ERR_UNAVAILABLE:
+      return "unavailable";
+    default:
+      return "internal error";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Method handlers
+// ---------------------------------------------------------------------------
+
+struct ListAccumulator {
+  std::string out{};
+  bool first = true;
+};
+
+void AppendTool(const IhsMcpHostTool* tool, void* user_data) {
+  auto* acc = static_cast<ListAccumulator*>(user_data);
+  if (!acc->first) {
+    acc->out += ",";
+  }
+  acc->first = false;
+  acc->out += R"({"name":)" + Escape(tool->name != nullptr ? tool->name : "");
+  acc->out += R"(,"description":)" +
+              Escape(tool->description != nullptr ? tool->description : "");
+  // The schema is already JSON, so it is spliced rather than escaped. A
+  // provider that registered something malformed would corrupt the envelope,
+  // which is why the registry validates it at registration.
+  acc->out += R"(,"inputSchema":)";
+  acc->out +=
+      (tool->input_schema_json != nullptr && tool->input_schema_json[0] != '\0')
+          ? tool->input_schema_json
+          : R"({"type":"object"})";
+  acc->out += "}";
+}
+
+void AppendResource(const IhsMcpHostResource* resource, void* user_data) {
+  auto* acc = static_cast<ListAccumulator*>(user_data);
+  if (!acc->first) {
+    acc->out += ",";
+  }
+  acc->first = false;
+  acc->out +=
+      R"({"uri":)" + Escape(resource->uri != nullptr ? resource->uri : "");
+  acc->out +=
+      R"(,"name":)" + Escape(resource->name != nullptr ? resource->name : "");
+  acc->out +=
+      R"(,"description":)" +
+      Escape(resource->description != nullptr ? resource->description : "");
+  acc->out += R"(,"mimeType":)" + Escape(resource->mime_type != nullptr
+                                             ? resource->mime_type
+                                             : "application/json");
+  acc->out += "}";
+}
+
+std::string HandleInitialize() {
+  // Only the capabilities actually served are advertised. listChanged is
+  // absent because nothing pushes notifications yet, and claiming it would
+  // have clients waiting for messages that never arrive.
+  return std::string(R"({"protocolVersion":")") + kProtocolVersion +
+         R"(","capabilities":{"tools":{},"resources":{}})" +
+         R"(,"serverInfo":{"name":"ivi-homescreen","version":"1"}})";
+}
+
+std::string HandleToolsList() {
+  ListAccumulator acc;
+  acc.out = R"({"tools":[)";
+  ihs_mcp_host_for_each_tool(AppendTool, &acc);
+  acc.out += "]}";
+  return acc.out;
+}
+
+std::string HandleResourcesList() {
+  ListAccumulator acc;
+  acc.out = R"({"resources":[)";
+  ihs_mcp_host_for_each_resource(AppendResource, &acc);
+  acc.out += "]}";
+  return acc.out;
+}
+
+// Serializes the params sub-object back to text. The host takes tool arguments
+// as JSON, so re-emitting is cheaper and safer than teaching it a value type.
+std::string ReEmit(const rapidjson::Value& value) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  value.Accept(writer);
+  return buffer.GetString();
+}
+
+std::string HandleToolsCall(const rapidjson::Value& params,
+                            const std::string& id) {
+  if (!params.IsObject() || !params.HasMember("name") ||
+      !params["name"].IsString()) {
+    return ErrorEnvelope(id, kInvalidParams, "tools/call requires a name");
+  }
+  const std::string name = params["name"].GetString();
+
+  std::string arguments = "{}";
+  if (params.HasMember("arguments") && params["arguments"].IsObject()) {
+    arguments = ReEmit(params["arguments"]);
+  }
+
+  IhsMcpPayload payload{};
+  const int status = ihs_mcp_host_call_tool(name.c_str(), arguments.c_str(),
+                                            arguments.size(), &payload);
+  if (status != IHS_MCP_OK) {
+    ihs_mcp_host_release_payload(&payload);
+    return ErrorEnvelope(id, JsonRpcCodeFor(status), StatusText(status));
+  }
+
+  const std::string content(payload.data != nullptr ? payload.data : "",
+                            payload.length);
+  ihs_mcp_host_release_payload(&payload);
+
+  // The tool's own JSON is carried as MCP text content: providers return a
+  // result document, and the specification's content array is the envelope a
+  // client expects to unwrap.
+  return ResultEnvelope(id, R"({"content":[{"type":"text","text":)" +
+                                Escape(content) + R"(}],"isError":false})");
+}
+
+std::string HandleResourcesRead(const rapidjson::Value& params,
+                                const std::string& id) {
+  if (!params.IsObject() || !params.HasMember("uri") ||
+      !params["uri"].IsString()) {
+    return ErrorEnvelope(id, kInvalidParams, "resources/read requires a uri");
+  }
+  const std::string uri = params["uri"].GetString();
+
+  IhsMcpPayload payload{};
+  const int status = ihs_mcp_host_read_resource(uri.c_str(), &payload);
+  if (status != IHS_MCP_OK) {
+    ihs_mcp_host_release_payload(&payload);
+    return ErrorEnvelope(id, JsonRpcCodeFor(status), StatusText(status));
+  }
+
+  const std::string content(payload.data != nullptr ? payload.data : "",
+                            payload.length);
+  ihs_mcp_host_release_payload(&payload);
+
+  return ResultEnvelope(id, R"({"contents":[{"uri":)" + Escape(uri) +
+                                R"(,"mimeType":"application/json","text":)" +
+                                Escape(content) + "}]}");
+}
+
+// Routes one JSON-RPC request. Returns the response text, or empty for a
+// notification -- a request with no id expects no reply, and answering one
+// would be a protocol error rather than merely noise.
+std::string Dispatch(const std::string& body) {
+  rapidjson::Document doc;
+  if (doc.Parse(body.c_str(), body.size()).HasParseError() || !doc.IsObject()) {
+    return ErrorEnvelope("null", kParseError, "invalid JSON");
+  }
+
+  std::string id = "null";
+  bool is_notification = true;
+  if (doc.HasMember("id") && !doc["id"].IsNull()) {
+    id = ReEmit(doc["id"]);
+    is_notification = false;
+  }
+
+  if (!doc.HasMember("method") || !doc["method"].IsString()) {
+    return is_notification
+               ? std::string()
+               : ErrorEnvelope(id, kInvalidRequest, "missing method");
+  }
+  const std::string method = doc["method"].GetString();
+
+  static const rapidjson::Value kEmpty(rapidjson::kObjectType);
+  const rapidjson::Value& params =
+      doc.HasMember("params") ? doc["params"] : kEmpty;
+
+  std::string response;
+  if (method == "initialize") {
+    response = ResultEnvelope(id, HandleInitialize());
+  } else if (method == "tools/list") {
+    response = ResultEnvelope(id, HandleToolsList());
+  } else if (method == "resources/list") {
+    response = ResultEnvelope(id, HandleResourcesList());
+  } else if (method == "tools/call") {
+    response = HandleToolsCall(params, id);
+  } else if (method == "resources/read") {
+    response = HandleResourcesRead(params, id);
+  } else if (method == "ping") {
+    response = ResultEnvelope(id, "{}");
+  } else if (method == "notifications/initialized") {
+    return {};  // a notification by definition; nothing to answer
+  } else {
+    response = ErrorEnvelope(id, kMethodNotFound, "unknown method: " + method);
+  }
+
+  return is_notification ? std::string() : response;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP framing
+// ---------------------------------------------------------------------------
+
+std::string HttpResponse(const int code,
+                         const char* reason,
+                         const std::string& body) {
+  std::string out = "HTTP/1.1 " + std::to_string(code) + " " + reason + "\r\n";
+  out += "Content-Type: application/json\r\n";
+  out += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+  // Nothing here is cacheable and every response is a live view of the UI.
+  out += "Cache-Control: no-store\r\n";
+  out += "Connection: close\r\n\r\n";
+  out += body;
+  return out;
+}
+
+bool WriteAll(const int fd, const std::string& data) {
+  size_t sent = 0;
+  while (sent < data.size()) {
+    const ssize_t n = ::write(fd, data.data() + sent, data.size() - sent);
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    sent += static_cast<size_t>(n);
+  }
+  return true;
+}
+
+// Reads until the header terminator, then exactly Content-Length bytes.
+// Returns false when the peer is malformed or over budget, having already
+// written the refusal.
+bool ReadRequest(const int fd, const size_t max_body, std::string* out_body) {
+  std::string buffer;
+  size_t header_end = std::string::npos;
+
+  while (true) {
+    char chunk[4096];
+    const ssize_t n = ::read(fd, chunk, sizeof(chunk));
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    if (n == 0) {
+      return false;  // peer closed before completing the request
+    }
+    buffer.append(chunk, static_cast<size_t>(n));
+
+    header_end = buffer.find("\r\n\r\n");
+    if (header_end != std::string::npos) {
+      break;
+    }
+    if (buffer.size() > kMaxHeaderBytes) {
+      WriteAll(fd, HttpResponse(431, "Request Header Fields Too Large", "{}"));
+      return false;
+    }
+  }
+
+  // Only POST carries a body, and every JSON-RPC call is a POST. Anything else
+  // is answered rather than ignored, so a browser or a probe gets a clear no.
+  if (buffer.rfind("POST ", 0) != 0) {
+    WriteAll(
+        fd, HttpResponse(405, "Method Not Allowed", R"({"error":"use POST"})"));
+    return false;
+  }
+
+  // Header names are case-insensitive, so match on a lowered copy while
+  // keeping the original for the body split.
+  std::string lowered = buffer.substr(0, header_end);
+  for (char& c : lowered) {
+    c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+  }
+
+  size_t content_length = 0;
+  const size_t cl = lowered.find("content-length:");
+  if (cl == std::string::npos) {
+    WriteAll(fd, HttpResponse(411, "Length Required",
+                              R"({"error":"Content-Length required"})"));
+    return false;
+  }
+  {
+    const size_t value_start = cl + std::strlen("content-length:");
+    const size_t line_end = lowered.find("\r\n", value_start);
+    const std::string value =
+        lowered.substr(value_start, line_end - value_start);
+    errno = 0;
+    char* end = nullptr;
+    const unsigned long long parsed = std::strtoull(value.c_str(), &end, 10);
+    if (errno != 0 || end == value.c_str()) {
+      WriteAll(fd, HttpResponse(400, "Bad Request",
+                                R"({"error":"bad Content-Length"})"));
+      return false;
+    }
+    content_length = static_cast<size_t>(parsed);
+  }
+
+  // Refused on the declared length, before reading it: an oversized body
+  // should cost the shell nothing to turn away.
+  if (content_length > max_body) {
+    WriteAll(fd, HttpResponse(413, "Content Too Large",
+                              R"({"error":"request too large"})"));
+    return false;
+  }
+
+  std::string body = buffer.substr(header_end + 4);
+  while (body.size() < content_length) {
+    char chunk[4096];
+    const size_t want = std::min(sizeof(chunk), content_length - body.size());
+    const ssize_t n = ::read(fd, chunk, want);
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    if (n == 0) {
+      return false;
+    }
+    body.append(chunk, static_cast<size_t>(n));
+  }
+  body.resize(content_length);
+
+  *out_body = std::move(body);
+  return true;
+}
+
+// The socket is 0600, so the filesystem already keeps other users out. This
+// is the second half of that: it rejects a peer running as a different uid
+// that reached the socket anyway -- through an inherited descriptor, or a
+// directory whose permissions were loosened after the fact.
+bool PeerIsOwner(const int fd) {
+  ucred credentials{};
+  socklen_t length = sizeof(credentials);
+  if (::getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &credentials, &length) != 0) {
+    return false;  // cannot establish who this is, so do not serve them
+  }
+  return credentials.uid == ::geteuid();
+}
+
+void ServeConnection(const int fd, const size_t max_body) {
+  if (!PeerIsOwner(fd)) {
+    Log(IHS_LEVEL_WARN, "mcp: refused a connection from another user");
+    WriteAll(fd, HttpResponse(403, "Forbidden", R"({"error":"forbidden"})"));
+    return;
+  }
+
+  std::string body;
+  if (!ReadRequest(fd, max_body, &body)) {
+    return;  // ReadRequest already answered, or the peer went away
+  }
+
+  const std::string response = Dispatch(body);
+  if (response.empty()) {
+    // A notification. HTTP still needs a reply, and 202 says "taken, nothing
+    // to return" without inventing a JSON-RPC response the client must ignore.
+    WriteAll(fd, HttpResponse(202, "Accepted", ""));
+    return;
+  }
+  WriteAll(fd, HttpResponse(200, "OK", response));
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+namespace {
+
+std::string DefaultSocketPath() {
+  const char* runtime_dir = ::getenv("XDG_RUNTIME_DIR");
+  std::string base;
+  if (runtime_dir != nullptr && runtime_dir[0] != '\0') {
+    base = runtime_dir;
+  } else {
+    base = "/run/user/" + std::to_string(::geteuid());
+  }
+  return base + "/ivi-homescreen/mcp.sock";
+}
+
+// Creates the socket's parent 0700. The directory is as much of the boundary
+// as the socket mode is: a world-writable parent would let another user
+// replace the socket with their own.
+bool EnsureParentDirectory(const std::string& path) {
+  const size_t slash = path.rfind('/');
+  if (slash == std::string::npos || slash == 0) {
+    return true;
+  }
+  const std::string parent = path.substr(0, slash);
+  if (::mkdir(parent.c_str(), 0700) == 0) {
+    return true;
+  }
+  return errno == EEXIST;
+}
+
+// Tells a stale socket from a live one by trying to connect. Only a socket
+// nobody answers is removed, so two shells racing for the same path produce a
+// refusal rather than one silently taking the other's clients.
+bool StaleSocketRemoved(const std::string& path) {
+  const int probe = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (probe < 0) {
+    return false;
+  }
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+
+  const bool live = ::connect(probe, reinterpret_cast<sockaddr*>(&address),
+                              sizeof(address)) == 0;
+  ::close(probe);
+  if (live) {
+    return false;  // someone is serving here; leave them alone
+  }
+  ::unlink(path.c_str());
+  return true;
+}
+
+void AcceptLoop() {
+  Transport& t = TheTransport();
+  const int listen_fd = t.listen_fd;
+  const int wake_fd = t.wake_fd;
+  const size_t max_body = t.max_request_bytes;
+
+  while (true) {
+    pollfd fds[2];
+    fds[0] = {listen_fd, POLLIN, 0};
+    fds[1] = {wake_fd, POLLIN, 0};
+    const int ready = ::poll(fds, 2, -1);
+    if (ready < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    if ((fds[1].revents & POLLIN) != 0) {
+      break;  // stop() asked
+    }
+    if ((fds[0].revents & POLLIN) == 0) {
+      continue;
+    }
+
+    const int client = ::accept4(listen_fd, nullptr, nullptr, SOCK_CLOEXEC);
+    if (client < 0) {
+      if (errno == EINTR || errno == EAGAIN) {
+        continue;
+      }
+      break;
+    }
+    // Served inline. Requests are short and the host serializes anyway, so a
+    // thread per connection would buy concurrency the registry cannot use.
+    ServeConnection(client, max_body);
+    ::close(client);
+  }
+}
+
+}  // namespace
+
+int ihs_mcp_transport_start(const IhsMcpTransportConfig* config) {
+  if (config == nullptr || config->struct_size == 0) {
+    return IHS_MCP_ERR_INVALID;
+  }
+
+  Transport& t = TheTransport();
+  const std::lock_guard<std::mutex> lock(t.mutex);
+  if (t.running) {
+    return IHS_MCP_OK;  // idempotent
+  }
+
+  const std::string path =
+      (config->socket_path != nullptr && config->socket_path[0] != '\0')
+          ? config->socket_path
+          : DefaultSocketPath();
+
+  if (path.size() >= sizeof(sockaddr_un::sun_path)) {
+    Log(IHS_LEVEL_ERROR, "mcp: socket path is too long: " + path);
+    return IHS_MCP_ERR_INVALID;
+  }
+  if (!EnsureParentDirectory(path)) {
+    Log(IHS_LEVEL_ERROR, "mcp: cannot create the socket directory for " + path +
+                             ": " + std::strerror(errno));
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+  if (::access(path.c_str(), F_OK) == 0 && !StaleSocketRemoved(path)) {
+    Log(IHS_LEVEL_ERROR, "mcp: " + path + " is already being served");
+    return IHS_MCP_ERR_REFUSED;
+  }
+
+  const int listen_fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (listen_fd < 0) {
+    Log(IHS_LEVEL_ERROR, std::string("mcp: socket(): ") + std::strerror(errno));
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+
+  // Narrow the mode across bind() rather than chmod'ing afterwards: between a
+  // permissive bind and a later chmod the socket is briefly connectable by
+  // anyone, and that window is the whole control.
+  const mode_t previous_umask = ::umask(0177);
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+  const bool bound = ::bind(listen_fd, reinterpret_cast<sockaddr*>(&address),
+                            sizeof(address)) == 0;
+  ::umask(previous_umask);
+
+  if (!bound) {
+    Log(IHS_LEVEL_ERROR, "mcp: bind(" + path + "): " + std::strerror(errno));
+    ::close(listen_fd);
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+  if (::listen(listen_fd, 4) != 0) {
+    Log(IHS_LEVEL_ERROR, std::string("mcp: listen(): ") + std::strerror(errno));
+    ::close(listen_fd);
+    ::unlink(path.c_str());
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+
+  int wake[2] = {-1, -1};
+  if (::pipe(wake) != 0) {
+    Log(IHS_LEVEL_ERROR, std::string("mcp: pipe(): ") + std::strerror(errno));
+    ::close(listen_fd);
+    ::unlink(path.c_str());
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+
+  t.listen_fd = listen_fd;
+  t.wake_fd = wake[0];
+  t.wake_write_fd = wake[1];
+  t.socket_path = path;
+  t.max_request_bytes = config->max_request_bytes != 0
+                            ? config->max_request_bytes
+                            : kDefaultMaxRequestBytes;
+  t.running = true;
+  t.thread = std::thread(AcceptLoop);
+
+  Log(IHS_LEVEL_INFO, "mcp: serving on " + path);
+  return IHS_MCP_OK;
+}
+
+void ihs_mcp_transport_stop() {
+  Transport& t = TheTransport();
+  std::thread thread;
+  {
+    const std::lock_guard<std::mutex> lock(t.mutex);
+    if (!t.running) {
+      return;
+    }
+    t.running = false;
+    const char byte = 1;
+    ssize_t written;
+    do {
+      written = ::write(t.wake_write_fd, &byte, 1);
+    } while (written < 0 && errno == EINTR);
+    thread = std::move(t.thread);
+  }
+
+  if (thread.joinable()) {
+    thread.join();
+  }
+
+  const std::lock_guard<std::mutex> lock(t.mutex);
+  ::close(t.listen_fd);
+  ::close(t.wake_fd);
+  ::close(t.wake_write_fd);
+  t.listen_fd = -1;
+  t.wake_fd = -1;
+  t.wake_write_fd = -1;
+  ::unlink(t.socket_path.c_str());
+  t.socket_path.clear();
+}
+
+bool ihs_mcp_transport_running() {
+  Transport& t = TheTransport();
+  const std::lock_guard<std::mutex> lock(t.mutex);
+  return t.running;
+}
+
+const char* ihs_mcp_transport_socket_path() {
+  Transport& t = TheTransport();
+  const std::lock_guard<std::mutex> lock(t.mutex);
+  return t.socket_path.c_str();
+}

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -34,6 +34,7 @@
 #if BUILD_ACCESSIBILITY && BUILD_MCP
 #include "ihs/ihs_mcp_host.h"
 #include "ihs/ihs_mcp_semantics.h"
+#include "ihs/ihs_mcp_transport.h"
 #endif
 
 #if BUILD_ACCESSIBILITY
@@ -327,6 +328,10 @@ void Engine::Shutdown() {
   // flight when it returns, and releases the hub registration that was keeping
   // semantics on. Safe when start never ran.
   if (m_enable_mcp) {
+    // Transport first: it routes into the provider, so stopping the provider
+    // while a request was in flight would tear out what that request is
+    // standing on. Stop guarantees nothing is in flight when it returns.
+    ihs_mcp_transport_stop();
     ihs_mcp_semantics_provider_stop();
   }
 #endif
@@ -407,6 +412,19 @@ FlutterEngineResult Engine::Run(FlutterDesktopEngineState* state) {
     const int status = ihs_mcp_semantics_provider_start();
     if (status == IHS_MCP_OK) {
       ihs::log::info("({}) MCP semantics provider started", m_index);
+      // Only once there is something to serve: the transport routes onto the
+      // registry, so binding a socket before the provider registered would
+      // advertise an empty tool list to whoever connected first.
+      IhsMcpTransportConfig transport{};
+      transport.struct_size = sizeof(transport);
+      const int served = ihs_mcp_transport_start(&transport);
+      if (served == IHS_MCP_OK) {
+        ihs::log::info("({}) MCP serving on {}", m_index,
+                       ihs_mcp_transport_socket_path());
+      } else {
+        ihs::log::error("({}) MCP transport failed to start: {}", m_index,
+                        served);
+      }
     } else {
       // Not fatal: the UI is the product and it runs without an agent
       // attached. Loud, though, because the image explicitly asked for this.

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -198,6 +198,8 @@ add_subdirectory(mutation_stack-test)
 # its tests would have nothing to link against otherwise.
 if (BUILD_MCP)
     add_subdirectory(mcp_provider-test)
+    # The transport routes onto the registry and needs nothing else.
+    add_subdirectory(mcp_transport-test)
     # The semantics provider needs the hub as well as the registry.
     if (BUILD_ACCESSIBILITY)
         add_subdirectory(mcp_semantics_provider-test)

--- a/test/unit_test/mcp_transport-test/CMakeLists.txt
+++ b/test/unit_test/mcp_transport-test/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# MCP transport tests: HTTP framing, JSON-RPC dispatch and the socket
+# permissions. Speaks to a real socket over loopback-free AF_UNIX, since the
+# framing and the file mode are the parts worth proving.
+set(TESTCASE_NAME "homescreen_mcp_transport_ut_test_driver")
+
+add_executable(${TESTCASE_NAME}
+        test_case_mcp_transport.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        ivi_homescreen::ihs_shared
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_mcp_transport.h"
+
+namespace {
+
+std::string TempSocketPath(const char* leaf) {
+  const char* base = std::getenv("TEST_SCRATCH_DIR");
+  if (base == nullptr || base[0] == '\0') {
+    base = std::getenv("TMPDIR");
+  }
+  if (base == nullptr || base[0] == '\0') {
+    base = "/tmp";
+  }
+  return std::string(base) + "/ihs-mcp-" + leaf + "-" +
+         std::to_string(::getpid()) + ".sock";
+}
+
+// One request, one connection: the transport answers with Connection: close,
+// which is what a client of a request/response transport expects.
+std::string Send(const std::string& path, const std::string& request) {
+  const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) {
+    return {};
+  }
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+  if (::connect(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) !=
+      0) {
+    ::close(fd);
+    return {};
+  }
+
+  size_t sent = 0;
+  while (sent < request.size()) {
+    const ssize_t n = ::write(fd, request.data() + sent, request.size() - sent);
+    if (n <= 0) {
+      break;
+    }
+    sent += static_cast<size_t>(n);
+  }
+
+  std::string response;
+  char chunk[4096];
+  while (true) {
+    const ssize_t n = ::read(fd, chunk, sizeof(chunk));
+    if (n <= 0) {
+      break;
+    }
+    response.append(chunk, static_cast<size_t>(n));
+  }
+  ::close(fd);
+  return response;
+}
+
+std::string Post(const std::string& path, const std::string& body) {
+  return Send(path, "POST / HTTP/1.1\r\nContent-Length: " +
+                        std::to_string(body.size()) + "\r\n\r\n" + body);
+}
+
+std::string StatusLine(const std::string& response) {
+  const size_t end = response.find("\r\n");
+  return end == std::string::npos ? response : response.substr(0, end);
+}
+
+std::string Body(const std::string& response) {
+  const size_t split = response.find("\r\n\r\n");
+  return split == std::string::npos ? std::string()
+                                    : response.substr(split + 4);
+}
+
+class McpTransportTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    path_ = TempSocketPath(
+        ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    ::unlink(path_.c_str());
+    IhsMcpTransportConfig config{};
+    config.struct_size = sizeof(config);
+    config.socket_path = path_.c_str();
+    ASSERT_EQ(ihs_mcp_transport_start(&config), IHS_MCP_OK);
+  }
+  void TearDown() override {
+    ihs_mcp_transport_stop();
+    ::unlink(path_.c_str());
+  }
+  std::string path_;
+};
+
+}  // namespace
+
+// The socket mode is the access control. Anything wider would put the UI's
+// drive surface within reach of every user on the system.
+TEST_F(McpTransportTest, SocketIsOwnerOnly) {
+  struct stat info{};
+  ASSERT_EQ(::stat(path_.c_str(), &info), 0);
+  EXPECT_EQ(info.st_mode & 0777, 0600u)
+      << "socket mode is " << std::oct << (info.st_mode & 0777);
+}
+
+TEST_F(McpTransportTest, ReportsWhereItIsServing) {
+  EXPECT_TRUE(ihs_mcp_transport_running());
+  EXPECT_EQ(std::string(ihs_mcp_transport_socket_path()), path_);
+}
+
+// A caller that cannot easily tell whether bring-up already ran must not end
+// up with two listeners or a replaced socket.
+TEST_F(McpTransportTest, StartIsIdempotent) {
+  IhsMcpTransportConfig config{};
+  config.struct_size = sizeof(config);
+  config.socket_path = path_.c_str();
+  EXPECT_EQ(ihs_mcp_transport_start(&config), IHS_MCP_OK);
+  EXPECT_EQ(std::string(ihs_mcp_transport_socket_path()), path_);
+}
+
+// Stop unlinks, so a restart is not refused by its own leftovers.
+TEST_F(McpTransportTest, StopRemovesTheSocket) {
+  ihs_mcp_transport_stop();
+  EXPECT_FALSE(ihs_mcp_transport_running());
+  struct stat info{};
+  EXPECT_NE(::stat(path_.c_str(), &info), 0);
+  EXPECT_STREQ(ihs_mcp_transport_socket_path(), "");
+}
+
+TEST_F(McpTransportTest, InitializeReportsProtocolAndCapabilities) {
+  const std::string response =
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 200 OK");
+  const std::string body = Body(response);
+  EXPECT_NE(body.find(R"("id":1)"), std::string::npos);
+  EXPECT_NE(body.find("protocolVersion"), std::string::npos);
+  // Only what is actually served is advertised: nothing pushes notifications
+  // yet, so claiming listChanged would leave clients waiting for messages
+  // that never come.
+  EXPECT_EQ(body.find("listChanged"), std::string::npos);
+}
+
+// With no provider registered the list is empty rather than absent, so a
+// client can tell "nothing to offer" from a malformed reply.
+TEST_F(McpTransportTest, ToolsAndResourcesListAreWellFormedWhenEmpty) {
+  std::string body =
+      Body(Post(path_, R"({"jsonrpc":"2.0","id":2,"method":"tools/list"})"));
+  EXPECT_NE(body.find(R"("tools":[)"), std::string::npos) << body;
+
+  body = Body(
+      Post(path_, R"({"jsonrpc":"2.0","id":3,"method":"resources/list"})"));
+  EXPECT_NE(body.find(R"("resources":[)"), std::string::npos) << body;
+}
+
+// The id is echoed verbatim, including a string id, so a client's own
+// correlation survives the round trip.
+TEST_F(McpTransportTest, RequestIdIsEchoedVerbatim) {
+  const std::string body =
+      Body(Post(path_, R"({"jsonrpc":"2.0","id":"abc-1","method":"ping"})"));
+  EXPECT_NE(body.find(R"("id":"abc-1")"), std::string::npos) << body;
+}
+
+TEST_F(McpTransportTest, UnknownMethodIsMethodNotFound) {
+  const std::string body = Body(
+      Post(path_, R"({"jsonrpc":"2.0","id":4,"method":"no/such/method"})"));
+  EXPECT_NE(body.find("-32601"), std::string::npos) << body;
+}
+
+TEST_F(McpTransportTest, MalformedJsonIsAParseError) {
+  const std::string body = Body(Post(path_, "not json at all"));
+  EXPECT_NE(body.find("-32700"), std::string::npos) << body;
+}
+
+TEST_F(McpTransportTest, ToolsCallWithoutANameIsInvalidParams) {
+  const std::string body = Body(Post(
+      path_, R"({"jsonrpc":"2.0","id":5,"method":"tools/call","params":{}})"));
+  EXPECT_NE(body.find("-32602"), std::string::npos) << body;
+}
+
+// A notification has no id and expects no reply. Answering one is a protocol
+// error, so the transport acknowledges at the HTTP layer and says nothing in
+// JSON-RPC.
+TEST_F(McpTransportTest, NotificationsGetNoJsonRpcReply) {
+  const std::string response =
+      Post(path_, R"({"jsonrpc":"2.0","method":"notifications/initialized"})");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 202 Accepted");
+  EXPECT_TRUE(Body(response).empty()) << Body(response);
+}
+
+// Only POST carries a request. A probe or a browser gets a clear answer
+// rather than a hang.
+TEST_F(McpTransportTest, NonPostIsRefused) {
+  const std::string response =
+      Send(path_, "GET / HTTP/1.1\r\nContent-Length: 0\r\n\r\n");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 405 Method Not Allowed");
+}
+
+TEST_F(McpTransportTest, MissingContentLengthIsRefused) {
+  const std::string response = Send(path_, "POST / HTTP/1.1\r\n\r\n");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 411 Length Required");
+}
+
+// Refused on the declared length, before the body is read: an oversized
+// request should cost the shell nothing to turn away.
+TEST_F(McpTransportTest, OversizedBodyIsRefusedBeforeReading) {
+  const std::string response =
+      Send(path_, "POST / HTTP/1.1\r\nContent-Length: 999999999\r\n\r\n");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 413 Content Too Large");
+}
+
+TEST_F(McpTransportTest, UnparseableContentLengthIsRefused) {
+  const std::string response =
+      Send(path_, "POST / HTTP/1.1\r\nContent-Length: abc\r\n\r\n");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 400 Bad Request");
+}
+
+// Header matching is case-insensitive, as HTTP requires; a client sending
+// lower-case headers must not be told its length is missing.
+TEST_F(McpTransportTest, HeaderNamesAreCaseInsensitive) {
+  const std::string body = R"({"jsonrpc":"2.0","id":6,"method":"ping"})";
+  const std::string response =
+      Send(path_, "POST / HTTP/1.1\r\ncontent-length: " +
+                      std::to_string(body.size()) + "\r\n\r\n" + body);
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 200 OK");
+}
+
+// A header section with no terminator must not let a peer stream forever.
+TEST_F(McpTransportTest, EndlessHeadersAreBounded) {
+  std::string request = "POST / HTTP/1.1\r\n";
+  request += "X-Filler: " + std::string(32 * 1024, 'a') + "\r\n";
+  const std::string response = Send(path_, request);
+  EXPECT_EQ(StatusLine(response),
+            "HTTP/1.1 431 Request Header Fields Too Large");
+}
+
+TEST(McpTransportLifecycle, StopWithoutStartIsHarmless) {
+  ihs_mcp_transport_stop();
+  EXPECT_FALSE(ihs_mcp_transport_running());
+  EXPECT_STREQ(ihs_mcp_transport_socket_path(), "");
+}
+
+TEST(McpTransportLifecycle, NullConfigIsRefused) {
+  EXPECT_EQ(ihs_mcp_transport_start(nullptr), IHS_MCP_ERR_INVALID);
+  EXPECT_FALSE(ihs_mcp_transport_running());
+}
+
+// A path that cannot fit in sun_path must be refused rather than silently
+// truncated to a different socket than the caller asked for.
+TEST(McpTransportLifecycle, OverlongPathIsRefused) {
+  IhsMcpTransportConfig config{};
+  config.struct_size = sizeof(config);
+  const std::string path = "/tmp/" + std::string(200, 'x') + ".sock";
+  config.socket_path = path.c_str();
+  EXPECT_EQ(ihs_mcp_transport_start(&config), IHS_MCP_ERR_INVALID);
+  EXPECT_FALSE(ihs_mcp_transport_running());
+}
+
+// A socket left behind by a crash must not stop the next start, but one that
+// is actually being served must not be stolen.
+TEST(McpTransportLifecycle, StaleSocketIsReplacedButALiveOneIsNot) {
+  const std::string path = TempSocketPath("stale");
+  ::unlink(path.c_str());
+
+  // Leave a socket file behind with nobody listening.
+  const int dead = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  ASSERT_GE(dead, 0);
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+  ASSERT_EQ(
+      ::bind(dead, reinterpret_cast<sockaddr*>(&address), sizeof(address)), 0);
+  ::close(dead);  // bound but never listened on, and now closed
+
+  IhsMcpTransportConfig config{};
+  config.struct_size = sizeof(config);
+  config.socket_path = path.c_str();
+  EXPECT_EQ(ihs_mcp_transport_start(&config), IHS_MCP_OK)
+      << "a stale socket should not block a restart";
+
+  // Now that one is live, a second start on the same path from a would-be
+  // second server is refused rather than replacing it. (Same process here, so
+  // this asserts the idempotent path rather than the refusal; the refusal is
+  // what StaleSocketRemoved's connect probe provides across processes.)
+  EXPECT_EQ(ihs_mcp_transport_start(&config), IHS_MCP_OK);
+
+  ihs_mcp_transport_stop();
+  ::unlink(path.c_str());
+}


### PR DESCRIPTION
The registry (#416), the semantics provider (#435) and the start wiring (#437) were all reachable only from inside the process. This is the transport: **JSON-RPC 2.0 over HTTP on a Unix domain socket**, which is what MCP's Streamable HTTP transport is once the network is taken out of it.

It routes onto `ihs_mcp_host` and knows nothing about tools or the semantics tree, so the routing layer stays transport-free as designed.

## Unix domain only, deliberately

A TCP listener would make the UI drivable from off-box. That is a product-security decision, not a transport one, and it is exactly the plan's OQ-2 — still open. So there is no address family to configure and no token to get wrong, and the decision sits where the operating system can enforce it.

Three controls, each covering a different way in:

- **The socket is bound under a `0177` umask, not chmod'ed afterwards.** Between a permissive `bind()` and a later `chmod()` the socket is briefly connectable by anyone, and that window is the entire control.
- **The parent directory is created `0700`.** A writable parent lets another user unlink the socket and put their own there; the mode on the socket alone would not stop that.
- **Every connection's peer uid is checked** (`SO_PEERCRED`) against the shell's own before a byte is read. That covers a descriptor that arrived some other way, or a directory whose permissions were loosened after the fact.

## Refusals are cheap on purpose

- An oversized request is refused on its **declared `Content-Length`, before the body is read** — so an attacker's large request costs the shell nothing.
- The header section is bounded independently (16 KiB), because headers are read before any length is known; without it a peer could stream header bytes forever.
- A non-POST gets `405` rather than hanging, so a probe or a browser gets a clear answer.

## Restart behavior 

A socket left behind by a crash is replaced; one that is **still being served is not**. The difference is a connect probe, so two shells racing for the same path produce a refusal rather than one silently taking the other's clients.

## Testing

**Driven end to end with a real client over the socket**, not only unit-tested. A harness publishing a tree through the hub, with the provider and transport started:

```
initialize      -> 200, protocolVersion 2025-06-18
tools/list      -> 200, 10 tools (ui_snapshot, ui_query, ui_tap, ...)
resources/list  -> 200, ['ui://semantics/tree']
resources/read  -> 200, tree nodes: 2, labels ['IVI Home', 'Play']
tools/call ui_tap {"node_id":1} -> 200
```

and on the host side:

```
[host] dispatch node=1 action=0x1
```

That is the whole chain: client → Unix socket → HTTP → JSON-RPC → registry → semantics provider → dispatch funnel → framework. The socket is `srw-------`.

Refusals verified the same way: `405` for GET, `411` with no Content-Length, `413` oversized, `-32700` on malformed JSON, `-32601` for an unknown method, `202` with an empty body for a notification.

21 unit tests cover framing, refusals, lifecycle and the socket mode. 27/27 in the suite; MCP-off leg still builds and references zero `ihs_mcp` symbols. clang-tidy clean on the new file, `scripts/format.sh --check` and `gen_config_reference.py --check` both pass.

## Limits

**No SSE, so no server-initiated messages.** `initialize` therefore does not advertise `listChanged`, because claiming it would leave clients waiting for notifications that never arrive. Resource subscriptions and `tools/list_changed` need the streaming half and are not here.

**Tool failures surface as JSON-RPC errors rather than `isError: true` content.** The MCP specification prefers the latter for a tool that ran and failed, reserving protocol errors for things like an unknown tool — but the host returns `IHS_MCP_ERR_NOT_FOUND` both for "no such tool" and for "no such node", so the transport cannot currently tell them apart. Separating them is a host/provider ABI change, not a transport fix.

**One connection is served at a time**, inline on the accept thread. Requests are short and the registry serializes anyway, so a thread per connection would buy concurrency nothing downstream can use.
