### PR TITLE
accessibility: let an assistive technology set a scroll position

### DIFF
--- a/shell/accessibility/accesskit_consumer.cc
+++ b/shell/accessibility/accesskit_consumer.cc
@@ -23,6 +23,8 @@
 
 #include <cerrno>
 #include <cstdint>
+#include <cstring>
+#include <vector>
 
 #include "ihs/ihs_semantics.h"
 
@@ -107,6 +109,8 @@ uint64_t ToIhsAction(const accesskit_action action) {
       return IHS_SEMANTICS_ACTION_EXPAND;
     case ACCESSKIT_ACTION_COLLAPSE:
       return IHS_SEMANTICS_ACTION_COLLAPSE;
+    case ACCESSKIT_ACTION_SET_SCROLL_OFFSET:
+      return IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET;
     default:
       return 0;
   }
@@ -148,6 +152,18 @@ void AddActions(accesskit_node* node,
   }
   if ((actions & IHS_SEMANTICS_ACTION_COLLAPSE) != 0) {
     accesskit_node_add_action(node, ACCESSKIT_ACTION_COLLAPSE);
+  }
+  // Setting a scrollable's offset. AccessKit carries a point for this, so both
+  // axes arrive and neither has to be inferred from which way the node
+  // scrolls -- which a node scrolling both ways would make unanswerable.
+  if ((actions & IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_SET_SCROLL_OFFSET);
+  }
+  // Replacing a field's text. AccessKit spells this SetValue, whose payload
+  // may be a string or a number; only the string form means text, and the
+  // handler checks which arrived.
+  if ((actions & IHS_SEMANTICS_ACTION_SET_TEXT) != 0) {
+    accesskit_node_add_action(node, ACCESSKIT_ACTION_SET_VALUE);
   }
   // Focus is offered only where the node can actually hold the accessibility
   // cursor. Advertising it everywhere -- as this did -- makes every static
@@ -376,16 +392,87 @@ void ActionHandler(accesskit_action_request* request, void* user_data) {
     return;
   }
   auto* consumer = static_cast<IhsSemanticsConsumer*>(user_data);
-  const uint64_t action = ToIhsAction(request->action);
-  if (action == 0) {
-    ihs::log::debug("accesskit: no hub equivalent for action {}",
-                    static_cast<int>(request->action));
-    return;
+
+  // Arguments travel in the hub's plain layout and the shell encodes them for
+  // the framework, so this builds bytes rather than a codec message.
+  uint64_t action = 0;
+  std::vector<uint8_t> argument;
+
+  if (request->action == ACCESSKIT_ACTION_SET_VALUE) {
+    // SetValue is two requests wearing one name, told apart by payload.
+    //
+    // A number is the live path on this platform: AT-SPI's Value.currentValue
+    // setter is the only route an assistive technology has to move a value,
+    // and accesskit's AT-SPI backend turns it into exactly this. It never
+    // emits SetScrollOffset, which would have carried both axes and spared
+    // the inference below.
+    if (request->data.has_value &&
+        request->data.value.tag == ACCESSKIT_ACTION_DATA_NUMERIC_VALUE) {
+      // Flutter reports one scroll position per scrollable, so the number is
+      // that scalar coming back and only its axis has to be recovered. Which
+      // way the node scrolls answers it; a node scrolling both ways does not
+      // have an answer, in Flutter's model either, so vertical wins as the
+      // commoner case rather than the request being dropped.
+      const double value = request->data.value.numeric_value;
+      bool horizontal = false;
+      if (const IhsSemanticsSnapshot* snapshot =
+              ihs_semantics_acquire_snapshot();
+          snapshot != nullptr) {
+        if (const IhsSemanticsNode* node = ihs_semantics_snapshot_node_by_id(
+                snapshot, static_cast<int32_t>(request->target_node));
+            node != nullptr) {
+          const bool vertical =
+              (node->actions & (IHS_SEMANTICS_ACTION_SCROLL_UP |
+                                IHS_SEMANTICS_ACTION_SCROLL_DOWN)) != 0;
+          horizontal = !vertical && (node->actions &
+                                     (IHS_SEMANTICS_ACTION_SCROLL_LEFT |
+                                      IHS_SEMANTICS_ACTION_SCROLL_RIGHT)) != 0;
+        }
+        ihs_semantics_release_snapshot(snapshot);
+      }
+      const double offset[2] = {horizontal ? value : 0.0,
+                                horizontal ? 0.0 : value};
+      const auto* bytes = reinterpret_cast<const uint8_t*>(offset);
+      action = IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET;
+      argument.assign(bytes, bytes + sizeof(offset));
+    } else if (request->data.has_value &&
+               request->data.value.tag == ACCESSKIT_ACTION_DATA_VALUE &&
+               request->data.value.value != nullptr) {
+      // A string means replace the text. Correct, and unreachable through
+      // AT-SPI today: accesskit's backend exposes no EditableText interface,
+      // so nothing on this platform produces it. Kept because it is the right
+      // mapping the moment one does.
+      action = IHS_SEMANTICS_ACTION_SET_TEXT;
+      const char* text = request->data.value.value;
+      argument.assign(text, text + std::strlen(text));
+    } else {
+      ihs::log::debug("accesskit: SetValue carried no usable payload");
+      return;
+    }
+  } else {
+    action = ToIhsAction(request->action);
+    if (action == 0) {
+      ihs::log::debug("accesskit: no hub equivalent for action {}",
+                      static_cast<int>(request->action));
+      return;
+    }
+    if (action == IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET) {
+      if (!request->data.has_value ||
+          request->data.value.tag != ACCESSKIT_ACTION_DATA_SET_SCROLL_OFFSET) {
+        ihs::log::debug("accesskit: scroll offset request carried no point");
+        return;
+      }
+      const accesskit_point& point = request->data.value.set_scroll_offset;
+      const double offset[2] = {point.x, point.y};
+      const auto* bytes = reinterpret_cast<const uint8_t*>(offset);
+      argument.assign(bytes, bytes + sizeof(offset));
+    }
   }
 
   const int status = ihs_semantics_dispatch(
-      consumer, 0, static_cast<int32_t>(request->target_node), action, nullptr,
-      0, nullptr, nullptr);
+      consumer, 0, static_cast<int32_t>(request->target_node), action,
+      argument.empty() ? nullptr : argument.data(), argument.size(), nullptr,
+      nullptr);
   if (status != IHS_SEMANTICS_OK) {
     // Expected in normal use: a screen reader may offer an action the node
     // does not implement, and the hub refuses rather than letting it vanish.

--- a/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
+++ b/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
@@ -362,3 +362,49 @@ TEST(AccessKitConsumer, LabelNodeWithNoTextCarriesNoValue) {
   const BuiltNode built(node);
   EXPECT_EQ(accesskit_node_value(built.get()), nullptr);
 }
+
+// The two parameterized actions must be advertised, or an assistive
+// technology has no way to ask for them in the first place.
+TEST(AccessKitConsumer, ParameterizedActionsAreAdvertised) {
+  IhsSemanticsPublishNode field =
+      PlainNode("Destination", IHS_SEMANTICS_ROLE_TEXT_INPUT);
+  field.actions = IHS_SEMANTICS_ACTION_SET_TEXT;
+  const BuiltNode built_field(field);
+  // AccessKit spells "replace the text" SetValue.
+  EXPECT_TRUE(accesskit_node_supports_action(built_field.get(),
+                                             ACCESSKIT_ACTION_SET_VALUE));
+
+  IhsSemanticsPublishNode list =
+      PlainNode("Media list", IHS_SEMANTICS_ROLE_SCROLL_VIEW);
+  list.actions = IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET;
+  const BuiltNode built_list(list);
+  EXPECT_TRUE(accesskit_node_supports_action(
+      built_list.get(), ACCESSKIT_ACTION_SET_SCROLL_OFFSET));
+}
+
+// A node that cannot take them must not claim them: an action offered and
+// then refused at the funnel is a worse answer than one never advertised.
+TEST(AccessKitConsumer, ParameterizedActionsAreNotClaimedWithoutSupport) {
+  const IhsSemanticsPublishNode plain =
+      PlainNode("Now playing", IHS_SEMANTICS_ROLE_LABEL);
+  const BuiltNode built(plain);
+  EXPECT_FALSE(
+      accesskit_node_supports_action(built.get(), ACCESSKIT_ACTION_SET_VALUE));
+  EXPECT_FALSE(accesskit_node_supports_action(
+      built.get(), ACCESSKIT_ACTION_SET_SCROLL_OFFSET));
+}
+
+// SetScrollOffset carries a point, so it needs no inference and maps straight
+// through. AccessKit's AT-SPI backend does not emit it today -- the numeric
+// SetValue path does the work on this platform -- but the mapping is exact
+// where it is produced.
+TEST(AccessKitConsumer, ScrollOffsetActionMapsToScrollToOffset) {
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_SET_SCROLL_OFFSET),
+            IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET);
+}
+
+// SetValue is not mapped by tag: its meaning depends on whether a string or a
+// number arrived, so the handler decides and this table must not guess.
+TEST(AccessKitConsumer, SetValueIsNotMappedByTagAlone) {
+  EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_SET_VALUE), 0u);
+}


### PR DESCRIPTION
An assistive technology could read a scrollable's position and not move it. The value reached AT-SPI (#436), but nothing carried a request back — setting `Value.currentValue` did nothing at all. This is the other caller #440 unblocked.

## The mapping had to be found empirically, and the obvious answer was wrong

AccessKit offers two routes:

- **`SetScrollOffset`** carries a `point`, so both axes arrive and neither has to be inferred. Exact.
- **`SetValue`** carries either a string or a number, so its meaning depends on the payload.

I implemented the exact one first. It never fired. `accesskit_atspi_common` **never emits `SetScrollOffset`** — the only emitter is `set_current_value` → `Action::SetValue` with a numeric payload, which is what AT-SPI's `Value.currentValue` setter produces. So the precise route is dead on this platform and the ambiguous one does all the work.

Both are handled now. `SetScrollOffset` maps straight through where it is produced; the numeric `SetValue` is the live path.

## The axis inference, which the exact route would have avoided

A number arrives with no axis. Flutter reports **one** scroll position per scrollable, so that number is the same scalar coming back, and only its axis has to be recovered — which way the node scrolls answers it.

A node scrolling both ways has no answer. Not in Flutter's model either, which still reports a single position for it. So vertical wins as the commoner case rather than the request being dropped on the floor. That is a judgement, and it is written down at the call site rather than left implicit.

## Also handled, and unreachable

`SetValue` carrying a **string** maps to set-text. That is the correct mapping, and nothing on this platform produces it: accesskit's AT-SPI backend exposes no `EditableText` interface. Kept because it is right the moment one appears, and called out in the code so nobody mistakes it for a tested path.

## Testing

Verified over the accessibility bus, not only by unit test. Setting `Value.currentValue = 300.0` on a vertically scrolling node:

```
[harness] dispatch node=4 action=0x800000 len=16 offset=(0,300)
```

`0x800000` is `SCROLL_TO_OFFSET`, and the axis is right. Before this change the same call produced nothing.

4 new unit tests (21 in the suite): both actions advertised only where the node supports them, `SetScrollOffset` mapping straight through, and `SetValue` deliberately **not** mapped by tag alone — its meaning depends on the payload, so the translation table must not guess.

29/29 across the suite, clang-tidy clean, `scripts/format.sh --check` passes.

## Note

These tests still do not run in CI — there is no `-D BUILD_ACCESSKIT=ON` leg. That is now 21 AccessKit tests that never execute there, covering the label-from-value rule, the empty-string boundary, and this mapping.
