### PR TITLE
mcp: implement resources/subscribe and filter notifications by it

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -280,17 +280,40 @@ install(TARGETS ihs_shared EXPORT ihs_shared_targets
 # ihs_mcp_* symbols to link, so installing headers that declare them would let
 # an out-of-tree consumer compile against a surface that is not there and fail
 # at link instead of at the include.
-set(_ihs_header_excludes PATTERN "flutter_desktop_bridge.h" EXCLUDE)
+#
+# Others are shell-internal for the same reason -- they are the producing side
+# of surfaces whose consuming side is installed, and nothing out of tree
+# implements a producer. Two of them already say so in their own file comment:
+#
+#   ihs_semantics_host.h   installs the host that publishes the tree. Only the
+#                          shell has a Flutter engine to publish from; a plugin
+#                          reads through ihs_semantics.h or IhsApi::semantics.
+#   ihs_mcp_registry.h     the routing layer the transport calls. A provider
+#                          registers through ihs_mcp_provider.h and never
+#                          addresses the registry directly.
+#   ihs_mcp_transport.h    starts and stops the listener, which the shell does
+#                          from its own config; an agent speaks to the socket
+#                          over the wire, not to this.
+#   ihs_mcp_semantics.h    "SHELL-ONLY lifecycle ... Not part of the plugin ABI"
+#   platform_view_host.h   "SHELL-ONLY host seam ... NOT part of the plugin ABI"
+#
+# Installing them publishes a producer surface as though it were supported, and
+# invites an out-of-tree caller to install a second semantics host or platform
+# view host, or start a second transport -- all process-global, and none a
+# thing to find out by trying. The in-tree users take them from the source
+# include directory, so nothing in this build depends on their being installed.
+set(_ihs_header_excludes
+        PATTERN "flutter_desktop_bridge.h" EXCLUDE
+        PATTERN "ihs_semantics_host.h" EXCLUDE
+        PATTERN "ihs_mcp_registry.h" EXCLUDE
+        PATTERN "ihs_mcp_transport.h" EXCLUDE
+        PATTERN "ihs_mcp_semantics.h" EXCLUDE
+        PATTERN "platform_view_host.h" EXCLUDE)
 if (NOT BUILD_ACCESSIBILITY)
-    list(APPEND _ihs_header_excludes
-            PATTERN "ihs_semantics.h" EXCLUDE
-            PATTERN "ihs_semantics_host.h" EXCLUDE)
+    list(APPEND _ihs_header_excludes PATTERN "ihs_semantics.h" EXCLUDE)
 endif ()
 if (NOT BUILD_MCP)
-    list(APPEND _ihs_header_excludes
-            PATTERN "ihs_mcp_provider.h" EXCLUDE
-            PATTERN "ihs_mcp_registry.h" EXCLUDE
-            PATTERN "ihs_mcp_transport.h" EXCLUDE)
+    list(APPEND _ihs_header_excludes PATTERN "ihs_mcp_provider.h" EXCLUDE)
 endif ()
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ihs
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -35,7 +35,10 @@
 #include <atomic>
 #include <cerrno>
 #include <cstring>
+#include <map>
 #include <mutex>
+#include <random>
+#include <set>
 #include <string>
 #include <thread>
 #include <vector>
@@ -82,6 +85,14 @@ constexpr int kMethodNotFound = -32601;
 constexpr int kInvalidParams = -32602;
 constexpr int kInternalError = -32603;
 
+// One open event stream. The session is empty when the client opened the
+// stream without identifying one, which is legal and means "send me
+// everything" -- see Transport::subscriptions.
+struct Stream {
+  int fd = -1;
+  std::string session{};
+};
+
 struct Transport {
   std::mutex mutex;
   bool running = false;
@@ -92,16 +103,33 @@ struct Transport {
   size_t max_request_bytes = kDefaultMaxRequestBytes;
   std::thread thread;
 
-  // Open event streams, one per client that asked for one. Raw descriptors
-  // because the only operations are write and close, and both happen under
-  // this mutex: a notification arrives on the registry's watcher thread while
-  // the accept loop may be adding a stream or dropping a dead one.
+  // Open event streams, one per client that asked for one.
   //
   // Separate from `mutex` so delivering an event never contends with an
   // accept or a stop -- and, more importantly, so a notification cannot
   // deadlock against a stop that is waiting to join the accept thread.
+  //
+  // This mutex also covers `subscriptions`: a subscribe arrives on the accept
+  // thread while a notification is being filtered on the registry's watcher
+  // thread, so the set a stream is matched against must not change underneath
+  // that match.
   std::mutex streams_mutex;
-  std::vector<int> streams;
+  std::vector<Stream> streams;
+
+  // Session id -> the resource URIs that session asked for.
+  //
+  // Keyed by session rather than by stream because a subscribe arrives on its
+  // own connection: every request here is Connection: close, so the POST that
+  // subscribes is never the connection the stream is on, and the session id is
+  // the only thing tying them together.
+  //
+  // A session absent from this map, or present with an empty set, receives
+  // every resource update. That is what a client which never subscribed got
+  // before subscriptions existed, and keeping it means adding this could not
+  // silently stop an existing client's notifications -- "subscribed to
+  // nothing" and "not interested in filtering" are not distinguishable, and
+  // the safe reading is the one that keeps delivering.
+  std::map<std::string, std::set<std::string>> subscriptions;
 };
 
 Transport& TheTransport() {
@@ -313,7 +341,126 @@ std::string HandleResourcesRead(const rapidjson::Value& params,
 // Routes one JSON-RPC request. Returns the response text, or empty for a
 // notification -- a request with no id expects no reply, and answering one
 // would be a protocol error rather than merely noise.
-std::string Dispatch(const std::string& body) {
+// A session identifier: 128 bits of randomness, hex.
+//
+// Random rather than a counter because the id is what authorizes a subscribe
+// to alter a session's filter. The socket's uid check is the real boundary and
+// this sits behind it, but a guessable id would let anything that got through
+// that boundary reshape another client's stream, and the cost of not being
+// guessable is one read.
+std::string NewSessionId() {
+  std::random_device source;
+  std::string out;
+  out.reserve(32);
+  for (int i = 0; i < 4; ++i) {
+    const uint32_t word = source();
+    for (int shift = 28; shift >= 0; shift -= 4) {
+      out.push_back("0123456789abcdef"[(word >> shift) & 0xfu]);
+    }
+  }
+  return out;
+}
+
+// resources/subscribe and resources/unsubscribe.
+//
+// The session comes from the Mcp-Session-Id header rather than the params: it
+// identifies the caller, and a client that could name any session in the body
+// could redirect another client's stream.
+std::string HandleSubscribe(const rapidjson::Value& params,
+                            const std::string& id,
+                            const std::string& session,
+                            const bool subscribing) {
+  if (!params.IsObject() || !params.HasMember("uri") ||
+      !params["uri"].IsString()) {
+    return ErrorEnvelope(id, kInvalidParams, "uri is required");
+  }
+  if (session.empty()) {
+    // Without a session there is nothing to attach the filter to: the stream
+    // this would govern is a different connection, and only the session id
+    // links them.
+    return ErrorEnvelope(id, kInvalidParams,
+                         "Mcp-Session-Id is required; call initialize first");
+  }
+
+  const std::string uri = params["uri"].GetString();
+
+  // Pass it to the registry so the provider owning the scheme can start or
+  // stop work on the strength of it.
+  //
+  // A scheme no provider claims is deliberately not an error. Providers
+  // register at any point in a session -- that is an explicit property of the
+  // registry, not an accident -- so refusing here would turn "subscribed
+  // before the provider came up" into a failure, and make the result depend on
+  // a race the client cannot see. The subscription is recorded either way and
+  // starts matching when the provider appears. Anything other than a missing
+  // provider is a real failure and is reported.
+  const int status = ihs_mcp_registry_subscribe(uri.c_str(), subscribing);
+  if (status != IHS_MCP_OK && status != IHS_MCP_ERR_NOT_FOUND) {
+    return ErrorEnvelope(id, JsonRpcCodeFor(status), StatusText(status));
+  }
+
+  Transport& t = TheTransport();
+  const std::lock_guard<std::mutex> lock(t.streams_mutex);
+  if (subscribing) {
+    t.subscriptions[session].insert(uri);
+  } else {
+    const auto it = t.subscriptions.find(session);
+    if (it != t.subscriptions.end()) {
+      it->second.erase(uri);
+      // An empty set would mean "send everything" rather than "send nothing",
+      // so unsubscribing from the last URI has to drop the session's filter
+      // entirely rather than leave one that reads as the opposite.
+      if (it->second.empty()) {
+        t.subscriptions.erase(it);
+      }
+    }
+  }
+  return ResultEnvelope(id, "{}");
+}
+
+// Whether a notification for `notified` concerns a subscription to
+// `subscribed`, which is true when either contains the other.
+//
+// Both directions are needed because the two names are not at the same
+// granularity. A provider signals that something under its scheme changed and
+// the registry reports the provider's prefix -- "ui://" -- while a client
+// subscribes to what resources/list advertises, which is the concrete
+// "ui://semantics/tree". Comparing those for equality would match nothing and
+// filter out every real subscriber's notifications.
+//
+// So the coarser name governs: a notification for "ui://" reaches a
+// subscription to "ui://semantics/tree", and a notification for a concrete URI
+// reaches a subscription to the scheme. The practical resolution is therefore
+// per-provider, not per-resource, and it sharpens on its own if providers
+// start reporting the resource that actually changed.
+bool UriConcerns(const std::string& notified, const std::string& subscribed) {
+  const std::string& shorter =
+      notified.size() <= subscribed.size() ? notified : subscribed;
+  const std::string& longer =
+      notified.size() <= subscribed.size() ? subscribed : notified;
+  return longer.compare(0, shorter.size(), shorter) == 0;
+}
+
+// Whether a stream should receive an update for `uri`. Caller holds
+// streams_mutex.
+bool StreamWantsLocked(const Transport& t,
+                       const Stream& stream,
+                       const std::string& uri) {
+  if (stream.session.empty()) {
+    return true;  // never identified a session, so never asked to filter
+  }
+  const auto it = t.subscriptions.find(stream.session);
+  if (it == t.subscriptions.end() || it->second.empty()) {
+    return true;  // identified, but subscribed to nothing: unfiltered
+  }
+  return std::any_of(
+      it->second.begin(), it->second.end(),
+      [&uri](const std::string& want) { return UriConcerns(uri, want); });
+}
+
+std::string Dispatch(const std::string& body,
+                     const std::string& session,
+                     std::string* out_new_session) {
   rapidjson::Document doc;
   if (doc.Parse(body.c_str(), body.size()).HasParseError() || !doc.IsObject()) {
     return ErrorEnvelope("null", kParseError, "invalid JSON");
@@ -339,6 +486,10 @@ std::string Dispatch(const std::string& body) {
 
   std::string response;
   if (method == "initialize") {
+    // A session is minted here rather than on connect: every request is
+    // Connection: close, so connections are not sessions, and initialize is
+    // the one point the protocol defines for establishing one.
+    *out_new_session = NewSessionId();
     response = ResultEnvelope(id, HandleInitialize());
   } else if (method == "tools/list") {
     response = ResultEnvelope(id, HandleToolsList());
@@ -346,6 +497,10 @@ std::string Dispatch(const std::string& body) {
     response = ResultEnvelope(id, HandleResourcesList());
   } else if (method == "tools/call") {
     response = HandleToolsCall(params, id);
+  } else if (method == "resources/subscribe") {
+    response = HandleSubscribe(params, id, session, /*subscribing=*/true);
+  } else if (method == "resources/unsubscribe") {
+    response = HandleSubscribe(params, id, session, /*subscribing=*/false);
   } else if (method == "resources/read") {
     response = HandleResourcesRead(params, id);
   } else if (method == "ping") {
@@ -365,12 +520,14 @@ std::string Dispatch(const std::string& body) {
 
 std::string HttpResponse(const int code,
                          const char* reason,
-                         const std::string& body) {
+                         const std::string& body,
+                         const std::string& extra_headers = {}) {
   std::string out = "HTTP/1.1 " + std::to_string(code) + " " + reason + "\r\n";
   out += "Content-Type: application/json\r\n";
   out += "Content-Length: " + std::to_string(body.size()) + "\r\n";
   // Nothing here is cacheable and every response is a live view of the UI.
   out += "Cache-Control: no-store\r\n";
+  out += extra_headers;
   out += "Connection: close\r\n\r\n";
   out += body;
   return out;
@@ -414,6 +571,28 @@ bool ReadHeaderBlock(const int fd, std::string* out_headers) {
   return true;
 }
 
+// The value of a header, or "" when absent. `name` must be lowercase and end
+// with ':'. Matches on a lowered copy because header names are
+// case-insensitive, and trims the optional leading space and the trailing CR.
+std::string HeaderValue(const std::string& raw_headers, const char* name) {
+  std::string lowered = raw_headers;
+  for (char& c : lowered) {
+    c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+  }
+  const std::string needle = std::string("\r\n") + name;
+  const size_t at = lowered.find(needle);
+  if (at == std::string::npos) {
+    return {};
+  }
+  size_t start = at + needle.size();
+  while (start < raw_headers.size() && raw_headers[start] == ' ') {
+    ++start;
+  }
+  const size_t end = raw_headers.find("\r\n", start);
+  return raw_headers.substr(
+      start, end == std::string::npos ? std::string::npos : end - start);
+}
+
 // True when the request carries an Origin header.
 //
 // Only a browser sets Origin, and no browser is a legitimate client of this
@@ -439,7 +618,10 @@ bool CarriesOrigin(const std::string& raw_headers) {
 // Reads until the header terminator, then exactly Content-Length bytes.
 // Returns false when the peer is malformed or over budget, having already
 // written the refusal.
-bool ReadRequest(const int fd, const size_t max_body, std::string* out_body) {
+bool ReadRequest(const int fd,
+                 const size_t max_body,
+                 std::string* out_body,
+                 std::string* out_headers) {
   std::string buffer;
   size_t header_end = std::string::npos;
 
@@ -482,9 +664,11 @@ bool ReadRequest(const int fd, const size_t max_body, std::string* out_body) {
     return false;
   }
 
+  *out_headers = buffer.substr(0, header_end);
+
   // Header names are case-insensitive, so match on a lowered copy while
   // keeping the original for the body split.
-  std::string lowered = buffer.substr(0, header_end);
+  std::string lowered = *out_headers;
   for (char& c : lowered) {
     c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
   }
@@ -568,17 +752,24 @@ std::string EventFrame(const std::string& json) {
 // on the registry's watcher thread, and blocking here would stop every other
 // provider's notifications too. Such a client is dropped: a partial frame
 // would desynchronise the stream, and there is no way to resend.
-void Broadcast(const std::string& json) {
+// `uri` empty means the event is not resource-scoped (a list_changed), which
+// every stream receives: there is nothing to filter it against.
+void Broadcast(const std::string& json, const std::string& uri = {}) {
   Transport& t = TheTransport();
   const std::string frame = EventFrame(json);
 
   const std::lock_guard<std::mutex> lock(t.streams_mutex);
   auto it = t.streams.begin();
   while (it != t.streams.end()) {
+    if (!uri.empty() && !StreamWantsLocked(t, *it, uri)) {
+      ++it;
+      continue;
+    }
     size_t sent = 0;
     bool alive = true;
     while (sent < frame.size()) {
-      const ssize_t n = ::write(*it, frame.data() + sent, frame.size() - sent);
+      const ssize_t n =
+          ::write(it->fd, frame.data() + sent, frame.size() - sent);
       if (n < 0) {
         if (errno == EINTR) {
           continue;
@@ -592,7 +783,7 @@ void Broadcast(const std::string& json) {
       ++it;
       continue;
     }
-    ::close(*it);
+    ::close(it->fd);
     it = t.streams.erase(it);
   }
 }
@@ -610,12 +801,15 @@ void OnRegistryNotification(const IhsMcpNotification kind,
   const std::string resource = uri != nullptr ? uri : "";
   Broadcast(R"({"jsonrpc":"2.0","method":"notifications/resources/updated")"
             R"(,"params":{"uri":)" +
-            Escape(resource) + "}}");
+                Escape(resource) + "}}",
+            resource);
 }
 
 // Turns an accepted connection into an event stream. Returns false when the
 // client did not ask for one, leaving it to be served as an ordinary request.
-bool TryOpenEventStream(const int fd, const std::string& headers) {
+bool TryOpenEventStream(const int fd,
+                        const std::string& headers,
+                        const std::string& session) {
   // A GET asking for the event-stream media type is how MCP's Streamable HTTP
   // transport opens the server-to-client direction.
   if (headers.rfind("GET ", 0) != 0) {
@@ -651,7 +845,7 @@ bool TryOpenEventStream(const int fd, const std::string& headers) {
 
   Transport& t = TheTransport();
   const std::lock_guard<std::mutex> lock(t.streams_mutex);
-  t.streams.push_back(fd);
+  t.streams.push_back(Stream{fd, session});
   return true;
 }
 
@@ -685,30 +879,43 @@ bool ServeConnection(const int fd, const size_t max_body) {
                                 R"({"error":"origin not allowed"})"));
       return false;
     }
-    if (TryOpenEventStream(fd, headers)) {
+    // The stream carries the session so notifications can be filtered to
+    // what it subscribed to; absent, it is an unfiltered stream.
+    if (TryOpenEventStream(fd, headers,
+                           HeaderValue(headers, "mcp-session-id:"))) {
       Transport& t = TheTransport();
       const std::lock_guard<std::mutex> lock(t.streams_mutex);
       // Kept open only if it actually joined the registry; a refused GET was
       // answered and is finished with.
-      return std::find(t.streams.begin(), t.streams.end(), fd) !=
+      return std::find_if(t.streams.begin(), t.streams.end(),
+                          [fd](const Stream& s) { return s.fd == fd; }) !=
              t.streams.end();
     }
     return false;
   }
 
   std::string body;
-  if (!ReadRequest(fd, max_body, &body)) {
+  std::string headers;
+  if (!ReadRequest(fd, max_body, &body, &headers)) {
     return false;  // ReadRequest already answered, or the peer went away
   }
 
-  const std::string response = Dispatch(body);
+  std::string new_session;
+  const std::string response =
+      Dispatch(body, HeaderValue(headers, "mcp-session-id:"), &new_session);
   if (response.empty()) {
     // A notification. HTTP still needs a reply, and 202 says "taken, nothing
     // to return" without inventing a JSON-RPC response the client must ignore.
     WriteAll(fd, HttpResponse(202, "Accepted", ""));
     return false;
   }
-  WriteAll(fd, HttpResponse(200, "OK", response));
+  // initialize answers with the session it minted. In the header rather than
+  // the result body, which is where the Streamable HTTP transport puts it and
+  // means no invented field in a response the specification defines.
+  const std::string extra = new_session.empty()
+                                ? std::string()
+                                : "Mcp-Session-Id: " + new_session + "\r\n";
+  WriteAll(fd, HttpResponse(200, "OK", response, extra));
   return false;
 }
 
@@ -947,10 +1154,13 @@ void ihs_mcp_transport_stop() {
   // Closing a stream is how a client learns the server is gone: there is no
   // "goodbye" event, and the specification expects the transport to end.
   const std::lock_guard<std::mutex> streams_lock(t.streams_mutex);
-  for (const int stream : t.streams) {
-    ::close(stream);
+  for (const Stream& stream : t.streams) {
+    ::close(stream.fd);
   }
   t.streams.clear();
+  // Subscriptions describe streams that no longer exist, and a restart mints
+  // new session ids, so nothing here could be matched again.
+  t.subscriptions.clear();
 }
 
 bool ihs_mcp_transport_running() {

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <poll.h>
+#include <sys/eventfd.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
@@ -467,4 +469,256 @@ TEST_F(McpTransportTest, StopClosesOpenStreams) {
   const ssize_t n = ::read(fd, chunk, sizeof(chunk));
   EXPECT_EQ(n, 0) << "expected end of stream, got " << n;
   ::close(fd);
+}
+
+namespace {
+
+// Opens a stream that identifies a session, so notifications to it can be
+// filtered by what that session subscribed to.
+int OpenStreamAs(const std::string& path,
+                 const std::string& session,
+                 std::string* out_headers) {
+  const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) {
+    return -1;
+  }
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::strncpy(address.sun_path, path.c_str(), sizeof(address.sun_path) - 1);
+  if (::connect(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) !=
+      0) {
+    ::close(fd);
+    return -1;
+  }
+  const std::string request =
+      "GET /mcp HTTP/1.1\r\nAccept: text/event-stream\r\n"
+      "Mcp-Session-Id: " +
+      session + "\r\n\r\n";
+  if (::write(fd, request.data(), request.size()) < 0) {
+    ::close(fd);
+    return -1;
+  }
+  char chunk[1024];
+  const ssize_t n = ::read(fd, chunk, sizeof(chunk));
+  if (n <= 0) {
+    ::close(fd);
+    return -1;
+  }
+  out_headers->assign(chunk, static_cast<size_t>(n));
+  return fd;
+}
+
+std::string SessionFrom(const std::string& response) {
+  const size_t at = response.find("Mcp-Session-Id: ");
+  if (at == std::string::npos) {
+    return {};
+  }
+  const size_t start = at + std::strlen("Mcp-Session-Id: ");
+  return response.substr(start, response.find("\r\n", start) - start);
+}
+
+std::string Subscribe(const std::string& path,
+                      const std::string& session,
+                      const std::string& uri,
+                      const char* method = "resources/subscribe") {
+  const std::string body =
+      std::string(R"({"jsonrpc":"2.0","id":90,"method":")") + method +
+      R"(","params":{"uri":")" + uri + R"("}})";
+  return Send(path, "POST / HTTP/1.1\r\nMcp-Session-Id: " + session +
+                        "\r\nContent-Length: " + std::to_string(body.size()) +
+                        "\r\n\r\n" + body);
+}
+
+// Reads whatever the stream has, without blocking past a short grace period.
+std::string DrainStream(const int fd, const int millis = 400) {
+  std::string out;
+  pollfd p{fd, POLLIN, 0};
+  while (::poll(&p, 1, millis) > 0 && (p.revents & POLLIN) != 0) {
+    char chunk[2048];
+    const ssize_t n = ::read(fd, chunk, sizeof(chunk));
+    if (n <= 0) {
+      break;
+    }
+    out.append(chunk, static_cast<size_t>(n));
+  }
+  return out;
+}
+
+}  // namespace
+
+// initialize is where a session comes from: every request is Connection:
+// close, so a connection cannot be one.
+TEST_F(McpTransportTest, InitializeMintsASession) {
+  const std::string response =
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})");
+  const std::string session = SessionFrom(response);
+  EXPECT_EQ(session.size(), 32u) << response;
+  // Two clients must not be handed the same one.
+  const std::string other = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  EXPECT_NE(session, other);
+}
+
+// The capability was advertised in initialize before any method implemented
+// it, so a client that took the advertisement at its word got
+// "method not found".
+TEST_F(McpTransportTest, SubscribeIsImplementedNotJustAdvertised) {
+  const std::string session = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  ASSERT_FALSE(session.empty());
+  const std::string body = Body(Subscribe(path_, session, "ui://"));
+  EXPECT_EQ(body.find("-32601"), std::string::npos) << body;
+  EXPECT_NE(body.find(R"("result")"), std::string::npos) << body;
+}
+
+// The filter belongs to a session, and the session comes from the header. A
+// body-supplied one would let a client redirect another client's stream.
+TEST_F(McpTransportTest, SubscribeWithoutASessionIsRefused) {
+  const std::string body = Body(Post(path_, R"({"jsonrpc":"2.0","id":91,)"
+                                            R"("method":"resources/subscribe",)"
+                                            R"("params":{"uri":"ui://"}})"));
+  EXPECT_NE(body.find("-32602"), std::string::npos) << body;
+}
+
+TEST_F(McpTransportTest, SubscribeWithoutAUriIsRefused) {
+  const std::string session = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  const std::string request =
+      R"({"jsonrpc":"2.0","id":92,"method":"resources/subscribe"})";
+  const std::string body = Body(
+      Send(path_, "POST / HTTP/1.1\r\nMcp-Session-Id: " + session +
+                      "\r\nContent-Length: " + std::to_string(request.size()) +
+                      "\r\n\r\n" + request));
+  EXPECT_NE(body.find("-32602"), std::string::npos) << body;
+}
+
+namespace {
+
+// The smallest provider that can be registered and signalled. Notifications
+// originate in the registry's watcher, so a real provider is the only way to
+// exercise delivery end to end.
+struct SignallingProvider {
+  static int ListTools(void*, const IhsMcpToolDesc** out, size_t* count) {
+    *out = nullptr;
+    *count = 0;
+    return IHS_MCP_OK;
+  }
+  static int ListResources(void*,
+                           const IhsMcpResourceDesc** out,
+                           size_t* count) {
+    *out = nullptr;
+    *count = 0;
+    return IHS_MCP_OK;
+  }
+  static int CallTool(void*, const char*, const char*, size_t, IhsMcpPayload*) {
+    return IHS_MCP_ERR_NOT_FOUND;
+  }
+  static int ReadResource(void*, const char*, IhsMcpPayload*) {
+    return IHS_MCP_ERR_NOT_FOUND;
+  }
+};
+
+}  // namespace
+
+// The point of the whole thing: a stream subscribed to one scheme must not be
+// woken by another's traffic. Driven through a real provider signal rather
+// than by calling the sink, because the URI the registry reports is decided
+// there and is the thing being filtered on.
+TEST_F(McpTransportTest, NotificationsGoOnlyToStreamsThatSubscribed) {
+  const std::string a = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  const std::string b = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  ASSERT_FALSE(a.empty());
+  ASSERT_FALSE(b.empty());
+
+  // Subscribed to the concrete resource, not the scheme the registry will
+  // report -- which is exactly the mismatch a naive equality check drops.
+  ASSERT_NE(
+      Body(Subscribe(path_, a, "ui://semantics/tree")).find(R"("result")"),
+      std::string::npos);
+  ASSERT_NE(Body(Subscribe(path_, b, "other://elsewhere")).find(R"("result")"),
+            std::string::npos);
+
+  std::string headers;
+  const int subscribed = OpenStreamAs(path_, a, &headers);
+  const int uninterested = OpenStreamAs(path_, b, &headers);
+  const int unfiltered = OpenStream(path_, &headers);  // never subscribed
+  ASSERT_GE(subscribed, 0);
+  ASSERT_GE(uninterested, 0);
+  ASSERT_GE(unfiltered, 0);
+
+  SignallingProvider mock;
+  const int notify = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+  ASSERT_GE(notify, 0);
+  IhsMcpProviderDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = "ui-test";
+  desc.tool_prefix = "ui_";
+  desc.resource_scheme = "ui";
+  desc.capability_mask = IHS_MCP_CAP_ALL;
+  desc.notify_fd = notify;
+  desc.user_data = &mock;
+  desc.callbacks.list_tools = &SignallingProvider::ListTools;
+  desc.callbacks.list_resources = &SignallingProvider::ListResources;
+  desc.callbacks.call_tool = &SignallingProvider::CallTool;
+  desc.callbacks.read_resource = &SignallingProvider::ReadResource;
+  IhsMcpProvider* provider = nullptr;
+  ASSERT_EQ(ihs_mcp_provider_register(&desc, &provider), IHS_MCP_OK);
+
+  const uint64_t one = 1;
+  ASSERT_EQ(::write(notify, &one, sizeof(one)),
+            static_cast<ssize_t>(sizeof(one)));
+
+  const std::string got_subscribed = DrainStream(subscribed);
+  const std::string got_uninterested = DrainStream(uninterested);
+  const std::string got_unfiltered = DrainStream(unfiltered);
+
+  EXPECT_NE(got_subscribed.find("resources/updated"), std::string::npos)
+      << "a subscription to the concrete URI must still match the scheme the "
+         "registry reports: ["
+      << got_subscribed << "]";
+  EXPECT_EQ(got_uninterested.find("resources/updated"), std::string::npos)
+      << "subscribed elsewhere, so this update was not its business: ["
+      << got_uninterested << "]";
+  EXPECT_NE(got_unfiltered.find("resources/updated"), std::string::npos)
+      << "a stream that never subscribed kept the old firehose: ["
+      << got_unfiltered << "]";
+
+  // tools/list_changed is not resource-scoped, so it is not filtered: every
+  // stream needs it, including the one subscribed to another scheme.
+  EXPECT_NE(got_uninterested.find("tools/list_changed"), std::string::npos)
+      << got_uninterested;
+
+  ihs_mcp_provider_unregister(provider);
+  ::close(notify);
+  ::close(subscribed);
+  ::close(uninterested);
+  ::close(unfiltered);
+}
+
+// Providers register at any point in a session, so a subscribe that arrives
+// before the provider owning the scheme is not a failure. Refusing it would
+// make the result depend on a startup race the client cannot see.
+TEST_F(McpTransportTest, SubscribeBeforeAnyProviderIsAccepted) {
+  const std::string session = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  ASSERT_FALSE(session.empty());
+  const std::string body =
+      Body(Subscribe(path_, session, "nobody-claims-this://x"));
+  EXPECT_NE(body.find(R"("result")"), std::string::npos) << body;
+}
+
+// Unsubscribing from the last URI restores the unfiltered stream rather than
+// leaving an empty set, which the filter would otherwise read as "everything"
+// anyway -- the two must not disagree.
+TEST_F(McpTransportTest, UnsubscribingFromTheLastUriRestoresEverything) {
+  const std::string session = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  ASSERT_FALSE(session.empty());
+  ASSERT_NE(Body(Subscribe(path_, session, "ui://")).find(R"("result")"),
+            std::string::npos);
+  const std::string body =
+      Body(Subscribe(path_, session, "ui://", "resources/unsubscribe"));
+  EXPECT_NE(body.find(R"("result")"), std::string::npos) << body;
 }


### PR DESCRIPTION
Every SSE stream received every notification. Now a stream receives what its session asked for.

## `subscribe` was advertised but not implemented

`initialize` has reported `resources.subscribe: true` since the event stream landed, and **no method implemented it** — a client that took the advertisement at its word got `-32601 method not found`. That is the same failure the comment directly above that capability warns about, in its own words: *"a client told to expect notifications that never arrive waits instead of polling."*

## Subscriptions belong to a session, not a connection

Every request here is `Connection: close`, so **the POST that subscribes is never the connection the stream is on**. Only a session id ties them together. `initialize` now mints one and returns it in `Mcp-Session-Id` — the header, where the Streamable HTTP transport puts it, rather than as an invented field in a result the spec already defines.

## Matching is containment, not equality

This is the part that would have quietly broken everything. The two names are not at the same granularity:

- the registry reports **`ui://`** — a provider signals that *something under its scheme* changed
- a client subscribes to **`ui://semantics/tree`** — what `resources/list` actually advertises

**An equality check matches neither, and would filter out every real subscriber's notifications.** So a match is containment in either direction, and the coarser name governs. The honest consequence: the practical resolution is **per-provider, not per-resource**, and it sharpens on its own if providers start naming the resource that changed. I'd rather say that than claim finer filtering than exists.

## An unsubscribed stream still gets everything

"Subscribed to nothing" and "not interested in filtering" are indistinguishable, so the reading that keeps delivering is the safe one. This matters concretely: **`scripts/mcp_inspector.py` opens a stream with no session** and depends on `resources/updated`. Adding filtering must not silently stop an existing client's notifications, and it doesn't — all pre-existing stream tests pass untouched.

## Providers are told, and a missing one is not an error

Subscribes go to `ihs_mcp_registry_subscribe` so the provider owning the scheme can start or stop work — the designed path, which I had initially bypassed.

A scheme no provider claims is **deliberately accepted**. Providers register at any point in a session, which is an explicit property of the registry rather than an accident, so refusing would turn "subscribed before the provider came up" into a failure and make the result depend on a startup race the client cannot see. The subscription is recorded either way and starts matching when the provider appears.

`tools/list_changed` is not resource-scoped and still reaches every stream.

## Testing

Driven through **a real provider signal**, not by calling the sink directly — the URI being filtered on is decided in the registry, so calling the sink would test the wrong string. One notification, three streams:

| Stream | Subscribed to | Receives `resources/updated` |
|---|---|---|
| A | `ui://semantics/tree` | yes — concrete URI still matches the scheme reported |
| B | `other://elsewhere` | no |
| C | nothing | yes — the pre-existing firehose |

Ablating the filter fails exactly the middle assertion, so the test is not vacuous.

37 transport tests (up from 30), 28/28 ctest, clang-tidy, `format.sh` and the config-reference gate clean.
