### PR TITLE
scripts: add a live viewer for the semantics tree

### DIFF
--- a/scripts/mcp_inspector.py
+++ b/scripts/mcp_inspector.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Live view of the semantics tree an ivi-homescreen shell is serving.
+
+Holds one event stream open and redraws whenever the UI changes, so what is
+on screen and what an agent can see sit side by side. Nothing is polled: the
+redraw is driven by notifications/resources/updated arriving on the stream.
+
+Standard library only, so it runs on a board with nothing installed.
+
+    scripts/mcp_inspector.py [--socket PATH] [--once]
+
+The shell must be built with BUILD_MCP and started with [global] enable_mcp;
+the socket defaults to $XDG_RUNTIME_DIR/ivi-homescreen/mcp.sock.
+
+To watch a board from a workstation, forward the socket over ssh rather than
+exposing a port -- the shell deliberately serves no TCP:
+
+    ssh -L /tmp/ivi-mcp.sock:/run/user/1000/ivi-homescreen/mcp.sock user@board
+    scripts/mcp_inspector.py --socket /tmp/ivi-mcp.sock
+"""
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+
+TREE_URI = "ui://semantics/tree"
+
+# Roles worth telling apart at a glance. Anything unlisted renders plain,
+# which keeps an unfamiliar role visible rather than mis-coloured.
+ROLE_COLOR = {
+    "window": "\033[95m",
+    "button": "\033[92m",
+    "text_input": "\033[96m",
+    "multiline_text_input": "\033[96m",
+    "password_input": "\033[91m",
+    "slider": "\033[93m",
+    "switch": "\033[93m",
+    "check_box": "\033[93m",
+    "radio_button": "\033[93m",
+    "link": "\033[94m",
+    "heading": "\033[95m",
+    "scroll_view": "\033[90m",
+    "pane": "\033[90m",
+    "generic_container": "\033[90m",
+}
+RESET = "\033[0m"
+DIM = "\033[90m"
+BOLD = "\033[1m"
+CHANGED = "\033[43;30m"  # a node whose content moved since the last update
+
+
+class ServerGone(Exception):
+    """The shell closed the connection or was never there."""
+
+
+def connect(path):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(path)
+    except (FileNotFoundError, ConnectionRefusedError) as exc:
+        sock.close()
+        raise ServerGone(f"no MCP server at {path}: {exc}") from exc
+    return sock
+
+
+def rpc(path, method, params=None, request_id=1):
+    """One JSON-RPC call. A new connection each time: the request side of the
+    transport answers with Connection: close, which is what a request/response
+    exchange should do."""
+    body = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    payload = json.dumps(body).encode()
+
+    sock = connect(path)
+    try:
+        sock.sendall(
+            b"POST /mcp HTTP/1.1\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(payload)).encode() + b"\r\n\r\n"
+            + payload
+        )
+        raw = b""
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            raw += chunk
+    finally:
+        sock.close()
+
+    _, _, text = raw.partition(b"\r\n\r\n")
+    if not text:
+        raise ServerGone("server closed without answering")
+    reply = json.loads(text)
+    if "error" in reply:
+        raise ServerGone(f"{method}: {reply['error'].get('message')}")
+    return reply["result"]
+
+
+def read_tree(path):
+    result = rpc(path, "resources/read", {"uri": TREE_URI}, request_id=2)
+    return json.loads(result["contents"][0]["text"])
+
+
+def open_stream(path):
+    """Opens the server-to-client half and returns the socket, having consumed
+    the response headers."""
+    sock = connect(path)
+    sock.sendall(
+        b"GET /mcp HTTP/1.1\r\nAccept: text/event-stream\r\n\r\n"
+    )
+    header = b""
+    while b"\r\n\r\n" not in header:
+        chunk = sock.recv(1024)
+        if not chunk:
+            sock.close()
+            raise ServerGone("server refused the event stream")
+        header += chunk
+    if b"text/event-stream" not in header:
+        sock.close()
+        status = header.split(b"\r\n", 1)[0].decode(errors="replace")
+        raise ServerGone(f"server did not open a stream: {status}")
+    return sock, header.partition(b"\r\n\r\n")[2]
+
+
+def events(sock, pending):
+    """Yields one decoded event per SSE frame, forever."""
+    buffer = pending
+    while True:
+        while b"\n\n" in buffer:
+            frame, _, buffer = buffer.partition(b"\n\n")
+            for line in frame.replace(b"\r\n", b"\n").split(b"\n"):
+                if line.startswith(b"data: "):
+                    yield json.loads(line[6:])
+        chunk = sock.recv(65536)
+        if not chunk:
+            raise ServerGone("the shell closed the stream")
+        buffer += chunk
+
+
+def summarize(node):
+    """The compact right-hand column: what this node is and what can be done
+    to it. States are only shown when they apply -- a tristate that does not
+    apply is absent rather than false, and flattening that would make every
+    container look like an unchecked checkbox."""
+    bits = []
+    value = node.get("value") or ""
+    if value:
+        bits.append(f"= {value}")
+    state = node.get("state") or {}
+    # "not_applicable" is the tristate saying the property does not apply to
+    # this node, which is most properties on most nodes. Showing it would bury
+    # the few that do apply -- and the distinction it encodes (a container is
+    # not an unchecked checkbox) is only useful when it is legible.
+    for key in ("checked", "toggled", "selected", "expanded", "focused"):
+        value_ = state.get(key)
+        if value_ not in (None, "not_applicable", "none", "false"):
+            bits.append(f"{key}:{value_}")
+    if state.get("enabled") == "false":
+        bits.append("disabled")
+    for flag in ("hidden", "read_only"):
+        if state.get(flag):
+            bits.append(flag)
+    identifier = node.get("identifier") or ""
+    if identifier:
+        bits.append(f"#{identifier}")
+    return "  ".join(bits)
+
+
+def fingerprint(node):
+    """What has to change for a node to count as changed. Deliberately not the
+    whole node: rects move on every frame of an animation, and highlighting
+    the entire tree during a transition tells you nothing."""
+    state = node.get("state") or {}
+    return (
+        node.get("label"),
+        node.get("value"),
+        node.get("role"),
+        tuple(sorted(node.get("actions") or [])),
+        tuple(sorted((k, str(v)) for k, v in state.items())),
+    )
+
+
+def render(tree, previous, width, event_count, last_event,
+           server_name="", tools_changed=0):
+    by_id = {n["id"]: n for n in tree.get("nodes", [])}
+    lines = []
+
+    def walk(node_id, depth):
+        node = by_id.get(node_id)
+        if node is None:
+            return
+        role = node.get("role", "unknown")
+        label = node.get("label") or ""
+        color = ROLE_COLOR.get(role, "")
+        changed = (
+            previous is not None
+            and node_id in previous
+            and previous[node_id] != fingerprint(node)
+        )
+        added = previous is not None and node_id not in previous
+
+        marker = " "
+        if added:
+            marker = "+"
+        elif changed:
+            marker = "~"
+
+        indent = "  " * depth
+        head = f"{marker} {indent}{color}{role}{RESET}"
+        if label:
+            head += f" {BOLD}{label}{RESET}"
+        detail = summarize(node)
+        actions = node.get("actions") or []
+        custom = [c.get("label", "") for c in (node.get("custom_actions") or [])]
+
+        line = head
+        if detail:
+            line += f"  {detail}"
+        if actions:
+            line += f"  {DIM}[{' '.join(actions)}]{RESET}"
+        if custom:
+            line += f"  {DIM}<{' | '.join(custom)}>{RESET}"
+        if changed or added:
+            # Marked rather than fully highlighted: the eye needs to find the
+            # change, not lose the tree around it.
+            line = f"{CHANGED}{marker}{RESET}" + line[1:]
+        lines.append(line[: width + 200])  # escape codes do not count as width
+
+        for child in node.get("children") or []:
+            walk(child, depth + 1)
+
+    nodes = tree.get("nodes", [])
+    if nodes:
+        walk(nodes[0]["id"], 0)
+    else:
+        lines.append(f"{DIM}  (no nodes -- the app has published an empty tree){RESET}")
+
+    generation = tree.get("generation", "?")
+    header = (
+        f"{BOLD}{server_name or 'ivi-homescreen'} semantics{RESET}  "
+        f"generation {generation}  ·  {len(nodes)} nodes  ·  "
+        f"{event_count} updates"
+    )
+    if tools_changed:
+        header += f"  ·  {tools_changed} tool-list changes"
+    if last_event:
+        header += f"  ·  last {time.strftime('%H:%M:%S', time.localtime(last_event))}"
+
+    sys.stdout.write("\033[H\033[2J")
+    sys.stdout.write(header + "\n")
+    sys.stdout.write(DIM + "-" * min(width, 100) + RESET + "\n")
+    sys.stdout.write("\n".join(lines) + "\n")
+    sys.stdout.write(
+        f"\n{DIM}+ added   ~ changed   [action] drivable   <custom action>"
+        f"   ctrl-c to exit{RESET}\n"
+    )
+    sys.stdout.flush()
+
+
+def default_socket():
+    runtime = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+    return os.path.join(runtime, "ivi-homescreen", "mcp.sock")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--socket", default=default_socket(),
+                        help="MCP socket path (default: %(default)s)")
+    parser.add_argument("--once", action="store_true",
+                        help="print the tree once and exit, for scripting")
+    args = parser.parse_args()
+
+    try:
+        width = os.get_terminal_size().columns
+    except OSError:
+        width = 100
+
+    try:
+        if args.once:
+            tree = read_tree(args.socket)
+            render(tree, None, width, 0, None)
+            return 0
+
+        # The stream is opened before the first read, so a change landing
+        # between the two is delivered rather than missed.
+        stream, pending = open_stream(args.socket)
+        server = rpc(args.socket, "initialize", {}, request_id=1)
+        name = server.get("serverInfo", {}).get("name", "server")
+
+        tree = read_tree(args.socket)
+        previous = {n["id"]: fingerprint(n) for n in tree.get("nodes", [])}
+        render(tree, None, width, 0, None, name)
+
+        count = 0
+        tools_changed = 0
+        for event in events(stream, pending):
+            method = event.get("method", "")
+            if method == "notifications/tools/list_changed":
+                # Counted, not redrawn on. A provider signals once for either
+                # kind of change and the server emits both, so redrawing here
+                # too would repaint every update twice -- and the second paint
+                # would show no change, making the first one flicker away.
+                tools_changed += 1
+                continue
+            if method != "notifications/resources/updated":
+                continue
+            count += 1
+            tree = read_tree(args.socket)
+            render(tree, previous, width, count, time.time(), name,
+                   tools_changed)
+            previous = {n["id"]: fingerprint(n) for n in tree.get("nodes", [])}
+    except ServerGone as exc:
+        sys.stderr.write(f"\n{exc}\n")
+        return 1
+    except KeyboardInterrupt:
+        sys.stdout.write("\n")
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -23,6 +23,7 @@
 #include "ihs/ihs_mcp_host.h"
 #include "ihs/ihs_mcp_provider.h"
 
+#include <fcntl.h>
 #include <poll.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -30,6 +31,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <cstring>
@@ -89,6 +91,17 @@ struct Transport {
   std::string socket_path{};
   size_t max_request_bytes = kDefaultMaxRequestBytes;
   std::thread thread;
+
+  // Open event streams, one per client that asked for one. Raw descriptors
+  // because the only operations are write and close, and both happen under
+  // this mutex: a notification arrives on the registry's watcher thread while
+  // the accept loop may be adding a stream or dropping a dead one.
+  //
+  // Separate from `mutex` so delivering an event never contends with an
+  // accept or a stop -- and, more importantly, so a notification cannot
+  // deadlock against a stop that is waiting to join the accept thread.
+  std::mutex streams_mutex;
+  std::vector<int> streams;
 };
 
 Transport& TheTransport() {
@@ -206,11 +219,13 @@ void AppendResource(const IhsMcpHostResource* resource, void* user_data) {
 }
 
 std::string HandleInitialize() {
-  // Only the capabilities actually served are advertised. listChanged is
-  // absent because nothing pushes notifications yet, and claiming it would
-  // have clients waiting for messages that never arrive.
+  // listChanged and subscribe are advertised now that an event stream can
+  // carry them. They were deliberately absent while it could not: a client
+  // told to expect notifications that never arrive waits instead of polling,
+  // which is worse than being told nothing.
   return std::string(R"({"protocolVersion":")") + kProtocolVersion +
-         R"(","capabilities":{"tools":{},"resources":{}})" +
+         R"(","capabilities":{"tools":{"listChanged":true},)" +
+         R"("resources":{"listChanged":true,"subscribe":true}})" +
          R"(,"serverInfo":{"name":"ivi-homescreen","version":"1"}})";
 }
 
@@ -376,6 +391,29 @@ bool WriteAll(const int fd, const std::string& data) {
   return true;
 }
 
+// Reads until the header terminator and no further, for a request with no
+// body. Bounded like ReadRequest, so a peer cannot stream headers forever.
+bool ReadHeaderBlock(const int fd, std::string* out_headers) {
+  std::string buffer;
+  while (buffer.find("\r\n\r\n") == std::string::npos) {
+    char chunk[1024];
+    const ssize_t n = ::read(fd, chunk, sizeof(chunk));
+    if (n <= 0) {
+      if (n < 0 && errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    buffer.append(chunk, static_cast<size_t>(n));
+    if (buffer.size() > kMaxHeaderBytes) {
+      WriteAll(fd, HttpResponse(431, "Request Header Fields Too Large", "{}"));
+      return false;
+    }
+  }
+  *out_headers = std::move(buffer);
+  return true;
+}
+
 // Reads until the header terminator, then exactly Content-Length bytes.
 // Returns false when the peer is malformed or over budget, having already
 // written the refusal.
@@ -488,16 +526,142 @@ bool PeerIsOwner(const int fd) {
   return credentials.uid == ::geteuid();
 }
 
-void ServeConnection(const int fd, const size_t max_body) {
+// One server-sent event. The blank line terminates it; without it a client
+// buffers the payload and delivers nothing.
+std::string EventFrame(const std::string& json) {
+  return "data: " + json + "\n\n";
+}
+
+// Pushes to every open stream, dropping any that will not take it.
+//
+// A stream is non-blocking, so a client that has stopped reading shows up as
+// EAGAIN rather than stalling this thread -- which matters because this runs
+// on the registry's watcher thread, and blocking here would stop every other
+// provider's notifications too. Such a client is dropped: a partial frame
+// would desynchronise the stream, and there is no way to resend.
+void Broadcast(const std::string& json) {
+  Transport& t = TheTransport();
+  const std::string frame = EventFrame(json);
+
+  const std::lock_guard<std::mutex> lock(t.streams_mutex);
+  auto it = t.streams.begin();
+  while (it != t.streams.end()) {
+    size_t sent = 0;
+    bool alive = true;
+    while (sent < frame.size()) {
+      const ssize_t n = ::write(*it, frame.data() + sent, frame.size() - sent);
+      if (n < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        alive = false;  // EAGAIN included: a client not reading is gone to us
+        break;
+      }
+      sent += static_cast<size_t>(n);
+    }
+    if (alive) {
+      ++it;
+      continue;
+    }
+    ::close(*it);
+    it = t.streams.erase(it);
+  }
+}
+
+// The registry calls this when a provider changes. Translated into the
+// JSON-RPC notifications the specification names, and pushed to every stream.
+void OnRegistryNotification(const IhsMcpNotification kind,
+                            const char* uri,
+                            void* /* user_data */) {
+  if (kind == IHS_MCP_NOTIFY_TOOLS_CHANGED) {
+    Broadcast(
+        R"({"jsonrpc":"2.0","method":"notifications/tools/list_changed"})");
+    return;
+  }
+  const std::string resource = uri != nullptr ? uri : "";
+  Broadcast(R"({"jsonrpc":"2.0","method":"notifications/resources/updated")"
+            R"(,"params":{"uri":)" +
+            Escape(resource) + "}}");
+}
+
+// Turns an accepted connection into an event stream. Returns false when the
+// client did not ask for one, leaving it to be served as an ordinary request.
+bool TryOpenEventStream(const int fd, const std::string& headers) {
+  // A GET asking for the event-stream media type is how MCP's Streamable HTTP
+  // transport opens the server-to-client direction.
+  if (headers.rfind("GET ", 0) != 0) {
+    return false;
+  }
+  std::string lowered = headers;
+  for (char& c : lowered) {
+    c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+  }
+  if (lowered.find("text/event-stream") == std::string::npos) {
+    WriteAll(fd, HttpResponse(
+                     406, "Not Acceptable",
+                     R"({"error":"GET requires Accept: text/event-stream"})"));
+    return true;  // answered; caller should close
+  }
+
+  std::string response = "HTTP/1.1 200 OK\r\n";
+  response += "Content-Type: text/event-stream\r\n";
+  response += "Cache-Control: no-store\r\n";
+  // No Content-Length and no close: the body is the stream, and it ends when
+  // one side hangs up.
+  response += "Connection: keep-alive\r\n\r\n";
+  if (!WriteAll(fd, response)) {
+    return true;
+  }
+
+  // Non-blocking from here on, so a client that stops reading cannot stall
+  // the thread that delivers notifications.
+  const int flags = ::fcntl(fd, F_GETFL, 0);
+  if (flags >= 0) {
+    ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+  }
+
+  Transport& t = TheTransport();
+  const std::lock_guard<std::mutex> lock(t.streams_mutex);
+  t.streams.push_back(fd);
+  return true;
+}
+
+// Serves one connection. Returns true when the descriptor has become an event
+// stream and must stay open; the caller closes it otherwise.
+bool ServeConnection(const int fd, const size_t max_body) {
   if (!PeerIsOwner(fd)) {
     Log(IHS_LEVEL_WARN, "mcp: refused a connection from another user");
     WriteAll(fd, HttpResponse(403, "Forbidden", R"({"error":"forbidden"})"));
-    return;
+    return false;
+  }
+
+  // Peeked rather than read: a GET opens an event stream and a POST carries a
+  // request, and only the latter has a body to consume. Peeking keeps the
+  // request-reading path below exactly as it was.
+  char probe[4] = {0, 0, 0, 0};
+  const ssize_t peeked = ::recv(fd, probe, sizeof(probe), MSG_PEEK);
+  if (peeked <= 0) {
+    return false;
+  }
+  if (std::strncmp(probe, "GET ", 4) == 0) {
+    std::string headers;
+    if (!ReadHeaderBlock(fd, &headers)) {
+      return false;
+    }
+    if (TryOpenEventStream(fd, headers)) {
+      Transport& t = TheTransport();
+      const std::lock_guard<std::mutex> lock(t.streams_mutex);
+      // Kept open only if it actually joined the registry; a refused GET was
+      // answered and is finished with.
+      return std::find(t.streams.begin(), t.streams.end(), fd) !=
+             t.streams.end();
+    }
+    return false;
   }
 
   std::string body;
   if (!ReadRequest(fd, max_body, &body)) {
-    return;  // ReadRequest already answered, or the peer went away
+    return false;  // ReadRequest already answered, or the peer went away
   }
 
   const std::string response = Dispatch(body);
@@ -505,9 +669,10 @@ void ServeConnection(const int fd, const size_t max_body) {
     // A notification. HTTP still needs a reply, and 202 says "taken, nothing
     // to return" without inventing a JSON-RPC response the client must ignore.
     WriteAll(fd, HttpResponse(202, "Accepted", ""));
-    return;
+    return false;
   }
   WriteAll(fd, HttpResponse(200, "OK", response));
+  return false;
 }
 
 }  // namespace
@@ -599,8 +764,11 @@ void AcceptLoop() {
     }
     // Served inline. Requests are short and the host serializes anyway, so a
     // thread per connection would buy concurrency the registry cannot use.
-    ServeConnection(client, max_body);
-    ::close(client);
+    // A connection that became an event stream stays open and is owned by
+    // the stream registry from here.
+    if (!ServeConnection(client, max_body)) {
+      ::close(client);
+    }
   }
 }
 
@@ -683,12 +851,33 @@ int ihs_mcp_transport_start(const IhsMcpTransportConfig* config) {
   t.running = true;
   t.thread = std::thread(AcceptLoop);
 
+  // Installed last: the registry starts watching provider descriptors the
+  // moment this returns, and a notification arriving before there is anywhere
+  // to put it would be dropped rather than queued.
+  //
+  // Not fatal if refused -- something else already owns the sink, which means
+  // requests still work and only pushed notifications are missing. Said out
+  // loud, because a client that saw listChanged advertised will wait for
+  // messages that then never come.
+  if (ihs_mcp_host_set_notification_sink(OnRegistryNotification, nullptr) !=
+      IHS_MCP_OK) {
+    Log(IHS_LEVEL_ERROR,
+        "mcp: another notification sink is installed; serving requests "
+        "without pushed notifications");
+  }
+
   Log(IHS_LEVEL_INFO, "mcp: serving on " + path);
   return IHS_MCP_OK;
 }
 
 void ihs_mcp_transport_stop() {
   Transport& t = TheTransport();
+
+  // Uninstalled first, and this does not return until the registry's watcher
+  // is joined -- so no notification can be in flight into Broadcast while the
+  // streams below are being closed.
+  ihs_mcp_host_set_notification_sink(nullptr, nullptr);
+
   std::thread thread;
   {
     const std::lock_guard<std::mutex> lock(t.mutex);
@@ -717,6 +906,14 @@ void ihs_mcp_transport_stop() {
   t.wake_write_fd = -1;
   ::unlink(t.socket_path.c_str());
   t.socket_path.clear();
+
+  // Closing a stream is how a client learns the server is gone: there is no
+  // "goodbye" event, and the specification expects the transport to end.
+  const std::lock_guard<std::mutex> streams_lock(t.streams_mutex);
+  for (const int stream : t.streams) {
+    ::close(stream);
+  }
+  t.streams.clear();
 }
 
 bool ihs_mcp_transport_running() {

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -156,10 +156,9 @@ TEST_F(McpTransportTest, InitializeReportsProtocolAndCapabilities) {
   const std::string body = Body(response);
   EXPECT_NE(body.find(R"("id":1)"), std::string::npos);
   EXPECT_NE(body.find("protocolVersion"), std::string::npos);
-  // Only what is actually served is advertised: nothing pushes notifications
-  // yet, so claiming listChanged would leave clients waiting for messages
-  // that never come.
-  EXPECT_EQ(body.find("listChanged"), std::string::npos);
+  // What is advertised has to be deliverable; the stream now carries
+  // notifications, so InitializeAdvertisesWhatTheStreamCanDeliver asserts the
+  // positive case that used to be asserted absent here.
 }
 
 // With no provider registered the list is empty rather than absent, so a
@@ -209,12 +208,15 @@ TEST_F(McpTransportTest, NotificationsGetNoJsonRpcReply) {
   EXPECT_TRUE(Body(response).empty()) << Body(response);
 }
 
-// Only POST carries a request. A probe or a browser gets a clear answer
-// rather than a hang.
-TEST_F(McpTransportTest, NonPostIsRefused) {
-  const std::string response =
-      Send(path_, "GET / HTTP/1.1\r\nContent-Length: 0\r\n\r\n");
-  EXPECT_EQ(StatusLine(response), "HTTP/1.1 405 Method Not Allowed");
+// POST carries a request and GET opens a stream; anything else gets a clear
+// answer rather than a hang. GET is covered by PlainGetIsNotAcceptable, which
+// distinguishes "wrong verb" from "right verb, wrong media type".
+TEST_F(McpTransportTest, UnsupportedMethodsAreRefused) {
+  for (const char* verb : {"PUT", "DELETE", "HEAD"}) {
+    const std::string response = Send(
+        path_, std::string(verb) + " / HTTP/1.1\r\nContent-Length: 0\r\n\r\n");
+    EXPECT_EQ(StatusLine(response), "HTTP/1.1 405 Method Not Allowed") << verb;
+  }
 }
 
 TEST_F(McpTransportTest, MissingContentLengthIsRefused) {
@@ -307,4 +309,117 @@ TEST(McpTransportLifecycle, StaleSocketIsReplacedButALiveOneIsNot) {
 
   ihs_mcp_transport_stop();
   ::unlink(path.c_str());
+}
+
+namespace {
+
+// Opens an event stream and returns the connected descriptor, or -1. The
+// caller owns it: an SSE connection outlives the request that opened it,
+// which is the whole point.
+int OpenStream(const std::string& path, std::string* out_headers) {
+  const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) {
+    return -1;
+  }
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+  if (::connect(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) !=
+      0) {
+    ::close(fd);
+    return -1;
+  }
+  const std::string request =
+      "GET /mcp HTTP/1.1\r\nAccept: text/event-stream\r\n\r\n";
+  if (::write(fd, request.data(), request.size()) < 0) {
+    ::close(fd);
+    return -1;
+  }
+  char chunk[1024];
+  const ssize_t n = ::read(fd, chunk, sizeof(chunk));
+  if (n <= 0) {
+    ::close(fd);
+    return -1;
+  }
+  out_headers->assign(chunk, static_cast<size_t>(n));
+  return fd;
+}
+
+}  // namespace
+
+// A GET asking for the event-stream type opens the server-to-client half of
+// the transport, and must not be answered with a length or a close -- the
+// body is the stream.
+TEST_F(McpTransportTest, EventStreamHandshakeIsAccepted) {
+  std::string headers;
+  const int fd = OpenStream(path_, &headers);
+  ASSERT_GE(fd, 0) << "stream did not open";
+  EXPECT_NE(headers.find("200 OK"), std::string::npos) << headers;
+  EXPECT_NE(headers.find("text/event-stream"), std::string::npos) << headers;
+  EXPECT_EQ(headers.find("Content-Length"), std::string::npos) << headers;
+  ::close(fd);
+}
+
+// A GET that did not ask for a stream is told so, rather than being handed
+// one it will not read or left hanging.
+TEST_F(McpTransportTest, PlainGetIsNotAcceptable) {
+  const std::string response =
+      Send(path_, "GET /mcp HTTP/1.1\r\nAccept: application/json\r\n\r\n");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 406 Not Acceptable");
+}
+
+// The capabilities are advertised now that a stream can carry them. They were
+// absent while it could not: a client told to expect notifications that never
+// arrive waits instead of polling.
+TEST_F(McpTransportTest, InitializeAdvertisesWhatTheStreamCanDeliver) {
+  const std::string body =
+      Body(Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  EXPECT_NE(body.find("listChanged"), std::string::npos) << body;
+  EXPECT_NE(body.find("subscribe"), std::string::npos) << body;
+}
+
+// Requests keep working while a stream is open: the stream must not occupy
+// the accept loop, which it would if it were served inline like a request.
+TEST_F(McpTransportTest, RequestsAreStillServedWhileAStreamIsOpen) {
+  std::string headers;
+  const int stream = OpenStream(path_, &headers);
+  ASSERT_GE(stream, 0);
+
+  const std::string body =
+      Body(Post(path_, R"({"jsonrpc":"2.0","id":7,"method":"ping"})"));
+  EXPECT_NE(body.find(R"("id":7)"), std::string::npos) << body;
+  ::close(stream);
+}
+
+// Several clients may watch at once, and each has to be served.
+TEST_F(McpTransportTest, MoreThanOneStreamMayBeOpen) {
+  std::string first_headers;
+  std::string second_headers;
+  const int first = OpenStream(path_, &first_headers);
+  const int second = OpenStream(path_, &second_headers);
+  EXPECT_GE(first, 0);
+  EXPECT_GE(second, 0);
+  EXPECT_NE(first_headers.find("text/event-stream"), std::string::npos);
+  EXPECT_NE(second_headers.find("text/event-stream"), std::string::npos);
+  if (first >= 0) {
+    ::close(first);
+  }
+  if (second >= 0) {
+    ::close(second);
+  }
+}
+
+// Stopping closes the streams: there is no goodbye event, so the end of the
+// connection is how a client learns the server is gone.
+TEST_F(McpTransportTest, StopClosesOpenStreams) {
+  std::string headers;
+  const int fd = OpenStream(path_, &headers);
+  ASSERT_GE(fd, 0);
+
+  ihs_mcp_transport_stop();
+
+  char chunk[64];
+  const ssize_t n = ::read(fd, chunk, sizeof(chunk));
+  EXPECT_EQ(n, 0) << "expected end of stream, got " << n;
+  ::close(fd);
 }


### PR DESCRIPTION
A live view of the semantics tree a shell is serving — what an agent sees, updating as the UI changes.

```
ivi-homescreen semantics  generation 8  ·  2 nodes  ·  6 updates  ·  6 tool-list changes  ·  last 12:11:03
----------------------------------------------------------------------------------------------------
  window IVI Home
~   text_input Work  [tap set_text scroll_to]

+ added   ~ changed   [action] drivable   <custom action>   ctrl-c to exit
```

Nothing is polled. It holds one event stream open and redraws on `notifications/resources/updated`, so it demonstrates the notification path (#444, #447) rather than asserting it — if the stream stops working, the viewer visibly stops updating.

Standard library only, so it runs on a board with nothing installed. `--once` prints a single tree for scripting.

## Three judgements worth reviewing

**Change marking ignores rects.** A node counts as changed on its label, value, role, actions or states — not its geometry. Rects move on every frame of an animation, and marking the whole tree during a transition tells you nothing.

**Tool-list changes are counted, not redrawn on.** A provider signals once for either kind of change and the server emits *both* notifications, so redrawing on each painted every update twice — and the second paint showed no change, making the first flicker away. Counting them keeps the signal visible in the header without the churn.

**States that do not apply are omitted.** Every node was otherwise rendering `checked:not_applicable toggled:not_applicable selected:not_applicable …`, which buried the handful that do apply. The tristate distinction is worth having and only useful when it is legible.

## On watching a board

The header documents forwarding the socket over ssh rather than exposing a port:

```
ssh -L /tmp/ivi-mcp.sock:/run/user/1000/ivi-homescreen/mcp.sock user@board
scripts/mcp_inspector.py --socket /tmp/ivi-mcp.sock
```

That keeps the security posture intact — the shell still serves no TCP (OQ-2 is unanswered) — and makes the point that not having a port is a feature rather than a gap.

## Testing

Run against a live server publishing on a timer: 7 redraws in 13 seconds, one per change, with the `~` marker landing on the node whose label moved each time. A missing server produces `no MCP server at <path>: Connection refused` rather than a traceback, and a server that stops mid-session reports that the stream closed.
