### PR TITLE
test: add an integration fixture that drives the shell over MCP

### DIFF
--- a/test/integration/mcp_drive_test/README.md
+++ b/test/integration/mcp_drive_test/README.md
@@ -1,0 +1,93 @@
+# mcp_drive_test
+
+Integration test app for **driving ivi-homescreen over MCP**, plus a driver
+that acts through the socket and checks what the application actually did.
+
+Every other MCP test in this repo runs against a mock host. Those prove a
+request reaches the shell; they cannot prove Flutter did anything with it,
+because there is no Flutter on the other side. This fixture is that other
+half:
+
+```
+MCP client (tools/drive.py)
+  -> Unix socket -> HTTP -> JSON-RPC        (transport)
+  -> ihs_mcp_host -> semantics provider     (routing)
+  -> ihs_semantics_dispatch                 (funnel: mask, attribution)
+  -> FlutterEngineSendSemanticsAction       (embedder)
+  -> SemanticsOwner.performAction           (framework)
+  -> the closure the widget registered      <- only this fixture reaches here
+```
+
+## The app reports through MCP
+
+Every handler writes into a status line that is itself a semantics node, so
+the driver reads results back over the same surface it used to act. The read
+path is therefore the assertion channel for the write path, and neither can
+pass on its own.
+
+The status value is semicolon-separated `key=value`, because one field is
+text the driver chose and the realistic `ui_set_text` case contains a space:
+
+```
+last=tap:save; events=3; text=Sarah Connor; opaque=16.0,412.0,240.0,80.0
+```
+
+`opaque` is where the unannotated region landed after layout. The app reports
+its own geometry so the driver can aim `ui_tap_at` without hard-coding a
+layout that breaks the first time a font or a screen size changes.
+
+## Checks
+
+| # | Check | What it validates |
+| --- | --- | --- |
+| C1 | tree | The app is described: status, Save, Locked and Destination are present, and Save offers `tap`. Checked first and separately — an empty tree means semantics never came up, which is a different fault from a dispatch not working |
+| C2 | dispatch | `ui_tap` invokes **the widget's own handler**. This is the claim the mock-host tests cannot make: they end where the shell begins |
+| C3 | set_text | `ui_set_text` reaches the field's editing connection and replaces its contents. This is plan R-9's stated exit criterion, and nothing else in the suite covers it |
+| C4a | exclusion | The `ExcludeSemantics` region is absent from the tree, so `ui_tap` has nothing to address |
+| C4b | pointer | `ui_tap_at` at that region's rect reaches it anyway. C4a and C4b together are the DR-7 contrast, demonstrated rather than argued |
+| C5 | enabled gate | A disabled control is refused **and never reaches the widget** — the framework drops such an action silently, so a client would otherwise see success and no effect |
+
+## Running it
+
+The shell must be built with `BUILD_MCP` (which requires `BUILD_ACCESSIBILITY`)
+and started with `[global] enable_mcp = true`:
+
+```bash
+cmake -B build/mcp -GNinja \
+  -D BUILD_ACCESSIBILITY=ON -D BUILD_MCP=ON
+ninja -C build/mcp
+
+emb -v cross . --backend software --build      # or your usual bundle step
+./build/mcp/shell/ivi-homescreen -b <bundle> --enable-mcp
+```
+
+Then, in another terminal:
+
+```bash
+test/integration/mcp_drive_test/tools/drive.py
+```
+
+It prints one line per check and exits non-zero if any failed. The socket
+defaults to `$XDG_RUNTIME_DIR/ivi-homescreen/mcp.sock`; pass `--socket` to
+point at another, including one forwarded from a board over ssh.
+
+## Why the driver keys on label and role, not identifier
+
+The app sets `identifier` on every control, and the driver prefers it when the
+engine reports one — but it matches on label and role first.
+
+Flutter **3.38.3**, the deployment floor this port targets (plan §2.2), never
+writes `identifier` at all. A fixture keyed on it would pass against a
+development engine and fail against every shipping target, which is the
+opposite of what an integration test is for.
+
+## What this still does not cover
+
+The checks drive the semantics and pointer paths. They do not exercise
+`ui_scroll_to`, the AccessKit bridge, or notification delivery under load —
+those have unit coverage and, for AccessKit, verification over a real AT-SPI
+bus, but not against a real engine here.
+
+C4b depends on the region being unobscured. If the app grows a layout where
+something overlaps it, that check will correctly start failing — a pointer
+tap is hit-tested, and that is the property under test.

--- a/test/integration/mcp_drive_test/analysis_options.yaml
+++ b/test/integration/mcp_drive_test/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: false

--- a/test/integration/mcp_drive_test/lib/main.dart
+++ b/test/integration/mcp_drive_test/lib/main.dart
@@ -1,0 +1,193 @@
+// Integration test app for driving ivi-homescreen over MCP.
+//
+// Everything else in the MCP suite runs against a mock host: those tests show
+// a request reaching the shell, not that Flutter did anything with it. This
+// app is the other half — a real engine, real widgets, real hit-testing — so
+// the claims that only hold end to end can be checked:
+//
+//   * a semantics dispatch invokes the handler the widget actually registered,
+//     rather than merely arriving at the funnel
+//   * ui_set_text replaces a TextField's contents (plan R-9's exit criterion)
+//   * ui_tap_at reaches a target the semantics tree does not describe, and
+//     ui_tap cannot — the DR-7 contrast, demonstrable rather than argued
+//   * a disabled control is refused before the framework silently drops it
+//
+// The app reports through MCP rather than stdout. Every handler writes into a
+// status line that is itself a semantics node, so the driver reads results
+// back over the same surface it used to act. That makes the read path the
+// assertion channel for the write path: if either direction is broken the
+// checks cannot pass by accident.
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const McpDriveTestApp());
+}
+
+class McpDriveTestApp extends StatelessWidget {
+  const McpDriveTestApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'mcp_drive_test',
+      debugShowCheckedModeBanner: false,
+      home: DriveTestPage(),
+    );
+  }
+}
+
+class DriveTestPage extends StatefulWidget {
+  const DriveTestPage({super.key});
+
+  @override
+  State<DriveTestPage> createState() => _DriveTestPageState();
+}
+
+class _DriveTestPageState extends State<DriveTestPage> {
+  // What the driver reads back. `last` is the most recent handler to fire and
+  // `events` counts them, so a check can tell "the handler ran again" from
+  // "the handler ran once and the value happens to match".
+  String _last = 'none';
+  int _events = 0;
+
+  final TextEditingController _destination =
+      TextEditingController(text: 'unset');
+
+  // Reported so the driver can aim ui_tap_at without hard-coding a layout.
+  // A fixture that encodes its own geometry breaks the first time a font or a
+  // screen size changes; asking the app where the target is does not.
+  final GlobalKey _opaqueKey = GlobalKey();
+  Rect? _opaqueRect;
+
+  void _record(String what) {
+    setState(() {
+      _last = what;
+      _events++;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    // After the first layout, publish where the unannotated region ended up.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _publishOpaqueRect());
+  }
+
+  void _publishOpaqueRect() {
+    final RenderObject? box = _opaqueKey.currentContext?.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) {
+      return;
+    }
+    final Offset origin = box.localToGlobal(Offset.zero);
+    setState(() {
+      _opaqueRect = origin & box.size;
+    });
+  }
+
+  @override
+  void dispose() {
+    _destination.dispose();
+    super.dispose();
+  }
+
+  String get _status {
+    final Rect? r = _opaqueRect;
+    final String geometry = r == null
+        ? 'opaque=unknown'
+        : 'opaque=${r.left.toStringAsFixed(1)},${r.top.toStringAsFixed(1)},'
+            '${r.width.toStringAsFixed(1)},${r.height.toStringAsFixed(1)}';
+    // Semicolon separated, not space: one of the fields is text a driver
+    // chose, and the realistic case for set_text has a space in it. A
+    // separator the payload can contain makes the fixture pass only for
+    // inputs that avoid it, which is the wrong way round.
+    return 'last=$_last; events=$_events; text=${_destination.text}; $geometry';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              // The report channel. A single node whose value carries the
+              // whole result, so one ui_query reads everything a check needs.
+              Semantics(
+                identifier: 'status',
+                label: 'status',
+                value: _status,
+                child: Text(_status),
+              ),
+              const SizedBox(height: 12),
+
+              // C2: an ordinary annotated button. ui_tap must invoke this
+              // handler -- the same closure a real tap would.
+              Semantics(
+                identifier: 'save',
+                child: ElevatedButton(
+                  onPressed: () => _record('tap:save'),
+                  child: const Text('Save'),
+                ),
+              ),
+              const SizedBox(height: 8),
+
+              // C5: disabled. The framework drops an action on it silently, so
+              // the provider must refuse before dispatching.
+              Semantics(
+                identifier: 'locked',
+                child: const ElevatedButton(
+                  onPressed: null,
+                  child: Text('Locked'),
+                ),
+              ),
+              const SizedBox(height: 8),
+
+              // C3: ui_set_text must replace the contents, and the framework
+              // must route it to this field's editing connection.
+              SizedBox(
+                width: 320,
+                child: Semantics(
+                  identifier: 'destination',
+                  child: TextField(
+                    controller: _destination,
+                    decoration: const InputDecoration(
+                      labelText: 'Destination',
+                    ),
+                    onChanged: (String value) => _record('text:$value'),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              // C4: the DR-7 case. ExcludeSemantics removes it from the tree
+              // entirely, so no node describes it and ui_tap has nothing to
+              // address -- exactly the custom-canvas or platform-view target
+              // the pointer fallback exists for. It still hit-tests, so
+              // ui_tap_at at the rect above reaches it.
+              ExcludeSemantics(
+                child: GestureDetector(
+                  key: _opaqueKey,
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () => _record('tap:opaque'),
+                  child: Container(
+                    width: 240,
+                    height: 80,
+                    color: Colors.blueGrey,
+                    alignment: Alignment.center,
+                    child: const Text(
+                      'unannotated region',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/integration/mcp_drive_test/pubspec.yaml
+++ b/test/integration/mcp_drive_test/pubspec.yaml
@@ -1,0 +1,21 @@
+name: mcp_drive_test
+description: Integration test app for driving ivi-homescreen over MCP.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/test/integration/mcp_drive_test/tools/drive.py
+++ b/test/integration/mcp_drive_test/tools/drive.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Drives mcp_drive_test over MCP and checks what the app actually did.
+
+Every other MCP test runs against a mock host and can only show that a
+request reached the shell. This one runs against a real engine, so it checks
+the things that are only true end to end -- that a dispatch invokes the
+handler the widget registered, that ui_set_text reaches a field's editing
+connection, and that ui_tap_at reaches a target the tree does not describe
+while ui_tap cannot.
+
+Results are read back through MCP: the app writes every handler's outcome
+into a status node, so the read path is the assertion channel for the write
+path and neither can pass alone.
+
+    tools/drive.py [--socket PATH] [--timeout SECONDS]
+
+Exits non-zero on the first failed check, listing every result.
+"""
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+
+TREE_URI = "ui://semantics/tree"
+
+
+class Failure(Exception):
+    pass
+
+
+def rpc(path, method, params=None, request_id=1):
+    body = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    payload = json.dumps(body).encode()
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(path)
+    except OSError as exc:
+        raise Failure(f"no MCP server at {path}: {exc}") from exc
+    try:
+        sock.sendall(
+            b"POST /mcp HTTP/1.1\r\nContent-Length: "
+            + str(len(payload)).encode()
+            + b"\r\n\r\n"
+            + payload
+        )
+        raw = b""
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+            raw += chunk
+    finally:
+        sock.close()
+
+    _, _, text = raw.partition(b"\r\n\r\n")
+    if not text:
+        raise Failure(f"{method}: server closed without answering")
+    return json.loads(text)
+
+
+def call_tool(path, name, arguments=None, request_id=1):
+    """Returns (ok, document). A tool that refuses is a result, not a crash:
+    several checks here assert precisely that something was refused."""
+    reply = rpc(path, "tools/call",
+                {"name": name, "arguments": arguments or {}}, request_id)
+    if "error" in reply:
+        return False, reply["error"]
+    content = reply["result"]["content"][0]["text"]
+    return not reply["result"].get("isError", False), json.loads(content)
+
+
+def read_tree(path):
+    reply = rpc(path, "resources/read", {"uri": TREE_URI}, request_id=2)
+    if "error" in reply:
+        raise Failure(f"resources/read: {reply['error']}")
+    return json.loads(reply["result"]["contents"][0]["text"])
+
+
+def find(tree, label=None, role=None, identifier=None):
+    """Finds a node by label and role, preferring an identifier when the
+    engine reports one.
+
+    Label and role are the primary key on purpose. Flutter 3.38.3 -- the
+    deployment floor this port targets (plan section 2.2) -- never writes
+    `identifier`, so a fixture keyed on it would pass on a development engine
+    and fail on every shipping target. The app still sets identifiers, which
+    a newer engine will use for a more exact match.
+    """
+    if identifier:
+        for node in tree.get("nodes", []):
+            if node.get("identifier") == identifier:
+                return node
+    for node in tree.get("nodes", []):
+        if label is not None and node.get("label") != label:
+            continue
+        if role is not None and node.get("role") != role:
+            continue
+        return node
+    return None
+
+
+def status_fields(path):
+    """The app's status node, parsed into a dict. Values are space separated
+    key=value pairs, which survives a round trip through a semantics value
+    without needing the app to embed JSON in a label."""
+    tree = read_tree(path)
+    node = find(tree, label="status", identifier="status")
+    if node is None:
+        raise Failure("the app published no status node; is it the right app?")
+    # Values may contain spaces -- set_text is given a name with one on
+    # purpose -- so the app separates fields with semicolons.
+    fields = {}
+    for part in (node.get("value") or "").split(";"):
+        key, _, value = part.strip().partition("=")
+        if key:
+            fields[key] = value
+    return fields
+
+
+def wait_for(path, predicate, timeout, what):
+    """Polls the status node until the app reports what was expected.
+
+    Polled rather than driven by a notification because the check is about a
+    widget handler having run, which is one frame later than the dispatch the
+    server acknowledged -- and a test that raced that would fail
+    intermittently for a reason unrelated to what it covers.
+    """
+    deadline = time.time() + timeout
+    last = {}
+    while time.time() < deadline:
+        last = status_fields(path)
+        if predicate(last):
+            return last
+        time.sleep(0.05)
+    raise Failure(f"timed out waiting for {what}; status was {last}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    default_runtime = os.environ.get("XDG_RUNTIME_DIR") or \
+        f"/run/user/{os.getuid()}"
+    parser.add_argument(
+        "--socket",
+        default=os.path.join(default_runtime, "ivi-homescreen", "mcp.sock"),
+        help="MCP socket path (default: %(default)s)")
+    parser.add_argument("--timeout", type=float, default=5.0,
+                        help="seconds to wait for the app to react")
+    args = parser.parse_args()
+
+    results = []
+
+    def check(name, description, fn):
+        try:
+            fn()
+        except Failure as exc:
+            results.append((name, description, False, str(exc)))
+        except Exception as exc:  # noqa: BLE001 - a driver bug is a failure too
+            results.append((name, description, False, f"{type(exc).__name__}: {exc}"))
+        else:
+            results.append((name, description, True, ""))
+
+    # C1 -- the tree describes the app. Everything after this depends on it,
+    # so it is checked first and separately: an empty tree means the app is
+    # not annotated or semantics never came up, which is a different problem
+    # from a dispatch not working.
+    def c1():
+        tree = read_tree(args.socket)
+        for label, role in (("status", None), ("Save", "button"),
+                            ("Locked", "button"), ("Destination", None)):
+            if find(tree, label=label, role=role) is None:
+                raise Failure(f"no node labelled {label!r}"
+                              + (f" with role {role}" if role else ""))
+        save = find(tree, label="Save", role="button", identifier="save")
+        if "tap" not in (save.get("actions") or []):
+            raise Failure(f"Save offers no tap action: {save.get('actions')}")
+
+    # C2 -- a dispatch invokes the widget's own handler. This is the claim the
+    # mock-host tests cannot make: they end where the shell begins.
+    def c2():
+        before = status_fields(args.socket)
+        node = find(read_tree(args.socket), label="Save", role="button",
+                    identifier="save")
+        ok, doc = call_tool(args.socket, "ui_tap", {"node_id": node["id"]}, 10)
+        if not ok:
+            raise Failure(f"ui_tap refused: {doc}")
+        after = wait_for(
+            args.socket,
+            lambda f: f.get("last") == "tap:save"
+            and f.get("events") != before.get("events"),
+            args.timeout, "the Save handler to run")
+        del after
+
+    # C3 -- plan R-9's exit criterion: the text actually lands in the field.
+    def c3():
+        node = find(read_tree(args.socket), label="Destination",
+                    identifier="destination")
+        ok, doc = call_tool(args.socket, "ui_set_text",
+                            {"node_id": node["id"], "text": "Sarah Connor"}, 11)
+        if not ok:
+            raise Failure(f"ui_set_text refused: {doc}")
+        wait_for(args.socket,
+                 lambda f: f.get("text") == "Sarah Connor",
+                 args.timeout, "the field to take the new text")
+
+    # C4 -- the DR-7 contrast, in both directions.
+    def c4_no_node():
+        tree = read_tree(args.socket)
+        for node in tree.get("nodes", []):
+            if (node.get("label") or "") == "unannotated region":
+                raise Failure("the excluded region appeared in the tree; "
+                              "ExcludeSemantics is not doing its job and the "
+                              "contrast this fixture exists to show is gone")
+
+    def c4_pointer_reaches():
+        fields = status_fields(args.socket)
+        geometry = fields.get("opaque", "")
+        try:
+            left, top, width, height = (float(v) for v in geometry.split(","))
+        except ValueError as exc:
+            raise Failure(f"app did not report its geometry: {geometry!r}") from exc
+        before = status_fields(args.socket)
+        ok, doc = call_tool(args.socket, "ui_tap_at",
+                            {"x": left + width / 2, "y": top + height / 2}, 12)
+        if not ok:
+            raise Failure(f"ui_tap_at refused: {doc}")
+        wait_for(
+            args.socket,
+            lambda f: f.get("last") == "tap:opaque"
+            and f.get("events") != before.get("events"),
+            args.timeout, "the unannotated region to receive a pointer tap")
+
+    # C5 -- a disabled control is refused rather than dispatched into silence.
+    def c5():
+        node = find(read_tree(args.socket), label="Locked", role="button",
+                    identifier="locked")
+        before = status_fields(args.socket)
+        ok, doc = call_tool(args.socket, "ui_tap", {"node_id": node["id"]}, 13)
+        if ok:
+            raise Failure("ui_tap on a disabled control was accepted")
+        time.sleep(0.2)
+        after = status_fields(args.socket)
+        if after.get("events") != before.get("events"):
+            raise Failure("a refused tap still reached the widget")
+
+    check("C1", "the tree describes the app", c1)
+    check("C2", "ui_tap invokes the widget's own handler", c2)
+    check("C3", "ui_set_text reaches the field (R-9)", c3)
+    check("C4a", "the unannotated region is absent from the tree", c4_no_node)
+    check("C4b", "ui_tap_at reaches it anyway (DR-7)", c4_pointer_reaches)
+    check("C5", "a disabled control is refused before dispatch", c5)
+
+    width = max(len(d) for _, d, _, _ in results)
+    failed = 0
+    for name, description, ok, detail in results:
+        mark = "PASS" if ok else "FAIL"
+        print(f"{name:4s} {description:<{width}s}  {mark}")
+        if not ok:
+            failed += 1
+            print(f"       {detail}")
+    print()
+    print(f"{len(results) - failed}/{len(results)} checks passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Failure as exc:
+        sys.stderr.write(f"{exc}\n")
+        sys.exit(1)


### PR DESCRIPTION
Every other MCP test in this repo runs against a mock host. Those prove a request reaches the shell; they cannot prove Flutter did anything with it, because there is no Flutter on the other side. This is the half that was missing.

```
MCP client (tools/drive.py)
  -> Unix socket -> HTTP -> JSON-RPC        transport
  -> ihs_mcp_host -> semantics provider     routing
  -> ihs_semantics_dispatch                 funnel: mask, attribution
  -> FlutterEngineSendSemanticsAction       embedder
  -> SemanticsOwner.performAction           framework
  -> the closure the widget registered      <- only this fixture reaches here
```

## Checks

| # | Check | Why it needs a real engine |
| --- | --- | --- |
| C1 | tree | The app is described and `Save` offers `tap`. Checked separately, because an empty tree means semantics never came up — a different fault from a dispatch not working |
| C2 | dispatch | `ui_tap` invokes **the widget's own handler**. This is the claim the mock-host tests cannot make: they end where the shell begins |
| C3 | set_text | The text reaches the field's editing connection. **This is R-9's stated exit criterion**, and nothing in the suite covered it |
| C4a | exclusion | An `ExcludeSemantics` region is absent from the tree, so `ui_tap` has nothing to address |
| C4b | pointer | `ui_tap_at` reaches it anyway. C4a and C4b together are the DR-7 contrast, demonstrated rather than argued |
| C5 | enabled gate | A disabled control is refused **and never reaches the widget** |

## The app reports through MCP

Every handler writes into a status node the driver reads back, so the read path is the assertion channel for the write path and neither can pass alone:

```
last=tap:save; events=3; text=Sarah Connor; opaque=16.0,412.0,240.0,80.0
```

The app also reports **where the unannotated region landed after layout**, so the driver aims `ui_tap_at` at a rect the app measured rather than a geometry hard-coded in the test — which would break on the first font or resolution change.

Fields are semicolon-separated because one of them is text the driver chose and the realistic `set_text` case contains a space. A separator the payload can contain makes a fixture pass only for inputs that avoid it, which is the wrong way round.

## Two things worth reviewing

**The driver keys on label and role, not identifier.** The app sets identifiers and the driver prefers one when the engine reports it — but matches on label and role first, because **Flutter 3.38.3, the deployment floor (plan §2.2), never writes `identifier` at all**. A fixture keyed on it would pass against a development engine and fail against every shipping target, which is precisely backwards for an integration test.

**C4b depends on the region being unobscured.** If the app later grows a layout where something overlaps it, that check will correctly start failing — a pointer tap is hit-tested, and that is the property under test. Noted in the README so a future failure is read as a signal rather than flake.

## State

`flutter analyze` is clean and the driver compiles. **I have not executed the checks end to end** — that needs a built shell with `BUILD_MCP`, a bundled app and a running engine, which this environment cannot do; the README gives the exact sequence. So this lands as a fixture that is correct on inspection and analysis, not one with a green run behind it, and I would rather say so than imply otherwise.

## What it does not cover

`ui_scroll_to`, the AccessKit bridge, and notification delivery under load. Those have unit coverage, and AccessKit additionally has verification over a real AT-SPI bus — but not against a real engine here.
