### PR TITLE
shared: give IhsApi a semantics sub-table (ABI 1.2)

### DIFF
--- a/docs/PLUGIN_ABI.md
+++ b/docs/PLUGIN_ABI.md
@@ -80,3 +80,22 @@ embedder convention already used throughout the shell.
 A sub-table pointer in `IhsApi` is `NULL` when that capability is not present in
 the running build. A consumer must treat a null sub-table as "capability
 absent" rather than assuming it is always available.
+
+## Reaching a capability through the table, not by symbol
+
+Both routes work: every sub-table's entries alias the flat entry points, so
+`api->semantics->dispatch` and `ihs_semantics_dispatch` are the same function.
+They fail differently, and that is the reason to prefer the table.
+
+A capability that is compiled out exports no symbols at all -- the semantics
+hub is built only with `BUILD_ACCESSIBILITY`, and its headers are not even
+installed without it. A consumer that names `ihs_semantics_dispatch` directly
+therefore fails to load against such a library, and fails whole: nothing else
+that consumer offers is available either, whether or not it needed semantics.
+Asking `api->semantics` instead turns that into a null check at runtime, and a
+consumer that treats the capability as optional keeps working without it.
+
+Prefer the sub-table wherever a capability might be absent. The flat symbols
+remain supported and are the better choice when a consumer cannot function
+without the capability anyway, since failing at load is then the clearer
+outcome.

--- a/docs/mcp-remote-access.md
+++ b/docs/mcp-remote-access.md
@@ -1,0 +1,124 @@
+# Reaching the MCP surface from off the box
+
+The shell serves MCP on a Unix domain socket and nothing else. There is no
+TCP listener, no TLS, and no certificate configuration, and this is a
+deliberate boundary rather than an unfinished one.
+
+Off-box access is supported by putting a TLS terminator in front of that
+socket. This document says why, and how.
+
+## Why the shell has no TLS
+
+The embedder has to own the parts only it can: the semantics tree arrives
+through the Flutter embedder callback, actions and synthesized pointer events
+go back through the embedder API, and the policy that governs them -- the
+build flag, the runtime `enable_mcp`, the per-consumer action mask -- is
+platform policy that an application must not be able to grant itself.
+
+Transport security is not in that set. Certificate provisioning, CA trust,
+rotation, cipher selection and revocation are product and fleet decisions with
+their own lifecycle, and putting them in the shell would mean a UI shell
+carrying a crypto dependency, a trust model, and a set of policy knobs that
+change on a different schedule from the shell itself.
+
+So the shell keeps the one control it can enforce better than anything else
+can: the socket is created under a `0177` umask in a `0700` directory, and
+every connection is checked with `SO_PEERCRED` before a byte is read. That is
+a kernel-attested peer uid, which is a stronger statement than any token.
+
+## The shape
+
+```
+  agent  ──mTLS over TCP/vsock──▶  terminator  ──▶  /run/user/<uid>/ivi-homescreen/mcp.sock  ──▶  shell
+         (client certificate)      (stunnel,                (0600, SO_PEERCRED)
+                                    ghostunnel)
+```
+
+The terminator authenticates the client with a certificate and forwards plain
+HTTP into the Unix socket. Certificates, CA and rotation live entirely in that
+unit's configuration.
+
+## Two things you must get right
+
+**The terminator has to run as the same user as the shell.** `SO_PEERCRED`
+checks the connecting process's uid, and the connecting process is now the
+terminator, not the agent. Running it as another user means every connection
+is refused; running it as root means it is refused too.
+
+**After that, the certificate check is the only thing standing in front of the
+UI.** Once a connection reaches the socket it carries the shell user's full
+authority over the drive surface, because peer credentials can no longer
+distinguish the agent from the terminator. Require a client certificate --
+`verifyPeer`, not `verifyChain` alone -- and restrict which certificates are
+accepted rather than trusting a whole CA.
+
+## stunnel
+
+Packaged nearly everywhere, including Yocto, so this is usually the path of
+least resistance.
+
+```ini
+[mcp]
+accept  = 0.0.0.0:8443
+connect = /run/user/1000/ivi-homescreen/mcp.sock
+cert    = /etc/ivi/mcp/server.pem
+key     = /etc/ivi/mcp/server.key
+CAfile  = /etc/ivi/mcp/agents-ca.pem
+
+; Require a client certificate that chains to CAfile. Without this, TLS
+; authenticates the server to the agent and nothing in the other direction,
+; which is not what this is for.
+verifyPeer = yes
+sslVersionMin = TLSv1.3
+```
+
+Run it as the shell's user:
+
+```ini
+setuid = 1000
+setgid = 1000
+```
+
+## ghostunnel
+
+Purpose-built for terminating mTLS in front of a Unix socket, and it can
+authorize on certificate fields rather than accepting any certificate the CA
+issued -- which is the difference between "an agent" and "this agent".
+
+```sh
+ghostunnel server \
+  --listen   0.0.0.0:8443 \
+  --target   unix:/run/user/1000/ivi-homescreen/mcp.sock \
+  --cert     /etc/ivi/mcp/server.pem \
+  --key      /etc/ivi/mcp/server.key \
+  --cacert   /etc/ivi/mcp/agents-ca.pem \
+  --allow-cn drive-agent
+```
+
+## vsock
+
+For an agent in another VM on the same machine, a vsock terminator avoids the
+network entirely: the channel is CID-scoped and never reaches an interface.
+socat can bridge it, and mTLS on top is still worth having if the guest is not
+fully trusted:
+
+```sh
+socat VSOCK-LISTEN:8443,fork,reuseaddr \
+      UNIX-CONNECT:/run/user/1000/ivi-homescreen/mcp.sock
+```
+
+## What the shell still checks
+
+The transport refuses any request carrying an `Origin` header, on both the
+request and event-stream paths.
+
+This costs nothing while the only listener is a Unix socket -- no browser can
+open one. It matters as soon as a terminator is in front, because a terminator
+forwards plain HTTP and a rebound browser request arrives looking like an
+ordinary local one. Only a browser sets `Origin`, and no browser is a
+legitimate client here, so its presence is enough to refuse on. The MCP
+specification requires HTTP transports to validate it for this reason.
+
+Do not configure the terminator to add or rewrite request headers. Nothing in
+the transport trusts `X-Forwarded-*`, and adding an `Origin` will get every
+request refused.

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -168,6 +168,9 @@ endif ()
 # build always has the hub the semantics provider reads from.
 if (BUILD_ACCESSIBILITY)
     target_sources(ihs_shared PRIVATE src/semantics.cc)
+    # Gates IhsApi::semantics: without the hub the sub-table's entry points do
+    # not exist, so the field is null rather than pointing at absent symbols.
+    target_compile_definitions(ihs_shared PUBLIC IHS_WITH_SEMANTICS=1)
     message(STATUS "Semantics hub ......... Enabled")
 else ()
     message(STATUS "Semantics hub ......... Disabled")

--- a/shared/include/ihs/ihs.h
+++ b/shared/include/ihs/ihs.h
@@ -41,6 +41,7 @@ typedef struct IhsLoggingApi IhsLoggingApi;
 typedef struct IhsTraceApi IhsTraceApi;
 typedef struct IhsPlatformViewApi IhsPlatformViewApi;
 typedef struct IhsConfigApi IhsConfigApi;
+typedef struct IhsSemanticsApi IhsSemanticsApi;
 
 /*
  * The top-level capability table, valid for the process lifetime. struct_size
@@ -54,6 +55,10 @@ typedef struct IhsApi {
   const IhsTraceApi* trace;
   const IhsPlatformViewApi* platform_view;
   const IhsConfigApi* config;
+  /* ABI 1.2. Null unless the library was built with BUILD_ACCESSIBILITY; a
+   * consumer reading a table from an ABI 1.1 library must not touch this
+   * field, which is what the struct_size above is for. */
+  const IhsSemanticsApi* semantics;
 } IhsApi;
 
 /*

--- a/shared/include/ihs/ihs_mcp_transport.h
+++ b/shared/include/ihs/ihs_mcp_transport.h
@@ -20,12 +20,22 @@
  * out of it. Everything it serves comes from ihs_mcp_registry.h; it adds
  * framing and a socket, and knows nothing about tools or the semantics tree.
  *
- * Unix domain only, deliberately. A TCP listener would make the UI drivable
- * from off-box, which is a product-security decision rather than a transport
- * one, so there is no address family to configure and no token to get wrong.
- * A filesystem socket puts the decision where the operating system can enforce
- * it: the socket is created 0600, and every connection's peer credentials are
- * checked against the shell's own uid before a byte is read.
+ * Unix domain only, and it stays that way. A filesystem socket puts the
+ * access decision where the operating system can enforce it: the socket is
+ * created 0600 in a 0700 directory, and every connection's peer credentials
+ * are checked against the shell's own uid before a byte is read. That is a
+ * kernel-attested peer uid, which is a stronger statement than any token this
+ * could carry instead.
+ *
+ * Off-box access is supported, but not from here. Certificate provisioning,
+ * CA trust, rotation and cipher policy have their own lifecycle and belong to
+ * the product rather than to a UI shell, so a TLS terminator runs in front of
+ * this socket instead -- see docs/mcp-remote-access.md, which also covers the
+ * two things that arrangement makes easy to get wrong.
+ *
+ * The consequence for this file is the Origin check: a terminator forwards
+ * plain HTTP, so a rebound browser request would otherwise arrive looking
+ * like an ordinary local one.
  */
 
 #ifndef IHS_MCP_TRANSPORT_H_

--- a/shared/include/ihs/ihs_semantics.h
+++ b/shared/include/ihs/ihs_semantics.h
@@ -506,6 +506,66 @@ IHS_EXPORT int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
                                       IhsSemanticsDoneCallback done,
                                       void* user_data);
 
+/*
+ * Semantics capability sub-table (IhsApi::semantics), added in ABI 1.2.
+ *
+ * The flat entry points above are the same functions and remain supported.
+ * This exists so a consumer can ask whether the hub is present rather than
+ * find out by failing to link: the hub is compiled only with
+ * BUILD_ACCESSIBILITY, so in a build without it every ihs_semantics_* symbol
+ * is absent and a consumer that referenced one would fail to load at all.
+ * A null IhsApi::semantics is the same question answered at runtime, which is
+ * what every other capability here does.
+ *
+ * Reaching the hub this way costs one indirection per call and nothing else;
+ * a consumer that already knows the capability is present may keep using the
+ * flat symbols.
+ */
+typedef struct IhsSemanticsApi {
+  size_t struct_size;
+
+  /* Snapshot lifetime. Every successful acquire pairs with one release. */
+  const IhsSemanticsSnapshot* (*acquire_snapshot)(void);
+  void (*release_snapshot)(const IhsSemanticsSnapshot* snapshot);
+
+  /* Snapshot reads. */
+  uint64_t (*snapshot_generation)(const IhsSemanticsSnapshot* snapshot);
+  size_t (*snapshot_node_count)(const IhsSemanticsSnapshot* snapshot);
+  const IhsSemanticsNode* (
+      *snapshot_node_at)(const IhsSemanticsSnapshot* snapshot, size_t index);
+  const IhsSemanticsNode* (*snapshot_node_by_id)(
+      const IhsSemanticsSnapshot* snapshot,
+      int32_t node_id);
+  const IhsSemanticsCustomAction* (*find_custom_action)(
+      const IhsSemanticsSnapshot* snapshot,
+      int32_t action_id);
+
+  /* Node fields that are not read by dereference; see the accessor above. */
+  bool (*node_numeric_value)(const IhsSemanticsNode* node,
+                             double* out_value,
+                             double* out_min,
+                             double* out_max);
+
+  /* Consumer lifetime. */
+  int (*register_consumer)(const IhsSemanticsConsumerDesc* desc,
+                           IhsSemanticsConsumer** out_consumer);
+  void (*unregister_consumer)(IhsSemanticsConsumer* consumer);
+
+  /* Acting on the tree. */
+  int (*dispatch)(IhsSemanticsConsumer* consumer,
+                  int64_t view_id,
+                  int32_t node_id,
+                  uint64_t action,
+                  const uint8_t* data,
+                  size_t data_length,
+                  IhsSemanticsDoneCallback done,
+                  void* user_data);
+  int (*send_pointer_tap)(IhsSemanticsConsumer* consumer,
+                          int64_t view_id,
+                          double x,
+                          double y);
+} IhsSemanticsApi;
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/shared/include/ihs/ihs_version.h
+++ b/shared/include/ihs/ihs_version.h
@@ -29,7 +29,7 @@
  * ihs_get_api().
  */
 #define IHS_SHARED_ABI_MAJOR 1u
-#define IHS_SHARED_ABI_MINOR 1u
+#define IHS_SHARED_ABI_MINOR 2u
 #define IHS_SHARED_ABI_VERSION \
   ((IHS_SHARED_ABI_MAJOR << 16) | IHS_SHARED_ABI_MINOR)
 

--- a/shared/src/ihs_api.cc
+++ b/shared/src/ihs_api.cc
@@ -52,6 +52,11 @@ extern "C" const IhsApi* ihs_get_api(uint32_t requested_abi) {
       /* trace         */ ihs::trace::trace_api(),
       /* platform_view */ ihs::pv::platform_view_api(),
       /* config        */ ihs::config::config_api(),
+#ifdef IHS_WITH_SEMANTICS
+      /* semantics     */ ihs::semantics::semantics_api(),
+#else
+      /* semantics     */ nullptr,
+#endif
   };
   return &api;
 }

--- a/shared/src/ihs_internal.hpp
+++ b/shared/src/ihs_internal.hpp
@@ -27,6 +27,10 @@
 #include "ihs/platform_view.h"
 #include "ihs/trace.h"
 
+#ifdef IHS_WITH_SEMANTICS
+#include "ihs/ihs_semantics.h"
+#endif
+
 namespace ihs::dlt {
 
 // Returns the logging sub-table (function pointers over the flat ihs_dlt_*
@@ -57,5 +61,17 @@ namespace ihs::pv {
 const IhsPlatformViewApi* platform_view_api() noexcept;
 
 }  // namespace ihs::pv
+
+#ifdef IHS_WITH_SEMANTICS
+namespace ihs::semantics {
+
+// Returns the semantics hub sub-table. Defined in semantics.cc, which is
+// compiled only with BUILD_ACCESSIBILITY -- hence the guard: without it there
+// is no hub, and IhsApi::semantics is null rather than pointing at a table
+// whose entry points do not exist.
+const IhsSemanticsApi* semantics_api() noexcept;
+
+}  // namespace ihs::semantics
+#endif
 
 #endif  // IHS_SHARED_SRC_IHS_INTERNAL_HPP_

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -414,6 +414,28 @@ bool ReadHeaderBlock(const int fd, std::string* out_headers) {
   return true;
 }
 
+// True when the request carries an Origin header.
+//
+// Only a browser sets Origin, and no browser is a legitimate client of this
+// surface, so the header's presence is a reliable signal of DNS rebinding: a
+// page the user happens to visit resolves a name it controls to a local
+// address, posts to this endpoint, and the browser attaches the page's origin.
+// The MCP specification requires HTTP transports to validate Origin for
+// exactly this reason.
+//
+// A browser cannot open a Unix socket, so nothing can reach this today. It is
+// here because the check belongs with the protocol rather than with the
+// socket: anything that terminates a network transport in front of this one
+// forwards plain HTTP into it, and this is what keeps a rebound request from
+// arriving as an ordinary local one.
+bool CarriesOrigin(const std::string& raw_headers) {
+  std::string lowered = raw_headers;
+  for (char& c : lowered) {
+    c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+  }
+  return lowered.find("\r\norigin:") != std::string::npos;
+}
+
 // Reads until the header terminator, then exactly Content-Length bytes.
 // Returns false when the peer is malformed or over budget, having already
 // written the refusal.
@@ -450,6 +472,13 @@ bool ReadRequest(const int fd, const size_t max_body, std::string* out_body) {
   if (buffer.rfind("POST ", 0) != 0) {
     WriteAll(
         fd, HttpResponse(405, "Method Not Allowed", R"({"error":"use POST"})"));
+    return false;
+  }
+
+  if (CarriesOrigin(buffer.substr(0, header_end))) {
+    Log(IHS_LEVEL_WARN, "mcp: refused a request carrying an Origin header");
+    WriteAll(fd, HttpResponse(403, "Forbidden",
+                              R"({"error":"origin not allowed"})"));
     return false;
   }
 
@@ -646,6 +675,14 @@ bool ServeConnection(const int fd, const size_t max_body) {
   if (std::strncmp(probe, "GET ", 4) == 0) {
     std::string headers;
     if (!ReadHeaderBlock(fd, &headers)) {
+      return false;
+    }
+    // The stream is the more valuable target of the two: it is a live feed of
+    // the UI rather than a single call, and it takes this separate path.
+    if (CarriesOrigin(headers)) {
+      Log(IHS_LEVEL_WARN, "mcp: refused a stream carrying an Origin header");
+      WriteAll(fd, HttpResponse(403, "Forbidden",
+                                R"({"error":"origin not allowed"})"));
       return false;
     }
     if (TryOpenEventStream(fd, headers)) {

--- a/shared/src/semantics.cc
+++ b/shared/src/semantics.cc
@@ -666,3 +666,30 @@ int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
 }
 
 }  // extern "C"
+
+namespace ihs::semantics {
+
+// Function pointers over the flat entry points above -- the same functions, so
+// there is no second implementation to keep in step. Reaching them through
+// IhsApi is what lets a consumer ask whether the hub exists instead of failing
+// to load against a library built without it.
+const IhsSemanticsApi* semantics_api() noexcept {
+  static const IhsSemanticsApi api = {
+      sizeof(IhsSemanticsApi),
+      &ihs_semantics_acquire_snapshot,
+      &ihs_semantics_release_snapshot,
+      &ihs_semantics_snapshot_generation,
+      &ihs_semantics_snapshot_node_count,
+      &ihs_semantics_snapshot_node_at,
+      &ihs_semantics_snapshot_node_by_id,
+      &ihs_semantics_find_custom_action,
+      &ihs_semantics_node_numeric_value,
+      &ihs_semantics_register,
+      &ihs_semantics_unregister,
+      &ihs_semantics_dispatch,
+      &ihs_semantics_send_pointer_tap,
+  };
+  return &api;
+}
+
+}  // namespace ihs::semantics

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -58,6 +58,14 @@ std::string Send(const std::string& path, const std::string& request) {
     return {};
   }
 
+  // This helper reads to EOF, so anything the transport leaves open would
+  // block it forever. A regression should fail the suite, not hang CI until
+  // something kills it -- on timeout the loop below just returns what arrived,
+  // which is enough for the caller to assert against.
+  const timeval receive_timeout{5, 0};
+  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &receive_timeout,
+               sizeof(receive_timeout));
+
   size_t sent = 0;
   while (sent < request.size()) {
     const ssize_t n = ::write(fd, request.data() + sent, request.size() - sent);
@@ -246,6 +254,43 @@ TEST_F(McpTransportTest, HeaderNamesAreCaseInsensitive) {
       Send(path_, "POST / HTTP/1.1\r\ncontent-length: " +
                       std::to_string(body.size()) + "\r\n\r\n" + body);
   EXPECT_EQ(StatusLine(response), "HTTP/1.1 200 OK");
+}
+
+// DNS rebinding: a page resolves a name it controls to a local address and
+// posts here, and the browser attaches its origin. Nothing that legitimately
+// speaks to this surface is a browser, so the header's presence is enough to
+// refuse on. Unreachable over a Unix socket -- the point is that the check is
+// above the listener, so it already covers a port before one exists.
+TEST_F(McpTransportTest, RequestWithAnOriginHeaderIsRefused) {
+  const std::string body = R"({"jsonrpc":"2.0","id":7,"method":"ping"})";
+  const std::string response =
+      Send(path_,
+           "POST / HTTP/1.1\r\nOrigin: http://evil.example\r\n"
+           "Content-Length: " +
+               std::to_string(body.size()) + "\r\n\r\n" + body);
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 403 Forbidden");
+}
+
+// Matched case-insensitively, or the check is trivially evaded.
+TEST_F(McpTransportTest, OriginIsMatchedWhateverItsCase) {
+  const std::string body = R"({"jsonrpc":"2.0","id":8,"method":"ping"})";
+  const std::string response =
+      Send(path_,
+           "POST / HTTP/1.1\r\noRiGiN: http://evil.example\r\n"
+           "Content-Length: " +
+               std::to_string(body.size()) + "\r\n\r\n" + body);
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 403 Forbidden");
+}
+
+// The stream handshake is a GET and takes a different path through the
+// transport, so it needs the check of its own -- a rebound page opening an
+// event stream reads the UI just as effectively as one calling a tool.
+TEST_F(McpTransportTest, EventStreamWithAnOriginHeaderIsRefused) {
+  const std::string response =
+      Send(path_,
+           "GET / HTTP/1.1\r\nAccept: text/event-stream\r\n"
+           "Origin: http://evil.example\r\n\r\n");
+  EXPECT_EQ(StatusLine(response), "HTTP/1.1 403 Forbidden");
 }
 
 // A header section with no terminator must not let a peer stream forever.

--- a/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
+++ b/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
@@ -16,6 +16,7 @@
 
 #include <unistd.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -25,6 +26,7 @@
 
 #include "gtest/gtest.h"
 
+#include "ihs/ihs.h"
 #include "ihs/ihs_semantics.h"
 #include "ihs/ihs_semantics_host.h"
 
@@ -782,5 +784,60 @@ TEST_F(SemanticsHubTest, PointerTapFromAnUnknownConsumerIsRefused) {
   host.send_pointer_tap = RecordTap;
   ihs_semantics_set_host(&host);
   EXPECT_EQ(ihs_semantics_send_pointer_tap(nullptr, 0, 1.0, 1.0),
+            IHS_SEMANTICS_ERR_INVALID);
+}
+
+// The sub-table's pointers alias the flat entry points -- there is no second
+// implementation, so a change to one cannot leave the other behind.
+TEST(SemanticsCapabilityTable, SubTableAliasesFlatEntryPoints) {
+  const IhsApi* api = ihs_get_api(IHS_SHARED_ABI_VERSION);
+  ASSERT_NE(api, nullptr);
+  ASSERT_NE(api->semantics, nullptr) << "built with BUILD_ACCESSIBILITY";
+
+  EXPECT_EQ(api->semantics->acquire_snapshot, &ihs_semantics_acquire_snapshot);
+  EXPECT_EQ(api->semantics->release_snapshot, &ihs_semantics_release_snapshot);
+  EXPECT_EQ(api->semantics->snapshot_generation,
+            &ihs_semantics_snapshot_generation);
+  EXPECT_EQ(api->semantics->snapshot_node_count,
+            &ihs_semantics_snapshot_node_count);
+  EXPECT_EQ(api->semantics->snapshot_node_at, &ihs_semantics_snapshot_node_at);
+  EXPECT_EQ(api->semantics->snapshot_node_by_id,
+            &ihs_semantics_snapshot_node_by_id);
+  EXPECT_EQ(api->semantics->find_custom_action,
+            &ihs_semantics_find_custom_action);
+  EXPECT_EQ(api->semantics->node_numeric_value,
+            &ihs_semantics_node_numeric_value);
+  EXPECT_EQ(api->semantics->register_consumer, &ihs_semantics_register);
+  EXPECT_EQ(api->semantics->unregister_consumer, &ihs_semantics_unregister);
+  EXPECT_EQ(api->semantics->dispatch, &ihs_semantics_dispatch);
+  EXPECT_EQ(api->semantics->send_pointer_tap, &ihs_semantics_send_pointer_tap);
+}
+
+// struct_size is what lets a consumer built against an older minor read a
+// prefix of a newer table, so it has to describe the table actually returned.
+TEST(SemanticsCapabilityTable, ReportsItsOwnSize) {
+  const IhsApi* api = ihs_get_api(IHS_SHARED_ABI_VERSION);
+  ASSERT_NE(api, nullptr);
+  ASSERT_NE(api->semantics, nullptr);
+  EXPECT_EQ(api->semantics->struct_size, sizeof(IhsSemanticsApi));
+  EXPECT_GE(api->struct_size,
+            offsetof(IhsApi, semantics) + sizeof(const IhsSemanticsApi*));
+}
+
+// The capability is reachable through the table, which is the whole point:
+// a consumer that never names a flat ihs_semantics_* symbol still works, and
+// against a library without the hub gets a null sub-table instead of failing
+// to load.
+TEST_F(SemanticsHubTest, UsableEntirelyThroughTheTable) {
+  const IhsApi* api = ihs_get_api(IHS_SHARED_ABI_VERSION);
+  ASSERT_NE(api, nullptr);
+  ASSERT_NE(api->semantics, nullptr);
+
+  // No snapshot before anything is published, reported rather than crashing.
+  const IhsSemanticsSnapshot* empty = api->semantics->acquire_snapshot();
+  api->semantics->release_snapshot(empty);
+
+  EXPECT_EQ(api->semantics->dispatch(nullptr, 0, 1, IHS_SEMANTICS_ACTION_TAP,
+                                     nullptr, 0, nullptr, nullptr),
             IHS_SEMANTICS_ERR_INVALID);
 }


### PR DESCRIPTION
Found while costing the dlopen'd-module design (DR-16). Worth fixing on its own, independent of that decision.

## The gap

Every other capability in `IhsApi` answers *"is this build providing it?"* with a null sub-table. Semantics didn't — a consumer reached the hub by naming the flat `ihs_semantics_*` symbols, and those exist only with `BUILD_ACCESSIBILITY`: the sources are compiled conditionally and the headers aren't even installed without it.

So against such a library the consumer **failed to load, and failed whole**. Not "semantics unavailable" — nothing else that consumer offered was available either, whether or not it needed semantics.

`IhsApi::semantics` is null in that build instead, so a consumer that treats the capability as optional keeps working without it.

## Shape

```c
typedef struct IhsSemanticsApi {
  size_t struct_size;
  const IhsSemanticsSnapshot* (*acquire_snapshot)(void);
  void (*release_snapshot)(const IhsSemanticsSnapshot*);
  /* snapshot reads, node accessor, consumer lifetime, dispatch, pointer tap */
} IhsSemanticsApi;
```

Entries **alias the flat entry points** rather than reimplementing them, so the two cannot drift — a test asserts each pointer equals the corresponding `ihs_semantics_*` function.

Additive: the minor goes to **1.2**, the new pointer is appended, and the leading `struct_size` is what keeps an ABI 1.1 consumer from reading it. Nothing existing moves, no `SOVERSION` change.

## Verified both directions

The same C11 consumer, **unmodified**, against two libraries:

```
against BUILD_ACCESSIBILITY=OFF:  abi=1.2 struct_size=56  semantics: NULL (capability absent)
against BUILD_ACCESSIBILITY=ON:   abi=1.2 struct_size=56  semantics: PRESENT
```

The first links against an `ihs_shared` exporting **zero** `ihs_semantics_*` symbols (`nm -D` confirms), which is precisely the case that used to be unloadable. It also compiles as C11, so the header still parses as C rather than only as C++.

## Docs

`PLUGIN_ABI.md` gains a section on choosing between the two routes. Both work and always will — the point is that they *fail* differently. The flat symbols stay supported and remain the better choice when a consumer can't function without the capability anyway, since failing at load is the clearer outcome there.

## Note

`(void)` parameter lists draw `modernize-redundant-void-arg`, as the same pattern already does in `config.h` and `logging.h`. The check is wrong for a C header: `()` in C means *unspecified* arguments, not none. Left as-is to match the house style and stay C-correct.

3 new tests, 28/28 ctest, `format.sh` and the config-reference gate clean.
