### PR TITLE
shared: encode StandardMessageCodec action arguments

### DIFF
--- a/shared/src/standard_message_encode.cc
+++ b/shared/src/standard_message_encode.cc
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "standard_message_encode.h"
+
+#include <cstring>
+
+namespace ihs::codec {
+namespace {
+
+// Wire tags, in the order Flutter's serializer defines them. Written out
+// rather than referenced because the enum lives in a header this library does
+// not include; the round-trip tests are what keep the two agreeing.
+constexpr uint8_t kString = 7;
+constexpr uint8_t kFloat64List = 11;
+constexpr uint8_t kMap = 13;
+constexpr uint8_t kInt32 = 3;
+
+// Sizes below 254 are a single byte; the two sentinels buy 16- and 32-bit
+// lengths. A reader that got this wrong would misread everything after it, so
+// it matches the serializer exactly rather than always using the wide form.
+void WriteSize(std::vector<uint8_t>& out, const size_t size) {
+  if (size < 254) {
+    out.push_back(static_cast<uint8_t>(size));
+  } else if (size <= 0xffff) {
+    out.push_back(254);
+    const auto value = static_cast<uint16_t>(size);
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&value);
+    out.insert(out.end(), bytes, bytes + sizeof(value));
+  } else {
+    out.push_back(255);
+    const auto value = static_cast<uint32_t>(size);
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&value);
+    out.insert(out.end(), bytes, bytes + sizeof(value));
+  }
+}
+
+// Typed lists are padded so their elements start on a natural boundary,
+// measured from the beginning of the message rather than from the list. The
+// decoder skips the same number of bytes by the same rule, so getting the
+// origin wrong shifts every element.
+void WriteAlignment(std::vector<uint8_t>& out, const size_t alignment) {
+  const size_t mod = out.size() % alignment;
+  if (mod == 0) {
+    return;
+  }
+  out.insert(out.end(), alignment - mod, 0);
+}
+
+void WriteInt32(std::vector<uint8_t>& out, const int32_t value) {
+  out.push_back(kInt32);
+  const auto* bytes = reinterpret_cast<const uint8_t*>(&value);
+  out.insert(out.end(), bytes, bytes + sizeof(value));
+}
+
+void WriteStringValue(std::vector<uint8_t>& out, const std::string& value) {
+  out.push_back(kString);
+  WriteSize(out, value.size());
+  out.insert(out.end(), value.begin(), value.end());
+}
+
+}  // namespace
+
+std::vector<uint8_t> EncodeString(const std::string& value) {
+  std::vector<uint8_t> out;
+  out.reserve(value.size() + 6);
+  WriteStringValue(out, value);
+  return out;
+}
+
+std::vector<uint8_t> EncodeFloat64List(const std::vector<double>& values) {
+  std::vector<uint8_t> out;
+  out.reserve(values.size() * sizeof(double) + 16);
+  out.push_back(kFloat64List);
+  WriteSize(out, values.size());
+  if (values.empty()) {
+    // An empty list still carries its tag and count; the alignment padding is
+    // skipped because there is nothing to align to.
+    return out;
+  }
+  WriteAlignment(out, sizeof(double));
+  const auto* bytes = reinterpret_cast<const uint8_t*>(values.data());
+  out.insert(out.end(), bytes, bytes + values.size() * sizeof(double));
+  return out;
+}
+
+std::vector<uint8_t> EncodeStringIntMap(
+    const std::vector<std::pair<std::string, int32_t>>& entries) {
+  std::vector<uint8_t> out;
+  out.push_back(kMap);
+  WriteSize(out, entries.size());
+  for (const auto& [key, value] : entries) {
+    WriteStringValue(out, key);
+    WriteInt32(out, value);
+  }
+  return out;
+}
+
+}  // namespace ihs::codec

--- a/shared/src/standard_message_encode.h
+++ b/shared/src/standard_message_encode.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The slice of Flutter's StandardMessageCodec needed to carry semantics action
+ * arguments. Internal to ihs_shared: not installed, not exported, and not part
+ * of the plugin ABI.
+ *
+ * Flutter vendors a complete codec in third_party, and this is deliberately
+ * not it. That one is C++ over flutter::EncodableValue, and ihs_shared links
+ * no Flutter library at all -- its whole premise is a flat C ABI with no C++
+ * crossing the boundary (docs/PLUGIN_ABI.md). Pulling libflutter in to encode
+ * three values would trade that for a handful of bytes.
+ *
+ * The cost of a second implementation is that it can drift from the one the
+ * framework actually decodes with, silently, which is R-9 in the plan. The
+ * mitigation is in the tests: everything encoded here is decoded again with
+ * Flutter's own vendored serializer and compared, so a divergence fails rather
+ * than reaching the framework as a dropped argument.
+ */
+
+#ifndef IHS_SHARED_SRC_STANDARD_MESSAGE_ENCODE_H_
+#define IHS_SHARED_SRC_STANDARD_MESSAGE_ENCODE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ihs::codec {
+
+/* A Dart String, which is what SemanticsAction.setText carries. */
+std::vector<uint8_t> EncodeString(const std::string& value);
+
+/*
+ * A Dart Float64List. SemanticsAction.scrollToOffset takes one holding the
+ * target offset as (dx, dy).
+ */
+std::vector<uint8_t> EncodeFloat64List(const std::vector<double>& values);
+
+/*
+ * A Dart Map<String, int>. SemanticsAction.setSelection takes one with "base"
+ * and "extent". Values are written as int32, which is what the framework reads
+ * a text offset as.
+ */
+std::vector<uint8_t> EncodeStringIntMap(
+    const std::vector<std::pair<std::string, int32_t>>& entries);
+
+}  // namespace ihs::codec
+
+#endif  // IHS_SHARED_SRC_STANDARD_MESSAGE_ENCODE_H_

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -207,6 +207,7 @@ if (BUILD_MCP)
 endif ()
 add_subdirectory(pixel_swizzle-test)
 add_subdirectory(scale_policy-test)
+add_subdirectory(standard_message_encode-test)
 add_subdirectory(text_input-test)
 # texture-test requires a live Wayland compositor, Flutter engine, and an app
 # bundle on disk — it is an integration test and has been moved to

--- a/test/unit_test/standard_message_encode-test/CMakeLists.txt
+++ b/test/unit_test/standard_message_encode-test/CMakeLists.txt
@@ -1,0 +1,45 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Round-trips ihs_shared's encoder against Flutter's own vendored serializer.
+# ihs_shared cannot link libflutter -- that is the whole reason the encoder
+# exists -- but the test can, which is what makes a second implementation of
+# the format safe to keep: a divergence fails here rather than reaching the
+# framework as a silently dropped argument.
+set(TESTCASE_NAME "homescreen_standard_message_encode_ut_test_driver")
+
+add_executable(${TESTCASE_NAME}
+        test_case_standard_message_encode.cc
+        # Compiled in rather than linked: these are internal to ihs_shared and
+        # deliberately not exported through the ihs_* ABI.
+        ${CMAKE_SOURCE_DIR}/shared/src/standard_message_encode.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_include_directories(${TESTCASE_NAME} PRIVATE
+        ${CMAKE_SOURCE_DIR}/shared/src
+)
+
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        flutter
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/standard_message_encode-test/test_case_standard_message_encode.cc
+++ b/test/unit_test/standard_message_encode-test/test_case_standard_message_encode.cc
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "flutter/standard_message_codec.h"
+
+#include "standard_message_encode.h"
+
+namespace {
+
+// Decodes with Flutter's own codec -- the one the framework decodes with on
+// the other side of the embedder call. This is the point of the suite: our
+// encoder is a second implementation of someone else's format, and only a
+// round trip through theirs can show the two still agree.
+flutter::EncodableValue Decode(const std::vector<uint8_t>& bytes) {
+  const auto& codec = flutter::StandardMessageCodec::GetInstance();
+  auto decoded = codec.DecodeMessage(bytes.data(), bytes.size());
+  return decoded == nullptr ? flutter::EncodableValue() : *decoded;
+}
+
+}  // namespace
+
+// SemanticsAction.setText carries the replacement text as a plain String.
+TEST(StandardMessageEncode, StringRoundTrips) {
+  const auto bytes = ihs::codec::EncodeString("Sarah Connor");
+  const auto value = Decode(bytes);
+  ASSERT_TRUE(std::holds_alternative<std::string>(value)) << "not a string";
+  EXPECT_EQ(std::get<std::string>(value), "Sarah Connor");
+}
+
+// The length prefix changes shape at 254 and again at 65536. A reader that
+// disagreed about which form was used would misread everything after it, so
+// each branch is exercised rather than assumed.
+TEST(StandardMessageEncode, StringLengthPrefixFormsAllRoundTrip) {
+  for (const size_t length : {size_t{0}, size_t{1}, size_t{253}, size_t{254},
+                              size_t{255}, size_t{65535}, size_t{65536}}) {
+    const std::string original(length, 'x');
+    const auto value = Decode(ihs::codec::EncodeString(original));
+    ASSERT_TRUE(std::holds_alternative<std::string>(value))
+        << "length " << length;
+    EXPECT_EQ(std::get<std::string>(value), original) << "length " << length;
+  }
+}
+
+// Multi-byte UTF-8 must survive: the length is in bytes, not characters, and
+// getting that wrong truncates a label mid-sequence.
+TEST(StandardMessageEncode, NonAsciiStringRoundTrips) {
+  const std::string original = "Fahrertür – 22°C";
+  const auto value = Decode(ihs::codec::EncodeString(original));
+  ASSERT_TRUE(std::holds_alternative<std::string>(value));
+  EXPECT_EQ(std::get<std::string>(value), original);
+}
+
+// SemanticsAction.scrollToOffset takes a Float64List of (dx, dy).
+TEST(StandardMessageEncode, Float64ListRoundTrips) {
+  const std::vector<double> original = {12.5, -400.25};
+  const auto value = Decode(ihs::codec::EncodeFloat64List(original));
+  ASSERT_TRUE(std::holds_alternative<std::vector<double>>(value))
+      << "not a Float64List";
+  EXPECT_EQ(std::get<std::vector<double>>(value), original);
+}
+
+// Elements are padded to an 8-byte boundary measured from the start of the
+// message. The padding is only visible when the preceding bytes leave the
+// stream misaligned, which the tag and a short count do -- so this is the
+// case that catches an alignment mistake.
+TEST(StandardMessageEncode, Float64ListIsAlignedFromTheStartOfTheMessage) {
+  const std::vector<double> original = {1.0, 2.0, 3.0};
+  const auto bytes = ihs::codec::EncodeFloat64List(original);
+  // tag + count is 2 bytes, so 6 bytes of padding must precede the doubles.
+  EXPECT_EQ(bytes.size(), 2u + 6u + original.size() * sizeof(double));
+  const auto value = Decode(bytes);
+  ASSERT_TRUE(std::holds_alternative<std::vector<double>>(value));
+  EXPECT_EQ(std::get<std::vector<double>>(value), original);
+}
+
+// An empty typed list is tag and count with no alignment padding, because
+// Flutter's writer returns before writing any. Asserted as exact bytes rather
+// than by round trip, because Flutter's own C++ reader is asymmetric here: it
+// calls ReadAlignment unconditionally, so decoding an empty list it just wrote
+// reads past the end and logs "Invalid read". Matching the writer is right --
+// the wire format is what the Dart side decodes -- so anyone tempted to add
+// padding to silence that warning would be breaking the encoding to satisfy a
+// reader nothing uses. scrollToOffset always carries two elements, so the case
+// is academic in this port regardless.
+TEST(StandardMessageEncode, EmptyFloat64ListMatchesTheWriterNotTheReader) {
+  const auto bytes = ihs::codec::EncodeFloat64List({});
+  ASSERT_EQ(bytes.size(), 2u) << "expected tag and count only";
+  EXPECT_EQ(bytes[0], 11);  // kFloat64List
+  EXPECT_EQ(bytes[1], 0);   // count
+}
+
+// SemanticsAction.setSelection takes a Map<String,int> of base and extent.
+TEST(StandardMessageEncode, StringIntMapRoundTrips) {
+  const std::vector<std::pair<std::string, int32_t>> original = {
+      {"base", 3}, {"extent", 11}};
+  const auto value = Decode(ihs::codec::EncodeStringIntMap(original));
+  ASSERT_TRUE(std::holds_alternative<flutter::EncodableMap>(value))
+      << "not a map";
+  const auto& map = std::get<flutter::EncodableMap>(value);
+  ASSERT_EQ(map.size(), 2u);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("base"))), 3);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("extent"))), 11);
+}
+
+// A collapsed selection and a zero offset are ordinary values, not absent
+// ones: encoding them as anything else would move the caret to the wrong place.
+TEST(StandardMessageEncode, ZeroValuesAreCarriedNotDropped) {
+  const auto value =
+      Decode(ihs::codec::EncodeStringIntMap({{"base", 0}, {"extent", 0}}));
+  const auto& map = std::get<flutter::EncodableMap>(value);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("base"))), 0);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("extent"))), 0);
+}
+
+// Negative offsets appear during overscroll, and a text offset is signed.
+TEST(StandardMessageEncode, NegativeValuesSurvive) {
+  const auto scroll = Decode(ihs::codec::EncodeFloat64List({-1.5, -2.5}));
+  EXPECT_EQ(std::get<std::vector<double>>(scroll),
+            (std::vector<double>{-1.5, -2.5}));
+
+  const auto selection = Decode(ihs::codec::EncodeStringIntMap({{"base", -1}}));
+  const auto& map = std::get<flutter::EncodableMap>(selection);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("base"))), -1);
+}
+
+TEST(StandardMessageEncode, EmptyMapRoundTrips) {
+  const auto value = Decode(ihs::codec::EncodeStringIntMap({}));
+  ASSERT_TRUE(std::holds_alternative<flutter::EncodableMap>(value));
+  EXPECT_TRUE(std::get<flutter::EncodableMap>(value).empty());
+}


### PR DESCRIPTION
Semantics actions that carry an argument — `SetText`, `ScrollToOffset`, `SetSelection` — need it as a StandardMessageCodec message, and nothing in `ihs_shared` could produce one. This adds the three shapes those actions use: a `String`, a `Float64List`, and a `Map<String, int>`.

This unblocks two separate things that are stuck on the same missing piece: the parameterized `ui_*` tools, and AccessKit's `SetValue` write path (an assistive technology can currently read a scroll position but not set one, because `SetValue` maps to `ScrollToOffset` and there was no payload to send).

## Why not the vendored codec

Flutter vendors a complete implementation in `third_party`, and this is deliberately not it.

`ihs_shared` links **only** `Threads::Threads` — no Flutter library. It uses Flutter's public *C* headers for the desktop-bridge forwarders and nothing else. The vendored codec is C++ over `flutter::EncodableValue`, so using it here means linking `libflutter.a` into the library whose stated premise is *"No C++ types, exceptions, or RTTI cross the boundary"* (`docs/PLUGIN_ABI.md`). That is a large trade for three values.

The alternative — encoding shell-side, where `libflutter` is already linked — would mean the hub ABI carrying typed Flutter data instead of opaque bytes, putting Flutter's data model into a surface that is deliberately free of it.

So: a small encoder here, internal to `ihs_shared`, not installed and not exported through the `ihs_*` ABI. The tests compile the source directly rather than linking it.

## What makes a second implementation safe to keep

A reimplementation of someone else's format can drift from it silently — that is R-9 in the plan, "codec mis-encoding drops action args silently framework-side". The mitigation is the point of this PR: **every encoding is decoded again with Flutter's own vendored serializer and compared.** The test driver can link `libflutter` even though `ihs_shared` cannot, so a divergence fails here rather than reaching the framework as a dropped argument.

10 tests, covering the parts actually worth doubting rather than the happy path:

- all three **length-prefix forms** (`<254`, the 16-bit sentinel, the 32-bit one) — a reader that disagreed about which was used would misread everything after it
- **multi-byte UTF-8**, where the length is bytes and not characters
- **alignment padding** for a typed list, which is measured from the start of the message rather than from the list; the assertion pins the exact byte count, so getting the origin wrong fails
- zero and negative values carried rather than dropped — a collapsed selection and a zero scroll offset are ordinary values

## One thing found on the way

Flutter's own C++ codec is **asymmetric for an empty typed list**: `WriteVector` returns before writing alignment when the count is zero, but `ReadVector` calls `ReadAlignment` unconditionally. So its reader walks past the end of what its writer just produced, and logs `Invalid read in StandardCodecByteStreamReader`.

This encoder matches the **writer**, because the writer is what the wire format is — the Dart side decodes these bytes, not Flutter's C++ reader. That case is asserted as exact bytes rather than by round trip, with a comment recording why, so nobody later "fixes" the encoder by adding padding to silence a warning from a reader nothing in this path uses. `ScrollToOffset` always carries two elements, so it is academic here regardless.

## Scope

**Not yet wired to a caller.** The tools that carry these arguments (`ui_set_text`, `ui_scroll_to`) and the AccessKit `SetValue` mapping come next; this is the piece both need, landed on its own so the format can be reviewed against Flutter's without a behaviour change alongside it.

28/28 tests, clang-tidy clean, `scripts/format.sh --check` and `gen_config_reference.py --check` both pass.
