### PR TITLE
shared: add the parameterized ui_set_text and ui_scroll_to tools

### DIFF
--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -19,6 +19,7 @@
 
 #include "ihs/ihs_mcp_semantics.h"
 
+#include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
@@ -65,6 +66,21 @@ constexpr char kQuerySchema[] =
     R"("role":{"type":"string","description":"Role name, e.g. button or slider."})"
     R"(}})";
 
+constexpr char kSetTextSchema[] =
+    R"({"type":"object","properties":{)"
+    R"("node_id":{"type":"integer"},)"
+    R"("identifier":{"type":"string"},)"
+    R"("text":{"type":"string","description":"Replacement text for the field."})"
+    R"(},"required":["text"]})";
+
+constexpr char kScrollToSchema[] =
+    R"({"type":"object","properties":{)"
+    R"("node_id":{"type":"integer"},)"
+    R"("identifier":{"type":"string"},)"
+    R"("dx":{"type":"number","description":"Horizontal offset in logical pixels."},)"
+    R"("dy":{"type":"number","description":"Vertical offset in logical pixels."})"
+    R"(}})";
+
 const ToolEntry kTools[] = {
     {"snapshot", "The whole semantics tree as JSON.", kEmptySchema, 0,
      IHS_MCP_CAP_INSPECT},
@@ -86,6 +102,10 @@ const ToolEntry kTools[] = {
      IHS_MCP_CAP_INTERACT},
     {"collapse", "Collapse a node.", kNodeSchema, IHS_SEMANTICS_ACTION_COLLAPSE,
      IHS_MCP_CAP_INTERACT},
+    {"set_text", "Replace the text in a text field.", kSetTextSchema,
+     IHS_SEMANTICS_ACTION_SET_TEXT, IHS_MCP_CAP_INTERACT},
+    {"scroll_to", "Scroll a container to a given offset.", kScrollToSchema,
+     IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET, IHS_MCP_CAP_INTERACT},
 };
 
 // The accessibility-focus actions are deliberately absent from the table
@@ -372,6 +392,40 @@ bool ExtractString(const char* json, const char* key, std::string* out) {
   return true;
 }
 
+// The extractors above scan for a key and take the next quoted run, which
+// cannot survive an escaped quote or a key-like substring inside a value.
+// That is tolerable for an identifier, which the application chooses, and not
+// for arbitrary text a client sends, so the parameterized arguments are parsed
+// properly instead.
+bool ReadStringArgument(const char* json, const char* key, std::string* out) {
+  rapidjson::Document doc;
+  if (json == nullptr || doc.Parse(json).HasParseError() || !doc.IsObject()) {
+    return false;
+  }
+  const auto member = doc.FindMember(key);
+  if (member == doc.MemberEnd() || !member->value.IsString()) {
+    return false;
+  }
+  out->assign(member->value.GetString(), member->value.GetStringLength());
+  return true;
+}
+
+// Absent or non-numeric yields the fallback: an axis a caller did not name is
+// zero rather than an error, so scrolling a vertical list needs only dy.
+double ReadNumberArgument(const char* json,
+                          const char* key,
+                          const double fallback) {
+  rapidjson::Document doc;
+  if (json == nullptr || doc.Parse(json).HasParseError() || !doc.IsObject()) {
+    return fallback;
+  }
+  const auto member = doc.FindMember(key);
+  if (member == doc.MemberEnd() || !member->value.IsNumber()) {
+    return fallback;
+  }
+  return member->value.GetDouble();
+}
+
 // Resolves the node a tool call names, by id or by identifier.
 const IhsSemanticsNode* ResolveNode(const IhsSemanticsSnapshot* snapshot,
                                     const char* arguments) {
@@ -546,11 +600,43 @@ int CallTool(void* /* user_data */,
   }
 
   const int32_t node_id = node->id;
+  const bool obscured = node->obscured;
   ihs_semantics_release_snapshot(snapshot);
 
+  // Arguments travel in the hub's plain layout; the shell encodes them for the
+  // framework (see ihs_semantics_dispatch). Building them here rather than in
+  // the caller keeps the byte layout in one place.
+  std::vector<uint8_t> argument;
+  if (tool->action == IHS_SEMANTICS_ACTION_SET_TEXT) {
+    // Refusing to type into a password field is a deliberate limit, not an
+    // oversight: an agent that can set text into an obscured field can also
+    // read back what it wrote through the app's own behaviour.
+    if (obscured) {
+      FillPayload(
+          out_result,
+          ErrorJson("refusing to set text on an obscured field", generation));
+      return IHS_MCP_ERR_REFUSED;
+    }
+    std::string text;
+    if (!ReadStringArgument(arguments_json, "text", &text)) {
+      FillPayload(out_result, ErrorJson("set_text requires text", generation));
+      return IHS_MCP_ERR_INVALID;
+    }
+    argument.assign(text.begin(), text.end());
+  } else if (tool->action == IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET) {
+    // Absent axes are zero rather than an error: scrolling a vertical list
+    // means naming dy, and demanding dx as well would be noise.
+    const double offset[2] = {ReadNumberArgument(arguments_json, "dx", 0.0),
+                              ReadNumberArgument(arguments_json, "dy", 0.0)};
+    const auto* bytes = reinterpret_cast<const uint8_t*>(offset);
+    argument.assign(bytes, bytes + sizeof(offset));
+  }
+
   Provider& p = TheProvider();
-  const int status = ihs_semantics_dispatch(
-      p.consumer, 0, node_id, tool->action, nullptr, 0, nullptr, nullptr);
+  const int status =
+      ihs_semantics_dispatch(p.consumer, 0, node_id, tool->action,
+                             argument.empty() ? nullptr : argument.data(),
+                             argument.size(), nullptr, nullptr);
   if (status != IHS_SEMANTICS_OK) {
     FillPayload(out_result, ErrorJson("dispatch refused", generation));
     return IHS_MCP_ERR_REFUSED;

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -36,6 +36,9 @@ struct MockHost {
   int dispatch_calls = 0;
   int32_t last_node_id = 0;
   uint64_t last_action = 0;
+  // The argument as the hub carried it, so a test can check the plain layout
+  // the shell will encode from.
+  std::vector<uint8_t> last_data;
   bool semantics_enabled = false;
 };
 
@@ -49,11 +52,12 @@ int OnDispatch(void* /*user_data*/,
                int64_t /*view_id*/,
                int32_t node_id,
                uint64_t action,
-               const uint8_t* /*data*/,
-               size_t /*data_length*/) {
+               const uint8_t* data,
+               size_t data_length) {
   g_host->dispatch_calls++;
   g_host->last_node_id = node_id;
   g_host->last_action = action;
+  g_host->last_data.assign(data, data + (data == nullptr ? 0 : data_length));
   return IHS_SEMANTICS_OK;
 }
 
@@ -359,4 +363,109 @@ TEST_F(McpSemanticsProviderTest, StoppingReleasesTheHubRegistration) {
   EXPECT_FALSE(host_.semantics_enabled);
   EXPECT_FALSE(ihs_mcp_semantics_provider_running());
   EXPECT_EQ(ihs_semantics_consumer_count(), 0u);
+}
+
+// set_text carries the replacement text in the hub's plain layout: the bytes
+// are the text, and the length is its size.
+TEST_F(McpSemanticsProviderTest, SetTextCarriesTheTextAsBytes) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& field =
+      tree.Add(1, "Destination", IHS_SEMANTICS_ROLE_TEXT_INPUT);
+  field.actions = IHS_SEMANTICS_ACTION_SET_TEXT;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  CallTool("ui_set_text", R"({"node_id":1,"text":"Fahrertur"})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  EXPECT_EQ(g_host->last_action, IHS_SEMANTICS_ACTION_SET_TEXT);
+  EXPECT_EQ(std::string(g_host->last_data.begin(), g_host->last_data.end()),
+            "Fahrertur");
+}
+
+// Text is parsed as JSON rather than scanned for, so an escaped quote inside
+// the value does not truncate it. Scanning for the next quoted run -- which is
+// how the identifier extractor works -- would stop at the backslash-quote.
+TEST_F(McpSemanticsProviderTest, SetTextSurvivesEscapesInTheValue) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& field =
+      tree.Add(1, "Destination", IHS_SEMANTICS_ROLE_TEXT_INPUT);
+  field.actions = IHS_SEMANTICS_ACTION_SET_TEXT;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  CallTool("ui_set_text", R"({"node_id":1,"text":"He said \"go\" now"})",
+           nullptr);
+  EXPECT_EQ(std::string(g_host->last_data.begin(), g_host->last_data.end()),
+            "He said \"go\" now");
+}
+
+// An agent that can type into a password field can also read back what it
+// wrote through the application's own behaviour, so the field is refused.
+TEST_F(McpSemanticsProviderTest, SetTextIsRefusedOnAnObscuredField) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& field =
+      tree.Add(1, "Password", IHS_SEMANTICS_ROLE_PASSWORD_INPUT);
+  field.actions = IHS_SEMANTICS_ACTION_SET_TEXT;
+  field.obscured = true;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body =
+      CallTool("ui_set_text", R"({"node_id":1,"text":"hunter2"})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_REFUSED);
+  EXPECT_EQ(g_host->dispatch_calls, 0);
+  EXPECT_NE(body.find("obscured"), std::string::npos) << body;
+}
+
+TEST_F(McpSemanticsProviderTest, SetTextWithoutTextIsRefused) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& field =
+      tree.Add(1, "Destination", IHS_SEMANTICS_ROLE_TEXT_INPUT);
+  field.actions = IHS_SEMANTICS_ACTION_SET_TEXT;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  CallTool("ui_set_text", R"({"node_id":1})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_INVALID);
+  EXPECT_EQ(g_host->dispatch_calls, 0);
+}
+
+// scroll_to carries two doubles, dx then dy. An axis the caller did not name
+// is zero, so scrolling a vertical list needs only dy.
+TEST_F(McpSemanticsProviderTest, ScrollToCarriesBothAxesAndDefaultsTheAbsent) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& list =
+      tree.Add(1, "Media list", IHS_SEMANTICS_ROLE_SCROLL_VIEW);
+  list.actions = IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  CallTool("ui_scroll_to", R"({"node_id":1,"dy":240.5})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  EXPECT_EQ(g_host->last_action, IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET);
+  ASSERT_EQ(g_host->last_data.size(), sizeof(double) * 2);
+  double offset[2] = {-1.0, -1.0};
+  std::memcpy(offset, g_host->last_data.data(), sizeof(offset));
+  EXPECT_DOUBLE_EQ(offset[0], 0.0);
+  EXPECT_DOUBLE_EQ(offset[1], 240.5);
+}
+
+// A node that does not offer the action is refused before dispatch, as with
+// every other action tool.
+TEST_F(McpSemanticsProviderTest, ParameterizedToolsRespectTheNodeActions) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  tree.Add(1, "Label", IHS_SEMANTICS_ROLE_LABEL);  // offers nothing
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  CallTool("ui_set_text", R"({"node_id":1,"text":"x"})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_REFUSED);
+  CallTool("ui_scroll_to", R"({"node_id":1,"dy":1})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_REFUSED);
+  EXPECT_EQ(g_host->dispatch_calls, 0);
 }


### PR DESCRIPTION
#440 landed the encoding for actions that take an argument, with no caller. These are the two the semantics tree can actually drive: replacing the text in a field, and scrolling a container to an offset. That takes the `ui_*` surface from 10 tools to 12.

Arguments travel in the hub's plain layout and the shell encodes them (#440), so the provider builds bytes and needs no codec — which is the split working as intended.

## Argument parsing had to change, and it was not cosmetic

The existing extractors find a key and take the next quoted run. That cannot survive an escaped quote inside a value: `{"text":"He said \"go\" now"}` truncates at the backslash-quote and silently sets the field to `He said \`.

Tolerable for an `identifier`, which the application chooses. Wrong for arbitrary text a client sends. So the new arguments are parsed as JSON; the identifier path is left exactly as it was, since changing it is a separate concern.

Verified over the socket rather than only in a unit test — the text arrives intact:

```
[host] dispatch node=1 action=0x200000 data_len=18 text='He said "go" \ now'
[host] dispatch node=1 action=0x200000 data_len=20 text='Fahrertür – 22°C'
[host] dispatch node=1 action=0x800000 data_len=16 offset=(0,240.5)
```

The second line is 16 characters in 20 bytes — the length is bytes, not characters, and multi-byte UTF-8 survives.

## Two deliberate behaviors

**`set_text` is refused on an obscured field.** An agent that can type into a password field can also read back what it wrote through the application's own behavior, so this is the point rather than an omission. The tool reports why instead of failing vaguely. This is the same posture as `ui_snapshot` already declining to serialize an obscured value.

**An axis absent from `scroll_to` is zero, not an error.** Scrolling a vertical list means naming `dy`; demanding `dx` as well would be noise.

Both tools otherwise behave like every other action tool: a node that does not offer the action, or that is disabled, is refused before dispatch rather than sent to the framework to be discarded in silence.

## Testing

6 new tests (22 in the suite), covering the byte layout each tool produces, an escaped quote surviving the round trip, the obscured refusal, a missing argument, and a node that offers nothing. The mock host now records the payload as well as the action, so the plain layout the shell will encode from is asserted directly.

28/28 across the whole suite, clang-tidy clean, `scripts/format.sh --check` and `gen_config_reference.py --check` both pass.

## Still outstanding on this thread

The AccessKit `SetValue` → `ScrollToOffset` mapping — the other caller #440 unblocked. An assistive technology can still read a scroll position but not set one. Left for its own change because it needs a decision the tools did not: `SetValue` gives a single number, and which axis it belongs to has to be inferred from the scroll actions the node offers.
