### PR TITLE
shell: encode semantics action arguments for the framework

### DIFF
--- a/shared/include/ihs/ihs_semantics.h
+++ b/shared/include/ihs/ihs_semantics.h
@@ -444,9 +444,26 @@ typedef void (*IhsSemanticsDoneCallback)(int status, void* user_data);
  * directly, so the hub can serialize onto the platform thread, enforce the
  * consumer's allow mask, and attribute every dispatch to a named actor.
  *
- * `data`/`data_length` carry arguments for the actions that take them (set
- * text, set selection, scroll to offset); pass NULL/0 otherwise. The buffer is
- * copied before this returns.
+ * `data`/`data_length` carry arguments for the actions that take them; pass
+ * NULL/0 otherwise. The buffer is copied before this returns.
+ *
+ * Arguments are plain, not framework-encoded. The shell encodes them for the
+ * framework, so a consumer needs no codec and this ABI stays free of a wire
+ * format it does not own:
+ *
+ *   IHS_SEMANTICS_ACTION_SET_TEXT          the replacement text, UTF-8, with
+ *                                          data_length as its size -- no
+ *                                          terminator, since the text may
+ *                                          legitimately contain a NUL
+ *   IHS_SEMANTICS_ACTION_SET_SELECTION     two int32 in native byte order:
+ *                                          base, then extent
+ *   IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET  two doubles in native byte order:
+ *                                          dx, then dy
+ *
+ * A buffer that does not match the action's layout, or one supplied for an
+ * action that takes no argument, fails with IHS_SEMANTICS_ERR_INVALID. The
+ * framework drops a malformed argument in silence, so refusing here is what
+ * keeps a caller from seeing a successful dispatch that did nothing.
  *
  * Returns immediately; `done` fires on the platform thread and may be null.
  * Callable from any thread.

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -56,7 +56,8 @@ if (BUILD_ACCESSIBILITY)
     target_sources(${PROJECT_NAME} PRIVATE
             accessibility/accessibility_tree.cc
             accessibility/semantics_translator.cc
-            accessibility/semantics_publisher.cc)
+            accessibility/semantics_publisher.cc
+            accessibility/semantics_action_args.cc)
     # The AccessKit bridge is a hub consumer; it only exists when the bindings
     # are present, which BUILD_ACCESSKIT arranges (see cmake/options.cmake).
     if (BUILD_ACCESSKIT)

--- a/shell/accessibility/semantics_action_args.cc
+++ b/shell/accessibility/semantics_action_args.cc
@@ -18,6 +18,7 @@
 
 #include <cstring>
 #include <string>
+#include <utility>
 
 #include "flutter/standard_message_codec.h"
 
@@ -34,7 +35,9 @@ constexpr size_t kOffsetBytes = sizeof(double) * 2;
 std::vector<uint8_t> Encode(const flutter::EncodableValue& value) {
   const auto& codec = flutter::StandardMessageCodec::GetInstance();
   auto encoded = codec.EncodeMessage(value);
-  return encoded != nullptr ? *encoded : std::vector<uint8_t>{};
+  // Moved rather than copied: the codec hands back an owning pointer, and the
+  // buffer is ours to take.
+  return encoded != nullptr ? std::move(*encoded) : std::vector<uint8_t>{};
 }
 
 }  // namespace

--- a/shell/accessibility/semantics_action_args.cc
+++ b/shell/accessibility/semantics_action_args.cc
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "semantics_action_args.h"
+
+#include <cstring>
+#include <string>
+
+#include "flutter/standard_message_codec.h"
+
+#include "ihs/ihs_semantics.h"
+
+namespace accessibility {
+namespace {
+
+// The hub's plain layouts, mirrored from ihs_semantics.h. Sizes are fixed so a
+// short buffer is a caller error rather than something to pad or guess at.
+constexpr size_t kSelectionBytes = sizeof(int32_t) * 2;
+constexpr size_t kOffsetBytes = sizeof(double) * 2;
+
+std::vector<uint8_t> Encode(const flutter::EncodableValue& value) {
+  const auto& codec = flutter::StandardMessageCodec::GetInstance();
+  auto encoded = codec.EncodeMessage(value);
+  return encoded != nullptr ? *encoded : std::vector<uint8_t>{};
+}
+
+}  // namespace
+
+std::optional<std::vector<uint8_t>> EncodeActionArguments(
+    const uint64_t action,
+    const uint8_t* data,
+    const size_t data_length) {
+  const bool empty = data == nullptr || data_length == 0;
+
+  if (action == IHS_SEMANTICS_ACTION_SET_TEXT) {
+    if (empty) {
+      return std::nullopt;  // replacing text with nothing still needs a string
+    }
+    // The bytes are the text itself, UTF-8, with the length carrying the size
+    // -- no terminator, since a caller may legitimately send one containing a
+    // NUL and truncating there would silently shorten it.
+    return Encode(flutter::EncodableValue(
+        std::string(reinterpret_cast<const char*>(data), data_length)));
+  }
+
+  if (action == IHS_SEMANTICS_ACTION_SET_SELECTION) {
+    if (empty || data_length != kSelectionBytes) {
+      return std::nullopt;
+    }
+    int32_t base = 0;
+    int32_t extent = 0;
+    std::memcpy(&base, data, sizeof(base));
+    std::memcpy(&extent, data + sizeof(base), sizeof(extent));
+    // The framework reads a Map rather than a pair, and reads it by name, so
+    // the keys are part of the contract rather than decoration.
+    flutter::EncodableMap selection;
+    selection[flutter::EncodableValue("base")] = flutter::EncodableValue(base);
+    selection[flutter::EncodableValue("extent")] =
+        flutter::EncodableValue(extent);
+    return Encode(flutter::EncodableValue(selection));
+  }
+
+  if (action == IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET) {
+    if (empty || data_length != kOffsetBytes) {
+      return std::nullopt;
+    }
+    double offset[2] = {0.0, 0.0};
+    std::memcpy(offset, data, sizeof(offset));
+    return Encode(
+        flutter::EncodableValue(std::vector<double>{offset[0], offset[1]}));
+  }
+
+  // Every other action takes no argument. Data supplied for one of those is
+  // refused rather than dropped: a caller that encoded something expects it to
+  // arrive, and an action that ignores it would look like it had worked.
+  if (!empty) {
+    return std::nullopt;
+  }
+  return std::vector<uint8_t>{};
+}
+
+}  // namespace accessibility

--- a/shell/accessibility/semantics_action_args.h
+++ b/shell/accessibility/semantics_action_args.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SHELL_ACCESSIBILITY_SEMANTICS_ACTION_ARGS_H_
+#define SHELL_ACCESSIBILITY_SEMANTICS_ACTION_ARGS_H_
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace accessibility {
+
+/*
+ * Turns a hub action argument into the StandardMessageCodec message the
+ * framework decodes.
+ *
+ * The split is deliberate. The hub is Flutter-neutral by construction, so its
+ * `data` carries the argument in a plain layout of its own (see
+ * ihs_semantics.h) and the encoding happens here, on the only side that
+ * already links Flutter. A consumer -- the MCP provider, AccessKit -- then
+ * needs no codec at all, and the hub ABI does not have Flutter's wire format
+ * baked into it.
+ *
+ * Uses the vendored flutter::StandardMessageCodec rather than a second
+ * implementation: a reimplementation can drift from the decoder silently,
+ * which drops arguments framework-side with no error anywhere (R-9).
+ *
+ * Returns the encoded message, or nullopt when `data` does not match the
+ * layout the action requires -- a truncated offset or a stray byte count is a
+ * caller error, and forwarding it would reach the framework as a silently
+ * ignored action rather than a refusal.
+ *
+ * An action that takes no argument returns an empty vector for null/0 input,
+ * so the caller can encode unconditionally.
+ */
+std::optional<std::vector<uint8_t>> EncodeActionArguments(uint64_t action,
+                                                          const uint8_t* data,
+                                                          size_t data_length);
+
+}  // namespace accessibility
+
+#endif  // SHELL_ACCESSIBILITY_SEMANTICS_ACTION_ARGS_H_

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -39,6 +39,7 @@
 
 #if BUILD_ACCESSIBILITY
 #include "ihs/ihs_semantics_host.h"
+#include "shell/accessibility/semantics_action_args.h"
 #include "shell/accessibility/semantics_publisher.h"
 #endif
 #include "hexdump.h"
@@ -1032,13 +1033,22 @@ int Engine::DispatchSemanticsAction(const int64_t view_id,
     return IHS_SEMANTICS_ERR_UNSUPPORTED_ACTION;
   }
 
-  // The hub does not thread-hop -- deliberately, since the task runner is
-  // ours. Copy the payload and post: `data` is only valid for this call, and
-  // the engine reads it on the platform thread afterwards.
-  std::vector<uint8_t> payload;
-  if (data != nullptr && data_length > 0) {
-    payload.assign(data, data + data_length);
+  // Encode here rather than in the hub: `data` arrives in the hub's own plain
+  // layout, and this is the only side that links Flutter, so consumers need no
+  // codec and the hub ABI keeps Flutter's wire format out of it.
+  auto encoded =
+      accessibility::EncodeActionArguments(action, data, data_length);
+  if (!encoded.has_value()) {
+    // The argument did not match what the action takes. Refusing beats
+    // forwarding: a malformed payload is dropped framework-side in silence,
+    // so the caller would see a successful dispatch that did nothing.
+    return IHS_SEMANTICS_ERR_INVALID;
   }
+
+  // The hub does not thread-hop -- deliberately, since the task runner is
+  // ours. The encoded buffer moves with the post: `data` is only valid for
+  // this call, and the engine reads the bytes on the platform thread after.
+  std::vector<uint8_t> payload = std::move(encoded.value());
 
   // The strand is serviced by the same thread that runs Flutter tasks, so
   // posting here lands the call on the platform thread with no extra

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -207,6 +207,7 @@ if (BUILD_MCP)
 endif ()
 add_subdirectory(pixel_swizzle-test)
 add_subdirectory(scale_policy-test)
+add_subdirectory(semantics_action_args-test)
 add_subdirectory(text_input-test)
 # texture-test requires a live Wayland compositor, Flutter engine, and an app
 # bundle on disk — it is an integration test and has been moved to

--- a/test/unit_test/semantics_action_args-test/CMakeLists.txt
+++ b/test/unit_test/semantics_action_args-test/CMakeLists.txt
@@ -1,0 +1,43 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Action-argument encoding: the hub's plain layouts turned into the
+# StandardMessageCodec messages the framework decodes. Every case is decoded
+# again with the same vendored codec, so a layout mistake fails here rather
+# than reaching the framework as an argument dropped in silence (R-9).
+set(TESTCASE_NAME "homescreen_semantics_action_args_ut_test_driver")
+
+add_executable(${TESTCASE_NAME}
+        test_case_semantics_action_args.cc
+        ${CMAKE_SOURCE_DIR}/shell/accessibility/semantics_action_args.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_include_directories(${TESTCASE_NAME} PRIVATE
+        ${CMAKE_SOURCE_DIR}/shell
+)
+
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        flutter
+        ivi_homescreen::ihs_shared
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/semantics_action_args-test/test_case_semantics_action_args.cc
+++ b/test/unit_test/semantics_action_args-test/test_case_semantics_action_args.cc
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "flutter/standard_message_codec.h"
+
+#include "ihs/ihs_semantics.h"
+
+#include "accessibility/semantics_action_args.h"
+
+using accessibility::EncodeActionArguments;
+
+namespace {
+
+flutter::EncodableValue Decode(const std::vector<uint8_t>& bytes) {
+  const auto& codec = flutter::StandardMessageCodec::GetInstance();
+  auto decoded = codec.DecodeMessage(bytes.data(), bytes.size());
+  return decoded == nullptr ? flutter::EncodableValue() : *decoded;
+}
+
+std::vector<uint8_t> Bytes(const void* data, const size_t length) {
+  const auto* p = static_cast<const uint8_t*>(data);
+  return {p, p + length};
+}
+
+}  // namespace
+
+// SetText carries the replacement string. The framework reads it as a String,
+// so anything else silently replaces nothing.
+TEST(SemanticsActionArgs, SetTextEncodesAString) {
+  const std::string text = "Sarah Connor";
+  const auto encoded = EncodeActionArguments(
+      IHS_SEMANTICS_ACTION_SET_TEXT,
+      reinterpret_cast<const uint8_t*>(text.data()), text.size());
+  ASSERT_TRUE(encoded.has_value());
+  const auto value = Decode(*encoded);
+  ASSERT_TRUE(std::holds_alternative<std::string>(value));
+  EXPECT_EQ(std::get<std::string>(value), text);
+}
+
+// The length is the size, not a terminator, so text containing a NUL survives
+// rather than being truncated at it.
+TEST(SemanticsActionArgs, SetTextKeepsEmbeddedNuls) {
+  const std::string text("a\0b", 3);
+  const auto encoded = EncodeActionArguments(
+      IHS_SEMANTICS_ACTION_SET_TEXT,
+      reinterpret_cast<const uint8_t*>(text.data()), text.size());
+  ASSERT_TRUE(encoded.has_value());
+  EXPECT_EQ(std::get<std::string>(Decode(*encoded)).size(), 3u);
+}
+
+TEST(SemanticsActionArgs, SetTextNonAsciiSurvives) {
+  const std::string text = "Fahrertür – 22°C";
+  const auto encoded = EncodeActionArguments(
+      IHS_SEMANTICS_ACTION_SET_TEXT,
+      reinterpret_cast<const uint8_t*>(text.data()), text.size());
+  ASSERT_TRUE(encoded.has_value());
+  EXPECT_EQ(std::get<std::string>(Decode(*encoded)), text);
+}
+
+// The framework reads the selection by key, so the names are contract.
+TEST(SemanticsActionArgs, SetSelectionEncodesBaseAndExtentByName) {
+  const int32_t selection[2] = {3, 11};
+  const auto raw = Bytes(selection, sizeof(selection));
+  const auto encoded = EncodeActionArguments(IHS_SEMANTICS_ACTION_SET_SELECTION,
+                                             raw.data(), raw.size());
+  ASSERT_TRUE(encoded.has_value());
+
+  const auto value = Decode(*encoded);
+  ASSERT_TRUE(std::holds_alternative<flutter::EncodableMap>(value));
+  const auto& map = std::get<flutter::EncodableMap>(value);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("base"))), 3);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("extent"))), 11);
+}
+
+// A collapsed selection at the start of a field is zeros, which is an ordinary
+// value and must not be mistaken for an absent argument.
+TEST(SemanticsActionArgs, SetSelectionCarriesZeroes) {
+  const int32_t selection[2] = {0, 0};
+  const auto raw = Bytes(selection, sizeof(selection));
+  const auto encoded = EncodeActionArguments(IHS_SEMANTICS_ACTION_SET_SELECTION,
+                                             raw.data(), raw.size());
+  ASSERT_TRUE(encoded.has_value());
+  // Bound to a named value first: std::get on the temporary Decode returns
+  // hands back a reference into it, and binding that to a const& does not
+  // extend the temporary's life.
+  const auto value = Decode(*encoded);
+  const auto& map = std::get<flutter::EncodableMap>(value);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("base"))), 0);
+  EXPECT_EQ(std::get<int32_t>(map.at(flutter::EncodableValue("extent"))), 0);
+}
+
+// ScrollToOffset takes a Float64List of (dx, dy).
+TEST(SemanticsActionArgs, ScrollToOffsetEncodesAFloat64List) {
+  const double offset[2] = {12.5, -400.25};
+  const auto raw = Bytes(offset, sizeof(offset));
+  const auto encoded = EncodeActionArguments(
+      IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET, raw.data(), raw.size());
+  ASSERT_TRUE(encoded.has_value());
+
+  const auto value = Decode(*encoded);
+  ASSERT_TRUE(std::holds_alternative<std::vector<double>>(value));
+  EXPECT_EQ(std::get<std::vector<double>>(value),
+            (std::vector<double>{12.5, -400.25}));
+}
+
+// A truncated argument is refused rather than padded. The framework drops a
+// malformed payload in silence, so forwarding one would show the caller a
+// dispatch that succeeded and did nothing.
+TEST(SemanticsActionArgs, ShortArgumentsAreRefused) {
+  const uint8_t stub[4] = {0, 0, 0, 0};
+  EXPECT_FALSE(EncodeActionArguments(IHS_SEMANTICS_ACTION_SET_SELECTION, stub,
+                                     sizeof(stub))
+                   .has_value());
+  EXPECT_FALSE(EncodeActionArguments(IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET,
+                                     stub, sizeof(stub))
+                   .has_value());
+}
+
+TEST(SemanticsActionArgs, MissingArgumentsAreRefused) {
+  for (const uint64_t action :
+       {IHS_SEMANTICS_ACTION_SET_TEXT, IHS_SEMANTICS_ACTION_SET_SELECTION,
+        IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET}) {
+    EXPECT_FALSE(EncodeActionArguments(action, nullptr, 0).has_value())
+        << "action 0x" << std::hex << action;
+  }
+}
+
+// An action that takes nothing encodes to nothing, so a caller can encode
+// unconditionally rather than branching on which action it holds.
+TEST(SemanticsActionArgs, ArgumentlessActionsEncodeEmpty) {
+  const auto encoded =
+      EncodeActionArguments(IHS_SEMANTICS_ACTION_TAP, nullptr, 0);
+  ASSERT_TRUE(encoded.has_value());
+  EXPECT_TRUE(encoded->empty());
+}
+
+// Data handed to an action that ignores it is a caller error worth reporting:
+// the action would appear to succeed while the argument went nowhere.
+TEST(SemanticsActionArgs, DataOnAnArgumentlessActionIsRefused) {
+  const uint8_t stray[2] = {1, 2};
+  EXPECT_FALSE(
+      EncodeActionArguments(IHS_SEMANTICS_ACTION_TAP, stray, sizeof(stray))
+          .has_value());
+}


### PR DESCRIPTION
Actions that take an argument — `SetText`, `SetSelection`, `ScrollToOffset` — had nowhere to get one. The hub carried a payload it never described, and nothing encoded it, so the parameterized actions could not be driven at all.

This replaces #439, which tried to solve the same problem by writing a StandardMessageCodec encoder from scratch. That was the wrong call: plan.md §184 says "no new serialization code", and the justification given there (that the vendored codec would breach the flat C ABI) does not hold — `ihs_shared.map` keeps every non-`ihs_*` symbol local, so linking `libflutter` crosses no plugin boundary.

## Where the encoding lives, and why

**In the shell, not the hub.** `data` arrives in a plain layout of the hub's own — now documented on `ihs_semantics_dispatch` — and the shell turns it into a StandardMessageCodec message on the only side that already links Flutter.

Two things follow. A consumer (the MCP provider, AccessKit) needs no codec at all. And an ABI that is deliberately Flutter-neutral does not acquire a wire format it does not own — which is what putting encoded bytes in the hub contract would have meant.

The layout is small and explicit:

| action | `data` |
|---|---|
| `SET_TEXT` | the replacement text, UTF-8, `data_length` as its size |
| `SET_SELECTION` | two `int32` native order: base, extent |
| `SCROLL_TO_OFFSET` | two `double` native order: dx, dy |

## Refusing rather than forwarding

A buffer that does not match the action's layout — a truncated offset, or data supplied for an action that ignores it — now fails the dispatch with `IHS_SEMANTICS_ERR_INVALID`.

That is the whole reason to check: the framework drops a payload it cannot read **without reporting anything**, so forwarding a malformed one shows the caller a dispatch that succeeded and did nothing. R-9 is exactly this failure mode, and it is invisible from both ends.

## Testing

10 tests decode every case back with the same vendored codec:

- the selection keys the framework reads **by name**, so `base`/`extent` are contract rather than decoration
- text with an **embedded NUL**, where the length is the size and not a terminator
- non-ASCII text, where the length is bytes and not characters
- zero and negative values carried rather than dropped — a collapsed selection is zeros, and an overscrolled offset is negative
- each refusal path

One of these caught a genuine use-after-free in the test code itself: `std::get<>(Decode(...))` bound to a `const&` returns a reference into a temporary that dies at the end of the full expression. It surfaced as a missing map key. Fixed by naming the value first; worth knowing because the passing variant of the same test had it right by accident.

28/28 in the suite, clang-tidy clean, `scripts/format.sh --check` and `gen_config_reference.py --check` both pass.

## On the conversion cost

Encoding goes through `EncodableValue`, and `EncodableMap` is a `std::map`, so a `SetSelection` allocates two red-black tree nodes plus the output buffer to produce 26 bytes. That is the price of using the vendored codec instead of writing bytes directly, and it is the right trade: these fire at human interaction rates — one text edit, one selection change, one scroll — not per frame. A hand-rolled encoder buys a few allocations and risks silent divergence from the decoder, which is what #439 was closed for.

One avoidable copy was found and removed while looking: the codec hands back an owning pointer, and the buffer was being copied out of it rather than moved.

## Scope

The tools that will carry these arguments (`ui_set_text`, `ui_scroll_to`) and the AccessKit `SetValue` → `ScrollToOffset` mapping are not here — this is the piece both need, landed on its own so the layout and the refusal behaviour can be reviewed without a behaviour change alongside them.
