### PR TITLE
mcp: refuse a browser origin, and document off-box access via a terminator

### DIFF
--- a/docs/mcp-remote-access.md
+++ b/docs/mcp-remote-access.md
@@ -1,0 +1,124 @@
+# Reaching the MCP surface from off the box
+
+The shell serves MCP on a Unix domain socket and nothing else. There is no
+TCP listener, no TLS, and no certificate configuration, and this is a
+deliberate boundary rather than an unfinished one.
+
+Off-box access is supported by putting a TLS terminator in front of that
+socket. This document says why, and how.
+
+## Why the shell has no TLS
+
+The embedder has to own the parts only it can: the semantics tree arrives
+through the Flutter embedder callback, actions and synthesized pointer events
+go back through the embedder API, and the policy that governs them -- the
+build flag, the runtime `enable_mcp`, the per-consumer action mask -- is
+platform policy that an application must not be able to grant itself.
+
+Transport security is not in that set. Certificate provisioning, CA trust,
+rotation, cipher selection and revocation are product and fleet decisions with
+their own lifecycle, and putting them in the shell would mean a UI shell
+carrying a crypto dependency, a trust model, and a set of policy knobs that
+change on a different schedule from the shell itself.
+
+So the shell keeps the one control it can enforce better than anything else
+can: the socket is created under a `0177` umask in a `0700` directory, and
+every connection is checked with `SO_PEERCRED` before a byte is read. That is
+a kernel-attested peer uid, which is a stronger statement than any token.
+
+## The shape
+
+```
+  agent  ──mTLS over TCP/vsock──▶  terminator  ──▶  /run/user/<uid>/ivi-homescreen/mcp.sock  ──▶  shell
+         (client certificate)      (stunnel,                (0600, SO_PEERCRED)
+                                    ghostunnel)
+```
+
+The terminator authenticates the client with a certificate and forwards plain
+HTTP into the Unix socket. Certificates, CA and rotation live entirely in that
+unit's configuration.
+
+## Two things you must get right
+
+**The terminator has to run as the same user as the shell.** `SO_PEERCRED`
+checks the connecting process's uid, and the connecting process is now the
+terminator, not the agent. Running it as another user means every connection
+is refused; running it as root means it is refused too.
+
+**After that, the certificate check is the only thing standing in front of the
+UI.** Once a connection reaches the socket it carries the shell user's full
+authority over the drive surface, because peer credentials can no longer
+distinguish the agent from the terminator. Require a client certificate --
+`verifyPeer`, not `verifyChain` alone -- and restrict which certificates are
+accepted rather than trusting a whole CA.
+
+## stunnel
+
+Packaged nearly everywhere, including Yocto, so this is usually the path of
+least resistance.
+
+```ini
+[mcp]
+accept  = 0.0.0.0:8443
+connect = /run/user/1000/ivi-homescreen/mcp.sock
+cert    = /etc/ivi/mcp/server.pem
+key     = /etc/ivi/mcp/server.key
+CAfile  = /etc/ivi/mcp/agents-ca.pem
+
+; Require a client certificate that chains to CAfile. Without this, TLS
+; authenticates the server to the agent and nothing in the other direction,
+; which is not what this is for.
+verifyPeer = yes
+sslVersionMin = TLSv1.3
+```
+
+Run it as the shell's user:
+
+```ini
+setuid = 1000
+setgid = 1000
+```
+
+## ghostunnel
+
+Purpose-built for terminating mTLS in front of a Unix socket, and it can
+authorize on certificate fields rather than accepting any certificate the CA
+issued -- which is the difference between "an agent" and "this agent".
+
+```sh
+ghostunnel server \
+  --listen   0.0.0.0:8443 \
+  --target   unix:/run/user/1000/ivi-homescreen/mcp.sock \
+  --cert     /etc/ivi/mcp/server.pem \
+  --key      /etc/ivi/mcp/server.key \
+  --cacert   /etc/ivi/mcp/agents-ca.pem \
+  --allow-cn drive-agent
+```
+
+## vsock
+
+For an agent in another VM on the same machine, a vsock terminator avoids the
+network entirely: the channel is CID-scoped and never reaches an interface.
+socat can bridge it, and mTLS on top is still worth having if the guest is not
+fully trusted:
+
+```sh
+socat VSOCK-LISTEN:8443,fork,reuseaddr \
+      UNIX-CONNECT:/run/user/1000/ivi-homescreen/mcp.sock
+```
+
+## What the shell still checks
+
+The transport refuses any request carrying an `Origin` header, on both the
+request and event-stream paths.
+
+This costs nothing while the only listener is a Unix socket -- no browser can
+open one. It matters as soon as a terminator is in front, because a terminator
+forwards plain HTTP and a rebound browser request arrives looking like an
+ordinary local one. Only a browser sets `Origin`, and no browser is a
+legitimate client here, so its presence is enough to refuse on. The MCP
+specification requires HTTP transports to validate it for this reason.
+
+Do not configure the terminator to add or rewrite request headers. Nothing in
+the transport trusts `X-Forwarded-*`, and adding an `Origin` will get every
+request refused.

--- a/shared/include/ihs/ihs_mcp_transport.h
+++ b/shared/include/ihs/ihs_mcp_transport.h
@@ -20,12 +20,22 @@
  * out of it. Everything it serves comes from ihs_mcp_registry.h; it adds
  * framing and a socket, and knows nothing about tools or the semantics tree.
  *
- * Unix domain only, deliberately. A TCP listener would make the UI drivable
- * from off-box, which is a product-security decision rather than a transport
- * one, so there is no address family to configure and no token to get wrong.
- * A filesystem socket puts the decision where the operating system can enforce
- * it: the socket is created 0600, and every connection's peer credentials are
- * checked against the shell's own uid before a byte is read.
+ * Unix domain only, and it stays that way. A filesystem socket puts the
+ * access decision where the operating system can enforce it: the socket is
+ * created 0600 in a 0700 directory, and every connection's peer credentials
+ * are checked against the shell's own uid before a byte is read. That is a
+ * kernel-attested peer uid, which is a stronger statement than any token this
+ * could carry instead.
+ *
+ * Off-box access is supported, but not from here. Certificate provisioning,
+ * CA trust, rotation and cipher policy have their own lifecycle and belong to
+ * the product rather than to a UI shell, so a TLS terminator runs in front of
+ * this socket instead -- see docs/mcp-remote-access.md, which also covers the
+ * two things that arrangement makes easy to get wrong.
+ *
+ * The consequence for this file is the Origin check: a terminator forwards
+ * plain HTTP, so a rebound browser request would otherwise arrive looking
+ * like an ordinary local one.
  */
 
 #ifndef IHS_MCP_TRANSPORT_H_

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -414,6 +414,28 @@ bool ReadHeaderBlock(const int fd, std::string* out_headers) {
   return true;
 }
 
+// True when the request carries an Origin header.
+//
+// Only a browser sets Origin, and no browser is a legitimate client of this
+// surface, so the header's presence is a reliable signal of DNS rebinding: a
+// page the user happens to visit resolves a name it controls to a local
+// address, posts to this endpoint, and the browser attaches the page's origin.
+// The MCP specification requires HTTP transports to validate Origin for
+// exactly this reason.
+//
+// A browser cannot open a Unix socket, so nothing can reach this today. It is
+// here because the check belongs with the protocol rather than with the
+// socket: anything that terminates a network transport in front of this one
+// forwards plain HTTP into it, and this is what keeps a rebound request from
+// arriving as an ordinary local one.
+bool CarriesOrigin(const std::string& raw_headers) {
+  std::string lowered = raw_headers;
+  for (char& c : lowered) {
+    c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+  }
+  return lowered.find("\r\norigin:") != std::string::npos;
+}
+
 // Reads until the header terminator, then exactly Content-Length bytes.
 // Returns false when the peer is malformed or over budget, having already
 // written the refusal.
@@ -450,6 +472,13 @@ bool ReadRequest(const int fd, const size_t max_body, std::string* out_body) {
   if (buffer.rfind("POST ", 0) != 0) {
     WriteAll(
         fd, HttpResponse(405, "Method Not Allowed", R"({"error":"use POST"})"));
+    return false;
+  }
+
+  if (CarriesOrigin(buffer.substr(0, header_end))) {
+    Log(IHS_LEVEL_WARN, "mcp: refused a request carrying an Origin header");
+    WriteAll(fd, HttpResponse(403, "Forbidden",
+                              R"({"error":"origin not allowed"})"));
     return false;
   }
 
@@ -646,6 +675,14 @@ bool ServeConnection(const int fd, const size_t max_body) {
   if (std::strncmp(probe, "GET ", 4) == 0) {
     std::string headers;
     if (!ReadHeaderBlock(fd, &headers)) {
+      return false;
+    }
+    // The stream is the more valuable target of the two: it is a live feed of
+    // the UI rather than a single call, and it takes this separate path.
+    if (CarriesOrigin(headers)) {
+      Log(IHS_LEVEL_WARN, "mcp: refused a stream carrying an Origin header");
+      WriteAll(fd, HttpResponse(403, "Forbidden",
+                                R"({"error":"origin not allowed"})"));
       return false;
     }
     if (TryOpenEventStream(fd, headers)) {

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -58,6 +58,14 @@ std::string Send(const std::string& path, const std::string& request) {
     return {};
   }
 
+  // This helper reads to EOF, so anything the transport leaves open would
+  // block it forever. A regression should fail the suite, not hang CI until
+  // something kills it -- on timeout the loop below just returns what arrived,
+  // which is enough for the caller to assert against.
+  const timeval receive_timeout{5, 0};
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &receive_timeout,
+               sizeof(receive_timeout));
+
   size_t sent = 0;
   while (sent < request.size()) {
     const ssize_t n = ::write(fd, request.data() + sent, request.size() - sent);
@@ -246,6 +254,43 @@ TEST_F(McpTransportTest, HeaderNamesAreCaseInsensitive) {
       Send(path_, "POST / HTTP/1.1\r\ncontent-length: " +
                       std::to_string(body.size()) + "\r\n\r\n" + body);
   EXPECT_EQ(StatusLine(response), "HTTP/1.1 200 OK");
+}
+
+// DNS rebinding: a page resolves a name it controls to a local address and
+// posts here, and the browser attaches its origin. Nothing that legitimately
+// speaks to this surface is a browser, so the header's presence is enough to
+// refuse on. Unreachable over a Unix socket -- the point is that the check is
+// above the listener, so it already covers a port before one exists.
+TEST_F(McpTransportTest, RequestWithAnOriginHeaderIsRefused) {
+  const std::string body = R"({"jsonrpc":"2.0","id":7,"method":"ping"})";
+  const std::string response =
+      Send(path_,
+           "POST / HTTP/1.1\r\nOrigin: http://evil.example\r\n"
+           "Content-Length: " +
+               std::to_string(body.size()) + "\r\n\r\n" + body);
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 403 Forbidden");
+}
+
+// Matched case-insensitively, or the check is trivially evaded.
+TEST_F(McpTransportTest, OriginIsMatchedWhateverItsCase) {
+  const std::string body = R"({"jsonrpc":"2.0","id":8,"method":"ping"})";
+  const std::string response =
+      Send(path_,
+           "POST / HTTP/1.1\r\noRiGiN: http://evil.example\r\n"
+           "Content-Length: " +
+               std::to_string(body.size()) + "\r\n\r\n" + body);
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 403 Forbidden");
+}
+
+// The stream handshake is a GET and takes a different path through the
+// transport, so it needs the check of its own -- a rebound page opening an
+// event stream reads the UI just as effectively as one calling a tool.
+TEST_F(McpTransportTest, EventStreamWithAnOriginHeaderIsRefused) {
+  const std::string response =
+      Send(path_,
+           "GET / HTTP/1.1\r\nAccept: text/event-stream\r\n"
+           "Origin: http://evil.example\r\n\r\n");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 403 Forbidden");
 }
 
 // A header section with no terminator must not let a peer stream forever.


### PR DESCRIPTION
**Resolves the off-box question** the transport header has carried since the socket landed, and adds the one check that decision makes necessary.

> **Scope changed after review.** This started as a listener table for in-shell TCP and vsock with mTLS. That was the wrong place to put it, so the listener refactor is gone and what remains is the decision, the documentation, and a 37-line check.

## The decision: terminate TLS outside the shell

Off-box agents are a requirement. But certificate provisioning, CA trust, rotation and cipher policy have their own lifecycle and belong to the product, not to a UI shell — putting them here would give the embedder **its first crypto dependency** and a trust model that changes on a different schedule from the shell itself.

So the shell keeps only the control it can enforce better than anything else can: a `0600` socket in a `0700` directory, with `SO_PEERCRED` checked before a byte is read. That is a kernel-attested peer uid, a stronger statement than any token it could carry instead.

Off-box access runs a TLS terminator in front of that socket.

```
agent ──mTLS──▶ terminator ──▶ mcp.sock (0600, SO_PEERCRED) ──▶ shell
```

`docs/mcp-remote-access.md` covers stunnel, ghostunnel and vsock, and **the two things this arrangement makes easy to get wrong**:

- **The terminator must run as the shell's user.** `SO_PEERCRED` now sees the terminator, not the agent. Any other uid — root included — and every connection is refused.
- **Past it, the client certificate is the only gate.** Peer credentials can no longer tell the agent from the terminator, so a connection that gets through carries the shell user's full authority over the drive surface. Require a client cert and restrict *which* certs, rather than trusting a whole CA.

## Why that makes the Origin check real rather than theoretical

A terminator forwards plain HTTP, so a **DNS-rebound** browser request arrives looking like an ordinary local one. Only a browser sets `Origin`, and none is a legitimate client here, so its presence is enough to refuse on. The MCP spec requires HTTP transports to validate it for exactly this reason.

Both the request path and the event-stream path are covered. **Ablating the check is what showed the second is not redundant:** the two POST tests fail as expected, but the GET test *hangs* — because without it the request opens a real event stream and the helper waits forever.

That hang is the finding. A rebound page would not merely call one tool; it would hold **a live feed of the UI's semantics tree**. I verified each test fails without the guard rather than assuming it would.

## Test helper

`Send()` reads to EOF, which is why the ablation hung instead of failing. It now takes a receive timeout, so a regression of this kind **fails the suite rather than hanging CI**.

## Not included, deliberately

No TCP listener, no vsock listener, no TLS, no certificate configuration, no new config keys. The transport header now states Unix-domain-only as settled and points at the doc, instead of describing it as a decision still to be made.

30 transport tests (up from 27), 28/28 ctest, clang-tidy clean, `format.sh` and the config-reference gate clean.
