### PR TITLE
mcp: fuzz the transport, and bound the per-client state it holds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,10 +57,11 @@ test/integration/*/pubspec.lock
 __pycache__/
 *.pyc
 
-# Working planning notes. Local to a checkout and deliberately never published:
-# they carry phase labels, decision-record ids and section numbers that mean
-# nothing to a reader who does not have the file, which is why commits, PR
-# summaries and source comments say what they mean instead. plan.md reached
-# origin once by accident and had to be removed from history; this is what
-# stops it happening again.
+# Working planning notes, which live outside the repository entirely and are
+# deliberately never published: they carry phase labels, decision-record ids
+# and section numbers that mean nothing to a reader who does not have the
+# file, which is why commits, PR summaries and source comments say what they
+# mean instead. A plan.md reached origin once by accident and had to be
+# removed from history. Nothing should recreate one here, and this is the
+# backstop for when something does.
 plan.md

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,11 @@ test/integration/*/pubspec.lock
 # Python bytecode from the fixture drivers.
 __pycache__/
 *.pyc
+
+# Working planning notes. Local to a checkout and deliberately never published:
+# they carry phase labels, decision-record ids and section numbers that mean
+# nothing to a reader who does not have the file, which is why commits, PR
+# summaries and source comments say what they mean instead. plan.md reached
+# origin once by accident and had to be removed from history; this is what
+# stops it happening again.
+plan.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,16 @@ if (BUILD_UNIT_TESTS)
     install(DIRECTORY DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/test/unit_test/test_images)
 endif ()
 
+#
+# Fuzz targets
+#
+# Independent of BUILD_UNIT_TESTS: these link no gtest and register no CTest
+# case, and a fuzz build should not have to carry the unit test suite.
+#
+if (BUILD_FUZZERS)
+    add_subdirectory(test/fuzz)
+endif ()
+
 if (NOT CMAKE_CROSSCOMPILING)
     include(packaging)
 endif ()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -663,6 +663,55 @@ _ihs_require_sanitizer(SANITIZE_UNDEFINED UBSan "UndefinedBehaviorSanitizer"
         "Usually a missing runtime rather than a compiler that cannot do it: the flag compiles and only the link fails. Install it (Fedora: libubsan; Debian/Ubuntu: libubsan1).")
 
 #
+# Fuzz targets
+#
+# Off by default: they are development tools, they never run to completion, and
+# they link a sanitizer runtime, so nothing an image ships wants them.
+#
+# clang only. libFuzzer is part of the clang toolchain and GCC has no
+# equivalent, so this fails rather than quietly producing no targets -- a
+# configure that reports success and builds no fuzzer is the same trap the
+# sanitizer checks above exist to close.
+#
+# Enable alongside the surface under test, e.g.
+#   -D BUILD_ACCESSIBILITY=ON -D BUILD_MCP=ON -D BUILD_FUZZERS=ON
+#
+# The targets carry their own -fsanitize list, so do not combine this with the
+# SANITIZE_* options: two sanitizer flag sets on one link is a toolchain error
+# or, worse, one of them silently winning.
+option(BUILD_FUZZERS "Build coverage-guided fuzz targets (clang only)" OFF)
+if (BUILD_FUZZERS)
+    if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        MESSAGE(FATAL_ERROR
+                "BUILD_FUZZERS=ON needs clang; this is "
+                "${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}. "
+                "libFuzzer ships with clang and has no GCC equivalent.\n"
+                "Configure with -DCMAKE_CXX_COMPILER=clang++ "
+                "-DCMAKE_C_COMPILER=clang, or -D BUILD_FUZZERS=OFF.")
+    endif ()
+    if (SANITIZE_ADDRESS OR SANITIZE_THREAD OR SANITIZE_MEMORY OR SANITIZE_UNDEFINED)
+        MESSAGE(FATAL_ERROR
+                "BUILD_FUZZERS=ON conflicts with the SANITIZE_* options: the "
+                "fuzz targets already link ASan and UBSan with the fuzzer "
+                "runtime, and a second -fsanitize list on the same link either "
+                "fails or silently overrides one of them.\n"
+                "Build the fuzzers in their own build directory.")
+    endif ()
+    # The instrumentation has to reach the code under test, not just the
+    # driver. Without this the fuzzer links, runs, and reports coverage in the
+    # tens -- its own driver -- so every mutation looks equally uninteresting
+    # and the corpus never grows. That failure is quiet: the run looks healthy
+    # and finds nothing, which is indistinguishable from code that has no bugs.
+    #
+    # fuzzer-no-link here and fuzzer at the target, so ordinary executables in
+    # the same build do not each acquire a main() from libFuzzer.
+    add_compile_options(-fsanitize=fuzzer-no-link,address,undefined
+            -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=address,undefined)
+    MESSAGE(STATUS "Fuzz targets ............ Enabled")
+endif ()
+
+#
 # Executable Name
 #
 if (NOT EXE_OUTPUT_NAME)

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -37,6 +37,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
+#include <deque>
 #include <map>
 #include <mutex>
 #include <random>
@@ -74,6 +75,27 @@ constexpr size_t kDefaultMaxRequestBytes = 1024 * 1024;
 // before any Content-Length is known, so without this a peer could stream
 // header bytes forever and never be refused.
 constexpr size_t kMaxHeaderBytes = 16 * 1024;
+
+// Bounds on what one client can make this transport hold on to.
+//
+// Every request is Connection: close, so a connection is not a lifetime and
+// there is nothing for the state below to be scoped to. Left unbounded, a
+// client that keeps asking makes the shell keep holding: open event streams
+// cost a descriptor each, and subscriptions cost memory keyed by strings the
+// client chose. Neither is reclaimed by anything the client does on its way
+// out, because a client that goes away does not say so.
+//
+// The numbers are generous against the real shape of this: an instrument
+// cluster is driven by one agent, occasionally a handful. Anything that
+// exceeds these is not a client that has been running a long time, it is a
+// client in a loop.
+constexpr size_t kMaxStreams = 32;
+constexpr size_t kMaxSessions = 64;
+constexpr size_t kMaxSubscriptionsPerSession = 64;
+
+// A resource URI is a name. The body limit alone would let one be a megabyte,
+// and it would then be held for as long as the session is.
+constexpr size_t kMaxUriBytes = 512;
 
 // The MCP revision this speaks. Sent back from initialize; a client asking for
 // something else still gets this, which is what the specification calls for --
@@ -132,6 +154,21 @@ struct Transport {
   // nothing" and "not interested in filtering" are not distinguishable, and
   // the safe reading is the one that keeps delivering.
   std::map<std::string, std::set<std::string>> subscriptions;
+
+  // Session ids this transport minted, least recently used first.
+  //
+  // A subscription may only name one of these. Without the check the id is
+  // whatever the client put in the header, so "session" would be a namespace
+  // the client writes into at will -- unbounded, and shared, which also lets
+  // one client unsubscribe another's URIs by naming its id.
+  //
+  // Bounded, and evicted least-recently-used rather than oldest-first: a
+  // long-lived agent stays at the back because every request it makes touches
+  // its id, so what falls off the front is a session nothing has spoken for.
+  // Eviction drops that session's filter, which means it receives everything
+  // rather than nothing -- the same reading as a session that never
+  // subscribed, and the safe direction to be wrong in.
+  std::deque<std::string> sessions;
 
   // Notification debounce.
   //
@@ -407,11 +444,45 @@ std::string NewSessionId() {
   return out;
 }
 
+// Records a freshly minted session, evicting the least recently used one if
+// that puts the count over the cap.
+//
+// Called with streams_mutex held, which is the lock covering both the session
+// list and the subscriptions keyed by it -- the two have to move together or
+// an evicted session leaves its filter behind, which is the leak this exists
+// to close.
+void RememberSessionLocked(Transport& t, const std::string& session) {
+  t.sessions.push_back(session);
+  while (t.sessions.size() > kMaxSessions) {
+    t.subscriptions.erase(t.sessions.front());
+    t.sessions.pop_front();
+  }
+}
+
+// Whether this transport minted `session`, moving it to the most-recently-used
+// end when it did. Called with streams_mutex held.
+//
+// The touch is what makes the cap survivable: without it the list is
+// oldest-first, and an agent that has been connected all day is evicted by
+// sixty-four initialize calls from anything else.
+bool TouchSessionLocked(Transport& t, const std::string& session) {
+  const auto it = std::find(t.sessions.begin(), t.sessions.end(), session);
+  if (it == t.sessions.end()) {
+    return false;
+  }
+  t.sessions.erase(it);
+  t.sessions.push_back(session);
+  return true;
+}
+
 // resources/subscribe and resources/unsubscribe.
 //
-// The session comes from the Mcp-Session-Id header rather than the params: it
-// identifies the caller, and a client that could name any session in the body
-// could redirect another client's stream.
+// The session comes from the Mcp-Session-Id header rather than the params, and
+// is checked against the ids this transport actually minted. The header is no
+// less client-controlled than the body would be, so taking it from there is
+// not by itself a protection -- the check is. Without it "session" is a
+// namespace the client writes into: unbounded, and shared, so one client can
+// name another's id and drop its subscriptions.
 std::string HandleSubscribe(const rapidjson::Value& params,
                             const std::string& id,
                             const std::string& session,
@@ -429,6 +500,11 @@ std::string HandleSubscribe(const rapidjson::Value& params,
   }
 
   const std::string uri = params["uri"].GetString();
+  if (uri.size() > kMaxUriBytes) {
+    return ErrorEnvelope(
+        id, kInvalidParams,
+        "uri is longer than " + std::to_string(kMaxUriBytes) + " bytes");
+  }
 
   // Pass it to the registry so the provider owning the scheme can start or
   // stop work on the strength of it.
@@ -447,8 +523,22 @@ std::string HandleSubscribe(const rapidjson::Value& params,
 
   Transport& t = TheTransport();
   const std::lock_guard<std::mutex> lock(t.streams_mutex);
+  if (!TouchSessionLocked(t, session)) {
+    return ErrorEnvelope(id, kInvalidParams,
+                         "unknown Mcp-Session-Id; call initialize first");
+  }
   if (subscribing) {
-    t.subscriptions[session].insert(uri);
+    auto& uris = t.subscriptions[session];
+    if (uris.size() >= kMaxSubscriptionsPerSession && uris.count(uri) == 0) {
+      // Refused rather than evicting one of its own: which URI a client cares
+      // about is its decision, and silently dropping one would leave it
+      // believing it is still being told about a resource it is not.
+      return ErrorEnvelope(id, kInvalidParams,
+                           "session already holds " +
+                               std::to_string(kMaxSubscriptionsPerSession) +
+                               " subscriptions");
+    }
+    uris.insert(uri);
   } else {
     const auto it = t.subscriptions.find(session);
     if (it != t.subscriptions.end()) {
@@ -536,6 +626,11 @@ std::string Dispatch(const std::string& body,
     // Connection: close, so connections are not sessions, and initialize is
     // the one point the protocol defines for establishing one.
     *out_new_session = NewSessionId();
+    {
+      Transport& t = TheTransport();
+      const std::lock_guard<std::mutex> lock(t.streams_mutex);
+      RememberSessionLocked(t, *out_new_session);
+    }
     response = ResultEnvelope(id, HandleInitialize());
   } else if (method == "tools/list") {
     response = ResultEnvelope(id, HandleToolsList());
@@ -970,6 +1065,16 @@ bool TryOpenEventStream(const int fd,
     return true;  // answered; caller should close
   }
 
+  {
+    Transport& t = TheTransport();
+    const std::lock_guard<std::mutex> lock(t.streams_mutex);
+    if (t.streams.size() >= kMaxStreams) {
+      WriteAll(fd, HttpResponse(503, "Service Unavailable",
+                                R"({"error":"too many open event streams"})"));
+      return true;  // answered; caller should close
+    }
+  }
+
   std::string response = "HTTP/1.1 200 OK\r\n";
   response += "Content-Type: text/event-stream\r\n";
   response += "Cache-Control: no-store\r\n";
@@ -1119,17 +1224,68 @@ bool StaleSocketRemoved(const std::string& path) {
   return true;
 }
 
+// Drops the streams that `poll` reported as hung up or readable.
+//
+// `polled` holds the two fixed descriptors first, so the streams begin at
+// index 2. Matching back by descriptor number is safe here for a reason worth
+// stating: streams are only ever added by the accept thread, which is the one
+// calling this, so the set cannot have grown since the snapshot. It can have
+// shrunk -- Broadcast drops a stream that will not take a frame -- and a
+// descriptor that is gone is simply not found, which is why nothing is closed
+// unless it was still present and removed here. Closing on the strength of the
+// snapshot alone would eventually close a descriptor belonging to something
+// else entirely.
+void ReapClosedStreams(const std::vector<pollfd>& polled) {
+  Transport& t = TheTransport();
+  const std::lock_guard<std::mutex> lock(t.streams_mutex);
+  for (size_t i = 2; i < polled.size(); ++i) {
+    if ((polled[i].revents & (POLLHUP | POLLERR | POLLNVAL | POLLIN)) == 0) {
+      continue;
+    }
+    const auto it =
+        std::find_if(t.streams.begin(), t.streams.end(),
+                     [&](const Stream& s) { return s.fd == polled[i].fd; });
+    if (it == t.streams.end()) {
+      continue;  // already dropped by a failed write; not ours to close
+    }
+    ::close(it->fd);
+    t.streams.erase(it);
+  }
+}
+
 void AcceptLoop() {
   Transport& t = TheTransport();
   const int listen_fd = t.listen_fd;
   const int wake_fd = t.wake_fd;
   const size_t max_body = t.max_request_bytes;
 
+  // Reused across iterations: two fixed entries plus one per open stream.
+  std::vector<pollfd> fds;
+  fds.reserve(2 + kMaxStreams);
+
   while (true) {
-    pollfd fds[2];
-    fds[0] = {listen_fd, POLLIN, 0};
-    fds[1] = {wake_fd, POLLIN, 0};
-    const int ready = ::poll(fds, 2, -1);
+    fds.clear();
+    fds.push_back({listen_fd, POLLIN, 0});
+    fds.push_back({wake_fd, POLLIN, 0});
+    // Watch the open streams too. Nothing is ever read from them -- they carry
+    // one direction -- but a client that hung up shows up as POLLHUP here, and
+    // that is the only prompt notice of it there is. The alternative is to
+    // discover the loss on the next write, which needs a notification that may
+    // never come, so an abandoned stream would hold its descriptor until the
+    // shell exits. A client looping over open-and-abandon then costs the whole
+    // process its descriptor table, not just the MCP surface.
+    //
+    // POLLIN is included because a client that sends on a stream has also
+    // given us EOF to detect: on a stream we never read, readable and hung-up
+    // arrive the same way and both mean the same thing.
+    {
+      const std::lock_guard<std::mutex> lock(t.streams_mutex);
+      for (const Stream& stream : t.streams) {
+        fds.push_back({stream.fd, POLLIN, 0});
+      }
+    }
+
+    const int ready = ::poll(fds.data(), fds.size(), -1);
     if (ready < 0) {
       if (errno == EINTR) {
         continue;
@@ -1139,6 +1295,11 @@ void AcceptLoop() {
     if ((fds[1].revents & POLLIN) != 0) {
       break;  // stop() asked
     }
+
+    // Reap before accepting, so a client at the stream cap that has already
+    // gone away does not keep a live one out.
+    ReapClosedStreams(fds);
+
     if ((fds[0].revents & POLLIN) == 0) {
       continue;
     }
@@ -1327,6 +1488,10 @@ void ihs_mcp_transport_stop() {
   // Subscriptions describe streams that no longer exist, and a restart mints
   // new session ids, so nothing here could be matched again.
   t.subscriptions.clear();
+  // The sessions themselves go with them. A session that survived a restart
+  // would let a client subscribe against an id from before the socket was
+  // rebound, and would spend the cap on ids nothing can reach.
+  t.sessions.clear();
 }
 
 bool ihs_mcp_transport_running() {

--- a/shell/accessibility/semantics_action_args.h
+++ b/shell/accessibility/semantics_action_args.h
@@ -35,8 +35,9 @@ namespace accessibility {
  * baked into it.
  *
  * Uses the vendored flutter::StandardMessageCodec rather than a second
- * implementation: a reimplementation can drift from the decoder silently,
- * which drops arguments framework-side with no error anywhere (R-9).
+ * implementation: a reimplementation can drift from the decoder silently, and
+ * the framework then drops the argument with no error raised anywhere -- the
+ * action appears to have been delivered and simply does nothing.
  *
  * Returns the encoded message, or nullopt when `data` does not match the
  * layout the action requires -- a truncated offset or a stray byte count is a

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -1064,8 +1064,9 @@ int Engine::SendSyntheticTap(const double x, const double y) {
   });
 
   // Accepted for delivery. Whether anything was under the point is not
-  // knowable here, and saying otherwise would be the automatic fallback DR-7
-  // exists to avoid.
+  // knowable here, and reporting success as though it were would be the
+  // silent-guess behaviour this path is deliberately not: a coordinate tap is
+  // asked for explicitly, never substituted for a failed lookup.
   return IHS_SEMANTICS_OK;
 }
 

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -373,9 +373,10 @@ class Engine {
   void SendPointerEvents();
 
   /*
-   * Synthesizes a tap at a point in logical coordinates, for the MCP pointer
-   * fallback (DR-7). Rides the ordinary input path, so it is hit-tested like
-   * a real tap rather than invoking a node's handler by id.
+   * Synthesizes a tap at a point in logical coordinates, for the MCP
+   * coordinate fallback -- the escape hatch for a control the semantics tree
+   * does not describe. Rides the ordinary input path, so it is hit-tested
+   * like a real tap rather than invoking a node's handler by id.
    */
   int SendSyntheticTap(double x, double y);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,3 +8,6 @@ endif ()
 
 add_subdirectory(unit_test)
 add_subdirectory(integration)
+# test/fuzz is added from the top-level CMakeLists instead: the fuzz targets
+# need no gtest and no golden images, so they must not depend on
+# BUILD_UNIT_TESTS being on as well.

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Coverage-guided fuzz targets. Built only when BUILD_FUZZERS is on, which
+# requires clang -- libFuzzer ships with it and has no GCC equivalent.
+#
+# These are not registered with CTest. A fuzz target runs until stopped, so a
+# test suite would either never finish or would run it for a token second and
+# report a pass that means nothing. Regression inputs are what belongs in
+# CTest, and they go in the unit tests beside the code they pin.
+
+# The instrumentation is applied build-wide by BUILD_FUZZERS (cmake/options.cmake)
+# so that ihs_shared is covered too; all that is left here is to pull in
+# libFuzzer's main(), which only these targets want.
+#
+# Deliberately not add_sanitizers(): the sanitizer set is already chosen, and
+# a second -fsanitize list on the same link is a toolchain error at best.
+function(ihs_add_fuzzer name)
+    add_executable(${name} ${ARGN})
+    target_link_options(${name} PRIVATE -fsanitize=fuzzer)
+    target_link_libraries(${name} PRIVATE ivi_homescreen::ihs_shared)
+    set_target_properties(${name} PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/fuzz")
+endfunction()
+
+if (BUILD_MCP)
+    ihs_add_fuzzer(fuzz_mcp_transport fuzz_mcp_transport.cc)
+endif ()

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,0 +1,110 @@
+# Fuzz targets
+
+Coverage-guided fuzzing of the surfaces that parse bytes from outside the
+process. Built only when `BUILD_FUZZERS=ON`, which requires clang.
+
+## Building
+
+```bash
+cmake -B build/fuzz -GNinja \
+  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+  -D BUILD_ACCESSIBILITY=ON -D BUILD_MCP=ON -D BUILD_FUZZERS=ON
+ninja -C build/fuzz wayland_protocols   # generated headers, needed first
+ninja -C build/fuzz fuzz_mcp_transport
+```
+
+`BUILD_FUZZERS` instruments the **whole build**, not just the target — the
+library under test has to carry the coverage counters or the fuzzer runs
+blind. A run whose first `INITED` line reports coverage in the tens is
+measuring its own driver and nothing else; a working one starts in the
+thousands. Nothing about a blind run looks broken, which is why it is worth
+checking the number rather than the exit status.
+
+Use a build directory of its own. `BUILD_FUZZERS` and the `SANITIZE_*` options
+refuse to configure together, since two `-fsanitize` lists on one link either
+fail or silently drop one of them.
+
+## Running
+
+Keep the checked-in corpus read-only and let the fuzzer grow a working one:
+
+```bash
+mkdir -p /tmp/ihs-fuzz-corpus
+./build/fuzz/fuzz/fuzz_mcp_transport \
+    /tmp/ihs-fuzz-corpus test/fuzz/corpus/mcp_transport \
+    -max_total_time=900 -print_final_stats=1
+```
+
+The first directory is the one libFuzzer writes to. Passing the seed corpus
+first instead means new units land in the source tree, mixed in with the
+curated seeds and no longer distinguishable from them.
+
+To replay one input:
+
+```bash
+./build/fuzz/fuzz/fuzz_mcp_transport test/fuzz/corpus/mcp_transport/tools_call
+```
+
+## `fuzz_mcp_transport`
+
+The input is the entire client side of one connection — request line, headers
+and body — written to the transport's Unix socket unmodified.
+
+Driving it through the socket rather than calling the parsers directly is the
+point. The header block, the `Content-Length` accounting, the JSON-RPC
+envelope and the routing onto a provider see the same bytes in the same order
+a client would send them, so a bug that lives in how they interact is
+reachable. It also keeps the target honest about what is actually exposed:
+these functions live in an anonymous namespace, and reaching them any other
+way would mean widening their visibility for the benefit of a test.
+
+Why this surface earns the machinery: peer credentials are the whole local
+trust model, and they are strong. But off-box access terminates TLS in front
+of the socket (`docs/mcp-remote-access.md`), and past that terminator the
+peer uid is the terminator's own. Every byte here came from somewhere else,
+and the parser runs before any of it is understood.
+
+The target registers a provider of its own so `tools/list`, `tools/call`,
+`resources/read` and the subscription paths route somewhere. Without it most
+of the dispatcher is unreachable — every call bottoms out in "no such tool"
+before the interesting code runs.
+
+One thing the driver does that is about the driver, not the transport: it
+drains the reply before closing. Closing on a partly-read response resets the
+connection before the server finishes writing, which would turn a real reply
+path into an untested one.
+
+It deliberately does **not** work around anything else. An earlier version
+restarted the transport after every event-stream handshake, because an
+abandoned stream's descriptor was held until a write to it failed and millions
+of executions turned that into descriptor exhaustion. That was a real defect,
+it is fixed, and the workaround is gone — a driver that compensates for the
+bug it exists to find will go on hiding the regression.
+
+### What it found
+
+The first sustained run surfaced three defects of one shape: client-controlled
+state with no bound and nothing to scope it to, since every request is
+`Connection: close` and a connection is therefore not a session. Abandoned
+event streams held their descriptors forever; `Mcp-Session-Id` was never
+checked against the ids the transport had minted, so the subscription map grew
+without limit and one client could name another's session; and nothing bounded
+the stream count, the subscriptions per session, or a URI's length. All are
+pinned by tests in `test/unit_test/mcp_transport-test/`.
+
+## Corpus
+
+`corpus/mcp_transport/` holds hand-written seeds: one per JSON-RPC method,
+plus the HTTP-level cases worth starting from (event-stream handshake, plain
+`GET`, an `Origin` header, a missing/unparseable/oversized `Content-Length`, a
+body shorter than declared, mixed-case header names).
+
+Seeds are for reaching code, not for asserting behaviour. Anything the fuzzer
+finds that should stay found belongs in a unit test beside the code it pins —
+`test/unit_test/mcp_transport-test/` — where it runs in CI and says what the
+correct answer is. A crashing input parked in a corpus directory only says
+that it once crashed.
+
+These targets are deliberately not registered with CTest: a fuzz target runs
+until it is stopped, so a test suite would either never finish or would run it
+for a token second and report a pass that means nothing.

--- a/test/fuzz/corpus/.gitattributes
+++ b/test/fuzz/corpus/.gitattributes
@@ -1,0 +1,5 @@
+# The seeds are raw HTTP requests. Their CRLF line endings are part of the
+# protocol, not a platform artifact -- normalising them to LF produces bytes
+# no HTTP parser accepts, and the seed would silently stop reaching the code
+# it was written for. Treated as binary so nothing rewrites them.
+* -text -diff

--- a/test/fuzz/corpus/mcp_transport/bad_content_length
+++ b/test/fuzz/corpus/mcp_transport/bad_content_length
@@ -1,0 +1,4 @@
+POST / HTTP/1.1
+Content-Length: not-a-number
+
+{}

--- a/test/fuzz/corpus/mcp_transport/bad_method
+++ b/test/fuzz/corpus/mcp_transport/bad_method
@@ -1,0 +1,3 @@
+DELETE / HTTP/1.1
+Host: localhost
+

--- a/test/fuzz/corpus/mcp_transport/batch
+++ b/test/fuzz/corpus/mcp_transport/batch
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 43
+
+[{"jsonrpc":"2.0","id":12,"method":"ping"}]

--- a/test/fuzz/corpus/mcp_transport/deep_nesting
+++ b/test/fuzz/corpus/mcp_transport/deep_nesting
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 119
+
+{"jsonrpc":"2.0","id":13,"method":"tools/call","params":{"name":"fz_echo","arguments":{"a":{"b":{"c":{"d":[1,2,3]}}}}}}

--- a/test/fuzz/corpus/mcp_transport/event_stream
+++ b/test/fuzz/corpus/mcp_transport/event_stream
@@ -1,0 +1,4 @@
+GET / HTTP/1.1
+Host: localhost
+Accept: text/event-stream
+

--- a/test/fuzz/corpus/mcp_transport/initialize
+++ b/test/fuzz/corpus/mcp_transport/initialize
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 106
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}

--- a/test/fuzz/corpus/mcp_transport/initialized
+++ b/test/fuzz/corpus/mcp_transport/initialized
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 54
+
+{"jsonrpc":"2.0","method":"notifications/initialized"}

--- a/test/fuzz/corpus/mcp_transport/malformed_json
+++ b/test/fuzz/corpus/mcp_transport/malformed_json
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 25
+
+{"jsonrpc":"2.0","id":11,

--- a/test/fuzz/corpus/mcp_transport/mixed_case_headers
+++ b/test/fuzz/corpus/mcp_transport/mixed_case_headers
@@ -1,0 +1,4 @@
+POST / HTTP/1.1
+cOnTeNt-LeNgTh: 2
+
+{}

--- a/test/fuzz/corpus/mcp_transport/no_content_length
+++ b/test/fuzz/corpus/mcp_transport/no_content_length
@@ -1,0 +1,4 @@
+POST / HTTP/1.1
+Host: localhost
+
+{}

--- a/test/fuzz/corpus/mcp_transport/origin_header
+++ b/test/fuzz/corpus/mcp_transport/origin_header
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Origin: http://evil.example
+Content-Length: 2
+
+{}

--- a/test/fuzz/corpus/mcp_transport/oversized_content_length
+++ b/test/fuzz/corpus/mcp_transport/oversized_content_length
@@ -1,0 +1,4 @@
+POST / HTTP/1.1
+Content-Length: 99999999
+
+{}

--- a/test/fuzz/corpus/mcp_transport/ping
+++ b/test/fuzz/corpus/mcp_transport/ping
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 40
+
+{"jsonrpc":"2.0","id":2,"method":"ping"}

--- a/test/fuzz/corpus/mcp_transport/plain_get
+++ b/test/fuzz/corpus/mcp_transport/plain_get
@@ -1,0 +1,4 @@
+GET / HTTP/1.1
+Host: localhost
+Accept: application/json
+

--- a/test/fuzz/corpus/mcp_transport/resources_list
+++ b/test/fuzz/corpus/mcp_transport/resources_list
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 50
+
+{"jsonrpc":"2.0","id":6,"method":"resources/list"}

--- a/test/fuzz/corpus/mcp_transport/resources_read
+++ b/test/fuzz/corpus/mcp_transport/resources_read
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 80
+
+{"jsonrpc":"2.0","id":7,"method":"resources/read","params":{"uri":"fz://state"}}

--- a/test/fuzz/corpus/mcp_transport/string_id
+++ b/test/fuzz/corpus/mcp_transport/string_id
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 44
+
+{"jsonrpc":"2.0","id":"abc","method":"ping"}

--- a/test/fuzz/corpus/mcp_transport/subscribe
+++ b/test/fuzz/corpus/mcp_transport/subscribe
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 85
+
+{"jsonrpc":"2.0","id":8,"method":"resources/subscribe","params":{"uri":"fz://state"}}

--- a/test/fuzz/corpus/mcp_transport/tools_call
+++ b/test/fuzz/corpus/mcp_transport/tools_call
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 103
+
+{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"fz_echo","arguments":{"text":"hello"}}}

--- a/test/fuzz/corpus/mcp_transport/tools_call_no_args
+++ b/test/fuzz/corpus/mcp_transport/tools_call_no_args
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 73
+
+{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"fz_act"}}

--- a/test/fuzz/corpus/mcp_transport/tools_list
+++ b/test/fuzz/corpus/mcp_transport/tools_list
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 46
+
+{"jsonrpc":"2.0","id":3,"method":"tools/list"}

--- a/test/fuzz/corpus/mcp_transport/truncated_body
+++ b/test/fuzz/corpus/mcp_transport/truncated_body
@@ -1,0 +1,4 @@
+POST / HTTP/1.1
+Content-Length: 400
+
+{"jsonrpc":"2.0"}

--- a/test/fuzz/corpus/mcp_transport/unknown_method
+++ b/test/fuzz/corpus/mcp_transport/unknown_method
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 44
+
+{"jsonrpc":"2.0","id":10,"method":"no/such"}

--- a/test/fuzz/corpus/mcp_transport/unsubscribe
+++ b/test/fuzz/corpus/mcp_transport/unsubscribe
@@ -1,0 +1,6 @@
+POST / HTTP/1.1
+Host: localhost
+Content-Type: application/json
+Content-Length: 87
+
+{"jsonrpc":"2.0","id":9,"method":"resources/unsubscribe","params":{"uri":"fz://state"}}

--- a/test/fuzz/fuzz_mcp_transport.cc
+++ b/test/fuzz/fuzz_mcp_transport.cc
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Fuzzes the MCP transport by speaking arbitrary bytes to its socket.
+ *
+ * The input is the whole client side of one connection -- request line,
+ * headers and body, unmodified. Driving it from outside rather than calling
+ * the parsers directly is deliberate: the header block, the Content-Length
+ * accounting, the JSON-RPC envelope and the routing onto a provider all see
+ * the same bytes a client would send, in the same order, and a bug that
+ * depends on how they interact is reachable. Calling an internal parser with
+ * a tidy string would test the parser and not the arrangement.
+ *
+ * The reason this surface is worth the machinery: peer credentials are the
+ * whole local trust model, but off-box access terminates TLS in front of the
+ * socket (docs/mcp-remote-access.md), and past that terminator every byte
+ * here came from somewhere else. The parser runs before any of it is
+ * understood.
+ *
+ * A provider is registered so tools/list, tools/call, resources/read and the
+ * subscription paths route somewhere instead of bottoming out in "no such
+ * tool" -- which would leave most of the dispatcher unreached.
+ */
+
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "ihs/ihs_mcp_provider.h"
+#include "ihs/ihs_mcp_transport.h"
+
+namespace {
+
+// Long enough that a slow reply is still collected, short enough that a
+// wedged server shows up as a throughput collapse rather than a hang.
+constexpr int kReplyTimeoutMs = 250;
+
+std::string* g_socket_path = nullptr;
+
+// A provider with one tool and one resource. It answers rather than
+// declining, so a call that parses reaches the reply-building path too.
+struct EchoProvider {
+  static int ListTools(void*, const IhsMcpToolDesc** out, size_t* count) {
+    static const IhsMcpToolDesc kTools[] = {
+        {"echo", "Returns its arguments.",
+         R"({"type":"object","properties":{"text":{"type":"string"}}})",
+         IHS_MCP_CAP_INSPECT},
+        {"act", "Pretends to do something.", R"({"type":"object"})",
+         IHS_MCP_CAP_INTERACT},
+    };
+    *out = kTools;
+    *count = sizeof(kTools) / sizeof(kTools[0]);
+    return IHS_MCP_OK;
+  }
+
+  static int ListResources(void*,
+                           const IhsMcpResourceDesc** out,
+                           size_t* count) {
+    static const IhsMcpResourceDesc kResources[] = {
+        {"fz://state", "state", "Fuzzing fixture state.", "application/json"},
+    };
+    *out = kResources;
+    *count = sizeof(kResources) / sizeof(kResources[0]);
+    return IHS_MCP_OK;
+  }
+
+  // The arguments are echoed back as an opaque string rather than re-parsed.
+  // Re-parsing here would fuzz rapidjson, which is not what this target is
+  // for; passing them through means whatever the transport extracted has to
+  // survive being embedded in a reply.
+  static int CallTool(void*,
+                      const char* name,
+                      const char* arguments_json,
+                      const size_t arguments_length,
+                      IhsMcpPayload* out) {
+    static std::string reply;
+    reply.assign(R"({"tool":")");
+    reply.append(name != nullptr ? name : "");
+    reply.append(R"(","argument_bytes":)");
+    reply.append(std::to_string(arguments_length));
+    reply.append(R"(,"arguments_were_null":)");
+    reply.append(arguments_json == nullptr ? "true" : "false");
+    reply.append("}");
+    out->struct_size = sizeof(IhsMcpPayload);
+    out->data = reply.c_str();
+    out->length = reply.size();
+    out->release = nullptr;
+    out->release_ctx = nullptr;
+    return IHS_MCP_OK;
+  }
+
+  static int ReadResource(void*, const char*, IhsMcpPayload* out) {
+    static const char kBody[] = R"({"ok":true})";
+    out->struct_size = sizeof(IhsMcpPayload);
+    out->data = kBody;
+    out->length = sizeof(kBody) - 1;
+    out->release = nullptr;
+    out->release_ctx = nullptr;
+    return IHS_MCP_OK;
+  }
+
+  static int Subscribe(void*, const char*, bool) { return IHS_MCP_OK; }
+};
+
+bool RegisterProvider() {
+  IhsMcpProviderDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = "fuzz";
+  desc.tool_prefix = "fz_";
+  desc.resource_scheme = "fz://";
+  desc.capability_mask = IHS_MCP_CAP_ALL;
+  desc.notify_fd = -1;
+  desc.user_data = nullptr;
+  desc.callbacks.list_tools = &EchoProvider::ListTools;
+  desc.callbacks.list_resources = &EchoProvider::ListResources;
+  desc.callbacks.call_tool = &EchoProvider::CallTool;
+  desc.callbacks.read_resource = &EchoProvider::ReadResource;
+  desc.callbacks.subscribe = &EchoProvider::Subscribe;
+
+  IhsMcpProvider* provider = nullptr;
+  return ihs_mcp_provider_register(&desc, &provider) == IHS_MCP_OK;
+}
+
+bool StartTransport() {
+  IhsMcpTransportConfig config{};
+  config.struct_size = sizeof(config);
+  config.socket_path = g_socket_path->c_str();
+  config.max_request_bytes = 64 * 1024;
+  return ihs_mcp_transport_start(&config) == IHS_MCP_OK;
+}
+
+int Connect() {
+  const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) {
+    return -1;
+  }
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  std::snprintf(address.sun_path, sizeof(address.sun_path), "%s",
+                g_socket_path->c_str());
+  if (::connect(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) !=
+      0) {
+    ::close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+}  // namespace
+
+extern "C" int LLVMFuzzerInitialize(int*, char***) {
+  const char* tmp = ::getenv("TMPDIR");
+  g_socket_path =
+      new std::string(std::string(tmp != nullptr ? tmp : "/tmp") +
+                      "/ihs-fuzz-mcp-" + std::to_string(::getpid()) + ".sock");
+  if (!RegisterProvider() || !StartTransport()) {
+    std::fprintf(stderr, "fuzz_mcp_transport: could not serve on %s\n",
+                 g_socket_path->c_str());
+    ::abort();  // running with no server under test would prove nothing
+  }
+  return 0;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, const size_t size) {
+  if (size == 0) {
+    return 0;
+  }
+  const int fd = Connect();
+  if (fd < 0) {
+    return 0;
+  }
+
+  // A short write is not worth retrying: the point is what the server does
+  // with what arrived, and a truncated request is itself a case under test.
+  // MSG_NOSIGNAL rather than a SIGPIPE handler, so a peer the server hung up
+  // on returns EPIPE here instead of killing the fuzzer mid-run.
+  const ssize_t written = ::send(fd, data, size, MSG_NOSIGNAL);
+  static_cast<void>(written);
+  ::shutdown(fd, SHUT_WR);  // the EOF a bodyless read is waiting for
+
+  // Drain the reply. Anything the server sends has to be read, or a large
+  // response would leave bytes in the socket buffer and the close would reset
+  // the connection before the server finished writing -- turning a real reply
+  // path into an untested one.
+  std::string reply;
+  char buffer[4096];
+  while (true) {
+    pollfd poll_fd = {fd, POLLIN, 0};
+    if (::poll(&poll_fd, 1, kReplyTimeoutMs) <= 0) {
+      break;
+    }
+    const ssize_t got = ::recv(fd, buffer, sizeof(buffer), 0);
+    if (got <= 0) {
+      break;
+    }
+    reply.append(buffer, static_cast<size_t>(got));
+    if (reply.size() > 1u << 20) {
+      break;
+    }
+  }
+  // Closing is all this does with a stream the input opened, deliberately.
+  //
+  // The first version of this driver restarted the transport whenever a reply
+  // announced an event stream, because an abandoned stream's descriptor was
+  // then held until a write to it failed -- which needs a notification that
+  // may never arrive -- and millions of executions turned that into descriptor
+  // exhaustion. The transport now reaps a hung-up stream on the accept
+  // thread's next wake, so the workaround is gone. Leaving it in would have
+  // been worse than useless: it papered over exactly the defect this target
+  // exists to find, and would have gone on hiding a regression in the reaping.
+  static_cast<void>(reply);
+  return 0;
+}

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <dirent.h>
 #include <poll.h>
 #include <sys/eventfd.h>
 #include <sys/socket.h>
@@ -26,6 +27,7 @@
 #include <cstring>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -954,4 +956,164 @@ TEST_F(McpTransportTest, AnUnknownToolRemainsAProtocolError) {
              R"("params":{"name":"nothing_claims_this","arguments":{}}})"));
   EXPECT_NE(body.find("-32601"), std::string::npos) << body;
   EXPECT_EQ(body.find(R"("isError")"), std::string::npos) << body;
+}
+
+// ---------------------------------------------------------------------------
+// Bounds on client-held state
+//
+// Every request is Connection: close, so a connection is not a lifetime and
+// there is nothing for the transport's per-client state to be scoped to.
+// Anything it keeps has to be bounded explicitly or a client in a loop makes
+// the shell hold memory and descriptors until it cannot serve at all. Each of
+// these was reachable before the bound existed; fuzzing found the first one.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// The number of descriptors the process holds. The transport's own are a
+// constant here, so what this measures across a loop is what the loop left
+// behind.
+size_t OpenDescriptorCount() {
+  size_t count = 0;
+  DIR* dir = ::opendir("/proc/self/fd");
+  if (dir == nullptr) {
+    return 0;
+  }
+  while (::readdir(dir) != nullptr) {
+    ++count;
+  }
+  ::closedir(dir);
+  return count;
+}
+
+}  // namespace
+
+// A client that opens an event stream and hangs up leaves a descriptor the
+// server is still holding. Nothing writes to that stream until a provider
+// signals, so without a positive check the loss is discovered only when a
+// notification happens to arrive -- which for an idle UI may be never.
+//
+// The cost is not confined to the MCP surface: descriptors are process-wide,
+// so a client looping over open-and-abandon eventually stops the shell from
+// opening anything at all.
+TEST_F(McpTransportTest, AnAbandonedStreamIsReclaimed) {
+  const size_t before = OpenDescriptorCount();
+  for (int i = 0; i < 40; ++i) {
+    std::string headers;
+    const int fd = OpenStream(path_, &headers);
+    ASSERT_GE(fd, 0) << "stream " << i << " was refused: the server is already "
+                     << "holding the ones before it";
+    ::close(fd);
+  }
+  // Reaping happens on the accept thread's next wake, so give it one.
+  for (int i = 0; i < 50 && OpenDescriptorCount() > before + 4; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  const size_t after = OpenDescriptorCount();
+  EXPECT_LE(after, before + 4)
+      << "40 abandoned streams left " << (after - before) << " descriptors";
+}
+
+// Live streams are bounded too. A client that opens them and keeps them open
+// is not reclaimable by any means, so the only answer is to stop accepting
+// them -- and to say so, rather than accepting and silently never delivering.
+TEST_F(McpTransportTest, OpenStreamsAreCapped) {
+  std::vector<int> held;
+  std::string refusal;
+  for (int i = 0; i < 200; ++i) {
+    std::string headers;
+    const int fd = OpenStream(path_, &headers);
+    if (fd < 0) {
+      break;
+    }
+    if (headers.find("text/event-stream") == std::string::npos) {
+      refusal = headers;
+      ::close(fd);
+      break;
+    }
+    held.push_back(fd);
+  }
+  EXPECT_FALSE(refusal.empty())
+      << "200 streams were all accepted; nothing bounds them";
+  EXPECT_NE(refusal.find("503"), std::string::npos) << refusal;
+  EXPECT_LT(held.size(), 200u);
+  for (const int fd : held) {
+    ::close(fd);
+  }
+}
+
+// The session id arrives in a header the client writes, so accepting any
+// non-empty string makes "session" a namespace the client owns: unbounded,
+// and shared. Checking it against the ids actually minted is what closes both
+// -- the growth, and one client naming another's session.
+TEST_F(McpTransportTest, SubscribeWithAnUnmintedSessionIsRefused) {
+  const std::string body =
+      Body(Subscribe(path_, "0123456789abcdef0123456789abcdef", "ui://"));
+  EXPECT_NE(body.find("-32602"), std::string::npos) << body;
+  EXPECT_NE(body.find("unknown"), std::string::npos) << body;
+}
+
+// The same check from the other side: a session this transport did mint is
+// accepted, so the refusal above is about provenance and not about subscribing
+// having stopped working.
+TEST_F(McpTransportTest, SubscribeWithAMintedSessionStillWorks) {
+  const std::string session = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  ASSERT_FALSE(session.empty());
+  const std::string body = Body(Subscribe(path_, session, "ui://"));
+  EXPECT_NE(body.find(R"("result")"), std::string::npos) << body;
+}
+
+// A URI is a name. The body limit alone would let one be a megabyte, and it
+// would then be held for as long as the session is.
+TEST_F(McpTransportTest, AnOverlongSubscriptionUriIsRefused) {
+  const std::string session = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  ASSERT_FALSE(session.empty());
+  const std::string body =
+      Body(Subscribe(path_, session, "ui://" + std::string(4096, 'x')));
+  EXPECT_NE(body.find("-32602"), std::string::npos) << body;
+}
+
+// One session cannot hold an unbounded number of URIs either. Refused rather
+// than evicting one of its own: which resource a client cares about is its
+// decision, and dropping one silently would leave it believing it is still
+// being told about something it is not.
+TEST_F(McpTransportTest, SubscriptionsPerSessionAreCapped) {
+  const std::string session = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  ASSERT_FALSE(session.empty());
+  std::string last;
+  for (int i = 0; i < 200; ++i) {
+    last = Body(Subscribe(path_, session, "ui://r/" + std::to_string(i)));
+    if (last.find(R"("error")") != std::string::npos) {
+      break;
+    }
+  }
+  EXPECT_NE(last.find("-32602"), std::string::npos)
+      << "200 subscriptions on one session were all accepted: " << last;
+}
+
+// Minting is bounded as well, or initialize alone is the growth path. Eviction
+// is least-recently-used rather than oldest-first, so an agent that keeps
+// working keeps its session: what falls off is an id nothing has spoken for.
+TEST_F(McpTransportTest, AWorkingSessionSurvivesOthersBeingMinted) {
+  const std::string mine = SessionFrom(
+      Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})"));
+  ASSERT_FALSE(mine.empty());
+  ASSERT_NE(Body(Subscribe(path_, mine, "ui://mine")).find(R"("result")"),
+            std::string::npos);
+
+  // Well past the cap, with the working session touched along the way, which
+  // is exactly what a client making requests does.
+  for (int i = 0; i < 200; ++i) {
+    Post(path_, R"({"jsonrpc":"2.0","id":1,"method":"initialize"})");
+    if (i % 4 == 0) {
+      Subscribe(path_, mine, "ui://mine");
+    }
+  }
+
+  const std::string body = Body(Subscribe(path_, mine, "ui://mine"));
+  EXPECT_NE(body.find(R"("result")"), std::string::npos)
+      << "the session was evicted while it was still being used: " << body;
 }


### PR DESCRIPTION
Fuzzes the MCP transport and fixes the three defects the first run found.

## The target

The input is the whole client side of one connection -- request line, headers
and body -- written to the socket unmodified, so the header block, the
`Content-Length` accounting, the JSON-RPC envelope and the routing onto a
provider see the same bytes in the same order a client would send them.

Worth the machinery because peer credentials are the whole local trust model,
but off-box access terminates TLS in front of the socket and past that
terminator the peer uid is the terminator's own. Every byte arriving there
came from somewhere else, and the parser runs before any of it is understood.

`BUILD_FUZZERS` instruments the **whole build**, not just the target. The
first attempt instrumented only the driver: it linked, ran, reported coverage
in the tens, and found nothing -- indistinguishable from code that has no bugs.
The option now refuses a non-clang compiler and refuses to combine with the
`SANITIZE_*` options rather than silently producing something that proves
nothing, and the README says what a working run's first coverage number looks
like.

## What it found

Three defects, all one shape: every request is `Connection: close`, so a
connection is not a lifetime and there was nothing for per-client state to be
scoped to. None of it was bounded, and a client that goes away does not say so.

| | Measured before | After |
| --- | --- | --- |
| Abandoned event streams | 200 descriptors per 200 open-and-abandon cycles, no ceiling | 0 |
| Subscription map | ~575 bytes per request, linear, never reclaimed | flat |
| Streams / subs-per-session / URI length | unbounded | capped |

**The descriptor leak is the serious one.** Nothing writes to a stream until a
provider signals, so a client that hung up was noticed only when a
notification happened to arrive -- for an idle UI, never. Descriptors are
process-wide, so this ends with the shell unable to open anything at all
rather than merely with MCP degraded. Fixed by polling the stream descriptors
in the accept loop, which already polls.

**The session one is also an access-control bug.** `Mcp-Session-Id` was never
checked against the ids the transport minted, so one client could name
another's session and drop its subscriptions. The comment claiming that taking
the id from the header rather than the body was the protection was wrong --
both are client-written, and the check is what protects.

None of these were gated by the local uid check. They are reachable by
anything the socket serves, which past a terminator is every client that
terminator admits.

## Verification

487,447 fuzz executions clean after the fix. Seven regression tests, five of
which fail with the change ablated -- the other two are controls: one proves
subscribing still works, and the other fails when eviction is changed from
least-recently-used to oldest-first, so it pins the policy rather than
restating it. A soak of 3000 sessions, 3000 subscribes and 3000 abandoned
streams leaves resident memory and the descriptor count exactly where they
started.

## Also here

Two commits removing local-planning-note leakage: an ignore rule, and three
source comments that cited identifiers from a document not in the repository.
Each now states its reasoning instead -- what the coordinate fallback is for
and why it reports delivery rather than success, and what a drifting second
codec implementation actually costs.

The fuzz targets are not registered with CTest: one runs until stopped, so a
suite would either never finish or run it for a token second and report a
meaningless pass. Anything found belongs in a unit test beside the code.
