### PR TITLE
ci: give the AccessKit fetch a retry window that outlasts an outage

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -219,11 +219,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${{github.workspace}}/.deps"
-          # Retried: this is a release download from github.com, which has
-          # returned 503 here, and the surrounding CI already sees transient
-          # network failures often enough that one attempt is not enough.
-          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
-            --connect-timeout 15 --max-time 300 \
+          # Retried patiently, not quickly. github.com returns 503 for this
+          # release often enough that it has failed the job twice; the first
+          # attempt at hardening gave up after about fifteen seconds, which is
+          # shorter than the outages actually last. --retry-max-time bounds
+          # the whole attempt instead, and omitting --retry-delay lets curl
+          # back off exponentially rather than hammering at a fixed interval.
+          #
+          # Matches what the oras fetch already does. The two are the same
+          # problem and should not drift apart again.
+          curl -fsSL --retry 8 --retry-all-errors --retry-max-time 300 \
+            --connect-timeout 15 \
             -o "${RUNNER_TEMP}/accesskit-c.zip" \
             "https://github.com/AccessKit/accesskit-c/releases/download/${ACCESSKIT_VERSION}/accesskit-c-${ACCESSKIT_VERSION}.zip"
           unzip -q "${RUNNER_TEMP}/accesskit-c.zip" -d "${{github.workspace}}/.deps"


### PR DESCRIPTION
The AccessKit leg failed again on `curl: (22) 503` from github.com. The retries ran — six attempts are visible in the log — but the whole window was about fifteen seconds, which is shorter than the outages have actually been lasting today.

```
19:15:44  curl: (22) The requested URL returned error: 503
19:15:47  curl: (22) The requested URL returned error: 503
...
19:15:59  ##[error]Process completed with exit code 22
```

Bounded by `--retry-max-time 300` now, and without a fixed `--retry-delay` so curl backs off exponentially instead of hammering at a constant interval.

**This is what the oras fetch already does.** I hardened that one in #446 and left this one at #445's weaker settings — they are the same problem and should not have drifted apart. The comment now says so, so the next person changing one looks at the other.

Note the cache did not save either PR here: cache entries created on a branch are not visible to other branches, and no run on `v3.0` has populated this key yet. Once one does, PRs restore it and the fetch stops happening at all — this makes the cold path survivable in the meantime.