### PR TITLE
mcp: collapse notification bursts, without dropping the last one

### DIFF
--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -34,6 +34,8 @@
 #include <algorithm>
 #include <atomic>
 #include <cerrno>
+#include <chrono>
+#include <condition_variable>
 #include <cstring>
 #include <map>
 #include <mutex>
@@ -130,6 +132,24 @@ struct Transport {
   // nothing" and "not interested in filtering" are not distinguishable, and
   // the safe reading is the one that keeps delivering.
   std::map<std::string, std::set<std::string>> subscriptions;
+
+  // Notification debounce.
+  //
+  // A provider signals per republished tree, so an animating UI produces one
+  // notification per frame. These carry no state beyond "something changed" --
+  // a client re-reads to find out what -- so collapsing a burst into one loses
+  // nothing, provided the last one still arrives. A client that misses the
+  // trailing edge is left believing a stale tree is current, with nothing to
+  // tell it otherwise, which is the failure this has to avoid rather than the
+  // volume.
+  std::mutex notify_mutex;
+  std::condition_variable notify_cv;
+  bool notify_running = false;
+  std::thread notify_thread;
+  bool tools_pending = false;
+  std::set<std::string> resources_pending;
+  std::chrono::steady_clock::time_point tools_last{};
+  std::map<std::string, std::chrono::steady_clock::time_point> resource_last;
 };
 
 Transport& TheTransport() {
@@ -790,19 +810,117 @@ void Broadcast(const std::string& json, const std::string& uri = {}) {
 
 // The registry calls this when a provider changes. Translated into the
 // JSON-RPC notifications the specification names, and pushed to every stream.
+// How long a burst is collapsed over. Long enough that an animating UI stops
+// waking every client every frame, short enough that a person driving the
+// agent does not perceive the delay -- and only ever delays a notification,
+// never drops the last one.
+constexpr auto kNotifyWindow = std::chrono::milliseconds(50);
+
+void EmitToolsChanged() {
+  Broadcast(R"({"jsonrpc":"2.0","method":"notifications/tools/list_changed"})");
+}
+
+void EmitResourceUpdated(const std::string& uri) {
+  Broadcast(R"({"jsonrpc":"2.0","method":"notifications/resources/updated")"
+            R"(,"params":{"uri":)" +
+                Escape(uri) + "}}",
+            uri);
+}
+
+// Sleeps out the window once something is pending, then flushes it.
+//
+// Idle costs nothing: this blocks until a notification actually arrives rather
+// than waking every window to find nothing to do.
+void NotifyLoop() {
+  Transport& t = TheTransport();
+  while (true) {
+    bool flush_tools = false;
+    std::vector<std::string> flush_resources;
+    {
+      std::unique_lock<std::mutex> lock(t.notify_mutex);
+      t.notify_cv.wait(lock, [&t]() {
+        return !t.notify_running || t.tools_pending ||
+               !t.resources_pending.empty();
+      });
+      if (!t.notify_running) {
+        // Nothing is flushed on the way out: stop() closes every stream, so
+        // there is no one left to tell.
+        return;
+      }
+      // Wait out the window with the lock released, so the burst this is
+      // collapsing can keep arriving while it does.
+      t.notify_cv.wait_for(lock, kNotifyWindow,
+                           [&t]() { return !t.notify_running; });
+      if (!t.notify_running) {
+        return;
+      }
+      const auto now = std::chrono::steady_clock::now();
+      flush_tools = t.tools_pending;
+      t.tools_pending = false;
+      if (flush_tools) {
+        t.tools_last = now;
+      }
+      for (const std::string& uri : t.resources_pending) {
+        flush_resources.push_back(uri);
+        t.resource_last[uri] = now;
+      }
+      t.resources_pending.clear();
+    }
+
+    // Emitted with the lock released: Broadcast takes the streams mutex, and
+    // nesting the two would put a lock order between the notification path and
+    // every other thing that touches streams.
+    if (flush_tools) {
+      EmitToolsChanged();
+    }
+    for (const std::string& uri : flush_resources) {
+      EmitResourceUpdated(uri);
+    }
+  }
+}
+
 void OnRegistryNotification(const IhsMcpNotification kind,
                             const char* uri,
                             void* /* user_data */) {
-  if (kind == IHS_MCP_NOTIFY_TOOLS_CHANGED) {
-    Broadcast(
-        R"({"jsonrpc":"2.0","method":"notifications/tools/list_changed"})");
-    return;
+  const std::string resource = kind == IHS_MCP_NOTIFY_TOOLS_CHANGED
+                                   ? std::string()
+                                   : std::string(uri != nullptr ? uri : "");
+
+  Transport& t = TheTransport();
+  bool emit_now = false;
+  {
+    const std::lock_guard<std::mutex> lock(t.notify_mutex);
+    const auto now = std::chrono::steady_clock::now();
+    // Leading edge: the first change after a quiet period goes out at once, so
+    // an idle UI reacting to a single action is not made to feel laggy by a
+    // mechanism that exists for bursts.
+    if (kind == IHS_MCP_NOTIFY_TOOLS_CHANGED) {
+      if (now - t.tools_last >= kNotifyWindow) {
+        t.tools_last = now;
+        emit_now = true;
+      } else {
+        t.tools_pending = true;
+      }
+    } else {
+      const auto last = t.resource_last.find(resource);
+      if (last == t.resource_last.end() ||
+          now - last->second >= kNotifyWindow) {
+        t.resource_last[resource] = now;
+        emit_now = true;
+      } else {
+        t.resources_pending.insert(resource);
+      }
+    }
   }
-  const std::string resource = uri != nullptr ? uri : "";
-  Broadcast(R"({"jsonrpc":"2.0","method":"notifications/resources/updated")"
-            R"(,"params":{"uri":)" +
-                Escape(resource) + "}}",
-            resource);
+  t.notify_cv.notify_one();
+
+  if (emit_now) {
+    if (kind == IHS_MCP_NOTIFY_TOOLS_CHANGED) {
+      EmitToolsChanged();
+    } else {
+      EmitResourceUpdated(resource);
+    }
+  }
 }
 
 // Turns an accepted connection into an event stream. Returns false when the
@@ -1094,6 +1212,11 @@ int ihs_mcp_transport_start(const IhsMcpTransportConfig* config) {
                             : kDefaultMaxRequestBytes;
   t.running = true;
   t.thread = std::thread(AcceptLoop);
+  {
+    const std::lock_guard<std::mutex> notify_lock(t.notify_mutex);
+    t.notify_running = true;
+  }
+  t.notify_thread = std::thread(NotifyLoop);
 
   // Installed last: the registry starts watching provider descriptors the
   // moment this returns, and a notification arriving before there is anywhere
@@ -1139,6 +1262,23 @@ void ihs_mcp_transport_stop() {
 
   if (thread.joinable()) {
     thread.join();
+  }
+
+  // Joined before the streams close, so no pending flush can write to a
+  // descriptor this is about to shut. The registry sink was uninstalled above,
+  // so nothing new can arrive while this winds down.
+  std::thread notify_thread;
+  {
+    const std::lock_guard<std::mutex> notify_lock(t.notify_mutex);
+    t.notify_running = false;
+    t.tools_pending = false;
+    t.resources_pending.clear();
+    t.resource_last.clear();
+    notify_thread = std::move(t.notify_thread);
+  }
+  t.notify_cv.notify_all();
+  if (notify_thread.joinable()) {
+    notify_thread.join();
   }
 
   const std::lock_guard<std::mutex> lock(t.mutex);

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -21,9 +21,11 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <thread>
 
 #include "gtest/gtest.h"
 
@@ -721,4 +723,107 @@ TEST_F(McpTransportTest, UnsubscribingFromTheLastUriRestoresEverything) {
   const std::string body =
       Body(Subscribe(path_, session, "ui://", "resources/unsubscribe"));
   EXPECT_NE(body.find(R"("result")"), std::string::npos) << body;
+}
+
+namespace {
+
+size_t CountOf(const std::string& haystack, const std::string& needle) {
+  size_t n = 0;
+  for (size_t at = haystack.find(needle); at != std::string::npos;
+       at = haystack.find(needle, at + needle.size())) {
+    n++;
+  }
+  return n;
+}
+
+// Registers a provider whose notify_fd the caller can signal. Returns the fd;
+// *out_provider receives the registration.
+int RegisterSignallingProvider(SignallingProvider* mock,
+                               IhsMcpProvider** out_provider) {
+  const int notify = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+  if (notify < 0) {
+    return -1;
+  }
+  IhsMcpProviderDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = "ui-burst";
+  desc.tool_prefix = "ui_";
+  desc.resource_scheme = "ui";
+  desc.capability_mask = IHS_MCP_CAP_ALL;
+  desc.notify_fd = notify;
+  desc.user_data = mock;
+  desc.callbacks.list_tools = &SignallingProvider::ListTools;
+  desc.callbacks.list_resources = &SignallingProvider::ListResources;
+  desc.callbacks.call_tool = &SignallingProvider::CallTool;
+  desc.callbacks.read_resource = &SignallingProvider::ReadResource;
+  if (ihs_mcp_provider_register(&desc, out_provider) != IHS_MCP_OK) {
+    ::close(notify);
+    return -1;
+  }
+  return notify;
+}
+
+void Signal(const int fd) {
+  const uint64_t one = 1;
+  (void)::write(fd, &one, sizeof(one));
+}
+
+}  // namespace
+
+// A change that arrives while a burst is being collapsed must still reach the
+// client. Dropping it would leave that client believing a stale tree is
+// current, with nothing to tell it otherwise -- worse than the volume the
+// debounce exists to reduce.
+TEST_F(McpTransportTest, TheLastChangeInABurstStillArrives) {
+  std::string headers;
+  const int stream = OpenStream(path_, &headers);
+  ASSERT_GE(stream, 0);
+
+  SignallingProvider mock;
+  IhsMcpProvider* provider = nullptr;
+  const int notify = RegisterSignallingProvider(&mock, &provider);
+  ASSERT_GE(notify, 0);
+
+  Signal(notify);  // leading edge: goes out at once
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  Signal(notify);  // inside the window: must not be lost
+
+  const std::string got = DrainStream(stream, 600);
+  EXPECT_EQ(CountOf(got, "resources/updated"), 2u)
+      << "expected the immediate one and the trailing flush: [" << got << "]";
+
+  ihs_mcp_provider_unregister(provider);
+  ::close(notify);
+  ::close(stream);
+}
+
+// An animating UI signals per republished tree. Collapsing that is the point:
+// the notifications carry no state beyond "something changed", so a client
+// that gets one instead of ten re-reads once and sees the same thing.
+TEST_F(McpTransportTest, ABurstIsCollapsedRatherThanForwardedWhole) {
+  std::string headers;
+  const int stream = OpenStream(path_, &headers);
+  ASSERT_GE(stream, 0);
+
+  SignallingProvider mock;
+  IhsMcpProvider* provider = nullptr;
+  const int notify = RegisterSignallingProvider(&mock, &provider);
+  ASSERT_GE(notify, 0);
+
+  // Spaced so the registry's watcher wakes for each one rather than draining
+  // them as a single signal -- otherwise this would measure the eventfd's
+  // coalescing instead of the debounce.
+  for (int i = 0; i < 10; i++) {
+    Signal(notify);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  const std::string got = DrainStream(stream, 600);
+  const size_t seen = CountOf(got, "resources/updated");
+  EXPECT_GE(seen, 1u) << got;
+  EXPECT_LT(seen, 10u) << "ten signals were forwarded whole: [" << got << "]";
+
+  ihs_mcp_provider_unregister(provider);
+  ::close(notify);
+  ::close(stream);
 }


### PR DESCRIPTION
Completes the **subscriptions + debounce** item (#461 was the subscriptions half).

## The problem

A provider signals once per republished tree, so **an animating UI woke every connected client every frame**.

## Why collapsing is safe

These notifications carry no state beyond *"something changed"* — a client re-reads to find out what. So one instead of ten tells it exactly the same thing.

## The part that has to be right: the trailing edge

A change arriving *while* a burst is being collapsed must still be delivered. A client that misses the last one is left believing a stale tree is current, **with nothing to tell it otherwise** — which is worse than the volume this reduces. That's the property the tests are built around, not the reduction.

The **leading edge is immediate**, so a single action on an otherwise idle UI isn't made to feel laggy by a mechanism that exists for bursts.

## Implementation notes

- The flusher **blocks until something is pending** rather than waking every window to find nothing to do — idle costs nothing.
- Joined before `stop()` closes the streams it writes to, so no pending flush can write to a descriptor about to shut. The registry sink is uninstalled first, so nothing new arrives during teardown.
- Emitting happens with the notify lock **released** — `Broadcast` takes the streams mutex, and nesting the two would introduce a lock order between the notification path and everything else touching streams.

## The tests space their signals, deliberately

Writing an eventfd ten times in a tight loop is coalesced by **the registry's own drain**, so an unspaced burst would have measured that rather than this — and passed whether or not the debounce existed. Spacing them at 5 ms makes the watcher wake for each.

- `TheLastChangeInABurstStillArrives` — a signal, then a second inside the window: exactly 2 notifications, the immediate one and the trailing flush
- `ABurstIsCollapsedRatherThanForwardedWhole` — ten spaced signals arrive as fewer than ten

Ablated (forwarding everything), **both fail** — the first because the trailing flush never happens, the second because all ten come through.

39 transport tests (up from 37), 28/28 ctest, clang-tidy, `format.sh` and the config-reference gate clean.

## Status

Mechanisms are done: T2 custom actions (#463), verify-after-act (#462), `ui_query` selectors (#464), subscriptions (#461) and debounce here. What remains is the **exit criterion** — an agent completing a multi-step flow against a real app using labels, roles and custom-action names.
