### PR TITLE
ci: stop artifact fetches from failing builds

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -344,12 +344,27 @@ jobs:
             libpugixml-dev libcurl4-openssl-dev
       - name: Fetch emb
         run: git clone --depth 1 https://github.com/toyota-connected/emb_cli.git emb_cli
+      # Same reasoning as the watchdog job: the engine is a download, and an
+      # uncached one fails the build as "Bundle failed" with no engine in it.
+      - name: Restore emb engine artifacts
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64
+          restore-keys: |
+            emb-engine-x86_64-
       - name: Build crash handler (emb local, software backend)
         run: |
           eval "$(./emb_cli/bootstrap.sh --shellenv)"
           emb --version
           emb -v cross . --backend software \
             -D BUILD_CRASH_HANDLER=ON --build
+      - name: Save emb engine artifacts
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64-${{ github.run_id }}
 
   # Aggregate gate so crash-handler can be a required status check even though
   # it is path-gated (skipped on docs/asset-only PRs). This job always runs and
@@ -402,6 +417,22 @@ jobs:
             libpugixml-dev libcurl4-openssl-dev
       - name: Fetch emb
         run: git clone --depth 1 https://github.com/toyota-connected/emb_cli.git emb_cli
+      # The engine artifacts are a download like any other, and this job had
+      # no cache for them at all -- so every run refetched them, and a run
+      # where that fetch failed produced a bundle with no libflutter_engine.so
+      # and a "Bundle failed" that reads like a build error.
+      #
+      # Restore and save are split, and the save runs on failure, because a
+      # cache that exists to make a fetch survivable has to be written on the
+      # path where the fetch went wrong -- otherwise it only ever helps runs
+      # that did not need it.
+      - name: Restore emb engine artifacts
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64
+          restore-keys: |
+            emb-engine-x86_64-
       - name: Build watchdog
         run: |
           eval "$(./emb_cli/bootstrap.sh --shellenv)"
@@ -409,6 +440,12 @@ jobs:
           emb -v cross . --backend software \
             -D BUILD_WATCHDOG=ON \
             --build
+      - name: Save emb engine artifacts
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64-${{ github.run_id }}
       - name: Install build deps
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -314,8 +314,14 @@ jobs:
       # new or bumped source misses and refetches; every other run stays off
       # the network entirely. Not keyed on the OS -- the sources are the same
       # archives for every target, so one entry serves the whole matrix.
-      - name: Cache augment sources
-        uses: actions/cache@v6
+      # Restore and save are separate so the save can run after a failed
+      # build. actions/cache skips saving when the job fails, which for a
+      # cache whose whole purpose is to stop a flaky download would be a
+      # deadlock: the archives only land after a green build, and the build
+      # cannot go green while the download keeps failing. Saving whatever did
+      # arrive means each attempt leaves the next one better off.
+      - name: Restore augment sources
+        uses: actions/cache/restore@v6
         with:
           path: |
             /emb/.config/flutter_workspace/overlay-src/*.tar.gz
@@ -356,6 +362,21 @@ jobs:
             grep -aE "Resolved|augment +:|build +:" /tmp/emb-build.log \
               | sed -E 's/^[[:space:]]*[^A-Za-z]*/- /' || true
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # always(): the point is to keep what a failed run managed to fetch.
+      # The key carries a run id so a partial set never claims to be the
+      # complete one; restore-keys above picks up the newest either way.
+      - name: Save augment sources
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            /emb/.config/flutter_workspace/overlay-src/*.tar.gz
+            /emb/.config/flutter_workspace/overlay-src/*.tar.xz
+            /emb/.config/flutter_workspace/overlay-src/*.tar.bz2
+            /emb/.config/flutter_workspace/overlay-src/*.tgz
+            /emb/.config/flutter_workspace/overlay-src/*.zip
+          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ github.run_id }}-${{ matrix.board }}-${{ matrix.pios }}-${{ matrix.backend }}
 
       - name: Upload homescreen binary
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -345,12 +345,42 @@ jobs:
           eval "$(../emb_cli/bootstrap.sh --shellenv)"
           emb --version
           start=$SECONDS
-          # -v streams the toolchain/compile output line-prefixed into the log
-          # (tee'd below) so every build leaves a full record, not just spinners.
-          emb -v cross . \
-            --target "${{ matrix.board }}-${{ matrix.pios }}" \
-            --build --backend "${{ matrix.backend }}" \
-            --no-verify -w /emb | tee /tmp/emb-build.log
+          # Retried only when the failure was an augment source download.
+          #
+          # emb retries those itself, four times with backoff, and github.com
+          # has been out for longer than that window -- a 503 and a mid-header
+          # disconnect have each failed this job. Retrying the whole step gives
+          # the origin minutes rather than seconds, and costs nothing when it
+          # succeeds because emb keeps each archive and skips what it already
+          # has, so an attempt resumes rather than restarting.
+          #
+          # Scoped to that one message on purpose: a compile error must still
+          # fail on the first attempt rather than being rebuilt three times.
+          attempt=1
+          while :; do
+            # -v streams the toolchain/compile output line-prefixed into the
+            # log (tee'd) so every build leaves a full record, not just
+            # spinners.
+            if emb -v cross . \
+                 --target "${{ matrix.board }}-${{ matrix.pios }}" \
+                 --build --backend "${{ matrix.backend }}" \
+                 --no-verify -w /emb | tee /tmp/emb-build.log; then
+              break
+            fi
+            if ! grep -q "augment: download failed" /tmp/emb-build.log; then
+              echo "::error::build failed for a reason other than a source download"
+              exit 1
+            fi
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::augment source download still failing after $attempt attempts"
+              exit 1
+            fi
+            # Surfaced rather than swallowed: a rising count is the signal
+            # that the origin is degrading rather than blipping.
+            echo "::warning::augment source download failed (attempt $attempt/3); retrying"
+            sleep $(( attempt * 30 ))
+            attempt=$(( attempt + 1 ))
+          done
           dur=$(( SECONDS - start ))
           # Per-job timing summary: the cache-hit consume should resolve in
           # seconds (no toolchain/sysroot fetch). emb prints resolve/augment/


### PR DESCRIPTION
#446 cached the augment archives so a flaky download would stop failing builds. It did not work, and the reason is a deadlock I built in:

**`actions/cache` skips its save step when the job fails.** So the archives are only written after a green build — and the build cannot go green while the download that fetches them keeps failing. The cache stays permanently cold exactly when it is most needed. `wayland-cxx-scanner` failed again on the same `Connection closed before full header was received`.

Restore and save are separate now, with the save under `if: always()`, so whatever a failed run did manage to fetch is kept and the next attempt starts closer to done. Several matrix legs fetch the same archives, so one leg getting through is enough to warm the rest.

The save key carries the run id and matrix leg so a partial set never claims to be the complete one; the `restore-keys` prefix picks up the newest entry regardless.

This follows the split `lint.yml` already uses for its clang-tidy cache — the same problem, already solved once in this repo.

Worth noting the general shape, since it caught me out: a cache that exists to make a fetch survivable must be written on the failure path, or it only ever helps runs that did not need it.

---

## Second commit: retry a build whose augment download failed

The cache above only helps once *something* downloads. With the origin returning 503 for the same `wayland-cxx-scanner` archive that previously closed mid-header, nothing does — so there is a second, complementary fix.

emb retries a source download four times with backoff. github.com has now outlasted that window twice today, in two different ways. Retrying the whole build step gives the origin minutes rather than seconds.

It costs nothing when the download succeeds, and little when it does not: emb keeps each archive it fetched and skips what it already has, so a retry **resumes** rather than starting over.

**Scoped to `augment: download failed` deliberately.** A compile error must still fail on the first attempt rather than being rebuilt three times before reporting the same thing. The retry count is surfaced as a warning, so a rising count reads as the origin degrading rather than as noise.

Together the three pieces cover the cases separately: the cache means most runs never fetch, the save-on-failure means a failed run still improves the next one, and the retry means one run can outlast a temporary outage.
