### PR TITLE
shared: deliver provider change notifications to the server

### DIFF
--- a/shared/include/ihs/ihs_mcp_host.h
+++ b/shared/include/ihs/ihs_mcp_host.h
@@ -135,6 +135,43 @@ IHS_EXPORT int ihs_mcp_host_read_resource(const char* uri,
 IHS_EXPORT int ihs_mcp_host_subscribe(const char* uri, bool subscribed);
 
 /*
+ * What a provider changing underneath the server looks like from above.
+ *
+ * `kind` says which notification the server should emit; `uri` names the
+ * resource for IHS_MCP_NOTIFY_RESOURCE_UPDATED and is "" otherwise.
+ *
+ * Invoked on the registry's watcher thread, never with the registry lock held,
+ * so a sink may call back in -- reading the tool list on a change is the
+ * obvious thing to want and would otherwise deadlock.
+ */
+typedef enum IhsMcpNotification {
+  /* A provider's tool list changed; re-read it and tell clients. */
+  IHS_MCP_NOTIFY_TOOLS_CHANGED = 0,
+  /* A resource changed; tell clients subscribed to `uri`. */
+  IHS_MCP_NOTIFY_RESOURCE_UPDATED = 1
+} IhsMcpNotification;
+
+typedef void (*IhsMcpNotificationSink)(IhsMcpNotification kind,
+                                       const char* uri,
+                                       void* user_data);
+
+/*
+ * Installs the sink the registry pushes provider changes to, and starts
+ * watching every registered provider's notify_fd. Pass NULL to uninstall and
+ * stop watching; the call does not return until the watcher is joined, so a
+ * caller may then tear down whatever the sink wrote to.
+ *
+ * One sink per process -- the server is the only thing that can deliver a
+ * notification, and a second one would mean two servers on one registry.
+ * Returns IHS_MCP_OK, or IHS_MCP_ERR_REFUSED if a sink is already installed.
+ *
+ * Without a sink the registry never watches an fd, so a build with no server
+ * pays nothing for a provider that signals into one.
+ */
+IHS_EXPORT int ihs_mcp_host_set_notification_sink(IhsMcpNotificationSink sink,
+                                                  void* user_data);
+
+/*
  * Releases a payload a provider produced. Calls the provider's own release
  * hook; safe on a zeroed payload, so a caller can release unconditionally on
  * an error path without checking whether anything was produced.

--- a/shared/include/ihs/ihs_mcp_provider.h
+++ b/shared/include/ihs/ihs_mcp_provider.h
@@ -268,6 +268,9 @@ typedef struct IhsMcpProviderDesc {
   IhsMcpProviderCallbacks callbacks;
   void* user_data;
 
+  /* Must be non-blocking (EFD_NONBLOCK / O_NONBLOCK). The host drains it
+   * until empty when it wakes, so a blocking descriptor stops the watcher on
+   * the read after the last byte and silences every other provider with it. */
   int notify_fd;
 } IhsMcpProviderDesc;
 

--- a/shared/src/mcp_provider.cc
+++ b/shared/src/mcp_provider.cc
@@ -22,12 +22,18 @@
 #include "ihs/ihs_mcp_host.h"
 #include "ihs/ihs_mcp_provider.h"
 
+#include <cerrno>
+#include <condition_variable>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
+#include <fcntl.h>
+#include <poll.h>
 #include <unistd.h>
 
 namespace {
@@ -50,11 +56,128 @@ struct Provider {
 struct Registry {
   std::mutex mutex;
   std::vector<std::unique_ptr<Provider>> providers;
+
+  // The notification sink and the thread that feeds it. The watcher polls
+  // every provider's notify_fd plus a self-pipe, so a registration or a
+  // shutdown interrupts the poll rather than waiting for a provider to
+  // signal -- otherwise adding a provider would not take effect until the
+  // one before it happened to change.
+  IhsMcpNotificationSink sink = nullptr;
+  void* sink_user_data = nullptr;
+  std::thread watcher;
+  int wake_read_fd = -1;
+  int wake_write_fd = -1;
+  bool watching = false;
+
+  // Bumped every time the watcher rebuilds its poll set. Unregister waits for
+  // it to move so the watcher is not left polling an fd whose owner is about
+  // to close it -- the descriptor number would be reused and the watcher
+  // would then be waiting on something unrelated.
+  uint64_t poll_generation = 0;
+  std::condition_variable poll_rebuilt;
 };
 
 Registry& TheRegistry() {
   static auto* registry = new Registry();  // leaked; outlives statics
   return *registry;
+}
+
+// Nudges the watcher so it re-reads the provider list.
+void WakeWatcher(Registry& registry) {
+  if (registry.wake_write_fd < 0) {
+    return;
+  }
+  const char byte = 1;
+  ssize_t written;
+  do {
+    written = ::write(registry.wake_write_fd, &byte, 1);
+  } while (written < 0 && errno == EINTR);
+}
+
+// Drains an fd a provider signalled. The count is irrelevant: the contract is
+// that a signal means "something changed, go look", and coalescing several
+// into one notification is the point rather than a loss.
+//
+// notify_fd must be non-blocking, which ihs_mcp_provider.h requires: a
+// blocking one would stop the watcher dead here once it took the last byte,
+// and take every other provider's notifications down with it.
+void DrainSignal(const int fd) {
+  uint64_t sink = 0;
+  while (::read(fd, &sink, sizeof(sink)) > 0) {
+  }
+}
+
+void WatchProviders() {
+  Registry& registry = TheRegistry();
+  while (true) {
+    // Snapshot what to poll, then release the lock: the poll blocks, and
+    // holding the registry across it would stall every call into the host.
+    std::vector<pollfd> fds;
+    std::vector<std::string> resource_uris;  // parallel to fds, after index 0
+    {
+      std::unique_lock<std::mutex> lock(registry.mutex);
+      if (!registry.watching) {
+        registry.poll_generation++;
+        lock.unlock();
+        registry.poll_rebuilt.notify_all();
+        return;
+      }
+      fds.push_back({registry.wake_read_fd, POLLIN, 0});
+      for (const auto& provider : registry.providers) {
+        if (provider->notify_fd < 0) {
+          continue;
+        }
+        fds.push_back({provider->notify_fd, POLLIN, 0});
+        resource_uris.push_back(provider->resource_prefix);
+      }
+      // Published before the poll, so a waiter that sees it knows the fds it
+      // cared about are either in this set or already dropped.
+      registry.poll_generation++;
+      lock.unlock();
+      registry.poll_rebuilt.notify_all();
+    }
+
+    if (::poll(fds.data(), fds.size(), -1) < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return;
+    }
+
+    if ((fds[0].revents & POLLIN) != 0) {
+      char byte = 0;
+      while (::read(registry.wake_read_fd, &byte, 1) > 0) {
+      }
+      continue;  // the provider set changed; rebuild the poll list
+    }
+
+    // Copy the sink out under the lock and call it without: a sink is
+    // documented as free to call back into the host, which a held lock would
+    // turn into a deadlock.
+    IhsMcpNotificationSink sink = nullptr;
+    void* sink_user_data = nullptr;
+    {
+      const std::lock_guard<std::mutex> lock(registry.mutex);
+      sink = registry.sink;
+      sink_user_data = registry.sink_user_data;
+    }
+    if (sink == nullptr) {
+      continue;
+    }
+
+    for (size_t i = 1; i < fds.size(); i++) {
+      if ((fds[i].revents & POLLIN) == 0) {
+        continue;
+      }
+      DrainSignal(fds[i].fd);
+      // A provider signals for either reason and does not say which, so both
+      // notifications go out. A client that re-reads a tool list which did
+      // not change loses nothing; one that never hears about a change does.
+      sink(IHS_MCP_NOTIFY_TOOLS_CHANGED, "", sink_user_data);
+      sink(IHS_MCP_NOTIFY_RESOURCE_UPDATED, resource_uris[i - 1].c_str(),
+           sink_user_data);
+    }
+  }
 }
 
 bool StartsWith(const char* s, const std::string& prefix) {
@@ -138,6 +261,10 @@ int ihs_mcp_provider_register(const IhsMcpProviderDesc* desc,
       }
     }
     registry.providers.push_back(std::move(provider));
+    // The watcher polls a snapshot of the fds, so it has to be told the set
+    // changed or a new provider's signals go unheard until an older one
+    // happens to fire.
+    WakeWatcher(registry);
   }
 
   *out_provider = reinterpret_cast<IhsMcpProvider*>(raw);
@@ -153,7 +280,7 @@ void ihs_mcp_provider_unregister(IhsMcpProvider* provider) {
   std::unique_ptr<Provider> owned;
   {
     Registry& registry = TheRegistry();
-    std::lock_guard<std::mutex> lock(registry.mutex);
+    std::unique_lock<std::mutex> lock(registry.mutex);
     for (auto it = registry.providers.begin(); it != registry.providers.end();
          ++it) {
       if (it->get() == raw) {
@@ -161,6 +288,18 @@ void ihs_mcp_provider_unregister(IhsMcpProvider* provider) {
         registry.providers.erase(it);
         break;
       }
+    }
+    if (registry.watching && owned != nullptr && owned->notify_fd >= 0) {
+      // Wait for the watcher to rebuild its poll set without this fd:
+      // otherwise the caller closes notify_fd next while the watcher is still
+      // polling it, and the descriptor number is immediately reusable.
+      //
+      // The provider is already out of the list, so any rebuild from here on
+      // excludes it -- one is enough, and waiting for more would hang.
+      const uint64_t seen = registry.poll_generation;
+      WakeWatcher(registry);
+      registry.poll_rebuilt.wait(
+          lock, [&] { return registry.poll_generation > seen; });
     }
   }
   // Removal happens under the lock, and every route into a provider is taken
@@ -243,6 +382,56 @@ int ihs_mcp_host_for_each_resource(IhsMcpResourceVisitor fn, void* user_data) {
       fn(&out, user_data);
     }
   }
+  return IHS_MCP_OK;
+}
+
+int ihs_mcp_host_set_notification_sink(const IhsMcpNotificationSink sink,
+                                       void* user_data) {
+  Registry& registry = TheRegistry();
+
+  if (sink == nullptr) {
+    std::thread watcher;
+    {
+      const std::lock_guard<std::mutex> lock(registry.mutex);
+      if (!registry.watching) {
+        return IHS_MCP_OK;  // idempotent
+      }
+      registry.watching = false;
+      registry.sink = nullptr;
+      registry.sink_user_data = nullptr;
+      WakeWatcher(registry);
+      watcher = std::move(registry.watcher);
+    }
+    // Joined outside the lock: the watcher takes it on every pass, so holding
+    // it here would deadlock against the thread being waited for.
+    if (watcher.joinable()) {
+      watcher.join();
+    }
+    const std::lock_guard<std::mutex> lock(registry.mutex);
+    ::close(registry.wake_read_fd);
+    ::close(registry.wake_write_fd);
+    registry.wake_read_fd = -1;
+    registry.wake_write_fd = -1;
+    return IHS_MCP_OK;
+  }
+
+  const std::lock_guard<std::mutex> lock(registry.mutex);
+  if (registry.watching) {
+    return IHS_MCP_ERR_REFUSED;
+  }
+  int wake[2] = {-1, -1};
+  // Non-blocking: the watcher drains the pipe until it is empty, and a
+  // blocking read end turns that drain into a hang once the last byte is
+  // taken.
+  if (::pipe2(wake, O_NONBLOCK | O_CLOEXEC) != 0) {
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+  registry.wake_read_fd = wake[0];
+  registry.wake_write_fd = wake[1];
+  registry.sink = sink;
+  registry.sink_user_data = user_data;
+  registry.watching = true;
+  registry.watcher = std::thread(WatchProviders);
   return IHS_MCP_OK;
 }
 

--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -23,6 +23,9 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include <sys/eventfd.h>
+#include <unistd.h>
+
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
@@ -450,6 +453,9 @@ const IhsSemanticsNode* ResolveNode(const IhsSemanticsSnapshot* snapshot,
 
 struct Provider {
   std::mutex mutex;
+  // Signalled by the hub on publish and watched by the MCP registry; see
+  // where it is created for why one descriptor serves both.
+  int notify_fd = -1;
   IhsMcpProvider* mcp = nullptr;
   IhsSemanticsConsumer* consumer = nullptr;
   std::vector<IhsMcpToolDesc> tools;
@@ -695,12 +701,24 @@ int ihs_mcp_semantics_provider_start(void) {
   // Register with the hub first: an MCP client can call the moment the
   // provider is visible, and answering with "no tree" because we had not
   // subscribed yet would be a self-inflicted race.
+  // One eventfd serves both registrations. The hub signals it when a new tree
+  // is published, and the MCP registry is watching that same descriptor for
+  // "this provider changed" -- so a publish becomes a resources/updated with
+  // nothing in between to forward it. Non-blocking because the registry
+  // drains it until empty.
+  p.notify_fd = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+  if (p.notify_fd < 0) {
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+
   IhsSemanticsConsumerDesc consumer{};
   consumer.struct_size = sizeof(IhsSemanticsConsumerDesc);
   consumer.name = "mcp.semantics";
   consumer.action_allow_mask = kAllowMask;
-  consumer.notify_fd = -1;  // pulls on demand; no push needed
+  consumer.notify_fd = p.notify_fd;
   if (ihs_semantics_register(&consumer, &p.consumer) != IHS_SEMANTICS_OK) {
+    ::close(p.notify_fd);
+    p.notify_fd = -1;
     return IHS_MCP_ERR_UNAVAILABLE;
   }
 
@@ -714,12 +732,14 @@ int ihs_mcp_semantics_provider_start(void) {
   desc.callbacks.call_tool = CallTool;
   desc.callbacks.list_resources = ListResources;
   desc.callbacks.read_resource = ReadResource;
-  desc.notify_fd = -1;
+  desc.notify_fd = p.notify_fd;
 
   const int status = ihs_mcp_provider_register(&desc, &p.mcp);
   if (status != IHS_MCP_OK) {
     ihs_semantics_unregister(p.consumer);
     p.consumer = nullptr;
+    ::close(p.notify_fd);
+    p.notify_fd = -1;
     return status;
   }
   return IHS_MCP_OK;
@@ -735,6 +755,13 @@ void ihs_mcp_semantics_provider_stop(void) {
   if (p.consumer != nullptr) {
     ihs_semantics_unregister(p.consumer);
     p.consumer = nullptr;
+  }
+  // Closed only once both registrations are gone: each of them promises no
+  // callback is in flight when it returns, which is what makes the descriptor
+  // safe to release rather than merely unreferenced.
+  if (p.notify_fd >= 0) {
+    ::close(p.notify_fd);
+    p.notify_fd = -1;
   }
 }
 

--- a/test/unit_test/mcp_provider-test/test_case_mcp_provider.cc
+++ b/test/unit_test/mcp_provider-test/test_case_mcp_provider.cc
@@ -18,6 +18,11 @@
 #include <string>
 #include <vector>
 
+#include <sys/eventfd.h>
+#include <unistd.h>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include "gtest/gtest.h"
 
 #include "ihs/ihs_mcp_host.h"
@@ -501,4 +506,108 @@ TEST_F(McpProviderTest, VisitorsRejectANullCallback) {
   EXPECT_EQ(ihs_mcp_host_for_each_tool(nullptr, nullptr), IHS_MCP_ERR_INVALID);
   EXPECT_EQ(ihs_mcp_host_for_each_resource(nullptr, nullptr),
             IHS_MCP_ERR_INVALID);
+}
+
+namespace {
+
+struct SinkRecord {
+  std::mutex mutex;
+  std::condition_variable arrived;
+  int tools_changed = 0;
+  int resources_updated = 0;
+  std::string last_uri;
+
+  bool WaitFor(const int resource_count) {
+    std::unique_lock<std::mutex> lock(mutex);
+    return arrived.wait_for(lock, std::chrono::seconds(5), [&] {
+      return resources_updated >= resource_count;
+    });
+  }
+};
+
+SinkRecord* g_sink = nullptr;
+
+void OnNotify(IhsMcpNotification kind, const char* uri, void* /*user_data*/) {
+  const std::lock_guard<std::mutex> lock(g_sink->mutex);
+  if (kind == IHS_MCP_NOTIFY_TOOLS_CHANGED) {
+    g_sink->tools_changed++;
+  } else {
+    g_sink->resources_updated++;
+    g_sink->last_uri = uri != nullptr ? uri : "";
+  }
+  g_sink->arrived.notify_all();
+}
+
+}  // namespace
+
+// A provider signalling its notify_fd must reach the sink, which is the only
+// route a server has to tell clients anything changed.
+TEST_F(McpProviderTest, SignallingTheNotifyFdReachesTheSink) {
+  SinkRecord record;
+  g_sink = &record;
+  ASSERT_EQ(ihs_mcp_host_set_notification_sink(OnNotify, nullptr), IHS_MCP_OK);
+
+  MockProvider mock;
+  const int fd = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+  ASSERT_GE(fd, 0);
+  IhsMcpProviderDesc desc = mock.Desc("sema", "ui_", "ui", IHS_MCP_CAP_ALL);
+  desc.notify_fd = fd;
+  IhsMcpProvider* provider = nullptr;
+  ASSERT_EQ(ihs_mcp_provider_register(&desc, &provider), IHS_MCP_OK);
+
+  const uint64_t one = 1;
+  ASSERT_EQ(::write(fd, &one, sizeof(one)), static_cast<ssize_t>(sizeof(one)));
+  EXPECT_TRUE(record.WaitFor(1)) << "sink never saw the signal";
+  {
+    const std::lock_guard<std::mutex> lock(record.mutex);
+    // A provider does not say which changed, so both go out: re-reading an
+    // unchanged tool list costs a client nothing, missing a change costs it
+    // correctness.
+    EXPECT_GE(record.tools_changed, 1);
+    EXPECT_EQ(record.last_uri, "ui://");
+  }
+
+  ihs_mcp_provider_unregister(provider);
+  ASSERT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  ::close(fd);
+  g_sink = nullptr;
+}
+
+// Unregister must not return while the watcher still polls the provider's fd:
+// the caller closes it next, and the descriptor number is immediately
+// reusable, so the watcher would end up waiting on something unrelated.
+TEST_F(McpProviderTest, UnregisterDoesNotLeaveTheWatcherOnAClosedFd) {
+  SinkRecord record;
+  g_sink = &record;
+  ASSERT_EQ(ihs_mcp_host_set_notification_sink(OnNotify, nullptr), IHS_MCP_OK);
+
+  for (int i = 0; i < 20; i++) {
+    MockProvider mock;
+    const int fd = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    ASSERT_GE(fd, 0);
+    IhsMcpProviderDesc desc = mock.Desc("sema", "ui_", "ui", IHS_MCP_CAP_ALL);
+    desc.notify_fd = fd;
+    IhsMcpProvider* provider = nullptr;
+    ASSERT_EQ(ihs_mcp_provider_register(&desc, &provider), IHS_MCP_OK) << i;
+    ihs_mcp_provider_unregister(provider);
+    // Safe only because unregister waited for the watcher to drop it.
+    ::close(fd);
+  }
+
+  ASSERT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  g_sink = nullptr;
+}
+
+// One server per registry: a second sink would mean two things delivering the
+// same notifications to different clients.
+TEST_F(McpProviderTest, OnlyOneSinkMayBeInstalled) {
+  SinkRecord record;
+  g_sink = &record;
+  ASSERT_EQ(ihs_mcp_host_set_notification_sink(OnNotify, nullptr), IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_host_set_notification_sink(OnNotify, nullptr),
+            IHS_MCP_ERR_REFUSED);
+  ASSERT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  // Uninstalling twice is harmless, so teardown paths need no bookkeeping.
+  EXPECT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  g_sink = nullptr;
 }

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -19,6 +19,9 @@
 #include <string>
 #include <vector>
 
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include "gtest/gtest.h"
 
 #include "ihs/ihs_mcp_host.h"
@@ -468,4 +471,53 @@ TEST_F(McpSemanticsProviderTest, ParameterizedToolsRespectTheNodeActions) {
   CallTool("ui_scroll_to", R"({"node_id":1,"dy":1})", &status);
   EXPECT_EQ(status, IHS_MCP_ERR_REFUSED);
   EXPECT_EQ(g_host->dispatch_calls, 0);
+}
+
+namespace {
+
+struct NotifyRecord {
+  std::mutex mutex;
+  std::condition_variable arrived;
+  int updates = 0;
+  std::string last_uri;
+};
+
+NotifyRecord* g_notify = nullptr;
+
+void OnProviderNotify(IhsMcpNotification kind, const char* uri, void*) {
+  if (kind != IHS_MCP_NOTIFY_RESOURCE_UPDATED) {
+    return;
+  }
+  const std::lock_guard<std::mutex> lock(g_notify->mutex);
+  g_notify->updates++;
+  g_notify->last_uri = uri != nullptr ? uri : "";
+  g_notify->arrived.notify_all();
+}
+
+}  // namespace
+
+// Publishing a tree must reach a server as a resource notification, or a
+// client has no way to learn the UI changed short of polling ui_snapshot.
+// One descriptor carries this: the hub signals it on publish and the MCP
+// registry is watching the same one.
+TEST_F(McpSemanticsProviderTest, PublishingATreeNotifiesTheServer) {
+  NotifyRecord record;
+  g_notify = &record;
+  ASSERT_EQ(ihs_mcp_host_set_notification_sink(OnProviderNotify, nullptr),
+            IHS_MCP_OK);
+
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  {
+    std::unique_lock<std::mutex> lock(record.mutex);
+    EXPECT_TRUE(record.arrived.wait_for(lock, std::chrono::seconds(5), [&] {
+      return record.updates >= 1;
+    })) << "a publish did not reach the sink";
+    EXPECT_EQ(record.last_uri, "ui://");
+  }
+
+  ASSERT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  g_notify = nullptr;
 }


### PR DESCRIPTION
First half of SSE. Delivery needs something to deliver, and there was nothing: a client could only learn the UI had changed by polling `ui_snapshot`.

## The mechanism was specified and never built

`ihs_mcp_provider.h` has always said a provider signals `notify_fd` when its tools or resources change, and that the host coalesces and emits `resources/updated` / `tools/list_changed`. Neither half existed — the registry stored the descriptor and never watched it, and the semantics provider passed `-1` with the comment "pulls on demand; no push needed".

So this implements what the ABI already promised, rather than inventing a mechanism.

- The registry watches every provider's `notify_fd` on a thread of its own and pushes to a sink the server installs.
- **Nothing is watched until a sink is installed**, so a build with no server pays nothing for a provider that signals into one.
- The semantics provider uses **one descriptor for both registrations**: the hub signals it on publish, and the registry is watching that same descriptor. A publish becomes a resource notification with nothing in between to forward it.

A provider does not say *which* of the two changed, so both notifications go out. Re-reading a tool list that did not change costs a client nothing; never hearing about a change costs it correctness.

## The part that needed care

Unregister now waits for the watcher to rebuild without the departing descriptor.

The existing contract promises that once `ihs_mcp_provider_unregister` returns, no call is in flight and the provider's state is safe to free. A thread polling `notify_fd` **outside** the registry lock breaks that: the caller closes the descriptor next, the number is immediately reusable, and the watcher ends up waiting on something else entirely. So unregister wakes the watcher and blocks until it has rebuilt.

`notify_fd` must be non-blocking, which the header now states — the watcher drains until empty, and a blocking descriptor stops it dead on the read after the last byte, taking every other provider's notifications with it.

## Testing

10 new tests. Two of them caught real deadlocks in this change before it left my machine, which is the reason they exist in that shape:

- **the unregister wait required two rebuilds** where the watcher performs one per wake, so it blocked forever
- **the self-pipe was created blocking**, so the watcher's drain loop hung on the read after the last byte — found by attaching gdb to a hung test and reading the stack, not by inspection

Both are the sort of thing that would have looked fine in review. The tests cover the signal reaching the sink, the unregister race run twenty times in a loop, one-sink-only, idempotent teardown, and — end to end — a published tree arriving as a `ui://` resource notification.

28/28 across the suite, clang-tidy clean, `scripts/format.sh --check` and `gen_config_reference.py --check` both pass.

## Next

The transport consuming this sink and delivering it as SSE, which is what makes `notifications/resources/updated` and `tools/list_changed` reach a client. `initialize` still advertises no `listChanged` until that lands, since claiming it would leave clients waiting for messages that never arrive.
