### PR TITLE
ci: cache emb augment sources so builds stop refetching them

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -269,6 +269,32 @@ jobs:
             i=$(( i + 1 ))
           done
 
+      # ...and rebuilding them means fetching their sources, which is the one
+      # network dependency left in this job. emb keeps the archive beside the
+      # extracted tree and skips the download when it is already there, so
+      # caching the archives alone turns the fetch into a no-op -- the
+      # extracted trees are not cached, since they are rebuilt against this
+      # image's toolchain regardless.
+      #
+      # This is not a hypothetical: github.com closed the connection mid-fetch
+      # for wayland-cxx-scanner and failed the build, and emb's own four
+      # retries had already been spent. Keyed on the augment definitions, so a
+      # new or bumped source misses and refetches; every other run stays off
+      # the network entirely. Not keyed on the OS -- the sources are the same
+      # archives for every target, so one entry serves the whole matrix.
+      - name: Cache augment sources
+        uses: actions/cache@v6
+        with:
+          path: |
+            /emb/.config/flutter_workspace/overlay-src/*.tar.gz
+            /emb/.config/flutter_workspace/overlay-src/*.tar.xz
+            /emb/.config/flutter_workspace/overlay-src/*.tar.bz2
+            /emb/.config/flutter_workspace/overlay-src/*.tgz
+            /emb/.config/flutter_workspace/overlay-src/*.zip
+          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}
+          restore-keys: |
+            emb-augment-src-
+
       # The image bakes the toolchain + sysroot at /emb, so -w /emb resolves as
       # a pure cache hit (no download/extract). Host build tools (cmake, ninja,
       # meson, wayland-scanner) are baked too; only the augment libs rebuild.

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -149,9 +149,14 @@ jobs:
           # eviction); the cache restores ~/oras-bin/oras otherwise.
           if [ ! -x "$HOME/oras-bin/oras" ]; then
             mkdir -p "$HOME/oras-bin"
-            curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
-              "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
-              | tar -xzf - -C "$HOME/oras-bin" oras
+            # To a file, not a pipe: see the build job's copy -- a curl retry
+            # restarts the stream and a pipe hands tar the truncated attempt
+            # followed by a whole one.
+            curl -fsSL --retry 8 --retry-all-errors --retry-max-time 300 \
+              --connect-timeout 15 -o /tmp/oras.tar.gz \
+              "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+            tar -xzf /tmp/oras.tar.gz -C "$HOME/oras-bin" oras
+            rm -f /tmp/oras.tar.gz
           fi
           sudo install -m 0755 "$HOME/oras-bin/oras" /usr/local/bin/oras
           # Retried for the same reason as the docker login above: the download
@@ -250,12 +255,32 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_USER: ${{ github.actor }}
         run: |
-          # Only fetch from GitHub releases on a cache miss (version bump); the
-          # cache restores /usr/local/bin/oras otherwise.
+          # Only fetch from GitHub releases on a cache miss (version bump or
+          # a key change); the cache restores /usr/local/bin/oras otherwise.
+          #
+          # A miss here is a miss in every matrix leg at once -- around 25 jobs
+          # asking GitHub for the same file in the same second, which is the
+          # concentration that provokes the failure rather than a symptom of
+          # it. So the fetch is staggered by a short per-job delay before it
+          # starts, and retried far more patiently than a warm path would
+          # need: the point is to outlast a bad window, not to fail fast.
+          #
+          # No --retry-delay: curl backs off exponentially without it, which
+          # spreads the retries too. PID-derived jitter because the container
+          # shell is dash and has no $RANDOM.
+          #
+          # Downloaded to a file rather than piped into tar: on a retry curl
+          # restarts the transfer from the beginning, so a pipe hands tar the
+          # truncated first attempt followed by a second full stream. That is
+          # why a flaky fetch here surfaced as "tar: exit 2" rather than a
+          # curl error -- the retries were making the input corrupt.
           if [ ! -x /usr/local/bin/oras ]; then
-            curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
-              "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
-              | tar -xzf - -C /usr/local/bin oras
+            sleep $(( $$ % 20 ))
+            curl -fsSL --retry 8 --retry-all-errors --retry-max-time 300 \
+              --connect-timeout 15 -o /tmp/oras.tar.gz \
+              "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+            tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras
+            rm -f /tmp/oras.tar.gz
           fi
           # This is the login that has actually failed in CI: ~25 matrix jobs
           # authenticate to ghcr.io at once, which is exactly the concentration

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -133,7 +133,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/oras-bin
-          key: oras-${{ env.ORAS_VERSION }}-linux-amd64
+          # The location is part of the key. The build job caches oras at a
+          # different path under what was the same key, and a cache entry
+          # restores to the path it was saved from -- so whichever job saved
+          # first owned the entry and the other got a "hit" that put the
+          # binary somewhere it does not look, then downloaded it again on
+          # every run.
+          key: oras-${{ env.ORAS_VERSION }}-linux-amd64-home
       - name: Install + log in oras
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -237,7 +243,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: /usr/local/bin/oras
-          key: oras-${{ env.ORAS_VERSION }}-linux-amd64
+          # Distinct from the publish job's entry; see the note there.
+          key: oras-${{ env.ORAS_VERSION }}-linux-amd64-usrlocal
       - name: Install + log in oras
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The build job's toolchain and sysroot are baked into the image, so `-w /emb` resolves as a pure cache hit and *"only the augment libs rebuild"* — which means fetching their sources. That fetch happens on **every job of every run**, once per matrix leg, and it is the one network dependency left in the job.

It failed:

```
augment: download failed (https://github.com/jwinarske/wayland-cxx-scanner/archive/….tar.gz):
HttpException: Connection closed before full header was received
##[error]Process completed with exit code 70
```

## Retrying is not the fix here

emb's `_download` already retries four times with backoff on 5xx, 429 and IOException. Those were spent before the error surfaced — the host was unavailable for the whole window, not for a moment. More retries would have made the job slower and still red.

The fix is not asking at all.

## Caching the archives, not the trees

`_fetchSource` keeps each archive beside its extracted tree and checks before downloading:

```dart
final tarball = File(p.join(src.path, p.basename(Uri.parse(lib.url).path)));
if (!tarball.existsSync()) {
  await _download(lib.url, tarball);
```

So restoring the archives turns the fetch into a no-op. Only the archives are cached — the extracted trees are rebuilt against the image's toolchain regardless, and caching them would be large and pointless. Locally the whole `overlay-src` is 975 MB; the archives in it are 62 MB, and most of that is an AccessKit zip these targets do not fetch.

Keyed on the augment definitions, so a new or bumped source misses and refetches while every other run stays off the network. **Not** keyed on the OS: the archives are byte-identical for every target, so one entry serves the whole matrix rather than one per leg.

## Why this keeps coming up

This is the third artifact host to fail a build today, in three different guises — TLS verification on submodule clones, HTTP 503 on the AccessKit release, and now a connection closed mid-fetch. The pattern is that anything fetched fresh on every run is a standing liability, and the ones already cached here (the emb store, the oras binary) were quietly unaffected each time.

Same reasoning as #445, applied to the remaining unguarded fetch.

---

## Also: the two oras caches shared one key

Prompted by checking whether oras was cached. It is, in both jobs — but:

| job | path | key (before) |
|---|---|---|
| publish | `~/oras-bin` | `oras-${ORAS_VERSION}-linux-amd64` |
| build | `/usr/local/bin/oras` | `oras-${ORAS_VERSION}-linux-amd64` |

Cache keys are repo-global and an entry restores to the path it was saved from. So whichever job saved first owned the entry, and the other got a *hit* that placed the binary somewhere it does not look — then fell through its own `if [ ! -x … ]` guard and downloaded it again. One of the two has been refetching oras on every run while reporting a cache hit.

Both keys now carry the location.

**This does not explain today's failure**, and I want to be clear about that: the failing step was `oras login ghcr.io`, which is authentication, not the download. That loop already retries five times with backoff and still exhausted them, so ghcr.io was genuinely refusing valid credentials for the whole window — the same degradation the existing comment describes ("~25 matrix jobs authenticate to ghcr.io at once"). Only a re-run clears that. The key fix removes wasted refetching, not that failure.
