### PR TITLE
shared: name the MCP routing surface a registry, not a host

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -192,7 +192,7 @@ if (BUILD_MCP)
     target_compile_definitions(ihs_shared PUBLIC IHS_WITH_MCP=1)
     # The semantics provider bridges the two: it needs the hub as well as the
     # registry, so it is only built when both are.
-    # The transport is framing over a socket: it routes onto ihs_mcp_host and
+    # The transport is framing over a socket: it routes onto ihs_mcp_registry and
     # knows nothing about tools, so it builds with the registry rather than
     # with the semantics provider.
     target_sources(ihs_shared PRIVATE src/mcp_transport.cc)
@@ -286,7 +286,7 @@ endif ()
 if (NOT BUILD_MCP)
     list(APPEND _ihs_header_excludes
             PATTERN "ihs_mcp_provider.h" EXCLUDE
-            PATTERN "ihs_mcp_host.h" EXCLUDE
+            PATTERN "ihs_mcp_registry.h" EXCLUDE
             PATTERN "ihs_mcp_transport.h" EXCLUDE)
 endif ()
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ihs

--- a/shared/include/ihs/ihs_mcp_registry.h
+++ b/shared/include/ihs/ihs_mcp_registry.h
@@ -15,11 +15,20 @@
  */
 
 /*
- * SHELL-ONLY routing surface for the MCP provider registry. This is NOT part
- * of the plugin ABI (docs/PLUGIN_ABI.md) -- a provider sees only
- * ihs/ihs_mcp_provider.h.
+ * SHELL-ONLY routing surface for the MCP provider registry.
  *
- *   provider --ihs_mcp_provider_*--> registry <--ihs_mcp_host_*-- MCP server
+ * Named "registry", not "host", deliberately. In MCP's own vocabulary a host
+ * is the application that owns clients and drives a model; a server is what
+ * exposes tools and resources. What this port ships is a **server**, and this
+ * header is the layer beneath it -- so calling it a host would name it after
+ * the one role in the protocol it is not. `ihs_semantics_host.h` keeps the
+ * word, where it means the embedding application and collides with nothing.
+ *
+ * This is NOT part of the plugin ABI (docs/PLUGIN_ABI.md) -- a provider sees
+ * only ihs/ihs_mcp_provider.h.
+ *
+ *   provider --ihs_mcp_provider_*--> registry <--ihs_mcp_registry_*-- MCP
+ * server
  *
  * The registry sits between them so neither has to know about the other. It
  * owns namespacing, capability masking, and the lifetime rules; the server
@@ -36,12 +45,12 @@
  *
  * Threading: callable from any thread; the registry serializes internally.
  * Provider callbacks are invoked on the calling thread, which for the real
- * server is the host thread -- matching what ihs_mcp_provider.h promises
- * providers.
+ * server is its own serving thread -- matching what ihs_mcp_provider.h
+ * promises providers.
  */
 
-#ifndef IHS_MCP_HOST_H_
-#define IHS_MCP_HOST_H_
+#ifndef IHS_MCP_REGISTRY_H_
+#define IHS_MCP_REGISTRY_H_
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -61,22 +70,22 @@ extern "C" {
  * `provider` is the owning provider's name, for logs and for attribution when
  * something has to be traced back to who offered it.
  */
-typedef struct IhsMcpHostTool {
+typedef struct IhsMcpRegistryTool {
   const char* name; /* prefixed */
   const char* description;
   const char* input_schema_json;
   const char* provider;
   uint64_t capability;
-} IhsMcpHostTool;
+} IhsMcpRegistryTool;
 
 /* One resource as clients see it. */
-typedef struct IhsMcpHostResource {
+typedef struct IhsMcpRegistryResource {
   const char* uri;
   const char* name;
   const char* description;
   const char* mime_type;
   const char* provider;
-} IhsMcpHostResource;
+} IhsMcpRegistryResource;
 
 /*
  * Visits every advertised tool across all providers, in registration order.
@@ -89,15 +98,16 @@ typedef struct IhsMcpHostResource {
  * registry's own lock held, and the pointers it receives are valid only for
  * the duration of the call.
  */
-typedef void (*IhsMcpToolVisitor)(const IhsMcpHostTool* tool, void* user_data);
-IHS_EXPORT int ihs_mcp_host_for_each_tool(IhsMcpToolVisitor fn,
-                                          void* user_data);
+typedef void (*IhsMcpToolVisitor)(const IhsMcpRegistryTool* tool,
+                                  void* user_data);
+IHS_EXPORT int ihs_mcp_registry_for_each_tool(IhsMcpToolVisitor fn,
+                                              void* user_data);
 
 /* The same, for resources. */
-typedef void (*IhsMcpResourceVisitor)(const IhsMcpHostResource* resource,
+typedef void (*IhsMcpResourceVisitor)(const IhsMcpRegistryResource* resource,
                                       void* user_data);
-IHS_EXPORT int ihs_mcp_host_for_each_resource(IhsMcpResourceVisitor fn,
-                                              void* user_data);
+IHS_EXPORT int ihs_mcp_registry_for_each_resource(IhsMcpResourceVisitor fn,
+                                                  void* user_data);
 
 /*
  * Routes a tool call by prefix to its provider and strips the prefix before
@@ -112,27 +122,27 @@ IHS_EXPORT int ihs_mcp_host_for_each_resource(IhsMcpResourceVisitor fn,
  *
  * `arguments_json` may be NULL, which is passed to the provider as "{}".
  * On IHS_MCP_OK the caller owns the payload and must release it with
- * ihs_mcp_host_release_payload.
+ * ihs_mcp_registry_release_payload.
  */
-IHS_EXPORT int ihs_mcp_host_call_tool(const char* name,
-                                      const char* arguments_json,
-                                      size_t arguments_length,
-                                      IhsMcpPayload* out_result);
+IHS_EXPORT int ihs_mcp_registry_call_tool(const char* name,
+                                          const char* arguments_json,
+                                          size_t arguments_length,
+                                          IhsMcpPayload* out_result);
 
 /*
  * Reads a resource, routed by URI scheme. Returns IHS_MCP_ERR_NOT_FOUND when
  * no provider claims the scheme or the provider does not serve the URI. On
  * IHS_MCP_OK the caller owns the payload.
  */
-IHS_EXPORT int ihs_mcp_host_read_resource(const char* uri,
-                                          IhsMcpPayload* out_content);
+IHS_EXPORT int ihs_mcp_registry_read_resource(const char* uri,
+                                              IhsMcpPayload* out_content);
 
 /*
  * Notes client interest in a URI, routed by scheme. Providers that left
- * `subscribe` NULL are a no-op success: the host tracks subscriptions itself
- * and the callback exists only so a provider can start or stop work.
+ * `subscribe` NULL are a no-op success: the registry tracks subscriptions
+ * itself and the callback exists only so a provider can start or stop work.
  */
-IHS_EXPORT int ihs_mcp_host_subscribe(const char* uri, bool subscribed);
+IHS_EXPORT int ihs_mcp_registry_subscribe(const char* uri, bool subscribed);
 
 /*
  * What a provider changing underneath the server looks like from above.
@@ -168,18 +178,19 @@ typedef void (*IhsMcpNotificationSink)(IhsMcpNotification kind,
  * Without a sink the registry never watches an fd, so a build with no server
  * pays nothing for a provider that signals into one.
  */
-IHS_EXPORT int ihs_mcp_host_set_notification_sink(IhsMcpNotificationSink sink,
-                                                  void* user_data);
+IHS_EXPORT int ihs_mcp_registry_set_notification_sink(
+    IhsMcpNotificationSink sink,
+    void* user_data);
 
 /*
  * Releases a payload a provider produced. Calls the provider's own release
  * hook; safe on a zeroed payload, so a caller can release unconditionally on
  * an error path without checking whether anything was produced.
  */
-IHS_EXPORT void ihs_mcp_host_release_payload(IhsMcpPayload* payload);
+IHS_EXPORT void ihs_mcp_registry_release_payload(IhsMcpPayload* payload);
 
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
 
-#endif /* IHS_MCP_HOST_H_ */
+#endif /* IHS_MCP_REGISTRY_H_ */

--- a/shared/include/ihs/ihs_mcp_transport.h
+++ b/shared/include/ihs/ihs_mcp_transport.h
@@ -17,8 +17,8 @@
 /*
  * The MCP transport: a Unix domain socket carrying JSON-RPC 2.0 over HTTP,
  * which is what the MCP Streamable HTTP transport is once the network is taken
- * out of it. Everything it serves comes from ihs_mcp_host.h; it adds framing
- * and a socket, and knows nothing about tools or the semantics tree.
+ * out of it. Everything it serves comes from ihs_mcp_registry.h; it adds
+ * framing and a socket, and knows nothing about tools or the semantics tree.
  *
  * Unix domain only, deliberately. A TCP listener would make the UI drivable
  * from off-box, which is a product-security decision rather than a transport

--- a/shared/src/mcp_provider.cc
+++ b/shared/src/mcp_provider.cc
@@ -17,10 +17,10 @@
 // MCP provider registry: namespacing, capability masking, and routing between
 // registered providers and the server above them. See
 // include/ihs/ihs_mcp_provider.h for the provider contract and
-// include/ihs/ihs_mcp_host.h for the shell-facing routing surface.
+// include/ihs/ihs_mcp_registry.h for the shell-facing routing surface.
 
-#include "ihs/ihs_mcp_host.h"
 #include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_mcp_registry.h"
 
 #include <cerrno>
 #include <condition_variable>
@@ -314,7 +314,7 @@ size_t ihs_mcp_provider_count(void) {
   return registry.providers.size();
 }
 
-int ihs_mcp_host_for_each_tool(IhsMcpToolVisitor fn, void* user_data) {
+int ihs_mcp_registry_for_each_tool(IhsMcpToolVisitor fn, void* user_data) {
   if (fn == nullptr) {
     return IHS_MCP_ERR_INVALID;
   }
@@ -338,7 +338,7 @@ int ihs_mcp_host_for_each_tool(IhsMcpToolVisitor fn, void* user_data) {
       const std::string prefixed =
           provider->tool_prefix +
           (tools[i].name != nullptr ? tools[i].name : "");
-      IhsMcpHostTool out;
+      IhsMcpRegistryTool out;
       out.name = prefixed.c_str();
       out.description =
           tools[i].description != nullptr ? tools[i].description : "";
@@ -353,7 +353,8 @@ int ihs_mcp_host_for_each_tool(IhsMcpToolVisitor fn, void* user_data) {
   return IHS_MCP_OK;
 }
 
-int ihs_mcp_host_for_each_resource(IhsMcpResourceVisitor fn, void* user_data) {
+int ihs_mcp_registry_for_each_resource(IhsMcpResourceVisitor fn,
+                                       void* user_data) {
   if (fn == nullptr) {
     return IHS_MCP_ERR_INVALID;
   }
@@ -371,7 +372,7 @@ int ihs_mcp_host_for_each_resource(IhsMcpResourceVisitor fn, void* user_data) {
       continue;
     }
     for (size_t i = 0; i < count; i++) {
-      IhsMcpHostResource out;
+      IhsMcpRegistryResource out;
       out.uri = resources[i].uri != nullptr ? resources[i].uri : "";
       out.name = resources[i].name != nullptr ? resources[i].name : "";
       out.description =
@@ -385,8 +386,8 @@ int ihs_mcp_host_for_each_resource(IhsMcpResourceVisitor fn, void* user_data) {
   return IHS_MCP_OK;
 }
 
-int ihs_mcp_host_set_notification_sink(const IhsMcpNotificationSink sink,
-                                       void* user_data) {
+int ihs_mcp_registry_set_notification_sink(const IhsMcpNotificationSink sink,
+                                           void* user_data) {
   Registry& registry = TheRegistry();
 
   if (sink == nullptr) {
@@ -435,10 +436,10 @@ int ihs_mcp_host_set_notification_sink(const IhsMcpNotificationSink sink,
   return IHS_MCP_OK;
 }
 
-int ihs_mcp_host_call_tool(const char* name,
-                           const char* arguments_json,
-                           size_t arguments_length,
-                           IhsMcpPayload* out_result) {
+int ihs_mcp_registry_call_tool(const char* name,
+                               const char* arguments_json,
+                               size_t arguments_length,
+                               IhsMcpPayload* out_result) {
   if (name == nullptr || out_result == nullptr) {
     return IHS_MCP_ERR_INVALID;
   }
@@ -495,7 +496,8 @@ int ihs_mcp_host_call_tool(const char* name,
                                        args_length, out_result);
 }
 
-int ihs_mcp_host_read_resource(const char* uri, IhsMcpPayload* out_content) {
+int ihs_mcp_registry_read_resource(const char* uri,
+                                   IhsMcpPayload* out_content) {
   if (uri == nullptr || out_content == nullptr) {
     return IHS_MCP_ERR_INVALID;
   }
@@ -509,7 +511,7 @@ int ihs_mcp_host_read_resource(const char* uri, IhsMcpPayload* out_content) {
                                            out_content);
 }
 
-int ihs_mcp_host_subscribe(const char* uri, bool subscribed) {
+int ihs_mcp_registry_subscribe(const char* uri, bool subscribed) {
   if (uri == nullptr) {
     return IHS_MCP_ERR_INVALID;
   }
@@ -527,7 +529,7 @@ int ihs_mcp_host_subscribe(const char* uri, bool subscribed) {
   return provider->callbacks.subscribe(provider->user_data, uri, subscribed);
 }
 
-void ihs_mcp_host_release_payload(IhsMcpPayload* payload) {
+void ihs_mcp_registry_release_payload(IhsMcpPayload* payload) {
   if (payload == nullptr || payload->release == nullptr) {
     return;
   }

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -16,12 +16,12 @@
 
 // MCP transport: JSON-RPC 2.0 over HTTP on a Unix domain socket. Framing and
 // dispatch only -- every method here is a thin translation onto
-// ihs_mcp_host.h, which is where tools and resources actually live.
+// ihs_mcp_registry.h, which is where tools and resources actually live.
 
 #include "ihs/ihs_mcp_transport.h"
 
-#include "ihs/ihs_mcp_host.h"
 #include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_mcp_registry.h"
 
 #include <fcntl.h>
 #include <poll.h>
@@ -179,7 +179,7 @@ struct ListAccumulator {
   bool first = true;
 };
 
-void AppendTool(const IhsMcpHostTool* tool, void* user_data) {
+void AppendTool(const IhsMcpRegistryTool* tool, void* user_data) {
   auto* acc = static_cast<ListAccumulator*>(user_data);
   if (!acc->first) {
     acc->out += ",";
@@ -199,7 +199,7 @@ void AppendTool(const IhsMcpHostTool* tool, void* user_data) {
   acc->out += "}";
 }
 
-void AppendResource(const IhsMcpHostResource* resource, void* user_data) {
+void AppendResource(const IhsMcpRegistryResource* resource, void* user_data) {
   auto* acc = static_cast<ListAccumulator*>(user_data);
   if (!acc->first) {
     acc->out += ",";
@@ -232,7 +232,7 @@ std::string HandleInitialize() {
 std::string HandleToolsList() {
   ListAccumulator acc;
   acc.out = R"({"tools":[)";
-  ihs_mcp_host_for_each_tool(AppendTool, &acc);
+  ihs_mcp_registry_for_each_tool(AppendTool, &acc);
   acc.out += "]}";
   return acc.out;
 }
@@ -240,7 +240,7 @@ std::string HandleToolsList() {
 std::string HandleResourcesList() {
   ListAccumulator acc;
   acc.out = R"({"resources":[)";
-  ihs_mcp_host_for_each_resource(AppendResource, &acc);
+  ihs_mcp_registry_for_each_resource(AppendResource, &acc);
   acc.out += "]}";
   return acc.out;
 }
@@ -268,16 +268,16 @@ std::string HandleToolsCall(const rapidjson::Value& params,
   }
 
   IhsMcpPayload payload{};
-  const int status = ihs_mcp_host_call_tool(name.c_str(), arguments.c_str(),
-                                            arguments.size(), &payload);
+  const int status = ihs_mcp_registry_call_tool(name.c_str(), arguments.c_str(),
+                                                arguments.size(), &payload);
   if (status != IHS_MCP_OK) {
-    ihs_mcp_host_release_payload(&payload);
+    ihs_mcp_registry_release_payload(&payload);
     return ErrorEnvelope(id, JsonRpcCodeFor(status), StatusText(status));
   }
 
   const std::string content(payload.data != nullptr ? payload.data : "",
                             payload.length);
-  ihs_mcp_host_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
 
   // The tool's own JSON is carried as MCP text content: providers return a
   // result document, and the specification's content array is the envelope a
@@ -295,15 +295,15 @@ std::string HandleResourcesRead(const rapidjson::Value& params,
   const std::string uri = params["uri"].GetString();
 
   IhsMcpPayload payload{};
-  const int status = ihs_mcp_host_read_resource(uri.c_str(), &payload);
+  const int status = ihs_mcp_registry_read_resource(uri.c_str(), &payload);
   if (status != IHS_MCP_OK) {
-    ihs_mcp_host_release_payload(&payload);
+    ihs_mcp_registry_release_payload(&payload);
     return ErrorEnvelope(id, JsonRpcCodeFor(status), StatusText(status));
   }
 
   const std::string content(payload.data != nullptr ? payload.data : "",
                             payload.length);
-  ihs_mcp_host_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
 
   return ResultEnvelope(id, R"({"contents":[{"uri":)" + Escape(uri) +
                                 R"(,"mimeType":"application/json","text":)" +
@@ -859,7 +859,7 @@ int ihs_mcp_transport_start(const IhsMcpTransportConfig* config) {
   // requests still work and only pushed notifications are missing. Said out
   // loud, because a client that saw listChanged advertised will wait for
   // messages that then never come.
-  if (ihs_mcp_host_set_notification_sink(OnRegistryNotification, nullptr) !=
+  if (ihs_mcp_registry_set_notification_sink(OnRegistryNotification, nullptr) !=
       IHS_MCP_OK) {
     Log(IHS_LEVEL_ERROR,
         "mcp: another notification sink is installed; serving requests "
@@ -876,7 +876,7 @@ void ihs_mcp_transport_stop() {
   // Uninstalled first, and this does not return until the registry's watcher
   // is joined -- so no notification can be in flight into Broadcast while the
   // streams below are being closed.
-  ihs_mcp_host_set_notification_sink(nullptr, nullptr);
+  ihs_mcp_registry_set_notification_sink(nullptr, nullptr);
 
   std::thread thread;
   {

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -32,7 +32,7 @@
 #include "config/common.h"
 #include "engine.h"
 #if BUILD_ACCESSIBILITY && BUILD_MCP
-#include "ihs/ihs_mcp_host.h"
+#include "ihs/ihs_mcp_registry.h"
 #include "ihs/ihs_mcp_semantics.h"
 #include "ihs/ihs_mcp_transport.h"
 #endif

--- a/test/integration/mcp_drive_test/README.md
+++ b/test/integration/mcp_drive_test/README.md
@@ -11,7 +11,7 @@ half:
 ```
 MCP client (tools/drive.py)
   -> Unix socket -> HTTP -> JSON-RPC        (transport)
-  -> ihs_mcp_host -> semantics provider     (routing)
+  -> ihs_mcp_registry -> semantics provider (routing)
   -> ihs_semantics_dispatch                 (funnel: mask, attribution)
   -> FlutterEngineSendSemanticsAction       (embedder)
   -> SemanticsOwner.performAction           (framework)

--- a/test/unit_test/mcp_provider-test/test_case_mcp_provider.cc
+++ b/test/unit_test/mcp_provider-test/test_case_mcp_provider.cc
@@ -25,8 +25,8 @@
 #include <mutex>
 #include "gtest/gtest.h"
 
-#include "ihs/ihs_mcp_host.h"
 #include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_mcp_registry.h"
 
 namespace {
 
@@ -137,8 +137,8 @@ IhsMcpToolDesc Tool(const char* name, uint64_t capability) {
 
 std::vector<std::string> ListedToolNames() {
   std::vector<std::string> names;
-  ihs_mcp_host_for_each_tool(
-      [](const IhsMcpHostTool* tool, void* user_data) {
+  ihs_mcp_registry_for_each_tool(
+      [](const IhsMcpRegistryTool* tool, void* user_data) {
         static_cast<std::vector<std::string>*>(user_data)->emplace_back(
             tool->name);
       },
@@ -297,7 +297,7 @@ TEST_F(McpProviderTest, ToolWithNoDeclaredCapabilityIsRefused) {
   EXPECT_TRUE(ListedToolNames().empty());
 
   IhsMcpPayload payload{};
-  EXPECT_EQ(ihs_mcp_host_call_tool("ui_mystery", nullptr, 0, &payload),
+  EXPECT_EQ(ihs_mcp_registry_call_tool("ui_mystery", nullptr, 0, &payload),
             IHS_MCP_ERR_CAPABILITY_DENIED);
 }
 
@@ -310,13 +310,13 @@ TEST_F(McpProviderTest, CallRoutesByPrefixAndStripsIt) {
   Register(scene.Desc("scene", "scene_", "scene", IHS_MCP_CAP_ALL));
 
   IhsMcpPayload payload{};
-  ASSERT_EQ(ihs_mcp_host_call_tool("scene_tap", "{\"a\":1}", 7, &payload),
+  ASSERT_EQ(ihs_mcp_registry_call_tool("scene_tap", "{\"a\":1}", 7, &payload),
             IHS_MCP_OK);
   // Reached the right provider, and saw its own unprefixed vocabulary.
   EXPECT_EQ(scene.last_tool_called, "tap");
   EXPECT_EQ(scene.last_arguments, "{\"a\":1}");
   EXPECT_TRUE(ui.last_tool_called.empty());
-  ihs_mcp_host_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
 }
 
 // Providers are promised a non-null argument object, so the registry supplies
@@ -327,10 +327,10 @@ TEST_F(McpProviderTest, AbsentArgumentsBecomeAnEmptyObject) {
   Register(mock.Desc("semantics", "ui_", "ui", IHS_MCP_CAP_ALL));
 
   IhsMcpPayload payload{};
-  ASSERT_EQ(ihs_mcp_host_call_tool("ui_snapshot", nullptr, 0, &payload),
+  ASSERT_EQ(ihs_mcp_registry_call_tool("ui_snapshot", nullptr, 0, &payload),
             IHS_MCP_OK);
   EXPECT_EQ(mock.last_arguments, "{}");
-  ihs_mcp_host_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
 }
 
 TEST_F(McpProviderTest, UnknownToolAndUnknownPrefixAreNotFound) {
@@ -339,9 +339,9 @@ TEST_F(McpProviderTest, UnknownToolAndUnknownPrefixAreNotFound) {
   Register(mock.Desc("semantics", "ui_", "ui", IHS_MCP_CAP_ALL));
 
   IhsMcpPayload payload{};
-  EXPECT_EQ(ihs_mcp_host_call_tool("ui_nonexistent", nullptr, 0, &payload),
+  EXPECT_EQ(ihs_mcp_registry_call_tool("ui_nonexistent", nullptr, 0, &payload),
             IHS_MCP_ERR_NOT_FOUND);
-  EXPECT_EQ(ihs_mcp_host_call_tool("scene_tap", nullptr, 0, &payload),
+  EXPECT_EQ(ihs_mcp_registry_call_tool("scene_tap", nullptr, 0, &payload),
             IHS_MCP_ERR_NOT_FOUND);
 }
 
@@ -355,7 +355,7 @@ TEST_F(McpProviderTest, ProviderWithoutListingCannotHaveToolsCalled) {
   Register(desc);
 
   IhsMcpPayload payload{};
-  EXPECT_EQ(ihs_mcp_host_call_tool("ui_tap", nullptr, 0, &payload),
+  EXPECT_EQ(ihs_mcp_registry_call_tool("ui_tap", nullptr, 0, &payload),
             IHS_MCP_ERR_CAPABILITY_DENIED);
   EXPECT_TRUE(mock.last_tool_called.empty());
 }
@@ -369,7 +369,7 @@ TEST_F(McpProviderTest, ProviderRefusalIsReportedVerbatim) {
   Register(mock.Desc("semantics", "ui_", "ui", IHS_MCP_CAP_ALL));
 
   IhsMcpPayload payload{};
-  EXPECT_EQ(ihs_mcp_host_call_tool("ui_tap", nullptr, 0, &payload),
+  EXPECT_EQ(ihs_mcp_registry_call_tool("ui_tap", nullptr, 0, &payload),
             IHS_MCP_ERR_REFUSED);
 }
 
@@ -395,8 +395,8 @@ TEST_F(McpProviderTest, ResourcesAreListedAndRoutedByScheme) {
 
   std::vector<std::string> uris;
   ASSERT_EQ(
-      ihs_mcp_host_for_each_resource(
-          [](const IhsMcpHostResource* resource, void* user_data) {
+      ihs_mcp_registry_for_each_resource(
+          [](const IhsMcpRegistryResource* resource, void* user_data) {
             static_cast<std::vector<std::string>*>(user_data)->emplace_back(
                 resource->uri);
           },
@@ -405,12 +405,13 @@ TEST_F(McpProviderTest, ResourcesAreListedAndRoutedByScheme) {
   ASSERT_EQ(uris.size(), 2u);
 
   IhsMcpPayload payload{};
-  ASSERT_EQ(ihs_mcp_host_read_resource("scene://graph", &payload), IHS_MCP_OK);
+  ASSERT_EQ(ihs_mcp_registry_read_resource("scene://graph", &payload),
+            IHS_MCP_OK);
   EXPECT_EQ(scene.last_uri_read, "scene://graph");
   EXPECT_TRUE(ui.last_uri_read.empty());
-  ihs_mcp_host_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
 
-  EXPECT_EQ(ihs_mcp_host_read_resource("nope://x", &payload),
+  EXPECT_EQ(ihs_mcp_registry_read_resource("nope://x", &payload),
             IHS_MCP_ERR_NOT_FOUND);
 }
 
@@ -418,13 +419,16 @@ TEST_F(McpProviderTest, SubscribeRoutesByScheme) {
   MockProvider mock;
   Register(mock.Desc("semantics", "ui_", "ui", IHS_MCP_CAP_ALL));
 
-  EXPECT_EQ(ihs_mcp_host_subscribe("ui://semantics/tree", true), IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_registry_subscribe("ui://semantics/tree", true),
+            IHS_MCP_OK);
   EXPECT_EQ(mock.last_uri_subscribed, "ui://semantics/tree");
   EXPECT_TRUE(mock.last_subscribed_state);
 
-  EXPECT_EQ(ihs_mcp_host_subscribe("ui://semantics/tree", false), IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_registry_subscribe("ui://semantics/tree", false),
+            IHS_MCP_OK);
   EXPECT_FALSE(mock.last_subscribed_state);
-  EXPECT_EQ(ihs_mcp_host_subscribe("nope://x", true), IHS_MCP_ERR_NOT_FOUND);
+  EXPECT_EQ(ihs_mcp_registry_subscribe("nope://x", true),
+            IHS_MCP_ERR_NOT_FOUND);
 }
 
 // A provider that is always current may leave subscribe NULL; the registry
@@ -436,7 +440,8 @@ TEST_F(McpProviderTest, ProviderWithoutSubscribeSucceedsAnyway) {
   desc.callbacks.subscribe = nullptr;
   Register(desc);
 
-  EXPECT_EQ(ihs_mcp_host_subscribe("ui://semantics/tree", true), IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_registry_subscribe("ui://semantics/tree", true),
+            IHS_MCP_OK);
   EXPECT_EQ(mock.subscribe_calls, 0);
 }
 
@@ -483,10 +488,10 @@ TEST_F(McpProviderTest, UnregisterReleasesTheNamespace) {
 // Releasing is idempotent so an error path can release unconditionally without
 // first working out whether anything was produced.
 TEST_F(McpProviderTest, PayloadReleaseIsIdempotentAndNullSafe) {
-  ihs_mcp_host_release_payload(nullptr);
+  ihs_mcp_registry_release_payload(nullptr);
 
   IhsMcpPayload payload{};
-  ihs_mcp_host_release_payload(&payload);  // zeroed: no release hook
+  ihs_mcp_registry_release_payload(&payload);  // zeroed: no release hook
 
   struct Counter {
     int releases = 0;
@@ -497,14 +502,15 @@ TEST_F(McpProviderTest, PayloadReleaseIsIdempotentAndNullSafe) {
   payload.release_ctx = &counter;
   payload.release = [](void* ctx) { static_cast<Counter*>(ctx)->releases++; };
 
-  ihs_mcp_host_release_payload(&payload);
-  ihs_mcp_host_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
   EXPECT_EQ(counter.releases, 1);
 }
 
 TEST_F(McpProviderTest, VisitorsRejectANullCallback) {
-  EXPECT_EQ(ihs_mcp_host_for_each_tool(nullptr, nullptr), IHS_MCP_ERR_INVALID);
-  EXPECT_EQ(ihs_mcp_host_for_each_resource(nullptr, nullptr),
+  EXPECT_EQ(ihs_mcp_registry_for_each_tool(nullptr, nullptr),
+            IHS_MCP_ERR_INVALID);
+  EXPECT_EQ(ihs_mcp_registry_for_each_resource(nullptr, nullptr),
             IHS_MCP_ERR_INVALID);
 }
 
@@ -545,7 +551,8 @@ void OnNotify(IhsMcpNotification kind, const char* uri, void* /*user_data*/) {
 TEST_F(McpProviderTest, SignallingTheNotifyFdReachesTheSink) {
   SinkRecord record;
   g_sink = &record;
-  ASSERT_EQ(ihs_mcp_host_set_notification_sink(OnNotify, nullptr), IHS_MCP_OK);
+  ASSERT_EQ(ihs_mcp_registry_set_notification_sink(OnNotify, nullptr),
+            IHS_MCP_OK);
 
   MockProvider mock;
   const int fd = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
@@ -568,7 +575,8 @@ TEST_F(McpProviderTest, SignallingTheNotifyFdReachesTheSink) {
   }
 
   ihs_mcp_provider_unregister(provider);
-  ASSERT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  ASSERT_EQ(ihs_mcp_registry_set_notification_sink(nullptr, nullptr),
+            IHS_MCP_OK);
   ::close(fd);
   g_sink = nullptr;
 }
@@ -579,7 +587,8 @@ TEST_F(McpProviderTest, SignallingTheNotifyFdReachesTheSink) {
 TEST_F(McpProviderTest, UnregisterDoesNotLeaveTheWatcherOnAClosedFd) {
   SinkRecord record;
   g_sink = &record;
-  ASSERT_EQ(ihs_mcp_host_set_notification_sink(OnNotify, nullptr), IHS_MCP_OK);
+  ASSERT_EQ(ihs_mcp_registry_set_notification_sink(OnNotify, nullptr),
+            IHS_MCP_OK);
 
   for (int i = 0; i < 20; i++) {
     MockProvider mock;
@@ -594,7 +603,8 @@ TEST_F(McpProviderTest, UnregisterDoesNotLeaveTheWatcherOnAClosedFd) {
     ::close(fd);
   }
 
-  ASSERT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  ASSERT_EQ(ihs_mcp_registry_set_notification_sink(nullptr, nullptr),
+            IHS_MCP_OK);
   g_sink = nullptr;
 }
 
@@ -603,11 +613,14 @@ TEST_F(McpProviderTest, UnregisterDoesNotLeaveTheWatcherOnAClosedFd) {
 TEST_F(McpProviderTest, OnlyOneSinkMayBeInstalled) {
   SinkRecord record;
   g_sink = &record;
-  ASSERT_EQ(ihs_mcp_host_set_notification_sink(OnNotify, nullptr), IHS_MCP_OK);
-  EXPECT_EQ(ihs_mcp_host_set_notification_sink(OnNotify, nullptr),
+  ASSERT_EQ(ihs_mcp_registry_set_notification_sink(OnNotify, nullptr),
+            IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_registry_set_notification_sink(OnNotify, nullptr),
             IHS_MCP_ERR_REFUSED);
-  ASSERT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  ASSERT_EQ(ihs_mcp_registry_set_notification_sink(nullptr, nullptr),
+            IHS_MCP_OK);
   // Uninstalling twice is harmless, so teardown paths need no bookkeeping.
-  EXPECT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_registry_set_notification_sink(nullptr, nullptr),
+            IHS_MCP_OK);
   g_sink = nullptr;
 }

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -24,8 +24,8 @@
 #include <mutex>
 #include "gtest/gtest.h"
 
-#include "ihs/ihs_mcp_host.h"
 #include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_mcp_registry.h"
 #include "ihs/ihs_mcp_semantics.h"
 #include "ihs/ihs_semantics.h"
 #include "ihs/ihs_semantics_host.h"
@@ -94,7 +94,7 @@ struct TreeBuilder {
 std::string CallTool(const char* name, const char* args, int* status_out) {
   IhsMcpPayload payload{};
   const int status =
-      ihs_mcp_host_call_tool(name, args, args ? strlen(args) : 0, &payload);
+      ihs_mcp_registry_call_tool(name, args, args ? strlen(args) : 0, &payload);
   if (status_out != nullptr) {
     *status_out = status;
   }
@@ -102,7 +102,7 @@ std::string CallTool(const char* name, const char* args, int* status_out) {
   if (payload.data != nullptr) {
     body.assign(payload.data, payload.length);
   }
-  ihs_mcp_host_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
   return body;
 }
 
@@ -153,8 +153,8 @@ TEST_F(McpSemanticsProviderTest, StartIsIdempotent) {
 // prefixed name and the provider still sees its own vocabulary.
 TEST_F(McpSemanticsProviderTest, ToolsAreAdvertisedUnderTheUiPrefix) {
   std::vector<std::string> names;
-  ihs_mcp_host_for_each_tool(
-      [](const IhsMcpHostTool* tool, void* user_data) {
+  ihs_mcp_registry_for_each_tool(
+      [](const IhsMcpRegistryTool* tool, void* user_data) {
         static_cast<std::vector<std::string>*>(user_data)->emplace_back(
             tool->name);
       },
@@ -171,8 +171,8 @@ TEST_F(McpSemanticsProviderTest, ToolsAreAdvertisedUnderTheUiPrefix) {
 // screen-reader cursor is exactly what the allow mask exists to prevent.
 TEST_F(McpSemanticsProviderTest, NoToolExposesAccessibilityFocus) {
   std::vector<std::string> names;
-  ihs_mcp_host_for_each_tool(
-      [](const IhsMcpHostTool* tool, void* user_data) {
+  ihs_mcp_registry_for_each_tool(
+      [](const IhsMcpRegistryTool* tool, void* user_data) {
         static_cast<std::vector<std::string>*>(user_data)->emplace_back(
             tool->name);
       },
@@ -339,13 +339,13 @@ TEST_F(McpSemanticsProviderTest, ResourceReturnsTheTree) {
   ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
 
   IhsMcpPayload payload{};
-  ASSERT_EQ(ihs_mcp_host_read_resource("ui://semantics/tree", &payload),
+  ASSERT_EQ(ihs_mcp_registry_read_resource("ui://semantics/tree", &payload),
             IHS_MCP_OK);
   const std::string body(payload.data, payload.length);
   EXPECT_TRUE(Contains(body, "\"nodes\""));
-  ihs_mcp_host_release_payload(&payload);
+  ihs_mcp_registry_release_payload(&payload);
 
-  EXPECT_EQ(ihs_mcp_host_read_resource("ui://nope", &payload),
+  EXPECT_EQ(ihs_mcp_registry_read_resource("ui://nope", &payload),
             IHS_MCP_ERR_NOT_FOUND);
 }
 
@@ -503,7 +503,7 @@ void OnProviderNotify(IhsMcpNotification kind, const char* uri, void*) {
 TEST_F(McpSemanticsProviderTest, PublishingATreeNotifiesTheServer) {
   NotifyRecord record;
   g_notify = &record;
-  ASSERT_EQ(ihs_mcp_host_set_notification_sink(OnProviderNotify, nullptr),
+  ASSERT_EQ(ihs_mcp_registry_set_notification_sink(OnProviderNotify, nullptr),
             IHS_MCP_OK);
 
   TreeBuilder tree;
@@ -518,6 +518,7 @@ TEST_F(McpSemanticsProviderTest, PublishingATreeNotifiesTheServer) {
     EXPECT_EQ(record.last_uri, "ui://");
   }
 
-  ASSERT_EQ(ihs_mcp_host_set_notification_sink(nullptr, nullptr), IHS_MCP_OK);
+  ASSERT_EQ(ihs_mcp_registry_set_notification_sink(nullptr, nullptr),
+            IHS_MCP_OK);
   g_notify = nullptr;
 }


### PR DESCRIPTION
In MCP's vocabulary a **host** is the application that owns clients and drives a model; a **server** is what exposes tools and resources. This port ships a server, and `ihs_mcp_host.h` was the layer beneath it — so the name pointed at the one role in the protocol it is not, and a reviewer who knows MCP could reasonably read the filename as the agent side.

The header always described itself as the registry's routing surface. It is now called that:

| before | after |
|---|---|
| `ihs_mcp_host.h` | `ihs_mcp_registry.h` |
| `ihs_mcp_host_call_tool` and 6 others | `ihs_mcp_registry_*` |
| `IhsMcpHostTool`, `IhsMcpHostResource` | `IhsMcpRegistryTool`, `IhsMcpRegistryResource` |

The reasoning is recorded at the top of the file, so the name is not "corrected" later by someone matching it to the semantics hub's host header.

**`ihs_semantics_host.h` keeps the word.** There "host" means the embedding application, which is standard usage and collides with nothing.

## Why now

It stops being cheap. The surface is days old, `BUILD_MCP` is off by default, and no out-of-tree consumer can have taken a dependency on it yet.

**I had been saying the rename was free "while the header is uninstalled". That was wrong** — `ihs_mcp_host.h` is installed whenever `BUILD_MCP` is on; it is only excluded when the flag is off. The argument for doing it now is the age of the surface, not its absence from the install set.

**No ABI version bump.** The exported symbol names change, which the versioning policy would normally call breaking — but these are not part of the plugin ABI. The header states that, and a provider only ever sees `ihs_mcp_provider.h`, which is unchanged. Flagging it explicitly rather than deciding silently: if you would rather this carry a major bump, say so and I will add one.

## An observation this turned up, deliberately not fixed here

`ihs_mcp_registry.h` and `ihs_semantics_host.h` both declare themselves shell-only and not part of the plugin ABI — and **both are installed** in an enabled build, with their symbols exported by the `ihs_*` version script. So the "not for consumers" claim is documentation rather than enforcement.

Excluding them from the install set would make it true, and would make future changes to either genuinely free. That is a change to what ships, so it belongs in its own PR with its own decision rather than riding along with a rename.

## Verification

28/28 tests, clang-format and the config-reference gate clean, and `nm -D` confirms the exported set is exactly the renamed symbols with the provider ABI untouched.
