### PR TITLE
shared: add ui_tap_at, the pointer fallback for what semantics cannot reach

### DIFF
--- a/shared/include/ihs/ihs_semantics.h
+++ b/shared/include/ihs/ihs_semantics.h
@@ -468,6 +468,35 @@ typedef void (*IhsSemanticsDoneCallback)(int status, void* user_data);
  * Returns immediately; `done` fires on the platform thread and may be null.
  * Callable from any thread.
  */
+/*
+ * Synthesize a tap at a point, in the same logical coordinates as a node's
+ * published rect.
+ *
+ * This is the fallback for what semantics cannot reach: a custom canvas hit
+ * region, a platform view, a widget nobody annotated. It is deliberately a
+ * separate call rather than a mode of dispatch, because the contract differs
+ * in ways a caller must choose knowingly:
+ *
+ *   - it is hit-tested, so whatever is drawn on top receives it instead, and
+ *     an obscured target is correctly unreachable
+ *   - it is coordinate-based, so it races animation and reflow
+ *   - it invokes no particular node, so nothing verifies it landed anywhere
+ *
+ * Dispatch has the opposite properties, and choosing between them is the
+ * caller's job. Nothing falls back automatically.
+ *
+ * Requires the consumer to hold IHS_SEMANTICS_ACTION_TAP: a synthesized tap
+ * is a tap, and a consumer denied that must not obtain it by another name.
+ * Returns IHS_SEMANTICS_ERR_MASKED otherwise, and
+ * IHS_SEMANTICS_ERR_UNSUPPORTED_ACTION on a shell with no input path.
+ *
+ * Returns immediately; the tap is delivered on the platform thread.
+ */
+IHS_EXPORT int ihs_semantics_send_pointer_tap(IhsSemanticsConsumer* consumer,
+                                              int64_t view_id,
+                                              double x,
+                                              double y);
+
 IHS_EXPORT int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
                                       int64_t view_id,
                                       int32_t node_id,

--- a/shared/include/ihs/ihs_semantics_host.h
+++ b/shared/include/ihs/ihs_semantics_host.h
@@ -90,6 +90,18 @@ typedef struct IhsSemanticsHost {
                   uint64_t action,
                   const uint8_t* data,
                   size_t data_length);
+
+  /*
+   * Synthesize a tap at a point, in the logical coordinates the published
+   * rects use. Distinct from dispatch because it is a different contract, not
+   * a different action: this rides the ordinary input path and is therefore
+   * hit-tested, where dispatch invokes a node's handler by id regardless of
+   * what is drawn on top of it.
+   *
+   * May be NULL on a shell that cannot synthesize input, which the hub
+   * reports as IHS_SEMANTICS_ERR_UNSUPPORTED_ACTION rather than pretending.
+   */
+  int (*send_pointer_tap)(void* user_data, int64_t view_id, double x, double y);
 } IhsSemanticsHost;
 
 /*

--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -84,6 +84,12 @@ constexpr char kScrollToSchema[] =
     R"("dy":{"type":"number","description":"Vertical offset in logical pixels."})"
     R"(}})";
 
+constexpr char kTapAtSchema[] =
+    R"({"type":"object","properties":{)"
+    R"("x":{"type":"number","description":"Screen x, in the same coordinates as a node rect."},)"
+    R"("y":{"type":"number","description":"Screen y, in the same coordinates as a node rect."})"
+    R"(},"required":["x","y"]})";
+
 const ToolEntry kTools[] = {
     {"snapshot", "The whole semantics tree as JSON.", kEmptySchema, 0,
      IHS_MCP_CAP_INSPECT},
@@ -109,6 +115,16 @@ const ToolEntry kTools[] = {
      IHS_SEMANTICS_ACTION_SET_TEXT, IHS_MCP_CAP_INTERACT},
     {"scroll_to", "Scroll a container to a given offset.", kScrollToSchema,
      IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET, IHS_MCP_CAP_INTERACT},
+    // Action 0: this one does not dispatch a semantics action at all, and the
+    // call handler routes it separately. Its description says so, because the
+    // difference is the caller's to reason about -- a tap that is hit-tested
+    // reaches what the tree cannot describe, and misses what is covered.
+    {"tap_at",
+     "Tap at a screen coordinate, for targets the semantics tree does not "
+     "describe. Unlike ui_tap this is hit-tested: whatever is drawn on top "
+     "receives it, it races animation, and nothing confirms what it hit. "
+     "Prefer ui_tap wherever a node offers it.",
+     kTapAtSchema, 0, IHS_MCP_CAP_INTERACT},
 };
 
 // The accessibility-focus actions are deliberately absent from the table
@@ -413,6 +429,24 @@ bool ReadStringArgument(const char* json, const char* key, std::string* out) {
   return true;
 }
 
+// Refuses rather than defaulting. A coordinate is not something to guess at:
+// tapping (0, 0) because the caller omitted y would press whatever is in the
+// corner, which is worse than an error.
+bool ReadNumberArgumentRequired(const char* json,
+                                const char* key,
+                                double* out) {
+  rapidjson::Document doc;
+  if (json == nullptr || doc.Parse(json).HasParseError() || !doc.IsObject()) {
+    return false;
+  }
+  const auto member = doc.FindMember(key);
+  if (member == doc.MemberEnd() || !member->value.IsNumber()) {
+    return false;
+  }
+  *out = member->value.GetDouble();
+  return true;
+}
+
 // Absent or non-numeric yields the fallback: an axis a caller did not name is
 // zero rather than an error, so scrolling a vertical list needs only dy.
 double ReadNumberArgument(const char* json,
@@ -579,6 +613,51 @@ int CallTool(void* /* user_data */,
   if (std::strcmp(name, "query") == 0) {
     FillPayload(out_result, RunQuery(snapshot, arguments_json));
     ihs_semantics_release_snapshot(snapshot);
+    return IHS_MCP_OK;
+  }
+
+  // Routed before the node lookup: this tool names no node, which is the
+  // whole point of it -- the target is a coordinate precisely because the
+  // tree does not describe what is there.
+  if (std::strcmp(name, "tap_at") == 0) {
+    const uint64_t generation_now = generation;
+    ihs_semantics_release_snapshot(snapshot);
+
+    double x = 0.0;
+    double y = 0.0;
+    if (!ReadNumberArgumentRequired(arguments_json, "x", &x) ||
+        !ReadNumberArgumentRequired(arguments_json, "y", &y)) {
+      FillPayload(out_result,
+                  ErrorJson("tap_at requires x and y", generation_now));
+      return IHS_MCP_ERR_INVALID;
+    }
+
+    Provider& provider = TheProvider();
+    const int tap_status =
+        ihs_semantics_send_pointer_tap(provider.consumer, 0, x, y);
+    if (tap_status != IHS_SEMANTICS_OK) {
+      FillPayload(out_result, ErrorJson("pointer tap refused", generation_now));
+      return IHS_MCP_ERR_REFUSED;
+    }
+
+    // Deliberately does not claim a target. Nothing here knows what was under
+    // the point, and reporting a node would be inventing the confirmation the
+    // caller chose this tool to go without.
+    rapidjson::StringBuffer tap_buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> tap_writer(tap_buffer);
+    tap_writer.StartObject();
+    tap_writer.Key("dispatched");
+    tap_writer.Bool(true);
+    tap_writer.Key("hit_tested");
+    tap_writer.Bool(true);
+    tap_writer.Key("x");
+    tap_writer.Double(x);
+    tap_writer.Key("y");
+    tap_writer.Double(y);
+    tap_writer.Key("generation_before");
+    tap_writer.Uint64(generation_now);
+    tap_writer.EndObject();
+    FillPayload(out_result, tap_buffer.GetString());
     return IHS_MCP_OK;
   }
 

--- a/shared/src/semantics.cc
+++ b/shared/src/semantics.cc
@@ -520,6 +520,66 @@ void ihs_semantics_unregister(IhsSemanticsConsumer* consumer) {
   }
 }
 
+int ihs_semantics_send_pointer_tap(IhsSemanticsConsumer* consumer,
+                                   const int64_t view_id,
+                                   const double x,
+                                   const double y) {
+  int status = IHS_SEMANTICS_OK;
+  std::string name;
+
+  if (consumer == nullptr || !std::isfinite(x) || !std::isfinite(y)) {
+    status = IHS_SEMANTICS_ERR_INVALID;
+  }
+
+  IhsSemanticsHost host{};
+  uint64_t allow_mask = 0;
+  if (status == IHS_SEMANTICS_OK) {
+    auto* raw = reinterpret_cast<Consumer*>(consumer);
+    Hub& hub = TheHub();
+    std::lock_guard<std::mutex> lock(hub.mutex);
+    bool found = false;
+    for (const auto& registered : hub.consumers) {
+      if (registered.get() == raw) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      status = IHS_SEMANTICS_ERR_INVALID;
+    } else {
+      name = raw->name;
+      allow_mask = raw->action_allow_mask;
+      host = hub.host;
+    }
+  }
+
+  // A synthesized tap is a tap. A consumer denied the action must not be able
+  // to perform it by coordinate instead, or the mask would arbitrate nothing.
+  if (status == IHS_SEMANTICS_OK &&
+      (IHS_SEMANTICS_ACTION_TAP & ~allow_mask) != 0) {
+    status = IHS_SEMANTICS_ERR_DENIED;
+  }
+
+  // No node is consulted deliberately: the point of this path is to reach
+  // what the tree does not describe, so there is nothing to validate against
+  // and nothing that can confirm the tap landed anywhere.
+  if (status == IHS_SEMANTICS_OK) {
+    if (host.send_pointer_tap == nullptr) {
+      status = IHS_SEMANTICS_ERR_UNSUPPORTED_ACTION;
+    } else {
+      status = host.send_pointer_tap(host.user_data, view_id, x, y);
+    }
+  }
+
+  // Traced like a dispatch, and with the coordinates: an action that names no
+  // node is exactly the one an audit needs the target of.
+  LogInfo("pointer tap consumer='" +
+          (name.empty() ? std::string("<unregistered>") : name) +
+          "' at=" + std::to_string(x) + "," + std::to_string(y) +
+          " status=" + std::to_string(status));
+  return status;
+}
+
 int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
                            int64_t view_id,
                            int32_t node_id,

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -1013,7 +1013,44 @@ void Engine::InstallSemanticsHost() {
                                            data_length);
   };
 
+  host.send_pointer_tap = [](void* user_data, const int64_t /* view_id */,
+                             const double x, const double y) -> int {
+    auto* engine = static_cast<Engine*>(user_data);
+    return engine->SendSyntheticTap(x, y);
+  };
+
   ihs_semantics_set_host(&host);
+}
+
+int Engine::SendSyntheticTap(const double x, const double y) {
+  if (m_flutter_engine == nullptr) {
+    return IHS_SEMANTICS_ERR_UNAVAILABLE;
+  }
+
+  // Posted rather than sent here: the coalescing buffer is drained on the
+  // platform thread, and a caller may be on any thread.
+  asio::post(*m_platform_task_runner->GetStrandContext(), [this, x, y]() {
+    if (m_flutter_engine == nullptr) {
+      return;
+    }
+    // Add, then down, then up -- the sequence a real seat produces. Sent
+    // through the ordinary coalescing path rather than around it, so a
+    // synthesized tap is hit-tested, scaled and batched exactly as a physical
+    // one is; anything else would make the fallback behave unlike the input
+    // it stands in for.
+    CoalesceMouseEvent(kFlutterPointerSignalKindNone, kAdd, x, y, 0.0, 0.0, 0,
+                       0);
+    CoalesceMouseEvent(kFlutterPointerSignalKindNone, kDown, x, y, 0.0, 0.0,
+                       kFlutterPointerButtonMousePrimary, 0);
+    CoalesceMouseEvent(kFlutterPointerSignalKindNone, kUp, x, y, 0.0, 0.0, 0,
+                       0);
+    SendPointerEvents();
+  });
+
+  // Accepted for delivery. Whether anything was under the point is not
+  // knowable here, and saying otherwise would be the automatic fallback DR-7
+  // exists to avoid.
+  return IHS_SEMANTICS_OK;
 }
 
 int Engine::DispatchSemanticsAction(const int64_t view_id,

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -372,6 +372,13 @@ class Engine {
    */
   void SendPointerEvents();
 
+  /*
+   * Synthesizes a tap at a point in logical coordinates, for the MCP pointer
+   * fallback (DR-7). Rides the ordinary input path, so it is hit-tested like
+   * a real tap rather than invoking a node's handler by id.
+   */
+  int SendSyntheticTap(double x, double y);
+
   /**
    * @brief Get backend of view
    * @return Backend*

--- a/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
+++ b/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
@@ -684,3 +684,103 @@ TEST_F(SemanticsHubTest, NumericValueAccessorLeavesOutputsAloneWhenAbsent) {
   EXPECT_FALSE(ihs_semantics_node_numeric_value(nullptr, &value, &min, &max));
   ihs_semantics_release_snapshot(snapshot);
 }
+
+namespace {
+
+int g_taps = 0;
+double g_tap_x = 0.0;
+double g_tap_y = 0.0;
+
+int RecordTap(void*, int64_t, double x, double y) {
+  g_taps++;
+  g_tap_x = x;
+  g_tap_y = y;
+  return IHS_SEMANTICS_OK;
+}
+
+}  // namespace
+
+// The pointer fallback reaches the shell with the coordinates it was given.
+TEST_F(SemanticsHubTest, PointerTapReachesTheHost) {
+  g_taps = 0;
+  IhsSemanticsHost host{};
+  host.struct_size = sizeof(host);
+  host.send_pointer_tap = RecordTap;
+  ihs_semantics_set_host(&host);
+
+  IhsSemanticsConsumer* consumer = Register("agent", IHS_SEMANTICS_ACTION_TAP);
+  ASSERT_NE(consumer, nullptr);
+  EXPECT_EQ(ihs_semantics_send_pointer_tap(consumer, 0, 120.5, 48.0),
+            IHS_SEMANTICS_OK);
+  EXPECT_EQ(g_taps, 1);
+  EXPECT_DOUBLE_EQ(g_tap_x, 120.5);
+  EXPECT_DOUBLE_EQ(g_tap_y, 48.0);
+  ihs_semantics_unregister(consumer);
+}
+
+// The one that matters: a synthesized tap is a tap, so a consumer denied the
+// action must not obtain it by coordinate instead. Without this the allow
+// mask would arbitrate nothing -- anything it refused could be performed by
+// naming a point rather than a node.
+TEST_F(SemanticsHubTest, PointerTapIsRefusedWithoutTapPermission) {
+  g_taps = 0;
+  IhsSemanticsHost host{};
+  host.struct_size = sizeof(host);
+  host.send_pointer_tap = RecordTap;
+  ihs_semantics_set_host(&host);
+
+  // Everything except tap.
+  IhsSemanticsConsumer* consumer = Register(
+      "observer", IHS_SEMANTICS_ACTION_ALL & ~IHS_SEMANTICS_ACTION_TAP);
+  ASSERT_NE(consumer, nullptr);
+  EXPECT_EQ(ihs_semantics_send_pointer_tap(consumer, 0, 1.0, 1.0),
+            IHS_SEMANTICS_ERR_DENIED);
+  EXPECT_EQ(g_taps, 0) << "a denied tap still reached the shell";
+  ihs_semantics_unregister(consumer);
+}
+
+// A shell with no input path says so rather than reporting a tap it never
+// delivered.
+TEST_F(SemanticsHubTest, PointerTapIsUnsupportedWithoutAHostHook) {
+  IhsSemanticsHost host{};
+  host.struct_size = sizeof(host);
+  host.send_pointer_tap = nullptr;
+  ihs_semantics_set_host(&host);
+
+  IhsSemanticsConsumer* consumer = Register("agent", IHS_SEMANTICS_ACTION_TAP);
+  ASSERT_NE(consumer, nullptr);
+  EXPECT_EQ(ihs_semantics_send_pointer_tap(consumer, 0, 1.0, 1.0),
+            IHS_SEMANTICS_ERR_UNSUPPORTED_ACTION);
+  ihs_semantics_unregister(consumer);
+}
+
+// A coordinate that is not a number would land somewhere unpredictable.
+TEST_F(SemanticsHubTest, NonFinitePointerCoordinatesAreRefused) {
+  g_taps = 0;
+  IhsSemanticsHost host{};
+  host.struct_size = sizeof(host);
+  host.send_pointer_tap = RecordTap;
+  ihs_semantics_set_host(&host);
+
+  IhsSemanticsConsumer* consumer = Register("agent", IHS_SEMANTICS_ACTION_TAP);
+  ASSERT_NE(consumer, nullptr);
+  const double nan_value = std::numeric_limits<double>::quiet_NaN();
+  const double infinity = std::numeric_limits<double>::infinity();
+  EXPECT_EQ(ihs_semantics_send_pointer_tap(consumer, 0, nan_value, 1.0),
+            IHS_SEMANTICS_ERR_INVALID);
+  EXPECT_EQ(ihs_semantics_send_pointer_tap(consumer, 0, 1.0, infinity),
+            IHS_SEMANTICS_ERR_INVALID);
+  EXPECT_EQ(g_taps, 0);
+  ihs_semantics_unregister(consumer);
+}
+
+// An unregistered consumer is refused, as with dispatch: the handle is how
+// the funnel knows who is asking, and attribution is the point of it.
+TEST_F(SemanticsHubTest, PointerTapFromAnUnknownConsumerIsRefused) {
+  IhsSemanticsHost host{};
+  host.struct_size = sizeof(host);
+  host.send_pointer_tap = RecordTap;
+  ihs_semantics_set_host(&host);
+  EXPECT_EQ(ihs_semantics_send_pointer_tap(nullptr, 0, 1.0, 1.0),
+            IHS_SEMANTICS_ERR_INVALID);
+}


### PR DESCRIPTION
A custom canvas hit region, a platform view, a widget nobody annotated — the semantics tree does not describe them, so there is no node to dispatch to and no way to drive them at all. `ui_tap_at(x, y)` synthesizes a tap at a coordinate instead. That takes the surface to 13 tools and closes DR-7.

## Deliberately not a fallback

It is a separate tool, not a mode of `ui_tap`, and nothing falls back to it automatically — which is what DR-7 decided. The contracts differ in ways a caller has to choose knowingly:

| | `ui_tap` | `ui_tap_at` |
|---|---|---|
| target | a node, by id | a coordinate |
| occlusion | invokes the handler regardless of what is drawn on top (R-8) | hit-tested; whatever is on top receives it |
| timing | stable across reflow | races animation and reflow |
| confirmation | the node offered the action | nothing confirms it hit anything |

The tool's own description says this, because the choice belongs to the caller rather than to us.

## It rides the real input path

`Add` → `Down` → `Up` through the same coalescing path a physical seat uses, rather than around it. So a synthesized tap is hit-tested, scaled and batched exactly as a real one — anything else would make the fallback behave unlike the input it stands in for, which is the one property it exists to provide.

## The part worth reviewing closely

**It requires the consumer to hold `IHS_SEMANTICS_ACTION_TAP`.**

A synthesized tap is a tap. Without that check the allow mask would arbitrate nothing: any action it refused could be performed by naming a point instead of a node, and DR-11's whole arbitration — the reason an agent cannot move a screen reader's cursor — would have a hole straight through it. The pointer path consults no node, so this is the only gate on it.

There is a test asserting a consumer denied `TAP` is refused **and that the tap never reaches the shell**, not merely that an error came back.

The call is also traced with its coordinates. An action that names no node is exactly the one an audit needs the target of.

## Testing

Driven over the socket: 13 tools listed, `ui_tap_at {"x":120.5,"y":48.0}` reaching the shell as `pointer tap view=0 at=(120.5,48)`, and a missing `y` refused rather than defaulted — tapping `(0, 0)` because a caller omitted a coordinate would press whatever is in the corner.

5 new hub tests: the tap reaches the host with its coordinates, a consumer without `TAP` is denied and nothing is delivered, a shell with no input path reports unsupported rather than claiming success, non-finite coordinates are refused, and an unregistered consumer is refused as with dispatch.

28/28 across the suite, clang-tidy clean, both repo gate scripts pass.

## What this still cannot prove

Every test here uses a mock host, so they show the request reaches the shell — not that Flutter hit anything. `ui_tap_at`'s entire contract is that it obeys real hit-testing, and that needs a real engine and real widgets.

A Flutter fixture under `test/integration/` is the way to close that, following the `multi_touch_test` pattern: annotated widgets alongside an **unannotated** hit region, so the DR-7 contrast is demonstrable rather than described — `ui_tap` cannot reach the region, `ui_tap_at` can. It would also satisfy R-9's stated exit criterion, an integration test asserting a Dart-side `TextField` receives its `SetText` value. Worth doing next.
