### PR TITLE
mcp: make custom actions invocable, not just discoverable

### DIFF
--- a/shared/include/ihs/ihs_semantics.h
+++ b/shared/include/ihs/ihs_semantics.h
@@ -459,6 +459,14 @@ typedef void (*IhsSemanticsDoneCallback)(int status, void* user_data);
  *                                          base, then extent
  *   IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET  two doubles in native byte order:
  *                                          dx, then dy
+ *   IHS_SEMANTICS_ACTION_CUSTOM_ACTION     one int32 in native byte order: the
+ *                                          id from the node's
+ *                                          custom_action_ids. Required, not
+ *                                          optional -- the id is the only
+ *                                          thing naming which of a node's
+ *                                          custom actions to run, and the
+ *                                          framework resolves the handler by
+ *                                          it
  *
  * A buffer that does not match the action's layout, or one supplied for an
  * action that takes no argument, fails with IHS_SEMANTICS_ERR_INVALID. The

--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -489,6 +489,67 @@ const IhsSemanticsSnapshot* WaitForNewerSnapshot(const uint64_t generation,
   return nullptr;
 }
 
+// How long an action waits for the tree to settle before reporting what it
+// sees (DR-8).
+//
+// A bound on waiting, not an expectation: an action that changes nothing pays
+// this in full, which is the cost of answering "did anything happen" in the
+// same round trip as the act. Longer than a frame because the framework has
+// to run the handler, rebuild, lay out and republish before the change is
+// visible here, and a bound tight enough to miss that would report "no
+// change" for actions that did change something -- the one wrong answer that
+// looks like a real result.
+constexpr int kVerifySettleMs = 150;
+
+// Appends the verify-after-act fields to a tool result (DR-8, plan 4.1).
+//
+// generation_after equal to generation_before is a real answer rather than a
+// failure: the action was accepted and the tree did not change, which is what
+// firing a network call or toggling something the semantics do not describe
+// looks like. Reporting it as an error would make a client retry an action
+// that already happened.
+void WriteOutcome(rapidjson::Writer<rapidjson::StringBuffer>& w,
+                  const char* mode,
+                  const uint64_t generation_before,
+                  const int32_t node_id,
+                  const bool report_node) {
+  const IhsSemanticsSnapshot* after =
+      WaitForNewerSnapshot(generation_before, kVerifySettleMs);
+  if (after == nullptr) {
+    // Nothing newer arrived. Read the current tree anyway rather than assuming
+    // it still matches: the wait can only end early on a newer generation, so
+    // this is the same tree, and looking is cheaper than reasoning about it.
+    after = ihs_semantics_acquire_snapshot();
+  }
+
+  w.Key("mode");
+  w.String(mode);
+  w.Key("generation_before");
+  w.Uint64(generation_before);
+  w.Key("generation_after");
+  w.Uint64(after != nullptr ? ihs_semantics_snapshot_generation(after)
+                            : generation_before);
+
+  if (report_node) {
+    const IhsSemanticsNode* node =
+        after != nullptr ? ihs_semantics_snapshot_node_by_id(after, node_id)
+                         : nullptr;
+    w.Key("node_after");
+    if (node == nullptr) {
+      // The node left the tree. A route change does exactly this, and it is
+      // the normal outcome of tapping something that navigates -- null says
+      // "gone" without dressing a successful action as a failure.
+      w.Null();
+    } else {
+      WriteNode(w, node, after);
+    }
+  }
+
+  if (after != nullptr) {
+    ihs_semantics_release_snapshot(after);
+  }
+}
+
 // Resolves the node a tool call names, by id or by identifier.
 const IhsSemanticsNode* ResolveNode(const IhsSemanticsSnapshot* snapshot,
                                     const char* arguments) {
@@ -666,9 +727,11 @@ int CallTool(void* /* user_data */,
       return IHS_MCP_ERR_REFUSED;
     }
 
-    // Deliberately does not claim a target. Nothing here knows what was under
-    // the point, and reporting a node would be inventing the confirmation the
-    // caller chose this tool to go without.
+    // Still claims no target: nothing here knows what was under the point, and
+    // naming a node would invent the confirmation the caller chose this tool
+    // to go without. The generations are reported regardless -- "the tree
+    // changed" is exactly the evidence a coordinate tap otherwise lacks, and
+    // it is the only thing this tool can honestly say about its effect.
     rapidjson::StringBuffer tap_buffer;
     rapidjson::Writer<rapidjson::StringBuffer> tap_writer(tap_buffer);
     tap_writer.StartObject();
@@ -680,8 +743,8 @@ int CallTool(void* /* user_data */,
     tap_writer.Double(x);
     tap_writer.Key("y");
     tap_writer.Double(y);
-    tap_writer.Key("generation_before");
-    tap_writer.Uint64(generation_now);
+    WriteOutcome(tap_writer, "pointer", generation_now, 0,
+                 /*report_node=*/false);
     tap_writer.EndObject();
     FillPayload(out_result, tap_buffer.GetString());
     return IHS_MCP_OK;
@@ -795,10 +858,6 @@ int CallTool(void* /* user_data */,
     return IHS_MCP_ERR_REFUSED;
   }
 
-  // Report the generation the decision was made against. A client that wants
-  // to know what changed re-reads the tree and compares; the hub cannot say
-  // here whether the widget did anything, and pretending otherwise would be
-  // worse than saying nothing.
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> w(buffer);
   w.StartObject();
@@ -806,8 +865,7 @@ int CallTool(void* /* user_data */,
   w.Bool(true);
   w.Key("node_id");
   w.Int(node_id);
-  w.Key("generation_before");
-  w.Uint64(generation);
+  WriteOutcome(w, "semantics", generation, node_id, /*report_node=*/true);
   w.EndObject();
   FillPayload(out_result, buffer.GetString());
   return IHS_MCP_OK;

--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -85,6 +85,14 @@ constexpr char kScrollToSchema[] =
     R"("dy":{"type":"number","description":"Vertical offset in logical pixels."})"
     R"(}})";
 
+constexpr char kCustomActionSchema[] =
+    R"({"type":"object","properties":{)"
+    R"("node_id":{"type":"integer"},)"
+    R"("identifier":{"type":"string"},)"
+    R"("action":{"type":"string","description":"Custom action label, exactly as the tree reports it."},)"
+    R"("action_id":{"type":"integer","description":"Custom action id, as an alternative to the label."})"
+    R"(}})";
+
 constexpr char kTapAtSchema[] =
     R"({"type":"object","properties":{)"
     R"("x":{"type":"number","description":"Screen x, in the same coordinates as a node rect."},)"
@@ -116,6 +124,11 @@ const ToolEntry kTools[] = {
      IHS_SEMANTICS_ACTION_SET_TEXT, IHS_MCP_CAP_INTERACT},
     {"scroll_to", "Scroll a container to a given offset.", kScrollToSchema,
      IHS_SEMANTICS_ACTION_SCROLL_TO_OFFSET, IHS_MCP_CAP_INTERACT},
+    {"custom_action",
+     "Invoke one of a node's application-defined actions, named by the label "
+     "the tree reports in custom_actions. These are the app's own verbs -- "
+     "there is no fixed set, and a node offers only what it declared.",
+     kCustomActionSchema, 0, IHS_MCP_CAP_INTERACT},
     // Action 0: this one does not dispatch a semantics action at all, and the
     // call handler routes it separately. Its description says so, because the
     // difference is the caller's to reason about -- a tap that is hit-tested
@@ -756,6 +769,86 @@ int CallTool(void* /* user_data */,
                 ErrorJson("no node matched node_id or identifier", generation));
     ihs_semantics_release_snapshot(snapshot);
     return IHS_MCP_ERR_NOT_FOUND;
+  }
+
+  // Custom actions are the application's own verbs, so they are invoked by
+  // name against a node rather than surfaced as tools of their own. A tool per
+  // custom action would mean a tool list that changes with every route, and
+  // names that collide the moment two nodes declare the same verb -- the tree
+  // already reports each node's set, which is where an agent looks anyway.
+  if (std::strcmp(name, "custom_action") == 0) {
+    if ((node->actions & IHS_SEMANTICS_ACTION_CUSTOM_ACTION) == 0) {
+      FillPayload(out_result,
+                  ErrorJson("node offers no custom actions", generation));
+      ihs_semantics_release_snapshot(snapshot);
+      return IHS_MCP_ERR_REFUSED;
+    }
+
+    std::string wanted;
+    int32_t action_id = 0;
+    const bool by_id = ExtractInt(arguments_json, "action_id", &action_id);
+    if (!by_id && !ReadStringArgument(arguments_json, "action", &wanted)) {
+      FillPayload(
+          out_result,
+          ErrorJson("custom_action requires action or action_id", generation));
+      ihs_semantics_release_snapshot(snapshot);
+      return IHS_MCP_ERR_INVALID;
+    }
+
+    // Resolved against this node's own declarations, not the snapshot's whole
+    // table: a label another node declared is not this node's to run, and
+    // dispatching it would be answered by whichever handler the framework
+    // found rather than the one the caller named.
+    bool found = false;
+    for (size_t i = 0; i < node->custom_action_count && !found; i++) {
+      const int32_t candidate = node->custom_action_ids[i];
+      if (by_id) {
+        found = candidate == action_id;
+        continue;
+      }
+      const IhsSemanticsCustomAction* declared =
+          ihs_semantics_find_custom_action(snapshot, candidate);
+      if (declared != nullptr && wanted == declared->label) {
+        action_id = candidate;
+        found = true;
+      }
+    }
+    if (!found) {
+      FillPayload(out_result,
+                  ErrorJson("node declares no such custom action", generation));
+      ihs_semantics_release_snapshot(snapshot);
+      return IHS_MCP_ERR_NOT_FOUND;
+    }
+
+    const int32_t target = node->id;
+    ihs_semantics_release_snapshot(snapshot);
+
+    std::vector<uint8_t> payload(sizeof(action_id));
+    std::memcpy(payload.data(), &action_id, sizeof(action_id));
+
+    Provider& provider = TheProvider();
+    const int custom_status = ihs_semantics_dispatch(
+        provider.consumer, 0, target, IHS_SEMANTICS_ACTION_CUSTOM_ACTION,
+        payload.data(), payload.size(), nullptr, nullptr);
+    if (custom_status != IHS_SEMANTICS_OK) {
+      FillPayload(out_result, ErrorJson("dispatch refused", generation));
+      return IHS_MCP_ERR_REFUSED;
+    }
+
+    rapidjson::StringBuffer custom_buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> custom_writer(custom_buffer);
+    custom_writer.StartObject();
+    custom_writer.Key("dispatched");
+    custom_writer.Bool(true);
+    custom_writer.Key("node_id");
+    custom_writer.Int(target);
+    custom_writer.Key("action_id");
+    custom_writer.Int(action_id);
+    WriteOutcome(custom_writer, "semantics", generation, target,
+                 /*report_node=*/true);
+    custom_writer.EndObject();
+    FillPayload(out_result, custom_buffer.GetString());
+    return IHS_MCP_OK;
   }
 
   // A disabled control is refused here rather than dispatched. The framework

--- a/shell/accessibility/semantics_action_args.cc
+++ b/shell/accessibility/semantics_action_args.cc
@@ -86,6 +86,17 @@ std::optional<std::vector<uint8_t>> EncodeActionArguments(
         flutter::EncodableValue(std::vector<double>{offset[0], offset[1]}));
   }
 
+  if (action == IHS_SEMANTICS_ACTION_CUSTOM_ACTION) {
+    if (empty || data_length != sizeof(int32_t)) {
+      return std::nullopt;
+    }
+    int32_t custom_action_id = 0;
+    std::memcpy(&custom_action_id, data, sizeof(custom_action_id));
+    // A bare int, not a map: the framework looks the handler up by this id
+    // directly, so wrapping it would not resolve to anything.
+    return Encode(flutter::EncodableValue(custom_action_id));
+  }
+
   // Every other action takes no argument. Data supplied for one of those is
   // refused rather than dropped: a caller that encoded something expects it to
   // arrive, and an action that ignores it would look like it had worked.

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -88,6 +88,15 @@ int OnPointerTap(void* /*user_data*/,
 struct TreeBuilder {
   std::vector<IhsSemanticsPublishNode> nodes;
   std::vector<std::vector<int32_t>> children;
+  std::vector<IhsSemanticsPublishCustomAction> custom_actions;
+  // Stable storage: a node points at its id list, so it must outlive Publish.
+  std::vector<std::vector<int32_t>> custom_ids;
+
+  // Declares a custom action and attaches it to the node most recently added.
+  void AddCustomAction(int32_t id, const char* label) {
+    custom_actions.push_back(IhsSemanticsPublishCustomAction{id, label, ""});
+    custom_ids.emplace_back();
+  }
 
   IhsSemanticsPublishNode& Add(int32_t id,
                                const char* label,
@@ -107,6 +116,9 @@ struct TreeBuilder {
     info.struct_size = sizeof(IhsSemanticsPublishInfo);
     info.nodes = nodes.data();
     info.node_count = nodes.size();
+    info.custom_actions =
+        custom_actions.empty() ? nullptr : custom_actions.data();
+    info.custom_action_count = custom_actions.size();
     return ihs_semantics_publish(&info);
   }
 };
@@ -645,4 +657,112 @@ TEST_F(McpSemanticsProviderTest, PointerTapReportsModeButNoNode) {
   EXPECT_TRUE(Contains(body, "\"mode\":\"pointer\"")) << body;
   EXPECT_TRUE(Contains(body, "\"generation_after\"")) << body;
   EXPECT_FALSE(Contains(body, "\"node_after\"")) << body;
+}
+
+namespace {
+
+// A node offering two application-defined verbs, which is the shape that
+// makes name resolution worth testing at all.
+void PublishWithCustomActions(TreeBuilder& tree) {
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& card = tree.Add(4, "Trip", IHS_SEMANTICS_ROLE_PANE);
+  card.actions = IHS_SEMANTICS_ACTION_CUSTOM_ACTION;
+  static const int32_t kIds[] = {71, 72};
+  card.custom_action_ids = kIds;
+  card.custom_action_count = 2;
+  tree.AddCustomAction(71, "Share");
+  tree.AddCustomAction(72, "Archive");
+}
+
+}  // namespace
+
+// The app's own verbs are invoked by the label the tree reports, which is what
+// an agent has: identifiers are absent at the deployment floor.
+TEST_F(McpSemanticsProviderTest, CustomActionIsInvokedByLabel) {
+  TreeBuilder tree;
+  PublishWithCustomActions(tree);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool(
+      "ui_custom_action", R"({"node_id":4,"action":"Archive"})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_EQ(host_.dispatch_calls, 1);
+  EXPECT_EQ(host_.last_action, IHS_SEMANTICS_ACTION_CUSTOM_ACTION);
+
+  // The id travels as the argument: it is the only thing naming which verb to
+  // run, and the framework resolves the handler by it.
+  ASSERT_EQ(host_.last_data.size(), sizeof(int32_t));
+  int32_t sent = 0;
+  std::memcpy(&sent, host_.last_data.data(), sizeof(sent));
+  EXPECT_EQ(sent, 72) << "dispatched the wrong verb";
+}
+
+TEST_F(McpSemanticsProviderTest, CustomActionMayBeNamedById) {
+  TreeBuilder tree;
+  PublishWithCustomActions(tree);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  CallTool("ui_custom_action", R"({"node_id":4,"action_id":71})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  int32_t sent = 0;
+  ASSERT_EQ(host_.last_data.size(), sizeof(sent));
+  std::memcpy(&sent, host_.last_data.data(), sizeof(sent));
+  EXPECT_EQ(sent, 71);
+}
+
+// Resolution is against the node's own declarations. A verb another node
+// declared is not this node's to run, and dispatching it would be answered by
+// whichever handler the framework found rather than the one named.
+TEST_F(McpSemanticsProviderTest, CustomActionDeclaredElsewhereIsRefused) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& first = tree.Add(4, "Trip", IHS_SEMANTICS_ROLE_PANE);
+  first.actions = IHS_SEMANTICS_ACTION_CUSTOM_ACTION;
+  static const int32_t kMine[] = {71};
+  first.custom_action_ids = kMine;
+  first.custom_action_count = 1;
+  IhsSemanticsPublishNode& second =
+      tree.Add(5, "Other", IHS_SEMANTICS_ROLE_PANE);
+  second.actions = IHS_SEMANTICS_ACTION_CUSTOM_ACTION;
+  static const int32_t kTheirs[] = {72};
+  second.custom_action_ids = kTheirs;
+  second.custom_action_count = 1;
+  tree.AddCustomAction(71, "Share");
+  tree.AddCustomAction(72, "Archive");
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool(
+      "ui_custom_action", R"({"node_id":4,"action":"Archive"})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_NOT_FOUND) << body;
+  EXPECT_EQ(host_.dispatch_calls, 0) << "dispatched another node's verb";
+}
+
+// A node that never declared any is refused before the label is even looked
+// at, like every other action it does not offer.
+TEST_F(McpSemanticsProviderTest, CustomActionOnANodeWithNoneIsRefused) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& plain =
+      tree.Add(8, "Label", IHS_SEMANTICS_ROLE_LABEL);
+  plain.actions = IHS_SEMANTICS_ACTION_TAP;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  CallTool("ui_custom_action", R"({"node_id":8,"action":"Share"})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_REFUSED);
+  EXPECT_EQ(host_.dispatch_calls, 0);
+}
+
+TEST_F(McpSemanticsProviderTest, CustomActionWithoutANameIsRefused) {
+  TreeBuilder tree;
+  PublishWithCustomActions(tree);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  CallTool("ui_custom_action", R"({"node_id":4})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_INVALID);
+  EXPECT_EQ(host_.dispatch_calls, 0);
 }

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -24,9 +24,11 @@
 #include <mutex>
 #include "gtest/gtest.h"
 
+#include <functional>
 #include "ihs/ihs_mcp_provider.h"
 #include "ihs/ihs_mcp_registry.h"
 #include "ihs/ihs_mcp_semantics.h"
+
 #include "ihs/ihs_semantics.h"
 #include "ihs/ihs_semantics_host.h"
 
@@ -43,6 +45,13 @@ struct MockHost {
   // the shell will encode from.
   std::vector<uint8_t> last_data;
   bool semantics_enabled = false;
+  int pointer_taps = 0;
+
+  // Called from inside the dispatch, so a test can republish the tree the way
+  // the framework would after handling the action. That is the case
+  // verify-after-act exists for: without it every action looks like one that
+  // changed nothing.
+  std::function<void()> on_dispatch;
 };
 
 MockHost* g_host = nullptr;
@@ -61,6 +70,17 @@ int OnDispatch(void* /*user_data*/,
   g_host->last_node_id = node_id;
   g_host->last_action = action;
   g_host->last_data.assign(data, data + (data == nullptr ? 0 : data_length));
+  if (g_host->on_dispatch) {
+    g_host->on_dispatch();
+  }
+  return IHS_SEMANTICS_OK;
+}
+
+int OnPointerTap(void* /*user_data*/,
+                 int64_t /*view_id*/,
+                 double /*x*/,
+                 double /*y*/) {
+  g_host->pointer_taps++;
   return IHS_SEMANTICS_OK;
 }
 
@@ -119,6 +139,7 @@ class McpSemanticsProviderTest : public ::testing::Test {
     host.struct_size = sizeof(IhsSemanticsHost);
     host.set_semantics_enabled = OnEnable;
     host.dispatch = OnDispatch;
+    host.send_pointer_tap = OnPointerTap;
     ihs_semantics_set_host(&host);
     ihs_semantics_clear();
     ASSERT_EQ(ihs_mcp_semantics_provider_start(), IHS_MCP_OK);
@@ -521,4 +542,107 @@ TEST_F(McpSemanticsProviderTest, PublishingATreeNotifiesTheServer) {
   ASSERT_EQ(ihs_mcp_registry_set_notification_sink(nullptr, nullptr),
             IHS_MCP_OK);
   g_notify = nullptr;
+}
+
+// DR-8: an action reports what the tree looks like afterwards, so an agent
+// gets act-and-verify in one round trip instead of acting blind and re-reading.
+TEST_F(McpSemanticsProviderTest, ActionReportsThePostActionNode) {
+  TreeBuilder before;
+  before.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& slider =
+      before.Add(12, "Temperature", IHS_SEMANTICS_ROLE_SLIDER);
+  slider.actions = IHS_SEMANTICS_ACTION_INCREASE;
+  slider.value = "21.0";
+  ASSERT_EQ(before.Publish(), IHS_SEMANTICS_OK);
+
+  // The framework handles the action and republishes, which is what makes the
+  // new value visible at all.
+  TreeBuilder after;
+  host_.on_dispatch = [&after]() {
+    after.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+    IhsSemanticsPublishNode& moved =
+        after.Add(12, "Temperature", IHS_SEMANTICS_ROLE_SLIDER);
+    moved.actions = IHS_SEMANTICS_ACTION_INCREASE;
+    moved.value = "22.0";
+    after.Publish();
+  };
+
+  int status = 0;
+  const std::string body =
+      CallTool("ui_increase", R"({"node_id":12})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  EXPECT_TRUE(Contains(body, "\"mode\":\"semantics\"")) << body;
+  EXPECT_TRUE(Contains(body, "\"node_after\"")) << body;
+  // The point of the whole feature: the caller learns the new value without
+  // a second call.
+  EXPECT_TRUE(Contains(body, "22.0")) << body;
+  EXPECT_FALSE(Contains(body, "21.0")) << body;
+}
+
+// A tap that navigates takes its own node out of the tree. That is a
+// successful action, not a failure, so it is reported as null rather than an
+// error a client would retry.
+TEST_F(McpSemanticsProviderTest, NodeThatLeftTheTreeIsNullNotAnError) {
+  TreeBuilder before;
+  before.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& link =
+      before.Add(7, "Next", IHS_SEMANTICS_ROLE_LINK);
+  link.actions = IHS_SEMANTICS_ACTION_TAP;
+  ASSERT_EQ(before.Publish(), IHS_SEMANTICS_OK);
+
+  TreeBuilder route;
+  host_.on_dispatch = [&route]() {
+    route.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+    route.Add(99, "Second page", IHS_SEMANTICS_ROLE_PANE);
+    route.Publish();
+  };
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":7})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_TRUE(Contains(body, "\"node_after\":null")) << body;
+}
+
+// An action that changes nothing visible -- firing a network call, say --
+// reports equal generations. That is an answer, and treating it as a failure
+// would make a client retry something that already happened.
+TEST_F(McpSemanticsProviderTest, NoTreeChangeIsAnAnswerNotAFailure) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& button =
+      tree.Add(3, "Sync", IHS_SEMANTICS_ROLE_BUTTON);
+  button.actions = IHS_SEMANTICS_ACTION_TAP;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":3})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_EQ(host_.dispatch_calls, 1);
+  // The node is still there and reported; only the generations say nothing
+  // moved.
+  EXPECT_TRUE(Contains(body, "\"node_after\"")) << body;
+  EXPECT_FALSE(Contains(body, "\"node_after\":null")) << body;
+
+  const size_t before_at = body.find("\"generation_before\":");
+  const size_t after_at = body.find("\"generation_after\":");
+  ASSERT_NE(before_at, std::string::npos) << body;
+  ASSERT_NE(after_at, std::string::npos) << body;
+  EXPECT_EQ(body.substr(before_at + 20, 3), body.substr(after_at + 19, 3))
+      << body;
+}
+
+// A coordinate tap still names no target -- nothing knows what was under the
+// point -- but it can say whether the tree moved, which is the only evidence
+// of effect available to it.
+TEST_F(McpSemanticsProviderTest, PointerTapReportsModeButNoNode) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body =
+      CallTool("ui_tap_at", R"({"x":10.0,"y":20.0})", &status);
+  EXPECT_TRUE(Contains(body, "\"mode\":\"pointer\"")) << body;
+  EXPECT_TRUE(Contains(body, "\"generation_after\"")) << body;
+  EXPECT_FALSE(Contains(body, "\"node_after\"")) << body;
 }

--- a/test/unit_test/semantics_action_args-test/test_case_semantics_action_args.cc
+++ b/test/unit_test/semantics_action_args-test/test_case_semantics_action_args.cc
@@ -162,3 +162,32 @@ TEST(SemanticsActionArgs, DataOnAnArgumentlessActionIsRefused) {
       EncodeActionArguments(IHS_SEMANTICS_ACTION_TAP, stray, sizeof(stray))
           .has_value());
 }
+
+// A custom action's argument is the id naming which of a node's verbs to run.
+// A bare int, not a map: the framework resolves the handler by it directly.
+TEST(SemanticsActionArgs, CustomActionEncodesTheActionId) {
+  const int32_t action_id = 72;
+  const auto* bytes = reinterpret_cast<const uint8_t*>(&action_id);
+  const auto encoded = accessibility::EncodeActionArguments(
+      IHS_SEMANTICS_ACTION_CUSTOM_ACTION, bytes, sizeof(action_id));
+  ASSERT_TRUE(encoded.has_value());
+  const flutter::EncodableValue value = Decode(*encoded);
+  ASSERT_TRUE(std::holds_alternative<int32_t>(value))
+      << "the framework looks the handler up by a bare int";
+  EXPECT_EQ(std::get<int32_t>(value), 72);
+}
+
+// Without an id there is nothing naming which verb to run, so this is refused
+// rather than dispatched as an action the framework would silently drop.
+TEST(SemanticsActionArgs, CustomActionWithoutAnIdIsRefused) {
+  EXPECT_FALSE(accessibility::EncodeActionArguments(
+                   IHS_SEMANTICS_ACTION_CUSTOM_ACTION, nullptr, 0)
+                   .has_value());
+}
+
+TEST(SemanticsActionArgs, CustomActionWithAWrongSizedIdIsRefused) {
+  const uint8_t stub[3] = {1, 2, 3};
+  EXPECT_FALSE(accessibility::EncodeActionArguments(
+                   IHS_SEMANTICS_ACTION_CUSTOM_ACTION, stub, sizeof(stub))
+                   .has_value());
+}


### PR DESCRIPTION
## Discoverable, but not invocable

The tree has reported each node's `custom_actions` with id and label since the provider landed. An agent could **see** the application's own verbs — Share, Archive, whatever the app declared — and had no way to run one.

## The gap was below the provider

`EncodeActionArguments` treated `IHS_SEMANTICS_ACTION_CUSTOM_ACTION` as taking **no argument** and refused any data:

> *"Every other action takes no argument. Data supplied for one of those is refused rather than dropped."*

But the framework resolves a custom action's handler **by an id it expects as a bare int**. So the action could not have worked whatever called it — adding only a tool would have produced a refusal at the encoder.

The hub layout gains one int32, documented alongside the other layouts on `ihs_semantics_dispatch`, and the shell encodes it as a bare int rather than wrapping it in a map (a map resolves to nothing).

## One tool taking a name, not a tool per action

`ui_custom_action` takes a node plus the label the tree reports, or the id.

I considered minting a tool per custom action, which is the literal reading of "custom actions as tools". It's the wrong shape here: custom actions are **per-app and per-node**, so a tool each would churn the advertised tool list on every route change, and collide the moment two nodes declare the same verb. The tree already reports each node's set, which is where an agent looks before acting anyway.

Labels rather than identifiers because **identifiers are empty at the 3.38.3 deployment floor**, so the label is what an agent actually has — which is also what the P4 exit criterion assumes.

## Resolution is per-node, and that's the interesting test

Custom action ids are resolved against **the node's own declarations**, not the snapshot's whole table. A verb another node declared is not this node's to run, and dispatching it would be answered by whichever handler the framework found rather than the one the caller named.

That's tested directly, because it is the failure mode that would otherwise **look like success**: two nodes, one declaring `Share` and the other `Archive`, asking node 4 for `Archive` is `NOT_FOUND` with zero dispatches.

## Testing

- invoked by label — the correct id (72, not 71) reaches the hub as the argument
- invoked by `action_id`
- a verb declared on a *different* node — refused, nothing dispatched
- a node offering no custom actions — refused before the label is examined
- neither `action` nor `action_id` — refused
- encoder: a bare `int32_t` round-trips through the codec; a missing or wrong-sized id is refused rather than dispatched as something the framework would silently drop

32 provider tests (up from 27), 13 encoder tests (up from 10), 28/28 ctest, clang-tidy, `format.sh` and the config-reference gate clean.

## Remaining

`ui_query` selector expansion and notification debounce.
