### PR TITLE
docs: a locked screen stops frames on purpose

### DIFF
--- a/test/integration/mcp_drive_test/README.md
+++ b/test/integration/mcp_drive_test/README.md
@@ -50,23 +50,30 @@ layout that breaks the first time a font or a screen size changes.
 ## The app must be composited, or nothing works
 
 This bit is not obvious and cost real time to find. If the surface is not
-being composited -- occluded, on another workspace, or under a compositor
-that stops sending frame callbacks once nothing is damaged -- then no frames
-run, `setState` never rebuilds, and **every check fails in a way that looks
-like the dispatch path is broken**. The action does reach the framework; the
-result simply never lands.
+being composited -- occluded, on another workspace, or behind a lock screen --
+then no frames run, `setState` never rebuilds, and **every check fails in a way
+that looks like the dispatch path is broken**. The action does reach the
+framework; the result simply never lands.
 
-Run it under a compositor you control rather than a desktop session:
+**Check the screen is unlocked first.** A locked desktop session stops
+presenting frames deliberately, so a run started before locking will stall
+partway through with the status frozen at whatever it last managed:
+
+```bash
+loginctl show-session "$(loginctl show-user "$USER" -p Display --value)" -p LockedHint
+# LockedHint=no  -> frames are being presented
+```
+
+Run it under a compositor you control rather than a desktop session, which
+sidesteps the lock policy as well as workspace and occlusion effects:
 
 ```bash
 weston --backend=headless --width=900 --height=700 --socket=wl-mcp-test &
 WAYLAND_DISPLAY=wl-mcp-test <shell> -b <bundle> --enable-mcp
 ```
 
-Even then a headless compositor may stop issuing frame callbacks while the UI
-is idle, which makes runs intermittent: the first interaction lands and later
-ones stall. If a check times out with the status frozen at an earlier value,
-that is this, not the tool it was exercising.
+If a check times out with the status frozen at an earlier value, suspect
+presentation before suspecting the tool it was exercising.
 
 ## Running it
 


### PR DESCRIPTION
The fixture README blamed intermittent runs on a headless compositor going idle while nothing was damaged. That diagnosis was wrong.

**A locked desktop session stops presenting frames deliberately.** A run that straddles a screen lock stalls with its status frozen at whatever it last managed — indistinguishable from a broken dispatch path, even though the action reached the framework fine. Confirmed directly: `LockedHint=yes` and `org.gnome.ScreenSaver.GetActive → true` during the runs I had called intermittent.

So the README now says to check first:

```bash
loginctl show-session "$(loginctl show-user "$USER" -p Display --value)" -p LockedHint
```

and notes that running under a compositor we control sidesteps the lock policy as well as workspace and occlusion effects — which is what CI should do.

This also retires the caveat on #456: the 6/6 run stands, and there is no vsync mystery to chase before putting the fixture in CI.