### PR TITLE
ci: do not cache an engine directory with no engine in it

### DIFF
--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -207,8 +207,26 @@ jobs:
           eval "$(./emb_cli/bootstrap.sh --shellenv)"
           ./scripts/vkms_harness_integration.sh
 
-      - name: Save emb engine artifacts
+      # Only save a cache that has something in it. The save runs on failure
+      # on purpose -- a run whose fetch died partway should still leave the
+      # next one better off -- but a run that fetched *nothing* would
+      # otherwise store an empty directory, and since the restore takes the
+      # newest prefix match that empty entry becomes what every later run
+      # restores. A cache added to break a deadlock would then cause one.
+      - name: Check the engine artifacts landed
         if: always()
+        id: engine_present
+        run: |
+          if find ~/.cache/emb/store/engine -name 'libflutter_engine.so' \
+               -print -quit 2>/dev/null | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::no engine artifacts to cache"
+          fi
+
+      - name: Save emb engine artifacts
+        if: always() && steps.engine_present.outputs.present == 'true'
         uses: actions/cache/save@v6
         with:
           path: ~/.cache/emb/store/engine

--- a/.github/workflows/oss-integration.yaml
+++ b/.github/workflows/oss-integration.yaml
@@ -80,8 +80,26 @@ jobs:
   # - Builds a homescreen binary with the watchdog enabled (software backend for CI)
   # - Runs test/integration/watchdog-test
   # - Checks if exited with code 0 (PASS) or 1 (FAIL)
-      - name: Save emb engine artifacts
+      # Only save a cache that has something in it. The save runs on failure
+      # on purpose -- a run whose fetch died partway should still leave the
+      # next one better off -- but a run that fetched *nothing* would
+      # otherwise store an empty directory, and since the restore takes the
+      # newest prefix match that empty entry becomes what every later run
+      # restores. A cache added to break a deadlock would then cause one.
+      - name: Check the engine artifacts landed
         if: always()
+        id: engine_present
+        run: |
+          if find ~/.cache/emb/store/engine -name 'libflutter_engine.so' \
+               -print -quit 2>/dev/null | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::no engine artifacts to cache"
+          fi
+
+      - name: Save emb engine artifacts
+        if: always() && steps.engine_present.outputs.present == 'true'
         uses: actions/cache/save@v6
         with:
           path: ~/.cache/emb/store/engine
@@ -157,8 +175,26 @@ jobs:
         run: |
           ./scripts/systemd_watchdog_integration.sh
 
-      - name: Save emb engine artifacts
+      # Only save a cache that has something in it. The save runs on failure
+      # on purpose -- a run whose fetch died partway should still leave the
+      # next one better off -- but a run that fetched *nothing* would
+      # otherwise store an empty directory, and since the restore takes the
+      # newest prefix match that empty entry becomes what every later run
+      # restores. A cache added to break a deadlock would then cause one.
+      - name: Check the engine artifacts landed
         if: always()
+        id: engine_present
+        run: |
+          if find ~/.cache/emb/store/engine -name 'libflutter_engine.so' \
+               -print -quit 2>/dev/null | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::no engine artifacts to cache"
+          fi
+
+      - name: Save emb engine artifacts
+        if: always() && steps.engine_present.outputs.present == 'true'
         uses: actions/cache/save@v6
         with:
           path: ~/.cache/emb/store/engine

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -359,8 +359,26 @@ jobs:
           emb --version
           emb -v cross . --backend software \
             -D BUILD_CRASH_HANDLER=ON --build
-      - name: Save emb engine artifacts
+      # Only save a cache that has something in it. The save runs on failure
+      # on purpose -- a run whose fetch died partway should still leave the
+      # next one better off -- but a run that fetched *nothing* would
+      # otherwise store an empty directory, and since the restore takes the
+      # newest prefix match that empty entry becomes what every later run
+      # restores. A cache added to break a deadlock would then cause one.
+      - name: Check the engine artifacts landed
         if: always()
+        id: engine_present
+        run: |
+          if find ~/.cache/emb/store/engine -name 'libflutter_engine.so' \
+               -print -quit 2>/dev/null | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::no engine artifacts to cache"
+          fi
+
+      - name: Save emb engine artifacts
+        if: always() && steps.engine_present.outputs.present == 'true'
         uses: actions/cache/save@v6
         with:
           path: ~/.cache/emb/store/engine
@@ -440,8 +458,26 @@ jobs:
           emb -v cross . --backend software \
             -D BUILD_WATCHDOG=ON \
             --build
-      - name: Save emb engine artifacts
+      # Only save a cache that has something in it. The save runs on failure
+      # on purpose -- a run whose fetch died partway should still leave the
+      # next one better off -- but a run that fetched *nothing* would
+      # otherwise store an empty directory, and since the restore takes the
+      # newest prefix match that empty entry becomes what every later run
+      # restores. A cache added to break a deadlock would then cause one.
+      - name: Check the engine artifacts landed
         if: always()
+        id: engine_present
+        run: |
+          if find ~/.cache/emb/store/engine -name 'libflutter_engine.so' \
+               -print -quit 2>/dev/null | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::no engine artifacts to cache"
+          fi
+
+      - name: Save emb engine artifacts
+        if: always() && steps.engine_present.outputs.present == 'true'
         uses: actions/cache/save@v6
         with:
           path: ~/.cache/emb/store/engine


### PR DESCRIPTION
Found by listing the actual cache entries rather than assuming the mechanism worked:

```
emb-engine-x86_64-…346   81,767,550 bytes   ref=refs/pull/450/merge
emb-engine-x86_64-…724          312 bytes   ref=refs/pull/447/merge   <- empty
emb-engine-x86_64-…424   81,767,883 bytes   ref=refs/pull/450/merge
```

The save runs on failure deliberately — a run whose fetch died partway should leave the next one better off. But a run that fetched **nothing** stored an empty directory, and since the restore takes the newest prefix match, that empty entry becomes what every later run in that scope restores.

So the cache added to break a deadlock had started causing one: #447 was restoring 312 bytes and refetching every time.

The save is now gated on the artifacts actually being present, and a run with nothing to cache emits a warning rather than quietly storing the absence. Applied to all five jobs that cache the engine.

I have deleted the poisoned entry so it stops being served.

## The general shape

Two rules, learned one failure at a time today, that pull against each other:

- a cache meant to make a fetch survivable **must** be written on the failure path, or it only helps runs that did not need it
- but writing on the failure path **must** check there is something worth writing, or the failure is what gets cached

The first without the second is what this fixes.