### PR TITLE
mcp: give ui_query the selectors an agent plans with

### DIFF
--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -67,7 +67,11 @@ constexpr char kQuerySchema[] =
     R"({"type":"object","properties":{)"
     R"("identifier":{"type":"string"},)"
     R"("label":{"type":"string","description":"Substring match, case sensitive."},)"
-    R"("role":{"type":"string","description":"Role name, e.g. button or slider."})"
+    R"("role":{"type":"string","description":"Role name, e.g. button or slider."},)"
+    R"("action":{"type":"string","description":"Only nodes offering this action, named as the tree reports it."},)"
+    R"("custom_action":{"type":"string","description":"Only nodes declaring a custom action with this label."},)"
+    R"("enabled":{"type":"string","enum":["true","false","not_applicable"],"description":"Enabled tristate, spelled as the tree reports it; not_applicable means enablement is meaningless for the node."},)"
+    R"("limit":{"type":"integer","description":"Cap on returned nodes. match_count and truncated always report the full total."})"
     R"(}})";
 
 constexpr char kSetTextSchema[] =
@@ -638,14 +642,59 @@ int ReadResource(void* /* user_data */,
   return IHS_MCP_OK;
 }
 
+// Resolves an action name to its bit, using the same table WriteActions
+// reports from -- so the names a client can select on are exactly the names it
+// was shown, and there is no second list to fall out of step.
+uint64_t ActionBitFor(const std::string& name) {
+  for (const ToolEntry& tool : kTools) {
+    if (tool.action != 0 && name == tool.name) {
+      return tool.action;
+    }
+  }
+  return 0;
+}
+
+bool DeclaresCustomAction(const IhsSemanticsSnapshot* snapshot,
+                          const IhsSemanticsNode* node,
+                          const std::string& label) {
+  for (size_t i = 0; i < node->custom_action_count; i++) {
+    const IhsSemanticsCustomAction* declared =
+        ihs_semantics_find_custom_action(snapshot, node->custom_action_ids[i]);
+    if (declared != nullptr && label == declared->label) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::string RunQuery(const IhsSemanticsSnapshot* snapshot,
                      const char* arguments) {
   std::string want_identifier;
   std::string want_label;
   std::string want_role;
+  std::string want_action;
+  std::string want_custom_action;
+  std::string want_enabled;
   ExtractString(arguments, "identifier", &want_identifier);
   ExtractString(arguments, "label", &want_label);
   ExtractString(arguments, "role", &want_role);
+  ExtractString(arguments, "action", &want_action);
+  ExtractString(arguments, "custom_action", &want_custom_action);
+  ExtractString(arguments, "enabled", &want_enabled);
+
+  int32_t limit = 0;
+  const bool bounded = ExtractInt(arguments, "limit", &limit) && limit > 0;
+
+  // An action name that names nothing would otherwise select every node, since
+  // a zero mask tests true against anything. Reported rather than silently
+  // widened: the caller misspelled a name it was given.
+  const uint64_t want_action_bit =
+      want_action.empty() ? 0 : ActionBitFor(want_action);
+  if (!want_action.empty() && want_action_bit == 0) {
+    return std::string(R"({"error":"no such action: )") + want_action +
+           R"(","generation":)" +
+           std::to_string(ihs_semantics_snapshot_generation(snapshot)) + "}";
+  }
 
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> w(buffer);
@@ -655,6 +704,8 @@ std::string RunQuery(const IhsSemanticsSnapshot* snapshot,
   w.Key("nodes");
   w.StartArray();
 
+  size_t matched = 0;
+  size_t emitted = 0;
   const size_t count = ihs_semantics_snapshot_node_count(snapshot);
   for (size_t i = 0; i < count; i++) {
     const IhsSemanticsNode* node = ihs_semantics_snapshot_node_at(snapshot, i);
@@ -673,9 +724,36 @@ std::string RunQuery(const IhsSemanticsSnapshot* snapshot,
     if (!want_role.empty() && want_role != RoleName(node->role)) {
       continue;
     }
+    if (want_action_bit != 0 && (node->actions & want_action_bit) == 0) {
+      continue;
+    }
+    if (!want_custom_action.empty() &&
+        !DeclaresCustomAction(snapshot, node, want_custom_action)) {
+      continue;
+    }
+    // Selected by tristate name rather than a bool, because the hub keeps
+    // "disabled" and "enablement does not apply" apart and a bool here would
+    // put them back together at the last step.
+    if (!want_enabled.empty() && want_enabled != TristateName(node->enabled)) {
+      continue;
+    }
+
+    matched++;
+    if (bounded && emitted >= static_cast<size_t>(limit)) {
+      continue;  // counted, not emitted: the count is what makes the cap
+                 // visible
+    }
     WriteNode(w, node, snapshot);
+    emitted++;
   }
   w.EndArray();
+
+  // A truncated result that looked complete would have an agent conclude the
+  // rest does not exist, so the cap reports itself.
+  w.Key("match_count");
+  w.Uint64(matched);
+  w.Key("truncated");
+  w.Bool(matched > emitted);
   w.EndObject();
   return buffer.GetString();
 }

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -766,3 +766,124 @@ TEST_F(McpSemanticsProviderTest, CustomActionWithoutANameIsRefused) {
   EXPECT_EQ(status, IHS_MCP_ERR_INVALID);
   EXPECT_EQ(host_.dispatch_calls, 0);
 }
+
+// Finding what can be acted on is the first thing an agent does, and the
+// action names are the ones the tree already reported on each node.
+TEST_F(McpSemanticsProviderTest, QuerySelectsByActionOffered) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& button =
+      tree.Add(1, "Fan", IHS_SEMANTICS_ROLE_BUTTON);
+  button.actions = IHS_SEMANTICS_ACTION_TAP;
+  IhsSemanticsPublishNode& slider =
+      tree.Add(2, "Temp", IHS_SEMANTICS_ROLE_SLIDER);
+  slider.actions = IHS_SEMANTICS_ACTION_INCREASE;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  int status = 0;
+  const std::string body =
+      CallTool("ui_query", R"({"action":"increase"})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK);
+  EXPECT_TRUE(Contains(body, "Temp")) << body;
+  EXPECT_FALSE(Contains(body, "Fan")) << body;
+}
+
+// A zero mask tests true against every node, so an unknown action name would
+// select the whole tree -- the opposite of what was asked for.
+TEST_F(McpSemanticsProviderTest, QueryWithAnUnknownActionIsAnError) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  tree.Add(1, "Fan", IHS_SEMANTICS_ROLE_BUTTON);
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const std::string body =
+      CallTool("ui_query", R"({"action":"levitate"})", nullptr);
+  EXPECT_TRUE(Contains(body, "no such action")) << body;
+  EXPECT_FALSE(Contains(body, "\"label\":\"Fan\"")) << body;
+}
+
+// The exit criterion drives flows by custom-action name, so finding the node
+// that offers one has to be a query rather than a walk of the whole tree.
+TEST_F(McpSemanticsProviderTest, QuerySelectsByCustomActionLabel) {
+  TreeBuilder tree;
+  PublishWithCustomActions(tree);
+  IhsSemanticsPublishNode& other =
+      tree.Add(9, "Plain", IHS_SEMANTICS_ROLE_PANE);
+  other.actions = IHS_SEMANTICS_ACTION_TAP;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const std::string body =
+      CallTool("ui_query", R"({"custom_action":"Archive"})", nullptr);
+  EXPECT_TRUE(Contains(body, "Trip")) << body;
+  EXPECT_FALSE(Contains(body, "Plain")) << body;
+}
+
+// Selected by tristate name, not a bool: the hub keeps "disabled" and
+// "enablement does not apply" apart, and a bool would rejoin them here.
+TEST_F(McpSemanticsProviderTest, QuerySelectsByEnabledTristate) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& live =
+      tree.Add(1, "Live", IHS_SEMANTICS_ROLE_BUTTON);
+  live.enabled = IHS_SEMANTICS_TRISTATE_TRUE;
+  IhsSemanticsPublishNode& dead =
+      tree.Add(2, "Dead", IHS_SEMANTICS_ROLE_BUTTON);
+  dead.enabled = IHS_SEMANTICS_TRISTATE_FALSE;
+  IhsSemanticsPublishNode& moot = tree.Add(3, "Moot", IHS_SEMANTICS_ROLE_LABEL);
+  moot.enabled = IHS_SEMANTICS_TRISTATE_NONE;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const std::string disabled =
+      CallTool("ui_query", R"({"enabled":"false"})", nullptr);
+  EXPECT_TRUE(Contains(disabled, "Dead")) << disabled;
+  EXPECT_FALSE(Contains(disabled, "Live")) << disabled;
+  EXPECT_FALSE(Contains(disabled, "Moot")) << disabled;
+
+  // Spelled exactly as the tree reports it -- the selector accepting a value
+  // the serializer never emits would match nothing and look like "no such
+  // nodes".
+  const std::string inapplicable =
+      CallTool("ui_query", R"({"enabled":"not_applicable"})", nullptr);
+  EXPECT_TRUE(Contains(inapplicable, "Moot")) << inapplicable;
+  EXPECT_FALSE(Contains(inapplicable, "Dead")) << inapplicable;
+}
+
+// Selectors narrow together; that is what makes having several worth anything.
+TEST_F(McpSemanticsProviderTest, QuerySelectorsCombine) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  IhsSemanticsPublishNode& right =
+      tree.Add(1, "Fan speed", IHS_SEMANTICS_ROLE_SLIDER);
+  right.actions = IHS_SEMANTICS_ACTION_INCREASE;
+  IhsSemanticsPublishNode& wrong_role =
+      tree.Add(2, "Fan speed", IHS_SEMANTICS_ROLE_BUTTON);
+  wrong_role.actions = IHS_SEMANTICS_ACTION_INCREASE;
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const std::string body = CallTool(
+      "ui_query", R"({"label":"Fan","role":"slider","action":"increase"})",
+      nullptr);
+  EXPECT_TRUE(Contains(body, "\"id\":1")) << body;
+  EXPECT_FALSE(Contains(body, "\"id\":2")) << body;
+}
+
+// A cap that looked like a complete answer would have an agent conclude the
+// rest does not exist, so the total is reported alongside the truncation.
+TEST_F(McpSemanticsProviderTest, QueryLimitReportsWhatItLeftOut) {
+  TreeBuilder tree;
+  tree.Add(0, "root", IHS_SEMANTICS_ROLE_WINDOW);
+  for (int32_t i = 1; i <= 5; i++) {
+    tree.Add(i, "Seat", IHS_SEMANTICS_ROLE_BUTTON);
+  }
+  ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
+
+  const std::string body =
+      CallTool("ui_query", R"({"label":"Seat","limit":2})", nullptr);
+  EXPECT_TRUE(Contains(body, "\"match_count\":5")) << body;
+  EXPECT_TRUE(Contains(body, "\"truncated\":true")) << body;
+
+  const std::string whole =
+      CallTool("ui_query", R"({"label":"Seat"})", nullptr);
+  EXPECT_TRUE(Contains(whole, "\"match_count\":5")) << whole;
+  EXPECT_TRUE(Contains(whole, "\"truncated\":false")) << whole;
+}


### PR DESCRIPTION
`ui_query` could narrow by identifier, label substring and role. Planning a flow needs more: *which nodes can I act on, which declares this verb, which of these is actually enabled.*

Adds `action`, `custom_action`, `enabled` and `limit`.

## Names come from one place

Action names resolve through the same `kTools` table `WriteActions` reports from, so **the names selectable are exactly the names a client was shown** — there is no second list to fall out of step with.

## An unknown action name is an error, not an empty filter

This is the one that would have bitten. A zero mask tests true against every node, so the natural implementation widens the query to **the whole tree** the moment a caller misspells a name — the opposite of what was asked, returned as though it were the answer. Now:

```json
{"error": "no such action: levitate", "generation": 12}
```

## `limit` reports what it left out

```json
{"nodes": [...], "match_count": 5, "truncated": true}
```

A capped result that looked complete would have an agent conclude the rest does not exist. The total is counted even for nodes not emitted.

## `enabled` selects by tristate, not by bool

The hub deliberately keeps *disabled* and *enablement is meaningless here* apart, and a bool at this layer would rejoin them at the last step.

**Writing this caught a mismatch worth recording:** the serializer spells the third state `not_applicable`, and I had drafted the schema offering `none`. A selector accepting a value the tree never emits matches nothing and reads as *"no such nodes"* — a wrong answer indistinguishable from a real one. The test now asserts the spelling the tree actually uses.

## Testing

- select by action offered — the slider matches `increase`, the button does not
- unknown action name — error, and demonstrably not "every node"
- select by custom-action label — finds the node declaring `Archive`, skips the one that doesn't
- select by each tristate, including `not_applicable`
- selectors combine: label + role + action picks one of two same-labelled nodes
- `limit` reports `match_count` 5 with `truncated` true; unbounded reports 5 and false

38 provider tests (up from 32), 28/28 ctest, clang-tidy, `format.sh` and the config-reference gate clean.

## Remaining

Notification debounce, then the HVAC-flow exit criterion.
