### PR TITLE
shared: stop installing the shell-only headers

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -280,17 +280,40 @@ install(TARGETS ihs_shared EXPORT ihs_shared_targets
 # ihs_mcp_* symbols to link, so installing headers that declare them would let
 # an out-of-tree consumer compile against a surface that is not there and fail
 # at link instead of at the include.
-set(_ihs_header_excludes PATTERN "flutter_desktop_bridge.h" EXCLUDE)
+#
+# Others are shell-internal for the same reason -- they are the producing side
+# of surfaces whose consuming side is installed, and nothing out of tree
+# implements a producer. Two of them already say so in their own file comment:
+#
+#   ihs_semantics_host.h   installs the host that publishes the tree. Only the
+#                          shell has a Flutter engine to publish from; a plugin
+#                          reads through ihs_semantics.h or IhsApi::semantics.
+#   ihs_mcp_registry.h     the routing layer the transport calls. A provider
+#                          registers through ihs_mcp_provider.h and never
+#                          addresses the registry directly.
+#   ihs_mcp_transport.h    starts and stops the listener, which the shell does
+#                          from its own config; an agent speaks to the socket
+#                          over the wire, not to this.
+#   ihs_mcp_semantics.h    "SHELL-ONLY lifecycle ... Not part of the plugin ABI"
+#   platform_view_host.h   "SHELL-ONLY host seam ... NOT part of the plugin ABI"
+#
+# Installing them publishes a producer surface as though it were supported, and
+# invites an out-of-tree caller to install a second semantics host or platform
+# view host, or start a second transport -- all process-global, and none a
+# thing to find out by trying. The in-tree users take them from the source
+# include directory, so nothing in this build depends on their being installed.
+set(_ihs_header_excludes
+        PATTERN "flutter_desktop_bridge.h" EXCLUDE
+        PATTERN "ihs_semantics_host.h" EXCLUDE
+        PATTERN "ihs_mcp_registry.h" EXCLUDE
+        PATTERN "ihs_mcp_transport.h" EXCLUDE
+        PATTERN "ihs_mcp_semantics.h" EXCLUDE
+        PATTERN "platform_view_host.h" EXCLUDE)
 if (NOT BUILD_ACCESSIBILITY)
-    list(APPEND _ihs_header_excludes
-            PATTERN "ihs_semantics.h" EXCLUDE
-            PATTERN "ihs_semantics_host.h" EXCLUDE)
+    list(APPEND _ihs_header_excludes PATTERN "ihs_semantics.h" EXCLUDE)
 endif ()
 if (NOT BUILD_MCP)
-    list(APPEND _ihs_header_excludes
-            PATTERN "ihs_mcp_provider.h" EXCLUDE
-            PATTERN "ihs_mcp_registry.h" EXCLUDE
-            PATTERN "ihs_mcp_transport.h" EXCLUDE)
+    list(APPEND _ihs_header_excludes PATTERN "ihs_mcp_provider.h" EXCLUDE)
 endif ()
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ihs
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
## What was being published

All five are the **producing** side of surfaces whose consuming side is installed, and nothing out of tree implements a producer:

| Header | Why it's shell-only |
|---|---|
| `ihs_semantics_host.h` | Installs the host that publishes the tree. Only the shell has an engine to publish from; a plugin reads via `ihs_semantics.h` or `IhsApi::semantics` |
| `ihs_mcp_registry.h` | The routing layer the transport calls. A provider registers through `ihs_mcp_provider.h` |
| `ihs_mcp_transport.h` | Starts and stops the listener, which the shell does from its own config. An agent talks to the socket over the wire |
| `ihs_mcp_semantics.h` | *"SHELL-ONLY lifecycle … Not part of the plugin ABI"* |
| `platform_view_host.h` | *"SHELL-ONLY host seam … NOT part of the plugin ABI"* |

**The last two say so in their own file comment and were installed anyway.**

Publishing a producer surface invites an out-of-tree caller to install a second semantics host, a second platform-view host, or start a second transport — all process-global, and none of them a thing to discover by trying.

## The consumer gate answered the question

I didn't have to guess which headers are really the plugin ABI. `shared/tests/consumer` — the CI gate that `find_package`s the installed package and compiles as strict C11 — includes exactly:

```
ihs.h  config.h  ihs_semantics.h  ihs_mcp_provider.h  location.h  logging.h  trace.h
```

and **none of the five**. So the surface it proves is precisely the surface that should ship.

Verified by installing both configurations and rebuilding that consumer against the trimmed prefix:

```
OK ihs_shared consumer smoke: abi=0x00010002 logging=present semantics=present mcp=present
```

In-tree users take these headers from the source include directory, so nothing in the build depended on their being installed. 28/28 ctest.

## A related gap, fixed while here

**`ihs_mcp_semantics.h` was missing from the `BUILD_MCP` exclusion list.** With MCP off it was installed regardless, declaring `ihs_mcp_*` symbols that library does not export — the exact failure that list exists to prevent, in its own words: *"installing headers that declare them would let an out-of-tree consumer compile against a surface that is not there and fail at link instead of at the include."*

Confirmed before and after: a `BUILD_MCP=OFF` install now carries no `ihs_mcp_*` header at all.

## Scope note

`platform_view_host.h` is a different subsystem from the one OQ-9 asked about. I included it because it is the identical mistake and its own header documents the intent — but it is the one item here worth a second opinion, since it changes what a platform-view integrator finds installed. Say the word and I'll split it out.
