### PR TITLE
mcp: action tools report post-action state

### DIFF
--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -489,6 +489,67 @@ const IhsSemanticsSnapshot* WaitForNewerSnapshot(const uint64_t generation,
   return nullptr;
 }
 
+// How long an action waits for the tree to settle before reporting what it
+// sees (DR-8).
+//
+// A bound on waiting, not an expectation: an action that changes nothing pays
+// this in full, which is the cost of answering "did anything happen" in the
+// same round trip as the act. Longer than a frame because the framework has
+// to run the handler, rebuild, lay out and republish before the change is
+// visible here, and a bound tight enough to miss that would report "no
+// change" for actions that did change something -- the one wrong answer that
+// looks like a real result.
+constexpr int kVerifySettleMs = 150;
+
+// Appends the verify-after-act fields to a tool result (DR-8, plan 4.1).
+//
+// generation_after equal to generation_before is a real answer rather than a
+// failure: the action was accepted and the tree did not change, which is what
+// firing a network call or toggling something the semantics do not describe
+// looks like. Reporting it as an error would make a client retry an action
+// that already happened.
+void WriteOutcome(rapidjson::Writer<rapidjson::StringBuffer>& w,
+                  const char* mode,
+                  const uint64_t generation_before,
+                  const int32_t node_id,
+                  const bool report_node) {
+  const IhsSemanticsSnapshot* after =
+      WaitForNewerSnapshot(generation_before, kVerifySettleMs);
+  if (after == nullptr) {
+    // Nothing newer arrived. Read the current tree anyway rather than assuming
+    // it still matches: the wait can only end early on a newer generation, so
+    // this is the same tree, and looking is cheaper than reasoning about it.
+    after = ihs_semantics_acquire_snapshot();
+  }
+
+  w.Key("mode");
+  w.String(mode);
+  w.Key("generation_before");
+  w.Uint64(generation_before);
+  w.Key("generation_after");
+  w.Uint64(after != nullptr ? ihs_semantics_snapshot_generation(after)
+                            : generation_before);
+
+  if (report_node) {
+    const IhsSemanticsNode* node =
+        after != nullptr ? ihs_semantics_snapshot_node_by_id(after, node_id)
+                         : nullptr;
+    w.Key("node_after");
+    if (node == nullptr) {
+      // The node left the tree. A route change does exactly this, and it is
+      // the normal outcome of tapping something that navigates -- null says
+      // "gone" without dressing a successful action as a failure.
+      w.Null();
+    } else {
+      WriteNode(w, node, after);
+    }
+  }
+
+  if (after != nullptr) {
+    ihs_semantics_release_snapshot(after);
+  }
+}
+
 // Resolves the node a tool call names, by id or by identifier.
 const IhsSemanticsNode* ResolveNode(const IhsSemanticsSnapshot* snapshot,
                                     const char* arguments) {
@@ -666,9 +727,11 @@ int CallTool(void* /* user_data */,
       return IHS_MCP_ERR_REFUSED;
     }
 
-    // Deliberately does not claim a target. Nothing here knows what was under
-    // the point, and reporting a node would be inventing the confirmation the
-    // caller chose this tool to go without.
+    // Still claims no target: nothing here knows what was under the point, and
+    // naming a node would invent the confirmation the caller chose this tool
+    // to go without. The generations are reported regardless -- "the tree
+    // changed" is exactly the evidence a coordinate tap otherwise lacks, and
+    // it is the only thing this tool can honestly say about its effect.
     rapidjson::StringBuffer tap_buffer;
     rapidjson::Writer<rapidjson::StringBuffer> tap_writer(tap_buffer);
     tap_writer.StartObject();
@@ -680,8 +743,8 @@ int CallTool(void* /* user_data */,
     tap_writer.Double(x);
     tap_writer.Key("y");
     tap_writer.Double(y);
-    tap_writer.Key("generation_before");
-    tap_writer.Uint64(generation_now);
+    WriteOutcome(tap_writer, "pointer", generation_now, 0,
+                 /*report_node=*/false);
     tap_writer.EndObject();
     FillPayload(out_result, tap_buffer.GetString());
     return IHS_MCP_OK;
@@ -795,10 +858,6 @@ int CallTool(void* /* user_data */,
     return IHS_MCP_ERR_REFUSED;
   }
 
-  // Report the generation the decision was made against. A client that wants
-  // to know what changed re-reads the tree and compares; the hub cannot say
-  // here whether the widget did anything, and pretending otherwise would be
-  // worse than saying nothing.
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> w(buffer);
   w.StartObject();
@@ -806,8 +865,7 @@ int CallTool(void* /* user_data */,
   w.Bool(true);
   w.Key("node_id");
   w.Int(node_id);
-  w.Key("generation_before");
-  w.Uint64(generation);
+  WriteOutcome(w, "semantics", generation, node_id, /*report_node=*/true);
   w.EndObject();
   FillPayload(out_result, buffer.GetString());
   return IHS_MCP_OK;

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -24,9 +24,11 @@
 #include <mutex>
 #include "gtest/gtest.h"
 
+#include <functional>
 #include "ihs/ihs_mcp_provider.h"
 #include "ihs/ihs_mcp_registry.h"
 #include "ihs/ihs_mcp_semantics.h"
+
 #include "ihs/ihs_semantics.h"
 #include "ihs/ihs_semantics_host.h"
 
@@ -43,6 +45,13 @@ struct MockHost {
   // the shell will encode from.
   std::vector<uint8_t> last_data;
   bool semantics_enabled = false;
+  int pointer_taps = 0;
+
+  // Called from inside the dispatch, so a test can republish the tree the way
+  // the framework would after handling the action. That is the case
+  // verify-after-act exists for: without it every action looks like one that
+  // changed nothing.
+  std::function<void()> on_dispatch;
 };
 
 MockHost* g_host = nullptr;
@@ -61,6 +70,17 @@ int OnDispatch(void* /*user_data*/,
   g_host->last_node_id = node_id;
   g_host->last_action = action;
   g_host->last_data.assign(data, data + (data == nullptr ? 0 : data_length));
+  if (g_host->on_dispatch) {
+    g_host->on_dispatch();
+  }
+  return IHS_SEMANTICS_OK;
+}
+
+int OnPointerTap(void* /*user_data*/,
+                 int64_t /*view_id*/,
+                 double /*x*/,
+                 double /*y*/) {
+  g_host->pointer_taps++;
   return IHS_SEMANTICS_OK;
 }
 
@@ -119,6 +139,7 @@ class McpSemanticsProviderTest : public ::testing::Test {
     host.struct_size = sizeof(IhsSemanticsHost);
     host.set_semantics_enabled = OnEnable;
     host.dispatch = OnDispatch;
+    host.send_pointer_tap = OnPointerTap;
     ihs_semantics_set_host(&host);
     ihs_semantics_clear();
     ASSERT_EQ(ihs_mcp_semantics_provider_start(), IHS_MCP_OK);
@@ -521,4 +542,107 @@ TEST_F(McpSemanticsProviderTest, PublishingATreeNotifiesTheServer) {
   ASSERT_EQ(ihs_mcp_registry_set_notification_sink(nullptr, nullptr),
             IHS_MCP_OK);
   g_notify = nullptr;
+}
+
+// DR-8: an action reports what the tree looks like afterwards, so an agent
+// gets act-and-verify in one round trip instead of acting blind and re-reading.
+TEST_F(McpSemanticsProviderTest, ActionReportsThePostActionNode) {
+  TreeBuilder before;
+  before.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& slider =
+      before.Add(12, "Temperature", IHS_SEMANTICS_ROLE_SLIDER);
+  slider.actions = IHS_SEMANTICS_ACTION_INCREASE;
+  slider.value = "21.0";
+  ASSERT_EQ(before.Publish(), IHS_SEMANTICS_OK);
+
+  // The framework handles the action and republishes, which is what makes the
+  // new value visible at all.
+  TreeBuilder after;
+  host_.on_dispatch = [&after]() {
+    after.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+    IhsSemanticsPublishNode& moved =
+        after.Add(12, "Temperature", IHS_SEMANTICS_ROLE_SLIDER);
+    moved.actions = IHS_SEMANTICS_ACTION_INCREASE;
+    moved.value = "22.0";
+    after.Publish();
+  };
+
+  int status = 0;
+  const std::string body =
+      CallTool("ui_increase", R"({"node_id":12})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  EXPECT_TRUE(Contains(body, "\"mode\":\"semantics\"")) << body;
+  EXPECT_TRUE(Contains(body, "\"node_after\"")) << body;
+  // The point of the whole feature: the caller learns the new value without
+  // a second call.
+  EXPECT_TRUE(Contains(body, "22.0")) << body;
+  EXPECT_FALSE(Contains(body, "21.0")) << body;
+}
+
+// A tap that navigates takes its own node out of the tree. That is a
+// successful action, not a failure, so it is reported as null rather than an
+// error a client would retry.
+TEST_F(McpSemanticsProviderTest, NodeThatLeftTheTreeIsNullNotAnError) {
+  TreeBuilder before;
+  before.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& link =
+      before.Add(7, "Next", IHS_SEMANTICS_ROLE_LINK);
+  link.actions = IHS_SEMANTICS_ACTION_TAP;
+  ASSERT_EQ(before.Publish(), IHS_SEMANTICS_OK);
+
+  TreeBuilder route;
+  host_.on_dispatch = [&route]() {
+    route.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+    route.Add(99, "Second page", IHS_SEMANTICS_ROLE_PANE);
+    route.Publish();
+  };
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":7})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_TRUE(Contains(body, "\"node_after\":null")) << body;
+}
+
+// An action that changes nothing visible -- firing a network call, say --
+// reports equal generations. That is an answer, and treating it as a failure
+// would make a client retry something that already happened.
+TEST_F(McpSemanticsProviderTest, NoTreeChangeIsAnAnswerNotAFailure) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& button =
+      tree.Add(3, "Sync", IHS_SEMANTICS_ROLE_BUTTON);
+  button.actions = IHS_SEMANTICS_ACTION_TAP;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":3})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_EQ(host_.dispatch_calls, 1);
+  // The node is still there and reported; only the generations say nothing
+  // moved.
+  EXPECT_TRUE(Contains(body, "\"node_after\"")) << body;
+  EXPECT_FALSE(Contains(body, "\"node_after\":null")) << body;
+
+  const size_t before_at = body.find("\"generation_before\":");
+  const size_t after_at = body.find("\"generation_after\":");
+  ASSERT_NE(before_at, std::string::npos) << body;
+  ASSERT_NE(after_at, std::string::npos) << body;
+  EXPECT_EQ(body.substr(before_at + 20, 3), body.substr(after_at + 19, 3))
+      << body;
+}
+
+// A coordinate tap still names no target -- nothing knows what was under the
+// point -- but it can say whether the tree moved, which is the only evidence
+// of effect available to it.
+TEST_F(McpSemanticsProviderTest, PointerTapReportsModeButNoNode) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body =
+      CallTool("ui_tap_at", R"({"x":10.0,"y":20.0})", &status);
+  EXPECT_TRUE(Contains(body, "\"mode\":\"pointer\"")) << body;
+  EXPECT_TRUE(Contains(body, "\"generation_after\"")) << body;
+  EXPECT_FALSE(Contains(body, "\"node_after\"")) << body;
 }


### PR DESCRIPTION
## Before

An action answered with an acknowledgement and the generation it *decided against*:

```json
{"dispatched": true, "node_id": 12, "generation_before": 4182}
```

The old comment was honest about the gap — *"the hub cannot say here whether the widget did anything"* — which left every agent to re-read the tree and diff it to find out.

## Now

```json
{"dispatched": true, "node_id": 12, "mode": "semantics",
 "generation_before": 4182, "generation_after": 4185,
 "node_after": {"id": 12, "value": "22.0", ...}}
```

Act and verify in one round trip. Purely additive — no existing field changed.

## Three outcomes, all normal results rather than errors

| Case | Reported as | Why it matters |
|---|---|---|
| The node changed | `node_after` with new state | The caller learns the new value without a second call |
| **The node left the tree** | `"node_after": null` | Tapping something that *navigates* does exactly this. Calling it an error would have clients retry an action that already succeeded |
| **Nothing changed** | equal generations | An action can legitimately have no visible effect — firing a network call. Saying so is an answer, not a failure |

`ui_tap_at` reports `mode: "pointer"` and the generations but **still names no node**: nothing there knows what was under the point, and naming one would invent the confirmation that tool exists to go without. Whether the tree moved is the only evidence of effect it can honestly offer.

## On the wait

A bound, not an expectation. An action that rebuilds returns in about a poll interval; only one that changes nothing pays the full 150 ms.

It is deliberately longer than a frame. The framework must run the handler, rebuild, lay out and republish before a change is visible here — **and a bound tight enough to miss that would report "no change" for actions that did change something**, which is the one wrong answer that looks like a real result.

## Testing

The mock host now republishes **from inside the dispatch**, the way the framework would. Without that hook the case this feature exists for cannot occur at all, and the tests would have been asserting against a tree that never moves:

- a slider at `21.0` increments and the response carries `22.0`, with `21.0` absent
- a tap that swaps the route reports `"node_after": null`, status OK
- a tap that changes nothing reports equal generations and the node still present, status OK
- `ui_tap_at` reports pointer mode with no `node_after`

One incidental fix: the mock host had no `send_pointer_tap`, so `ui_tap_at` was being refused by the hub before reaching any of this.

27 provider tests (up from 23), 28/28 ctest, clang-tidy, `format.sh` and the config-reference gate clean.

## Remaining

Custom actions as tools, `ui_query` selector expansion, and notification debounce.
