### PR TITLE
mcp: drive a multi-step flow end to end, and fix the chain it found broken

### DIFF
--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -232,6 +232,13 @@ void WriteActions(rapidjson::Writer<rapidjson::StringBuffer>& w,
       w.String(tool.name);
     }
   }
+  // Named separately because its tool carries no action bit: ui_custom_action
+  // is routed by name and resolves an id before dispatching, so the loop above
+  // cannot reach it. Without this a node able to run the app's own verbs looks
+  // like a node offering nothing.
+  if ((actions & IHS_SEMANTICS_ACTION_CUSTOM_ACTION) != 0) {
+    w.String("custom_action");
+  }
   w.EndArray();
 }
 

--- a/shell/accessibility/semantics_publisher.cc
+++ b/shell/accessibility/semantics_publisher.cc
@@ -232,6 +232,9 @@ uint64_t ToIhsActions(const NodeSpec& spec) {
   if (spec.action_collapse) {
     actions |= IHS_SEMANTICS_ACTION_COLLAPSE;
   }
+  if (spec.action_custom_action) {
+    actions |= IHS_SEMANTICS_ACTION_CUSTOM_ACTION;
+  }
   return actions;
 }
 

--- a/shell/accessibility/semantics_translator.cc
+++ b/shell/accessibility/semantics_translator.cc
@@ -316,6 +316,7 @@ NodeSpec TranslateView(int32_t id,
       Has(actions, kFlutterSemanticsActionScrollToOffset);
   spec.action_expand = Has(actions, kFlutterSemanticsActionExpand);
   spec.action_collapse = Has(actions, kFlutterSemanticsActionCollapse);
+  spec.action_custom_action = Has(actions, kFlutterSemanticsActionCustomAction);
 
   return spec;
 }

--- a/shell/accessibility/semantics_translator.h
+++ b/shell/accessibility/semantics_translator.h
@@ -119,6 +119,10 @@ struct NodeSpec {
   bool action_scroll_to_offset = false;
   bool action_expand = false;
   bool action_collapse = false;
+  // Set when the node declares application-defined actions. The ids
+  // themselves travel separately; this is what marks the node as able to
+  // run one at all.
+  bool action_custom_action = false;
 };
 
 // Pure translation from a Flutter semantics node's identity + flags + actions

--- a/test/integration/mcp_drive_test/lib/main.dart
+++ b/test/integration/mcp_drive_test/lib/main.dart
@@ -19,6 +19,8 @@
 // checks cannot pass by accident.
 
 import 'package:flutter/material.dart';
+// CustomSemanticsAction is not exported by material.dart.
+import 'package:flutter/semantics.dart';
 
 void main() {
   runApp(const McpDriveTestApp());
@@ -51,6 +53,13 @@ class _DriveTestPageState extends State<DriveTestPage> {
   String _last = 'none';
   int _events = 0;
 
+  // The multi-step flow's state. A slider carries a
+  // value the framework reports on the node itself, so a check can verify from
+  // the action's own node_after rather than reading the status line back --
+  // which is the difference verify-after-act is meant to make.
+  double _temperature = 21.0;
+  String _mode = 'manual';
+
   final TextEditingController _destination =
       TextEditingController(text: 'unset');
 
@@ -59,6 +68,14 @@ class _DriveTestPageState extends State<DriveTestPage> {
   // screen size changes; asking the app where the target is does not.
   final GlobalKey _opaqueKey = GlobalKey();
   Rect? _opaqueRect;
+
+  void _setMode(String mode) {
+    setState(() {
+      _mode = mode;
+      _last = 'mode:$mode';
+      _events++;
+    });
+  }
 
   void _record(String what) {
     setState(() {
@@ -101,7 +118,8 @@ class _DriveTestPageState extends State<DriveTestPage> {
     // chose, and the realistic case for set_text has a space in it. A
     // separator the payload can contain makes the fixture pass only for
     // inputs that avoid it, which is the wrong way round.
-    return 'last=$_last; events=$_events; text=${_destination.text}; $geometry';
+    return 'last=$_last; events=$_events; text=${_destination.text}; '
+        'temp=${_temperature.toStringAsFixed(1)}; mode=$_mode; $geometry';
   }
 
   @override
@@ -124,6 +142,58 @@ class _DriveTestPageState extends State<DriveTestPage> {
                 label: 'status',
                 value: _status,
                 child: ExcludeSemantics(child: Text(_status)),
+              ),
+              const SizedBox(height: 12),
+
+              // A slider, for the multi-step flow. Chosen because the
+              // framework puts increase/decrease on the node and reports the
+              // current setting as the node's own value -- so a driver can
+              // verify from node_after directly, without the status line.
+              //
+              // Wrapped and merged for the same reason as everything else
+              // here: a bare Semantics(label:) would sit above the slider and
+              // leave the actionable node unlabelled.
+              MergeSemantics(
+                child: Semantics(
+                  identifier: 'temperature',
+                  label: 'Temperature',
+                  child: Slider(
+                    value: _temperature,
+                    min: 16,
+                    max: 28,
+                    divisions: 24,
+                    onChanged: (double value) {
+                      setState(() {
+                        _temperature = value;
+                        _last = 'temp';
+                        _events++;
+                      });
+                    },
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              // Custom actions: the application's own verbs, which have no
+              // fixed set and are named only by their labels. An agent finds
+              // these through the tree and invokes them by name, since
+              // identifiers are empty at the deployment floor.
+              MergeSemantics(
+                child: Semantics(
+                  identifier: 'climate',
+                  label: 'Climate',
+                  customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
+                    const CustomSemanticsAction(label: 'Set to Auto'):
+                        () => _setMode('auto'),
+                    const CustomSemanticsAction(label: 'Set to Manual'):
+                        () => _setMode('manual'),
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.all(12),
+                    color: const Color(0xFFE0E0E0),
+                    child: const ExcludeSemantics(child: Text('Climate')),
+                  ),
+                ),
               ),
               const SizedBox(height: 12),
 

--- a/test/integration/mcp_drive_test/tools/drive.py
+++ b/test/integration/mcp_drive_test/tools/drive.py
@@ -34,6 +34,7 @@ Exits non-zero on the first failed check, listing every result.
 import argparse
 import json
 import os
+import re
 import socket
 import sys
 import time
@@ -155,6 +156,42 @@ def wait_for(path, predicate, timeout, what):
     raise Failure(f"timed out waiting for {what}; status was {last}")
 
 
+def query(path, **selectors):
+    """ui_query with any of its selectors. Returns the decoded result."""
+    ok, doc = call_tool(path, "ui_query", selectors, request_id=7)
+    if not ok:
+        raise Failure(f"ui_query {selectors}: {doc}")
+    return doc
+
+
+def act(path, tool, arguments, what):
+    """Invokes an action tool and returns its verify-after-act result.
+
+    The point of DR-8 is that this is enough on its own: the caller does not
+    re-read the tree to find out what happened, because the response already
+    carries the node as it stands afterwards.
+    """
+    ok, doc = call_tool(path, tool, arguments, request_id=8)
+    if not ok:
+        raise Failure(f"{tool} ({what}) was refused: {doc}")
+    if not doc.get("dispatched"):
+        raise Failure(f"{tool} ({what}) was not dispatched: {doc}")
+    return doc
+
+
+def numeric(value):
+    """The leading number in a slider's reported value, or None.
+
+    The framework formats this itself and the exact spelling is not ours to
+    depend on -- percentages and units both occur -- so this reads the number
+    and ignores the rest rather than matching a string.
+    """
+    if value is None:
+        return None
+    match = re.search(r"-?\d+(?:\.\d+)?", str(value))
+    return float(match.group()) if match else None
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     default_runtime = os.environ.get("XDG_RUNTIME_DIR") or \
@@ -262,12 +299,94 @@ def main():
         if after.get("events") != before.get("events"):
             raise Failure("a refused tap still reached the widget")
 
+    # C6 -- a multi-step flow driven entirely by what
+    # an agent can actually see, with each step verified from the action's own
+    # response rather than by re-reading the tree.
+    #
+    # No node ids are carried in from outside and no identifiers are used:
+    # identifiers are empty at the 3.38.3 deployment floor (plan section 2.2),
+    # so a flow that depended on them would pass here and fail on a target.
+    def c6_multi_step_flow():
+        # Step 1: find the control by role and the action it offers, which is
+        # how an agent picks a target it was not told about.
+        found = query(args.socket, role="slider", action="increase")
+        if found.get("match_count", 0) < 1:
+            raise Failure("no slider offering increase; the app did not "
+                          "publish one, or the selectors did not match it")
+        slider = found["nodes"][0]
+        if slider.get("label") != "Temperature":
+            raise Failure(f"found the wrong slider: {slider.get('label')!r}")
+
+        start = numeric(slider.get("value"))
+        if start is None:
+            raise Failure(f"slider reports no numeric value: {slider!r}")
+        app_start = numeric(status_fields(args.socket).get("temp"))
+        if app_start is None:
+            raise Failure("the app did not report its temperature")
+
+        # Step 2: act, and read the outcome out of the action's own reply.
+        first = act(args.socket, "ui_increase", {"node_id": slider["id"]},
+                    "raise the temperature")
+        if first.get("mode") != "semantics":
+            raise Failure(f"expected a semantics dispatch: {first}")
+        after = first.get("node_after")
+        if after is None:
+            raise Failure("node_after was null; the slider left the tree")
+        raised = numeric(after.get("value"))
+        if raised is None or raised <= start:
+            raise Failure(
+                f"the slider did not move: {start} -> {raised}. The action "
+                f"reached the framework, so either the widget ignored it or "
+                f"node_after is reporting the pre-action tree")
+
+        # Step 3: again, to show the flow accumulates rather than each step
+        # being read against a stale baseline.
+        second = act(args.socket, "ui_increase", {"node_id": slider["id"]},
+                     "raise it again")
+        twice = numeric((second.get("node_after") or {}).get("value"))
+        if twice is None or twice <= raised:
+            raise Failure(f"second step did not advance: {raised} -> {twice}")
+
+        # Step 4: a custom action, found and invoked by its label. These are
+        # the application's own verbs -- there is no fixed set, and the label
+        # is the only handle an agent has on one.
+        climate = query(args.socket, custom_action="Set to Auto")
+        if climate.get("match_count", 0) < 1:
+            raise Failure("no node declares the custom action 'Set to Auto'")
+        node = climate["nodes"][0]
+        act(args.socket, "ui_custom_action",
+            {"node_id": node["id"], "action": "Set to Auto"},
+            "switch the climate mode")
+
+        # The custom action's effect is app state rather than node state, so
+        # this one step is confirmed through the status line -- which is also
+        # the proof the widget's own closure ran, not merely that the dispatch
+        # was accepted.
+        fields = wait_for(args.socket, lambda f: f.get("mode") == "auto",
+                          args.timeout, "the custom action's handler to run")
+
+        # And the slider's movement reached the app's own state, not just the
+        # semantics node.
+        #
+        # Compared as a direction, not a number. The framework reports a
+        # slider's semantic value as a percentage of its range while the app
+        # holds degrees, so the two are the same movement in different units
+        # and equating them would be checking the unit conversion rather than
+        # the dispatch.
+        reported = numeric(fields.get("temp"))
+        if reported is None or reported <= app_start:
+            raise Failure(
+                f"the tree moved but the app did not: app was {app_start}, "
+                f"now {reported}, while node_after went {start} -> {twice}")
+
     check("C1", "the tree describes the app", c1)
     check("C2", "ui_tap invokes the widget's own handler", c2)
     check("C3", "ui_set_text reaches the field (R-9)", c3)
     check("C4a", "the unannotated region is absent from the tree", c4_no_node)
     check("C4b", "ui_tap_at reaches it anyway (DR-7)", c4_pointer_reaches)
     check("C5", "a disabled control is refused before dispatch", c5)
+    check("C6", "a multi-step flow by role, label and custom-action name",
+          c6_multi_step_flow)
 
     width = max(len(d) for _, d, _, _ in results)
     failed = 0

--- a/test/unit_test/semantics_translator-test/test_case_semantics_translator.cc
+++ b/test/unit_test/semantics_translator-test/test_case_semantics_translator.cc
@@ -195,3 +195,37 @@ TEST(SemanticsTranslator, EmptyNodeIsInertGenericContainer) {
   EXPECT_FALSE(s.action_tap);
   EXPECT_FALSE(s.focusable);
 }
+
+// ─── Actions ───────────────────────────────────────────────────────────────
+
+// Every action the hub can dispatch has to be read off the engine's mask
+// here, or the bit is never set and the action is refused before it is tried.
+//
+// Custom actions were missed for exactly that reason, and the unit tests did
+// not catch it because they published trees with the bit set by hand. Only
+// driving a real engine showed the node arriving with no custom-action bit at
+// all, so this asserts the translation rather than the fixture's arrangement
+// of it.
+TEST(SemanticsTranslator, CustomActionIsReadFromTheEngineMask) {
+  EXPECT_TRUE(Translate(1, Flags(0),
+                        Actions(kFlutterSemanticsActionCustomAction), false,
+                        false)
+                  .action_custom_action);
+  EXPECT_FALSE(
+      Translate(1, Flags(0), Actions(kFlutterSemanticsActionTap), false, false)
+          .action_custom_action);
+}
+
+// The neighbouring actions, so a future edit that renumbers or drops one is
+// caught here rather than in a flow that mysteriously stops working.
+TEST(SemanticsTranslator, ActionBitsAreReadIndividually) {
+  const NodeSpec tap =
+      Translate(1, Flags(0), Actions(kFlutterSemanticsActionTap), false, false);
+  EXPECT_TRUE(tap.action_tap);
+  EXPECT_FALSE(tap.action_increase);
+
+  const NodeSpec increase = Translate(
+      1, Flags(0), Actions(kFlutterSemanticsActionIncrease), false, false);
+  EXPECT_TRUE(increase.action_increase);
+  EXPECT_FALSE(increase.action_tap);
+}


### PR DESCRIPTION
**The MCP feature driven as a whole flow against a real engine — and doing that found a chain broken in three places.**

## The flow

Everything so far exercised the feature a step at a time. This drives a whole flow the way an agent actually has to:

1. **find** a slider by `role` + the `action` it offers — not by an id passed in from outside
2. **raise it twice**, reading each result out of the action's own `node_after`, never re-reading the tree
3. **invoke a custom action by its label** — `"Set to Auto"`
4. confirm the app's own state moved, not just the semantics node

**No identifiers anywhere.** They are empty on the engine revisions deployed today, so a flow resting on them would pass here and fail on every shipping target.

```
C1   the tree describes the app                               PASS
C2   ui_tap invokes the widget's own handler                  PASS
C3   ui_set_text reaches the field                            PASS
C4a  the unannotated region is absent from the tree           PASS
C4b  ui_tap_at reaches it anyway                              PASS
C5   a disabled control is refused before dispatch            PASS
C6   a multi-step flow by role, label and custom-action name  PASS

7/7 checks passed
```

Repeatable — three consecutive runs, all 7/7. (Under a compositor we control, and with the screen unlocked; that was checked first.)

## The custom action was refused on the first real run

The cause was three layers below where I had worked. **`semantics_translator` never read `kFlutterSemanticsActionCustomAction`** — there was no `action_custom_action` field at all — so the bit was never set on any node in production, and **every custom action was refused before dispatch**.

Downstream of that: the publisher had nothing to carry, and `WriteActions` couldn't have displayed it either, because `ui_custom_action` is routed by name and carries no action bit, so the loop over `kTools` cannot reach it. A node able to run the app's own verbs advertised **nothing**.

Making custom actions invocable needed four changes — encoder, translator, publisher, serializer. Only the encoder was in place.

## Why the unit tests didn't catch it

**They published trees with the bit set by hand.** The existing test wrote `card.actions = IHS_SEMANTICS_ACTION_CUSTOM_ACTION` and then asserted the provider did the right thing with it — which it did. Nothing exercised the path where the *engine* decides what a node offers.

The new translator test asserts the mapping from the engine's action mask rather than a fixture's arrangement of it. That is the specific gap that let this through.

## One fixture bug, worth knowing when annotating an app

**Flutter reports a slider's semantic value as a percentage of its range.** My check compared it against an app-held value in degrees — comparing units, not behaviour, and my own helper comment had noted percentages occur before I did it anyway. It compares direction now.

28/28 ctest, 14 translator tests, `format.sh` and the config-reference gate clean.
