### PR TITLE
ci: cache the Flutter engine in every job that fetches it

### DIFF
--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -179,6 +179,22 @@ jobs:
         if: steps.vkms.outputs.available == 'true'
         run: git clone --depth 1 https://github.com/toyota-connected/emb_cli.git emb_cli
 
+      # The engine is a download and this job had no cache for it, so every
+      # run refetched it -- and a run whose fetch failed produced a bundle
+      # with no libflutter_engine.so, reported as "Bundle failed", which reads
+      # like a build error rather than a download that never happened.
+      #
+      # Restore and save are split with the save under always(), because a
+      # cache meant to make a fetch survivable has to be written on the path
+      # where the fetch went wrong; otherwise it only helps runs that did not
+      # need it. Same treatment as the crash-handler and watchdog jobs.
+      - name: Restore emb engine artifacts
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64
+          restore-keys: |
+            emb-engine-x86_64-
       - name: Harness integration (census + input harness on vkms)
         if: steps.vkms.outputs.available == 'true'
         env:
@@ -190,3 +206,10 @@ jobs:
           source ./setup_env.sh
           eval "$(./emb_cli/bootstrap.sh --shellenv)"
           ./scripts/vkms_harness_integration.sh
+
+      - name: Save emb engine artifacts
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64-${{ github.run_id }}

--- a/.github/workflows/oss-integration.yaml
+++ b/.github/workflows/oss-integration.yaml
@@ -51,6 +51,25 @@ jobs:
       - name: Fetch emb
         run: git clone --depth 1 https://github.com/toyota-connected/emb_cli.git emb_cli
 
+      # The engine is a download, and this job had no cache for it, so every
+      # run refetched it -- and a run where that fetch failed produced a
+      # bundle with no libflutter_engine.so and a "Bundle failed" that reads
+      # like a build error rather than a download that did not happen.
+      #
+      # Restore and save are split with the save under always(), because a
+      # cache that exists to make a fetch survivable has to be written on the
+      # path where the fetch went wrong; otherwise it only helps the runs that
+      # did not need it.
+      #
+      # The same-named jobs in oss-ivi-homescreen.yml carry this too. They
+      # share names but not definitions, which is how this pair was missed.
+      - name: Restore emb engine artifacts
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64
+          restore-keys: |
+            emb-engine-x86_64-
       - name: Crash-handler integration test (emb local)
         run: |
           eval "$(./emb_cli/bootstrap.sh --shellenv)"
@@ -61,6 +80,13 @@ jobs:
   # - Builds a homescreen binary with the watchdog enabled (software backend for CI)
   # - Runs test/integration/watchdog-test
   # - Checks if exited with code 0 (PASS) or 1 (FAIL)
+      - name: Save emb engine artifacts
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64-${{ github.run_id }}
+
   watchdog:
     if: ${{ github.server_url == 'https://github.com' && github.ref != 'refs/heads/agl' }}
     runs-on: ubuntu-22.04
@@ -92,6 +118,25 @@ jobs:
       - name: Fetch emb
         run: git clone --depth 1 https://github.com/toyota-connected/emb_cli.git emb_cli
 
+      # The engine is a download, and this job had no cache for it, so every
+      # run refetched it -- and a run where that fetch failed produced a
+      # bundle with no libflutter_engine.so and a "Bundle failed" that reads
+      # like a build error rather than a download that did not happen.
+      #
+      # Restore and save are split with the save under always(), because a
+      # cache that exists to make a fetch survivable has to be written on the
+      # path where the fetch went wrong; otherwise it only helps the runs that
+      # did not need it.
+      #
+      # The same-named jobs in oss-ivi-homescreen.yml carry this too. They
+      # share names but not definitions, which is how this pair was missed.
+      - name: Restore emb engine artifacts
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64
+          restore-keys: |
+            emb-engine-x86_64-
       - name: Watchdog integration test (emb local)
         run: |
           eval "$(./emb_cli/bootstrap.sh --shellenv)"
@@ -111,3 +156,10 @@ jobs:
         shell: bash
         run: |
           ./scripts/systemd_watchdog_integration.sh
+
+      - name: Save emb engine artifacts
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.cache/emb/store/engine
+          key: emb-engine-x86_64-${{ github.run_id }}


### PR DESCRIPTION
#451 added engine caching to the `crash-handler` and `watchdog` jobs in `oss-ivi-homescreen.yml`. **`oss-integration.yaml` has its own jobs with the same names**, and those are the ones that had been failing — the "Bundle failed … libflutter_engine.so" symptom came from `Watchdog integration test (emb local)`, which lives here.

They share names and nothing else, which is how the pair was missed. Both needed it; I patched the wrong file for that particular symptom.

Same shape as before: restore before the emb step, save under `if: always()` at the end, so a run whose fetch failed still leaves the next one better off.

The comment now points at the other file, so the next person changing one finds the other.