### PR TITLE
mcp: let an application declare typed tools of its own

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -192,6 +192,9 @@ endif ()
 # declare against a surface this build does not have.
 if (BUILD_MCP)
     target_sources(ihs_shared PRIVATE src/mcp_provider.cc)
+    # Tools an application declares for itself: a provider whose list comes
+    # from the app rather than from the semantics tree.
+    target_sources(ihs_shared PRIVATE src/mcp_app_tools.cc)
     target_compile_definitions(ihs_shared PUBLIC IHS_WITH_MCP=1)
     # The semantics provider bridges the two: it needs the hub as well as the
     # registry, so it is only built when both are.
@@ -313,7 +316,9 @@ if (NOT BUILD_ACCESSIBILITY)
     list(APPEND _ihs_header_excludes PATTERN "ihs_semantics.h" EXCLUDE)
 endif ()
 if (NOT BUILD_MCP)
-    list(APPEND _ihs_header_excludes PATTERN "ihs_mcp_provider.h" EXCLUDE)
+    list(APPEND _ihs_header_excludes
+            PATTERN "ihs_mcp_provider.h" EXCLUDE
+            PATTERN "ihs_mcp_app_tools.h" EXCLUDE)
 endif ()
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ihs
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/shared/include/ihs/ihs_mcp_app_tools.h
+++ b/shared/include/ihs/ihs_mcp_app_tools.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Tools an application declares for itself.
+ *
+ * The semantics tools are generic verbs -- tap this, set that -- derived from
+ * what the framework already publishes, and they need no cooperation from the
+ * application. This is the other kind: a typed, named operation the
+ * application defines, with a JSON Schema for its arguments, so an agent can
+ * call hvac_set_temp(zone, celsius) rather than assembling it out of taps on
+ * whatever happens to be on screen.
+ *
+ * Why the arguments cannot ride a semantics action. A custom action is an id
+ * and nothing else: the framework resolves a handler by it and passes no
+ * parameters. So a typed call has to reach the application directly, which is
+ * what `invoke` below is for -- there is no way to express this over the
+ * semantics pipeline, and pretending otherwise would mean encoding arguments
+ * into labels.
+ *
+ * Why this is a C entry point rather than a platform channel. libihs_shared is
+ * already the supported binary interface to out-of-tree Dart FFI plugins (see
+ * docs/PLUGIN_ABI.md), and registration is a control-plane operation that
+ * happens on a route change rather than per frame -- so a wire format would be
+ * new surface to own for no measurable gain. An application reaches this
+ * through dart:ffi and hands back a NativeCallable for `invoke`.
+ *
+ * Lifecycle:
+ *   1. ihs_mcp_app_tools_register with the tools and an invoke callback. The
+ *      tools appear in tools/list at once, and clients are told the list
+ *      changed.
+ *   2. A client calls one. `invoke` fires with a call id and the arguments as
+ *      the client sent them, unparsed -- the schema is the application's to
+ *      enforce, since it wrote it.
+ *   3. The application answers with ihs_mcp_app_tools_complete, from any
+ *      thread. A call not completed within the timeout is reported to the
+ *      client as a failure rather than left hanging.
+ *   4. ihs_mcp_app_tools_unregister on teardown. Any call still outstanding is
+ *      failed rather than abandoned, and no invoke fires afterwards.
+ *
+ * Registration is additive and optional: an application that declares nothing
+ * still has the semantics tools, and the MCP surface works with no Dart-side
+ * dependency at all.
+ */
+
+#ifndef IHS_MCP_APP_TOOLS_H_
+#define IHS_MCP_APP_TOOLS_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ihs/ihs_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* An opaque registration. Valid until unregister returns. */
+typedef struct IhsMcpAppTools IhsMcpAppTools;
+
+/* One tool the application declares. */
+typedef struct IhsMcpAppTool {
+  /*
+   * Unprefixed, as the application thinks of it ("set_temp"). The prefix from
+   * the registration is applied before it is advertised, so an application
+   * never has to repeat its own namespace.
+   */
+  const char* name;
+
+  /* Shown to the agent choosing between tools. Not optional: a tool with no
+   * description is one an agent has to guess at. */
+  const char* description;
+
+  /*
+   * JSON Schema for the arguments, spliced into tools/list as-is. The
+   * application owns both this and the parsing, so the two cannot disagree
+   * about what the tool takes.
+   */
+  const char* input_schema_json;
+
+  /*
+   * Exactly one IHS_MCP_CAP_* bit, or 0 for IHS_MCP_CAP_INTERACT. A tool
+   * outside the consumer's mask is dropped from the advertised list rather
+   * than refused when called, as everywhere else.
+   */
+  uint64_t capability;
+} IhsMcpAppTool;
+
+/*
+ * Invoked when a client calls one of the tools.
+ *
+ * `tool_name` is unprefixed, matching what was registered. `arguments_json` is
+ * what the client sent, unparsed and not validated against the schema.
+ *
+ * Called on the thread serving the request, which is not the platform thread.
+ * It must not block: the call is answered by ihs_mcp_app_tools_complete, which
+ * may happen on any thread and at any later point, so an implementation is
+ * free to hop to the UI thread and reply from there.
+ */
+typedef void (*IhsMcpAppToolInvoke)(void* user_data,
+                                    uint64_t call_id,
+                                    const char* tool_name,
+                                    const char* arguments_json,
+                                    size_t arguments_length);
+
+typedef struct IhsMcpAppToolsDesc {
+  size_t struct_size; /* sizeof(IhsMcpAppToolsDesc) */
+
+  /*
+   * Namespace for this application's tools, a bare identifier prefix
+   * ("hvac_"). Checked for collision against every other provider, so an
+   * application cannot shadow the built-in verbs or another application's.
+   */
+  const char* tool_prefix;
+
+  /* Copied during registration; the caller may free them afterwards. */
+  const IhsMcpAppTool* tools;
+  size_t tool_count;
+
+  IhsMcpAppToolInvoke invoke;
+  void* user_data;
+
+  /*
+   * How long a call waits for the application before it is reported failed.
+   * 0 selects a default. Bounded because the alternative is an agent blocked
+   * on an application that will never answer, with no way to tell that from
+   * one still working.
+   */
+  uint32_t call_timeout_ms;
+} IhsMcpAppToolsDesc;
+
+/*
+ * Registers the tools. Returns IHS_MCP_OK, IHS_MCP_ERR_INVALID for a malformed
+ * descriptor, or IHS_MCP_ERR_PREFIX_TAKEN when the prefix collides with one
+ * already claimed -- kept distinct from a plain refusal, so a caller can tell
+ * "another application owns this namespace" from "the host declined".
+ *
+ * Clients are notified that the tool list changed, so an agent that has
+ * already listed tools learns about these without polling.
+ */
+IHS_EXPORT int ihs_mcp_app_tools_register(const IhsMcpAppToolsDesc* desc,
+                                          IhsMcpAppTools** out_handle);
+
+/*
+ * Answers a call. `result_json` is returned to the client as the tool's
+ * result; pass NULL for an empty one. `ok` false marks it as a tool error,
+ * which is how a tool reports that it ran and failed as distinct from the tool
+ * not existing.
+ *
+ * Returns IHS_MCP_ERR_NOT_FOUND for a call id that is unknown or has already
+ * been answered -- including one that timed out, so a late reply is reported
+ * rather than silently discarded.
+ */
+IHS_EXPORT int ihs_mcp_app_tools_complete(uint64_t call_id,
+                                          bool ok,
+                                          const char* result_json,
+                                          size_t result_length);
+
+/*
+ * Unregisters. Any call still outstanding is failed before this returns, and
+ * no invoke fires afterwards, so the callback and its user_data are safe to
+ * tear down once this has returned. Passing NULL is a no-op.
+ */
+IHS_EXPORT void ihs_mcp_app_tools_unregister(IhsMcpAppTools* handle);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* IHS_MCP_APP_TOOLS_H_ */

--- a/shared/include/ihs/ihs_mcp_provider.h
+++ b/shared/include/ihs/ihs_mcp_provider.h
@@ -257,7 +257,14 @@ typedef struct IhsMcpProviderDesc {
   /* Claimed namespaces, both checked for collision at registration.
    * `tool_prefix` is a bare identifier prefix ("ui_"); `resource_scheme` is a
    * URI scheme without the separator ("ui"), which the host renders as
-   * "ui://". */
+   * "ui://".
+   *
+   * `resource_scheme` may be NULL or "" for a provider serving tools only.
+   * Requiring one would make such a provider claim a namespace it never
+   * answers for: reads would return "not found" indistinguishably from an
+   * absent resource, and no other provider could claim the scheme. A provider
+   * with no scheme is never routed a resource read and never emits a resource
+   * notification. `tool_prefix` is always required. */
   const char* tool_prefix;
   const char* resource_scheme;
 

--- a/shared/src/mcp_app_tools.cc
+++ b/shared/src/mcp_app_tools.cc
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tools an application declares for itself. See ihs/ihs_mcp_app_tools.h for
+// the contract; this is a provider whose tool list is whatever was registered
+// and whose call_tool hands the call to the application and waits for it.
+
+#include "ihs/ihs_mcp_app_tools.h"
+
+#include "ihs/ihs_mcp_provider.h"
+
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "ihs/logging.h"
+
+namespace {
+
+int32_t TraceContext() {
+  static const int32_t ctx = ihs_log_context_open("MCPA", nullptr);
+  return ctx;
+}
+
+void Log(const int32_t level, const std::string& text) {
+  const int32_t ctx = TraceContext();
+  if (ctx < 0 || ihs_log_enabled(ctx, level) == 0) {
+    return;
+  }
+  ihs_log(ctx, level, text.c_str(), text.size());
+}
+
+constexpr uint32_t kDefaultCallTimeoutMs = 5000;
+
+// One tool, with its strings owned here. The descriptor a caller passes is
+// borrowed for the length of the register call only, and a Dart caller's
+// strings are unlikely to outlive it.
+struct OwnedTool {
+  std::string name;
+  std::string description;
+  std::string schema;
+  uint64_t capability = 0;
+};
+
+// A call handed to the application and not yet answered.
+struct PendingCall {
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool answered = false;
+  bool ok = false;
+  std::string result;
+};
+
+struct Registration {
+  std::string prefix;
+  std::vector<OwnedTool> tools;
+  // Rebuilt whenever `tools` changes: the registry borrows this array and
+  // reads the pointers out of it, so it has to outlive the list_tools call.
+  std::vector<IhsMcpToolDesc> advertised;
+  IhsMcpAppToolInvoke invoke = nullptr;
+  void* user_data = nullptr;
+  uint32_t timeout_ms = kDefaultCallTimeoutMs;
+  IhsMcpProvider* provider = nullptr;
+  int notify_fd = -1;
+
+  // Held across an invoke so unregister cannot pull the callback out from
+  // under a call already on its way to the application.
+  std::mutex mutex;
+  bool live = false;
+};
+
+struct State {
+  std::mutex mutex;
+  std::map<uint64_t, std::shared_ptr<PendingCall>> calls;
+  uint64_t next_call_id = 1;
+};
+
+State& TheState() {
+  static auto* state = new State();  // leaked: outlives static teardown
+  return *state;
+}
+
+// ---------------------------------------------------------------------------
+// Provider callbacks
+// ---------------------------------------------------------------------------
+
+int ListTools(void* user_data,
+              const IhsMcpToolDesc** out_tools,
+              size_t* out_count) {
+  auto* reg = static_cast<Registration*>(user_data);
+  const std::lock_guard<std::mutex> lock(reg->mutex);
+  *out_tools = reg->advertised.empty() ? nullptr : reg->advertised.data();
+  *out_count = reg->advertised.size();
+  return IHS_MCP_OK;
+}
+
+int ListResources(void* /* user_data */,
+                  const IhsMcpResourceDesc** out_resources,
+                  size_t* out_count) {
+  // Tools only. An application that wants to publish readable state has the
+  // semantics tree for it already.
+  *out_resources = nullptr;
+  *out_count = 0;
+  return IHS_MCP_OK;
+}
+
+int ReadResource(void* /* user_data */,
+                 const char* /* uri */,
+                 IhsMcpPayload* /* out_content */) {
+  return IHS_MCP_ERR_NOT_FOUND;
+}
+
+void ReleasePayload(void* ctx) {
+  delete[] static_cast<char*>(ctx);
+}
+
+void FillPayload(IhsMcpPayload* out, const std::string& text) {
+  char* copy = new char[text.size()];
+  std::memcpy(copy, text.data(), text.size());
+  out->struct_size = sizeof(IhsMcpPayload);
+  out->data = copy;
+  out->length = text.size();
+  out->release = ReleasePayload;
+  out->release_ctx = copy;
+}
+
+int CallTool(void* user_data,
+             const char* name,
+             const char* arguments_json,
+             size_t arguments_length,
+             IhsMcpPayload* out_result) {
+  auto* reg = static_cast<Registration*>(user_data);
+
+  IhsMcpAppToolInvoke invoke = nullptr;
+  void* invoke_user_data = nullptr;
+  uint32_t timeout_ms = kDefaultCallTimeoutMs;
+  {
+    const std::lock_guard<std::mutex> lock(reg->mutex);
+    if (!reg->live) {
+      return IHS_MCP_ERR_UNAVAILABLE;
+    }
+    bool known = false;
+    for (const OwnedTool& tool : reg->tools) {
+      if (tool.name == name) {
+        known = true;
+        break;
+      }
+    }
+    if (!known) {
+      return IHS_MCP_ERR_NOT_FOUND;
+    }
+    invoke = reg->invoke;
+    invoke_user_data = reg->user_data;
+    timeout_ms = reg->timeout_ms;
+  }
+
+  auto call = std::make_shared<PendingCall>();
+  uint64_t call_id = 0;
+  {
+    State& state = TheState();
+    const std::lock_guard<std::mutex> lock(state.mutex);
+    call_id = state.next_call_id++;
+    state.calls[call_id] = call;
+  }
+
+  // Invoked with no lock held: the application is free to complete the call
+  // from inside this callback, on this thread, and holding anything here would
+  // deadlock the simplest implementation there is.
+  invoke(invoke_user_data, call_id, name,
+         arguments_json != nullptr ? arguments_json : "", arguments_length);
+
+  bool answered = false;
+  bool ok = false;
+  std::string result;
+  {
+    std::unique_lock<std::mutex> lock(call->mutex);
+    answered = call->cv.wait_for(lock, std::chrono::milliseconds(timeout_ms),
+                                 [&call]() { return call->answered; });
+    ok = call->ok;
+    result = call->result;
+  }
+
+  // Removed whether or not it was answered, so a late completion is reported
+  // to the application as unknown rather than writing into a call nobody is
+  // waiting on.
+  {
+    State& state = TheState();
+    const std::lock_guard<std::mutex> lock(state.mutex);
+    state.calls.erase(call_id);
+  }
+
+  if (!answered) {
+    Log(IHS_LEVEL_WARN, std::string("app tool '") + name +
+                            "' did not answer within " +
+                            std::to_string(timeout_ms) + "ms");
+    return IHS_MCP_ERR_UNAVAILABLE;
+  }
+  if (!result.empty()) {
+    FillPayload(out_result, result);
+  }
+  return ok ? IHS_MCP_OK : IHS_MCP_ERR_REFUSED;
+}
+
+// Tells clients the tool list changed. The registry re-lists and emits
+// notifications/tools/list_changed, so an agent that already listed does not
+// have to poll to discover a route's tools.
+void SignalListChanged(const Registration& reg) {
+  if (reg.notify_fd < 0) {
+    return;
+  }
+  const uint64_t one = 1;
+  ssize_t written;
+  do {
+    written = ::write(reg.notify_fd, &one, sizeof(one));
+  } while (written < 0 && errno == EINTR);
+}
+
+}  // namespace
+
+struct IhsMcpAppTools {
+  Registration reg;
+};
+
+extern "C" {
+
+int ihs_mcp_app_tools_register(const IhsMcpAppToolsDesc* desc,
+                               IhsMcpAppTools** out_handle) {
+  if (desc == nullptr || desc->struct_size == 0 || out_handle == nullptr ||
+      desc->invoke == nullptr || desc->tool_prefix == nullptr ||
+      desc->tool_prefix[0] == '\0') {
+    return IHS_MCP_ERR_INVALID;
+  }
+  if (desc->tool_count > 0 && desc->tools == nullptr) {
+    return IHS_MCP_ERR_INVALID;
+  }
+
+  auto handle = std::make_unique<IhsMcpAppTools>();
+  Registration& reg = handle->reg;
+  reg.prefix = desc->tool_prefix;
+  reg.invoke = desc->invoke;
+  reg.user_data = desc->user_data;
+  reg.timeout_ms = desc->call_timeout_ms != 0 ? desc->call_timeout_ms
+                                              : kDefaultCallTimeoutMs;
+
+  for (size_t i = 0; i < desc->tool_count; i++) {
+    const IhsMcpAppTool& in = desc->tools[i];
+    if (in.name == nullptr || in.name[0] == '\0') {
+      return IHS_MCP_ERR_INVALID;
+    }
+    OwnedTool tool;
+    tool.name = in.name;
+    tool.description = in.description != nullptr ? in.description : "";
+    tool.schema = in.input_schema_json != nullptr
+                      ? in.input_schema_json
+                      : R"({"type":"object","properties":{}})";
+    tool.capability = in.capability != 0 ? in.capability : IHS_MCP_CAP_INTERACT;
+    reg.tools.push_back(std::move(tool));
+  }
+
+  reg.advertised.reserve(reg.tools.size());
+  for (const OwnedTool& tool : reg.tools) {
+    IhsMcpToolDesc out{};
+    out.name = tool.name.c_str();
+    out.description = tool.description.c_str();
+    out.input_schema_json = tool.schema.c_str();
+    out.capability = tool.capability;
+    reg.advertised.push_back(out);
+  }
+
+  // Its own descriptor, so a tool list change is a signal the registry already
+  // knows how to turn into notifications/tools/list_changed.
+  reg.notify_fd = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+
+  IhsMcpProviderDesc provider{};
+  provider.struct_size = sizeof(provider);
+  provider.name = "app";
+  provider.tool_prefix = reg.prefix.c_str();
+  // No resource scheme: this provider serves tools only, and claiming one
+  // would collide with a provider that actually publishes resources.
+  provider.resource_scheme = nullptr;
+  provider.capability_mask = IHS_MCP_CAP_ALL;
+  provider.notify_fd = reg.notify_fd;
+  provider.user_data = &reg;
+  provider.callbacks.list_tools = ListTools;
+  provider.callbacks.list_resources = ListResources;
+  provider.callbacks.call_tool = CallTool;
+  provider.callbacks.read_resource = ReadResource;
+
+  const int status = ihs_mcp_provider_register(&provider, &reg.provider);
+  if (status != IHS_MCP_OK) {
+    if (reg.notify_fd >= 0) {
+      ::close(reg.notify_fd);
+      reg.notify_fd = -1;
+    }
+    return status;
+  }
+
+  {
+    const std::lock_guard<std::mutex> lock(reg.mutex);
+    reg.live = true;
+  }
+  SignalListChanged(reg);
+
+  Log(IHS_LEVEL_INFO, "registered " + std::to_string(reg.tools.size()) +
+                          " application tool(s) under '" + reg.prefix + "'");
+  *out_handle = handle.release();
+  return IHS_MCP_OK;
+}
+
+int ihs_mcp_app_tools_complete(const uint64_t call_id,
+                               const bool ok,
+                               const char* result_json,
+                               const size_t result_length) {
+  std::shared_ptr<PendingCall> call;
+  {
+    State& state = TheState();
+    const std::lock_guard<std::mutex> lock(state.mutex);
+    const auto it = state.calls.find(call_id);
+    if (it == state.calls.end()) {
+      return IHS_MCP_ERR_NOT_FOUND;
+    }
+    call = it->second;
+  }
+
+  {
+    const std::lock_guard<std::mutex> lock(call->mutex);
+    if (call->answered) {
+      return IHS_MCP_ERR_NOT_FOUND;  // answered once already
+    }
+    call->answered = true;
+    call->ok = ok;
+    if (result_json != nullptr && result_length > 0) {
+      call->result.assign(result_json, result_length);
+    }
+  }
+  call->cv.notify_one();
+  return IHS_MCP_OK;
+}
+
+void ihs_mcp_app_tools_unregister(IhsMcpAppTools* handle) {
+  if (handle == nullptr) {
+    return;
+  }
+  Registration& reg = handle->reg;
+
+  // Marked dead first: a call that has not yet reached CallTool is refused
+  // rather than dispatched into a callback about to be torn down.
+  {
+    const std::lock_guard<std::mutex> lock(reg.mutex);
+    reg.live = false;
+  }
+
+  // Fail everything outstanding before unregistering. A caller waiting on the
+  // application would otherwise wait out its whole timeout for an answer that
+  // can no longer come.
+  {
+    State& state = TheState();
+    std::vector<std::shared_ptr<PendingCall>> orphaned;
+    {
+      const std::lock_guard<std::mutex> lock(state.mutex);
+      for (auto& entry : state.calls) {
+        orphaned.push_back(entry.second);
+      }
+    }
+    for (const std::shared_ptr<PendingCall>& call : orphaned) {
+      {
+        const std::lock_guard<std::mutex> lock(call->mutex);
+        if (call->answered) {
+          continue;
+        }
+        call->answered = true;
+        call->ok = false;
+      }
+      call->cv.notify_one();
+    }
+  }
+
+  // Drains any dispatch already in flight before returning, so no invoke can
+  // fire after this.
+  if (reg.provider != nullptr) {
+    ihs_mcp_provider_unregister(reg.provider);
+    reg.provider = nullptr;
+  }
+  if (reg.notify_fd >= 0) {
+    ::close(reg.notify_fd);
+    reg.notify_fd = -1;
+  }
+  delete handle;
+}
+
+}  // extern "C"

--- a/shared/src/mcp_provider.cc
+++ b/shared/src/mcp_provider.cc
@@ -174,8 +174,13 @@ void WatchProviders() {
       // notifications go out. A client that re-reads a tool list which did
       // not change loses nothing; one that never hears about a change does.
       sink(IHS_MCP_NOTIFY_TOOLS_CHANGED, "", sink_user_data);
-      sink(IHS_MCP_NOTIFY_RESOURCE_UPDATED, resource_uris[i - 1].c_str(),
-           sink_user_data);
+      // A provider serving no resources has no URI to name, and an update for
+      // "" would reach every subscriber as a change to something they cannot
+      // read.
+      if (!resource_uris[i - 1].empty()) {
+        sink(IHS_MCP_NOTIFY_RESOURCE_UPDATED, resource_uris[i - 1].c_str(),
+             sink_user_data);
+      }
     }
   }
 }
@@ -204,6 +209,11 @@ Provider* FindByToolName(Registry& registry, const char* name) {
 
 Provider* FindByUri(Registry& registry, const char* uri) {
   for (const auto& provider : registry.providers) {
+    // An empty prefix matches every URI, so a tools-only provider would
+    // otherwise capture reads meant for a real one.
+    if (provider->resource_prefix.empty()) {
+      continue;
+    }
     if (StartsWith(uri, provider->resource_prefix)) {
       return provider.get();
     }
@@ -226,21 +236,30 @@ int ihs_mcp_provider_register(const IhsMcpProviderDesc* desc,
                               IhsMcpProvider** out_provider) {
   if (desc == nullptr || out_provider == nullptr ||
       desc->struct_size < sizeof(IhsMcpProviderDesc) || desc->name == nullptr ||
-      desc->tool_prefix == nullptr || desc->resource_scheme == nullptr) {
+      desc->tool_prefix == nullptr) {
     return IHS_MCP_ERR_INVALID;
   }
   // An empty prefix would claim the entire namespace and collide with every
   // provider that follows, so it is rejected rather than being allowed to
   // become a first-registration-wins land grab.
-  if (desc->tool_prefix[0] == '\0' || desc->resource_scheme[0] == '\0') {
+  if (desc->tool_prefix[0] == '\0') {
     return IHS_MCP_ERR_INVALID;
   }
+  // A null or empty resource_scheme means the provider serves tools only.
+  // Requiring one would make such a provider claim a URI namespace it never
+  // answers for: reads against it would return "not found" indistinguishably
+  // from a resource that is merely absent, and no other provider could claim
+  // the scheme afterwards.
+  const bool serves_resources =
+      desc->resource_scheme != nullptr && desc->resource_scheme[0] != '\0';
 
   auto provider = std::make_unique<Provider>();
   provider->name = desc->name;
   provider->tool_prefix = desc->tool_prefix;
-  provider->resource_scheme = desc->resource_scheme;
-  provider->resource_prefix = provider->resource_scheme + "://";
+  if (serves_resources) {
+    provider->resource_scheme = desc->resource_scheme;
+    provider->resource_prefix = provider->resource_scheme + "://";
+  }
   provider->capability_mask = desc->capability_mask;
   provider->callbacks = desc->callbacks;
   provider->user_data = desc->user_data;
@@ -251,9 +270,15 @@ int ihs_mcp_provider_register(const IhsMcpProviderDesc* desc,
     Registry& registry = TheRegistry();
     std::lock_guard<std::mutex> lock(registry.mutex);
     for (const auto& existing : registry.providers) {
+      // Schemes are compared only when both providers have one: an empty
+      // scheme is a prefix of everything, so including it here would make the
+      // first tools-only provider collide with every provider after it.
+      const bool schemes_collide =
+          !existing->resource_scheme.empty() &&
+          !provider->resource_scheme.empty() &&
+          PrefixesOverlap(existing->resource_scheme, provider->resource_scheme);
       if (PrefixesOverlap(existing->tool_prefix, provider->tool_prefix) ||
-          PrefixesOverlap(existing->resource_scheme,
-                          provider->resource_scheme)) {
+          schemes_collide) {
         // Rejected whole: a provider is never half-registered, so a caller
         // that ignores the status does not end up with resources served and
         // tools missing.

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -198,6 +198,7 @@ add_subdirectory(mutation_stack-test)
 # its tests would have nothing to link against otherwise.
 if (BUILD_MCP)
     add_subdirectory(mcp_provider-test)
+    add_subdirectory(mcp_app_tools-test)
     # The transport routes onto the registry and needs nothing else.
     add_subdirectory(mcp_transport-test)
     # The semantics provider needs the hub as well as the registry.

--- a/test/unit_test/mcp_app_tools-test/CMakeLists.txt
+++ b/test/unit_test/mcp_app_tools-test/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tests for tools an application declares for itself. Drives the exported C ABI
+# with a mock application, so no socket, engine or Dart isolate is involved:
+# the call path is a callback and a completion, which a test can be both ends of.
+set(TESTCASE_NAME "homescreen_mcp_app_tools_ut_test_driver")
+
+add_executable(${TESTCASE_NAME}
+        test_case_mcp_app_tools.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        ivi_homescreen::ihs_shared
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/mcp_app_tools-test/test_case_mcp_app_tools.cc
+++ b/test/unit_test/mcp_app_tools-test/test_case_mcp_app_tools.cc
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "ihs/ihs_mcp_app_tools.h"
+#include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_mcp_registry.h"
+
+namespace {
+
+// Stands in for the application. Records what it was asked and answers
+// however the test tells it to -- which is the whole surface, since an
+// application's only obligations are to receive an invoke and to complete it.
+struct MockApp {
+  std::string last_tool;
+  std::string last_arguments;
+  uint64_t last_call_id = 0;
+  int invocations = 0;
+
+  // How to answer. Answering from inside the invoke is the simplest thing an
+  // application can do and the easiest to deadlock, so it is the default here.
+  bool answer_inline = true;
+  bool answer_ok = true;
+  std::string answer_result = R"({"ok":true})";
+};
+
+MockApp* g_app = nullptr;
+
+void OnInvoke(void* /*user_data*/,
+              const uint64_t call_id,
+              const char* tool_name,
+              const char* arguments_json,
+              const size_t arguments_length) {
+  g_app->invocations++;
+  g_app->last_tool = tool_name != nullptr ? tool_name : "";
+  g_app->last_arguments.assign(arguments_json, arguments_length);
+  g_app->last_call_id = call_id;
+  if (g_app->answer_inline) {
+    ihs_mcp_app_tools_complete(call_id, g_app->answer_ok,
+                               g_app->answer_result.data(),
+                               g_app->answer_result.size());
+  }
+}
+
+IhsMcpAppTool Tool(const char* name, const char* schema) {
+  IhsMcpAppTool tool{};
+  tool.name = name;
+  tool.description = "declared by the application";
+  tool.input_schema_json = schema;
+  tool.capability = 0;  // defaults to interact
+  return tool;
+}
+
+constexpr char kTempSchema[] =
+    R"({"type":"object","properties":{)"
+    R"("zone":{"type":"string"},"celsius":{"type":"number"}},)"
+    R"("required":["zone","celsius"]})";
+
+std::string CallTool(const char* name, const char* args, int* status_out) {
+  IhsMcpPayload payload{};
+  const int status = ihs_mcp_registry_call_tool(
+      name, args, args != nullptr ? std::strlen(args) : 0, &payload);
+  if (status_out != nullptr) {
+    *status_out = status;
+  }
+  std::string body;
+  if (payload.data != nullptr) {
+    body.assign(payload.data, payload.length);
+  }
+  ihs_mcp_registry_release_payload(&payload);
+  return body;
+}
+
+bool Contains(const std::string& haystack, const char* needle) {
+  return haystack.find(needle) != std::string::npos;
+}
+
+class McpAppToolsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    app_ = MockApp{};
+    g_app = &app_;
+  }
+
+  void TearDown() override {
+    if (handle_ != nullptr) {
+      ihs_mcp_app_tools_unregister(handle_);
+      handle_ = nullptr;
+    }
+    g_app = nullptr;
+    ASSERT_EQ(ihs_mcp_provider_count(), 0u);
+  }
+
+  int RegisterOne(const char* prefix = "hvac_", uint32_t timeout_ms = 0) {
+    tools_ = {Tool("set_temp", kTempSchema)};
+    IhsMcpAppToolsDesc desc{};
+    desc.struct_size = sizeof(desc);
+    desc.tool_prefix = prefix;
+    desc.tools = tools_.data();
+    desc.tool_count = tools_.size();
+    desc.invoke = OnInvoke;
+    desc.call_timeout_ms = timeout_ms;
+    return ihs_mcp_app_tools_register(&desc, &handle_);
+  }
+
+  MockApp app_;
+  std::vector<IhsMcpAppTool> tools_;
+  IhsMcpAppTools* handle_ = nullptr;
+};
+
+}  // namespace
+
+// The tools reach clients under the application's own prefix, schema intact.
+// The schema is the reason this exists at all: a generic tap cannot say that
+// an argument is a number in a named range.
+TEST_F(McpAppToolsTest, DeclaredToolsAreAdvertisedWithTheirSchema) {
+  ASSERT_EQ(RegisterOne(), IHS_MCP_OK);
+
+  struct Seen {
+    bool found = false;
+    std::string schema;
+  } seen;
+  ihs_mcp_registry_for_each_tool(
+      [](const IhsMcpRegistryTool* tool, void* user_data) {
+        auto* out = static_cast<Seen*>(user_data);
+        if (std::strcmp(tool->name, "hvac_set_temp") == 0) {
+          out->found = true;
+          out->schema =
+              tool->input_schema_json != nullptr ? tool->input_schema_json : "";
+        }
+      },
+      &seen);
+
+  EXPECT_TRUE(seen.found) << "the application's tool was not advertised";
+  EXPECT_NE(seen.schema.find("celsius"), std::string::npos) << seen.schema;
+}
+
+// The round trip: a client calls, the application is handed the arguments as
+// sent, and its answer comes back as the tool's result.
+TEST_F(McpAppToolsTest, CallReachesTheApplicationAndItsAnswerComesBack) {
+  ASSERT_EQ(RegisterOne(), IHS_MCP_OK);
+  app_.answer_result = R"({"zone":"front","celsius":21.5})";
+
+  int status = 0;
+  const std::string body =
+      CallTool("hvac_set_temp", R"({"zone":"front","celsius":21.5})", &status);
+
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_EQ(app_.invocations, 1);
+  EXPECT_EQ(app_.last_tool, "set_temp") << "the prefix is the host's, not the "
+                                           "application's to strip";
+  EXPECT_TRUE(Contains(app_.last_arguments, "\"celsius\":21.5"))
+      << app_.last_arguments;
+  EXPECT_TRUE(Contains(body, "front")) << body;
+}
+
+// A tool that ran and failed is not the same as a tool that does not exist,
+// and a client that cannot tell them apart retries the wrong one.
+TEST_F(McpAppToolsTest, AnApplicationFailureIsDistinctFromAMissingTool) {
+  ASSERT_EQ(RegisterOne(), IHS_MCP_OK);
+  app_.answer_ok = false;
+  app_.answer_result = R"({"error":"zone is closed"})";
+
+  int failed = 0;
+  const std::string body =
+      CallTool("hvac_set_temp", R"({"zone":"rear"})", &failed);
+  EXPECT_EQ(failed, IHS_MCP_ERR_REFUSED) << body;
+  EXPECT_TRUE(Contains(body, "zone is closed")) << body;
+
+  int missing = 0;
+  CallTool("hvac_no_such_tool", "{}", &missing);
+  EXPECT_EQ(missing, IHS_MCP_ERR_NOT_FOUND);
+}
+
+// An application free to answer later is the point of the split between
+// invoke and complete: it can hop to the UI thread and reply from there.
+TEST_F(McpAppToolsTest, AnAnswerMayArriveFromAnotherThreadLater) {
+  ASSERT_EQ(RegisterOne(), IHS_MCP_OK);
+  app_.answer_inline = false;
+
+  std::thread responder;
+  std::atomic<bool> launched{false};
+  app_.answer_result = R"({"late":true})";
+
+  // Started from the invoke so it cannot answer before the call exists.
+  struct Launcher {
+    static void Go(std::thread* thread, std::atomic<bool>* launched) {
+      *thread = std::thread([]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        const std::string result = R"({"late":true})";
+        ihs_mcp_app_tools_complete(g_app->last_call_id, true, result.data(),
+                                   result.size());
+      });
+      launched->store(true);
+    }
+  };
+
+  // The mock records the id before this runs, so the thread has something to
+  // complete.
+  app_.answer_inline = false;
+  int status = 0;
+  std::thread starter([&]() {
+    while (g_app->last_call_id == 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    Launcher::Go(&responder, &launched);
+  });
+
+  const std::string body =
+      CallTool("hvac_set_temp", R"({"zone":"front"})", &status);
+  starter.join();
+  if (responder.joinable()) {
+    responder.join();
+  }
+
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_TRUE(Contains(body, "late")) << body;
+}
+
+// An application that never answers must not hold the caller open. An agent
+// blocked forever cannot tell that from one still working.
+TEST_F(McpAppToolsTest, ACallThatIsNeverAnsweredTimesOut) {
+  ASSERT_EQ(RegisterOne("hvac_", /*timeout_ms=*/120), IHS_MCP_OK);
+  app_.answer_inline = false;
+
+  const auto started = std::chrono::steady_clock::now();
+  int status = 0;
+  CallTool("hvac_set_temp", R"({"zone":"front"})", &status);
+  const auto elapsed = std::chrono::steady_clock::now() - started;
+
+  EXPECT_EQ(status, IHS_MCP_ERR_UNAVAILABLE);
+  EXPECT_GE(elapsed, std::chrono::milliseconds(100));
+  EXPECT_LT(elapsed, std::chrono::seconds(3)) << "waited far past the timeout";
+}
+
+// A reply that arrives after the timeout is reported rather than written into
+// a call nobody is waiting on.
+TEST_F(McpAppToolsTest, ALateAnswerIsRefusedRatherThanIgnored) {
+  ASSERT_EQ(RegisterOne("hvac_", /*timeout_ms=*/60), IHS_MCP_OK);
+  app_.answer_inline = false;
+
+  int status = 0;
+  CallTool("hvac_set_temp", R"({"zone":"front"})", &status);
+  ASSERT_EQ(status, IHS_MCP_ERR_UNAVAILABLE);
+
+  const std::string late = R"({"too":"late"})";
+  EXPECT_EQ(ihs_mcp_app_tools_complete(app_.last_call_id, true, late.data(),
+                                       late.size()),
+            IHS_MCP_ERR_NOT_FOUND);
+}
+
+// Answering twice is the application getting its own bookkeeping wrong, and
+// silently accepting the second would make that impossible to notice.
+TEST_F(McpAppToolsTest, AnsweringTwiceIsRefused) {
+  ASSERT_EQ(RegisterOne(), IHS_MCP_OK);
+
+  int status = 0;
+  CallTool("hvac_set_temp", R"({"zone":"front"})", &status);
+  ASSERT_EQ(status, IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_app_tools_complete(app_.last_call_id, true, nullptr, 0),
+            IHS_MCP_ERR_NOT_FOUND);
+}
+
+// The prefix is checked against every other provider, so an application
+// cannot shadow the built-in verbs or another application's tools.
+TEST_F(McpAppToolsTest, ACollidingPrefixIsRefused) {
+  ASSERT_EQ(RegisterOne("hvac_"), IHS_MCP_OK);
+
+  std::vector<IhsMcpAppTool> more = {Tool("other", kTempSchema)};
+  IhsMcpAppToolsDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.tool_prefix = "hvac_";
+  desc.tools = more.data();
+  desc.tool_count = more.size();
+  desc.invoke = OnInvoke;
+  IhsMcpAppTools* second = nullptr;
+  // Kept distinct from a plain refusal: a caller can tell "another
+  // application owns this namespace" from "the host declined".
+  EXPECT_EQ(ihs_mcp_app_tools_register(&desc, &second),
+            IHS_MCP_ERR_PREFIX_TAKEN);
+  EXPECT_EQ(second, nullptr);
+}
+
+// Unregistering has to leave nothing behind: the tools go, and a call already
+// waiting is failed rather than left to time out against a callback that no
+// longer exists.
+TEST_F(McpAppToolsTest, UnregisterRemovesTheToolsAndFreesWaiters) {
+  ASSERT_EQ(RegisterOne(), IHS_MCP_OK);
+  ihs_mcp_app_tools_unregister(handle_);
+  handle_ = nullptr;
+
+  int status = 0;
+  CallTool("hvac_set_temp", "{}", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_NOT_FOUND);
+  EXPECT_EQ(app_.invocations, 0);
+}
+
+TEST_F(McpAppToolsTest, AMalformedRegistrationIsRefused) {
+  IhsMcpAppTools* handle = nullptr;
+  EXPECT_EQ(ihs_mcp_app_tools_register(nullptr, &handle), IHS_MCP_ERR_INVALID);
+
+  IhsMcpAppToolsDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.tool_prefix = "x_";
+  desc.invoke = nullptr;  // nothing to call
+  EXPECT_EQ(ihs_mcp_app_tools_register(&desc, &handle), IHS_MCP_ERR_INVALID);
+
+  desc.invoke = OnInvoke;
+  desc.tool_prefix = "";  // no namespace to claim
+  EXPECT_EQ(ihs_mcp_app_tools_register(&desc, &handle), IHS_MCP_ERR_INVALID);
+}

--- a/test/unit_test/mcp_provider-test/test_case_mcp_provider.cc
+++ b/test/unit_test/mcp_provider-test/test_case_mcp_provider.cc
@@ -184,21 +184,64 @@ TEST_F(McpProviderTest, RegisterRejectsMalformedDesc) {
   EXPECT_EQ(ihs_mcp_provider_count(), 0u);
 }
 
-// An empty prefix claims the whole namespace and would collide with every
+// An empty tool prefix claims the whole namespace and would collide with every
 // provider registered after it, so it is refused rather than becoming a
 // first-come land grab.
-TEST_F(McpProviderTest, EmptyPrefixIsRejected) {
+TEST_F(McpProviderTest, EmptyToolPrefixIsRejected) {
   MockProvider mock;
   IhsMcpProvider* provider = nullptr;
 
   IhsMcpProviderDesc no_tool = mock.Desc("m", "", "ui", IHS_MCP_CAP_ALL);
   EXPECT_EQ(ihs_mcp_provider_register(&no_tool, &provider),
             IHS_MCP_ERR_INVALID);
-
-  IhsMcpProviderDesc no_scheme = mock.Desc("m", "ui_", "", IHS_MCP_CAP_ALL);
-  EXPECT_EQ(ihs_mcp_provider_register(&no_scheme, &provider),
-            IHS_MCP_ERR_INVALID);
   EXPECT_EQ(ihs_mcp_provider_count(), 0u);
+}
+
+// A resource scheme is optional, unlike the tool prefix: a provider may serve
+// tools only. Requiring one would make such a provider claim a namespace it
+// never answers for -- reads would return "not found" indistinguishably from
+// an absent resource, and no other provider could claim the scheme.
+TEST_F(McpProviderTest, AProviderMayServeToolsOnly) {
+  MockProvider mock;
+  IhsMcpProvider* provider = nullptr;
+  IhsMcpProviderDesc desc = mock.Desc("m", "app_", "", IHS_MCP_CAP_ALL);
+  ASSERT_EQ(ihs_mcp_provider_register(&desc, &provider), IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_provider_count(), 1u);
+  ihs_mcp_provider_unregister(provider);
+}
+
+// An empty scheme is a prefix of every string, so treating it as a claim would
+// make the first tools-only provider collide with everything after it.
+TEST_F(McpProviderTest, ToolsOnlyProvidersDoNotCollideOverTheEmptyScheme) {
+  MockProvider first;
+  MockProvider second;
+  IhsMcpProvider* a = nullptr;
+  IhsMcpProvider* b = nullptr;
+  IhsMcpProviderDesc first_desc = first.Desc("a", "hvac_", "", IHS_MCP_CAP_ALL);
+  IhsMcpProviderDesc second_desc =
+      second.Desc("b", "media_", "", IHS_MCP_CAP_ALL);
+  ASSERT_EQ(ihs_mcp_provider_register(&first_desc, &a), IHS_MCP_OK);
+  ASSERT_EQ(ihs_mcp_provider_register(&second_desc, &b), IHS_MCP_OK);
+  EXPECT_EQ(ihs_mcp_provider_count(), 2u);
+  ihs_mcp_provider_unregister(a);
+  ihs_mcp_provider_unregister(b);
+}
+
+// An empty resource prefix matches every URI, so a tools-only provider must
+// not capture reads meant for one that actually serves resources.
+TEST_F(McpProviderTest, AToolsOnlyProviderIsNotRoutedResourceReads) {
+  MockProvider tools_only;
+  IhsMcpProvider* provider = nullptr;
+  IhsMcpProviderDesc desc = tools_only.Desc("app", "app_", "", IHS_MCP_CAP_ALL);
+  ASSERT_EQ(ihs_mcp_provider_register(&desc, &provider), IHS_MCP_OK);
+
+  IhsMcpPayload payload{};
+  EXPECT_EQ(ihs_mcp_registry_read_resource("ui://semantics/tree", &payload),
+            IHS_MCP_ERR_NOT_FOUND);
+  EXPECT_EQ(tools_only.last_uri_read, "")
+      << "a tools-only provider was handed a resource read";
+  ihs_mcp_registry_release_payload(&payload);
+  ihs_mcp_provider_unregister(provider);
 }
 
 TEST_F(McpProviderTest, DuplicatePrefixIsRejected) {


### PR DESCRIPTION
First slice of application-declared tools: the host side. An application registers typed tools with JSON Schemas under its own prefix; a call reaches it and it answers.

```c
ihs_mcp_app_tools_register(&desc, &handle);   // hvac_set_temp, with a schema
// ... a client calls it ...
//     invoke(user_data, call_id, "set_temp", "{\"zone\":\"front\",...}")
ihs_mcp_app_tools_complete(call_id, true, result_json, len);
```

## Two departures from the sketched design, both deliberate

**The arguments cannot ride a semantics action.** A custom action is an id and nothing else — the framework resolves a handler by it and passes no parameters. So "bind a tool invocation to a custom-action dispatch" cannot carry `(zone, celsius)` at all, and a typed call has to reach the application directly. The alternative would be encoding arguments into labels.

**A C entry point rather than a channel.** `libihs_shared` is already the supported binary interface to out-of-tree Dart FFI plugins, and registration is control-plane — a route change, not a frame. A wire format would be new surface to own for no measurable gain; the BEVE argument is payload size on hot paths, and this isn't one. The Dart side reaches this through `dart:ffi` and hands back a `NativeCallable` for `invoke`, so **no Dart API DL and no new dependency**.

## Why invoke and complete are split

An application will want to hop to the UI thread and answer from there, so a single blocking callback would be the wrong shape. Completion may arrive on any thread, later.

- **Bounded by a timeout** — an agent blocked forever on an application that will never answer cannot tell that from one still working.
- **A late reply is reported**, not written into a call nobody is waiting on.
- **Unregister fails anything outstanding** rather than leaving it to wait out a callback that no longer exists.
- **A tool that ran and failed** is distinct from a tool that doesn't exist, or a client retries the wrong one.

## This needed the registry relaxed

Every provider had to claim a resource scheme. A tools-only application would have had to claim `hvac://` and never answer for it — reads there returning "not found" **indistinguishably from an absent resource**, and no provider that would actually serve the scheme able to claim it.

A scheme is now optional. The subtlety: **an empty scheme is a prefix of every string**, so it's kept out of the collision check (or the first tools-only provider collides with everything after it) and out of resource routing (or it captures reads meant for a real provider). Such a provider also emits no resource notification, since a `resources/updated` for `""` would reach every subscriber as a change to something they cannot read.

Three new registry tests cover exactly those three traps.

## Testing

10 new tests driving the ABI with a mock application — the test is both ends, which is the whole surface. Advertisement with schema intact, the round trip, application failure vs missing tool, an answer from another thread 50 ms later, timeout, late answer refused, double answer refused, prefix collision, unregister freeing waiters, malformed registration.

29 test suites (up from 28), all green. Installed header verified present with MCP on and absent with it off.

## Next

The Dart helper package, and a round-trip through the real fixture app.
