### PR TITLE
ci: build and test with AccessKit enabled

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -169,6 +169,84 @@ jobs:
         working-directory: ${{github.workspace}}/build/accessibility
         run: ninja -C . homescreen
 
+  # The AccessKit bridge is off by default and needs bindings that are not a
+  # system package, so nothing else here compiles it. Every defect found in
+  # that adapter so far has been a silent one -- a tree of nameless static
+  # text, a live region that never announced, a write path that dropped every
+  # request -- which is exactly the class a build-and-test leg catches and a
+  # reviewer does not.
+  #
+  # Uses the upstream release rather than the .emb augment: the augment builds
+  # the crate from source to give board targets an aarch64 library, which
+  # needs a Rust toolchain, while the release ships a prebuilt x86_64 static
+  # library that this runner can use directly.
+  accesskit:
+    name: accesskit (BUILD_ACCESSKIT=ON)
+    if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' && always() }}
+    runs-on: ubuntu-22.04
+    env:
+      ACCESSKIT_VERSION: "0.22.3"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Update apt package index
+        # See the accessibility job: the cache action pins versions from the
+        # runner's stale index, which 404s once a revision is superseded.
+        run: sudo apt-get update
+      - name: Install build deps
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: >-
+            ninja-build
+            libwayland-dev wayland-protocols libxkbcommon-dev libpugixml-dev
+            mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils
+
+      - name: Fetch the AccessKit C bindings
+        run: |
+          set -euo pipefail
+          curl -fsSL -o "${RUNNER_TEMP}/accesskit-c.zip" \
+            "https://github.com/AccessKit/accesskit-c/releases/download/${ACCESSKIT_VERSION}/accesskit-c-${ACCESSKIT_VERSION}.zip"
+          unzip -q "${RUNNER_TEMP}/accesskit-c.zip" -d "${RUNNER_TEMP}"
+          # accesskit-config.cmake sits at the top of the archive, so this is
+          # what find_package(ACCESSKIT) resolves against.
+          test -f "${RUNNER_TEMP}/accesskit-c-${ACCESSKIT_VERSION}/accesskit-config.cmake"
+
+      - name: Configure (AccessKit enabled)
+        run: |
+          cmake -GNinja \
+            -B ${{github.workspace}}/build/accesskit \
+            -D CMAKE_BUILD_TYPE=Debug \
+            -D BUILD_ACCESSIBILITY=ON \
+            -D BUILD_ACCESSKIT=ON \
+            -D BUILD_UNIT_TESTS=ON \
+            -D CMAKE_PREFIX_PATH="${RUNNER_TEMP}/accesskit-c-${ACCESSKIT_VERSION}" \
+            -D CMAKE_STAGING_PREFIX=${{github.workspace}}/build/staging/usr/local \
+            -D BUILD_NUMBER=${GITHUB_RUN_ID}
+
+      - name: Generate Wayland protocol headers
+        # The unit-test targets compile the Wayland sources without depending
+        # on the scanner targets, so ninja will otherwise compile them before
+        # the headers exist.
+        working-directory: ${{github.workspace}}/build/accesskit
+        run: |
+          ninja $(ninja -t targets all \
+            | grep -oE "^shell/wayland-protocols/[a-z0-9_]+\.hpp" \
+            | sort -u | tr '\n' ' ')
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build/accesskit
+        run: ninja
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build/accesskit
+        # The whole suite, not just the AccessKit cases: enabling the bridge
+        # changes what the shell links and registers, so a regression it
+        # causes may well surface somewhere else.
+        run: ctest --output-on-failure
+
   # Path-gate the (expensive) crash-handler build: it is a full
   # BUILD_CRASH_HANDLER=ON compile, so it only needs to run when build inputs
   # change. Docs/asset-only PRs skip it. Non-PR events (schedule / release /


### PR DESCRIPTION
The AccessKit bridge is off by default and needs bindings that are not a system package, so nothing in CI compiled it and none of its tests ran anywhere but a developer's machine. That is now 21 tests, and it matters more than the count suggests: **every defect found in that adapter has been a silent one.**

- static text reached a screen reader with **no name at all** — AccessKit takes a Label's name from its value, Flutter puts it in the label
- live regions never announced, because the announcement is built from that same missing name
- the focus action was advertised on every node, so containers and labels all looked like focus targets
- an assistive technology could read a scroll position and not set one

None of those raise an error anywhere. They are invisible without an assistive technology attached, which is exactly the class a build-and-test leg catches and a reviewer does not.

## Approach

**Uses the upstream release, not the `.emb` augment.** The augment builds the crate from source so board targets get a library for their own architecture, which needs a Rust toolchain and the target's std. The release ships a prebuilt x86_64 static library plus `accesskit-config.cmake` at the top of the archive, which is all an ubuntu runner needs — a `curl`, an `unzip`, and a `CMAKE_PREFIX_PATH`.

**Runs the whole suite, not just the AccessKit cases.** Enabling the bridge changes what the shell links and what registers with the hub, so a regression it causes may surface somewhere else entirely.

**Generates the Wayland protocol headers first.** The unit-test targets compile the Wayland sources without depending on the scanner targets, so ninja will otherwise compile them before the headers exist — a known trap in this tree.

## Verified locally before writing it

The recipe was run end to end against the same prebuilt release the job downloads:

```
-- AccessKit ............... Enabled
100% tests passed, 0 tests failed out of 1     # accesskit filter
```

Full build clean, whole suite green. The job is the same sequence with the download in front.

## Note

This covers x86_64 only. The aarch64 path — where the augment and its patch matter — is still verified by hand on a board rather than continuously; that has not changed and is not something a GitHub runner can do without a cross toolchain and a Rust target.
