### PR TITLE
build: fix the unit-test link failure, and test the engine entry-point choice

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -586,6 +586,54 @@ jobs:
         working-directory: ${{github.workspace}}/build/unit-tests
         run: ctest --output-on-failure --test-dir .
 
+      # A second configuration of the same sources, for one reason: the link
+      # flags differ by build type. -Wl,--as-needed is appended to
+      # CMAKE_EXE_LINKER_FLAGS_RELEASE only, and every other unit-test
+      # configuration in this repository is Debug -- so a library dropped for
+      # want of a DT_NEEDED is invisible here. That is not hypothetical: it
+      # left 19 test drivers unable to link against libGLESv2 while CI stayed
+      # green.
+      #
+      # The flags are deliberately minimal, and adding more backends here
+      # would quietly switch this check off. Measured on the defect this leg
+      # exists for: the default backend set fails 16 targets, wayland-egl
+      # alone fails 19, and turning every backend on fails none -- because
+      # some other consumer then names the library early enough to keep it.
+      # The default set is also what a contributor gets, since Release is what
+      # an unset CMAKE_BUILD_TYPE selects.
+      #
+      # Runs in this job rather than a new one: the checkout and packages are
+      # already here, and a runner of its own would cost more than the build.
+      # Coverage stays on the Debug build, which is where it has to be.
+      - name: Configure (Release, link-flag coverage)
+        run: |
+          cmake -GNinja \
+            -B ${{github.workspace}}/build/unit-tests-release \
+            -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_UNIT_TESTS=ON \
+            -D CMAKE_STAGING_PREFIX=${{github.workspace}}/build/staging-release/usr/local \
+            -D BUILD_NUMBER=${GITHUB_RUN_ID}
+
+      # Same ordering hazard the accesskit job documents: the unit-test targets
+      # compile the Wayland sources without depending on the scanner targets,
+      # so a fresh build directory races and ninja can reach them first. It
+      # surfaces as a couple of dozen compile errors that vanish on a second
+      # run, which is a confusing way to learn about a missing edge.
+      - name: Generate Wayland protocol headers (Release)
+        working-directory: ${{github.workspace}}/build/unit-tests-release
+        run: |
+          ninja $(ninja -t targets all \
+            | grep -oE "^shell/wayland-protocols/[a-z0-9_]+\.hpp" \
+            | sort -u | tr '\n' ' ')
+
+      - name: Build (Release)
+        working-directory: ${{github.workspace}}/build/unit-tests-release
+        run: ninja -C .
+
+      - name: Run unit tests (Release)
+        working-directory: ${{github.workspace}}/build/unit-tests-release
+        run: ctest --output-on-failure --test-dir .
+
       - name: Capture coverage data
         working-directory: ${{github.workspace}}/build/unit-tests
         run: |

--- a/shell/accessibility/semantics_action_args.h
+++ b/shell/accessibility/semantics_action_args.h
@@ -51,6 +51,46 @@ std::optional<std::vector<uint8_t>> EncodeActionArguments(uint64_t action,
                                                           const uint8_t* data,
                                                           size_t data_length);
 
+/*
+ * Which engine entry point a semantics dispatch should use.
+ *
+ * The go-forward call carries a view id; the deprecated one does not and
+ * always lands on the implicit view. Whether the first exists is decided at
+ * load time by an optional symbol resolve, because a header that declares it
+ * says nothing about what the deployed engine exports.
+ */
+enum class SemanticsDispatchRoute {
+  /* FlutterEngineSendSemanticsAction: carries the view id. */
+  kSendWithViewId,
+  /* FlutterEngineDispatchSemanticsAction: implicit view only. */
+  kDeprecatedImplicitView,
+  /* Neither is correct: refuse. */
+  kRefuseMultiview,
+};
+
+/*
+ * Chooses the route, given whether the engine exported the newer entry point
+ * and which view the action is for.
+ *
+ * Extracted from the dispatch itself so the decision can be tested without an
+ * engine of the older revision to hand -- which is the only other way to reach
+ * two of these three answers, and is why they went unexercised.
+ *
+ * The case worth stating: an older engine plus a non-zero view id is refused
+ * rather than sent through the deprecated call. That entry point has no view
+ * id, so the action would arrive at the implicit view -- a different control
+ * than the caller named, activated silently and reported as success.
+ */
+constexpr SemanticsDispatchRoute ChooseSemanticsDispatch(
+    const bool engine_has_send_with_view_id,
+    const int64_t view_id) {
+  if (engine_has_send_with_view_id) {
+    return SemanticsDispatchRoute::kSendWithViewId;
+  }
+  return view_id == 0 ? SemanticsDispatchRoute::kDeprecatedImplicitView
+                      : SemanticsDispatchRoute::kRefuseMultiview;
+}
+
 }  // namespace accessibility
 
 #endif  // SHELL_ACCESSIBILITY_SEMANTICS_ACTION_ARGS_H_

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -1136,39 +1136,43 @@ int Engine::DispatchSemanticsAction(const int64_t view_id,
   // The strand is serviced by the same thread that runs Flutter tasks, so
   // posting here lands the call on the platform thread with no extra
   // synchronization.
-  asio::post(*m_platform_task_runner->GetStrandContext(),
-             [this, view_id, node_id, fl_action,
-              payload = std::move(payload)]() mutable {
-               if (m_flutter_engine == nullptr) {
-                 return;
-               }
-               const uint8_t* bytes =
-                   payload.empty() ? nullptr : payload.data();
-               if (LibFlutterEngine->SendSemanticsAction != nullptr) {
-                 FlutterSendSemanticsActionInfo info = {};
-                 info.struct_size = sizeof(FlutterSendSemanticsActionInfo);
-                 info.view_id = view_id;
-                 info.node_id = static_cast<uint64_t>(node_id);
-                 info.action = fl_action;
-                 info.data = bytes;
-                 info.data_length = payload.size();
-                 LibFlutterEngine->SendSemanticsAction(m_flutter_engine, &info);
-                 return;
-               }
-               // Older engine: the deprecated entry point has no view id, so
-               // a multiview dispatch would land on the wrong view. Refuse
-               // rather than silently target the implicit one.
-               if (view_id != 0) {
-                 ihs::log::warn(
-                     "Dropping semantics action for view {}: this engine only "
-                     "exposes the single-view dispatch entry point",
-                     view_id);
-                 return;
-               }
-               LibFlutterEngine->DispatchSemanticsAction(
-                   m_flutter_engine, static_cast<uint64_t>(node_id), fl_action,
-                   bytes, payload.size());
-             });
+  asio::post(
+      *m_platform_task_runner->GetStrandContext(),
+      [this, view_id, node_id, fl_action,
+       payload = std::move(payload)]() mutable {
+        if (m_flutter_engine == nullptr) {
+          return;
+        }
+        const uint8_t* bytes = payload.empty() ? nullptr : payload.data();
+        switch (accessibility::ChooseSemanticsDispatch(
+            LibFlutterEngine->SendSemanticsAction != nullptr, view_id)) {
+          case accessibility::SemanticsDispatchRoute::kSendWithViewId: {
+            FlutterSendSemanticsActionInfo info = {};
+            info.struct_size = sizeof(FlutterSendSemanticsActionInfo);
+            info.view_id = view_id;
+            info.node_id = static_cast<uint64_t>(node_id);
+            info.action = fl_action;
+            info.data = bytes;
+            info.data_length = payload.size();
+            LibFlutterEngine->SendSemanticsAction(m_flutter_engine, &info);
+            return;
+          }
+          case accessibility::SemanticsDispatchRoute::kDeprecatedImplicitView:
+            LibFlutterEngine->DispatchSemanticsAction(
+                m_flutter_engine, static_cast<uint64_t>(node_id), fl_action,
+                bytes, payload.size());
+            return;
+          case accessibility::SemanticsDispatchRoute::kRefuseMultiview:
+            // The deprecated entry point has no view id, so this action
+            // would land on the implicit view -- a different control
+            // than the caller named, activated silently.
+            ihs::log::warn(
+                "Dropping semantics action for view {}: this engine "
+                "only exposes the single-view dispatch entry point",
+                view_id);
+            return;
+        }
+      });
 
   // Accepted for delivery. Whether the widget does anything with it is not
   // knowable here, and the hub's contract says so.

--- a/shell/platform/homescreen/CMakeLists.txt
+++ b/shell/platform/homescreen/CMakeLists.txt
@@ -65,6 +65,29 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(XKBCOMMON_PLATFORM REQUIRED IMPORTED_TARGET xkbcommon)
 target_link_libraries(platform_homescreen PUBLIC PkgConfig::XKBCOMMON_PLATFORM)
 
+# The external-texture path calls GL directly (flutter_desktop_texture_registrar.cc
+# populates a FlutterOpenGLTexture; flutter_desktop.cc frees one), so declare
+# that here rather than relying on a consumer to have linked GL already.
+#
+# Relying on the consumer is what was happening, and it does not survive
+# -Wl,--as-needed. A consumer that names GL *before* this archive gets no
+# DT_NEEDED for it: at the point the linker saw libGLESv2 nothing had asked for
+# a GL symbol yet, and the archive members that do are pulled in afterwards.
+# The shell binary happened to order it the other way round; the unit test
+# drivers did not, and 19 of them failed to link on undefined glGenTextures.
+#
+# Declaring it on the target that actually calls GL puts the ordering in
+# CMake's hands for every consumer at once, which is the same reasoning as the
+# xkbcommon line above.
+#
+# Gated on a GL backend to match the guard in flutter_desktop.cc: a build with
+# none of them compiles the GL branches out and must not acquire a GL
+# dependency it has no use for.
+if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_DRM_KMS_EGL)
+    pkg_check_modules(GLES_PLATFORM REQUIRED IMPORTED_TARGET glesv2)
+    target_link_libraries(platform_homescreen PUBLIC PkgConfig::GLES_PLATFORM)
+endif ()
+
 # platform_homescreen needs no Wayland binding dependency: it includes no
 # Wayland protocol headers directly. The generated protocol headers attach to
 # the shell binary in shell/CMakeLists.txt.

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -185,10 +185,22 @@ add_subdirectory(watchdog-test)
 add_subdirectory(wake_event_fd-test)
 add_subdirectory(libinput_log-test)
 add_subdirectory(partial_repaint_gate-test)
-add_subdirectory(gl_process_resolver-test)
+# EglProcessResolver is compiled only with a GL-based backend, so its test has
+# nothing to link against otherwise. The source list these drivers are built
+# from is the shell target's own, which means it already follows the backend
+# gating -- and a test subdirectory that does not follow it too is a build
+# break in any configuration nobody happens to run.
+if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_HEADLESS_EGL OR
+        BUILD_BACKEND_DRM_KMS_EGL)
+    add_subdirectory(gl_process_resolver-test)
+endif ()
 add_subdirectory(shared_library-test)
 add_subdirectory(backing_store_pool-test)
-add_subdirectory(present_layer_sequencer-test)
+# PresentLayerSequencer orders wl_subsurfaces, so it exists only in a Wayland
+# build -- same reasoning as gl_process_resolver-test above.
+if (BUILD_BACKEND_WAYLAND_EGL OR BUILD_BACKEND_WAYLAND_VULKAN)
+    add_subdirectory(present_layer_sequencer-test)
+endif ()
 add_subdirectory(compositor_registry-test)
 add_subdirectory(platform_view_registry-test)
 add_subdirectory(backend_output_binding-test)

--- a/test/unit_test/semantics_action_args-test/test_case_semantics_action_args.cc
+++ b/test/unit_test/semantics_action_args-test/test_case_semantics_action_args.cc
@@ -191,3 +191,47 @@ TEST(SemanticsActionArgs, CustomActionWithAWrongSizedIdIsRefused) {
                    IHS_SEMANTICS_ACTION_CUSTOM_ACTION, stub, sizeof(stub))
                    .has_value());
 }
+
+// ---------------------------------------------------------------------------
+// Engine entry-point selection
+//
+// FlutterEngineSendSemanticsAction is resolved optionally at load time: the
+// vendored header declaring it says nothing about what the deployed engine
+// exports, and the deployment floor is older than the header. Two of the three
+// answers below are only reachable against such an engine, which is why they
+// went unexercised -- the decision is extracted so it can be tested without
+// one to hand.
+// ---------------------------------------------------------------------------
+
+TEST(SemanticsDispatchRouteTest, NewerEngineCarriesTheViewId) {
+  EXPECT_EQ(accessibility::ChooseSemanticsDispatch(true, 0),
+            accessibility::SemanticsDispatchRoute::kSendWithViewId);
+  EXPECT_EQ(accessibility::ChooseSemanticsDispatch(true, 3),
+            accessibility::SemanticsDispatchRoute::kSendWithViewId);
+}
+
+// The single-view case degrades cleanly: the deprecated entry point always
+// lands on the implicit view, which for view 0 is the right one.
+TEST(SemanticsDispatchRouteTest, OlderEngineUsesTheDeprecatedCallForViewZero) {
+  EXPECT_EQ(accessibility::ChooseSemanticsDispatch(false, 0),
+            accessibility::SemanticsDispatchRoute::kDeprecatedImplicitView);
+}
+
+// The case that matters. An older engine cannot address a view, so sending
+// through the deprecated call would activate a control on the implicit view --
+// a different one than the caller named, silently, and reported as success.
+// Refusing is the only answer that does not lie.
+TEST(SemanticsDispatchRouteTest, OlderEngineRefusesAMultiviewDispatch) {
+  EXPECT_EQ(accessibility::ChooseSemanticsDispatch(false, 1),
+            accessibility::SemanticsDispatchRoute::kRefuseMultiview);
+  EXPECT_EQ(accessibility::ChooseSemanticsDispatch(false, 42),
+            accessibility::SemanticsDispatchRoute::kRefuseMultiview);
+}
+
+// The choice is made without touching the engine, so it is usable from a
+// constant expression -- and, more to the point, a change that made it depend
+// on runtime state would stop compiling here rather than quietly becoming
+// untestable again.
+static_assert(accessibility::ChooseSemanticsDispatch(false, 1) ==
+                  accessibility::SemanticsDispatchRoute::kRefuseMultiview,
+              "the route decision must stay a pure function of its inputs");


### PR DESCRIPTION
Two pre-existing build defects on `v3.0`, and one path that was reasoned about
rather than executed.

## The GL link failure

19 of 29 unit test drivers fail to link on undefined `glGenTextures` and
friends, pulled in from `libplatform_homescreen.a`.

The ordering is the whole bug. With `-Wl,--as-needed` a shared library gets a
`DT_NEEDED` only if something has asked for one of its symbols by the time the
linker reaches it. `libGLESv2` came first, nothing had needed GL yet, so it was
dropped -- and the archive members that call GL are pulled in afterwards, with
nothing left to resolve against. The shell binary happened to name GL after
the archive; the test drivers named it before.

Fixed by declaring the dependency on `platform_homescreen`, whose own
translation units call GL. That puts the ordering in CMake's hands for every
consumer at once, and it is the same reasoning as the `xkbcommon` line
immediately above it, which exists for the same class of failure. Gated on a
GL backend to match the guard in `flutter_desktop.cc`.

**Why CI is green.** `-Wl,--as-needed` is appended to
`CMAKE_EXE_LINKER_FLAGS_RELEASE` only, and both CI jobs that set
`BUILD_UNIT_TESTS=ON` configure `CMAKE_BUILD_TYPE=Debug`. Measured against
`v3.0`'s own files: Debug + unit tests gives 0 failures, Release + unit tests
gives 19. So this bites anyone running `cmake -B build -D BUILD_UNIT_TESTS=ON`
without naming a build type, since Release is the default when it is unset --
and nothing in CI can currently catch it. The third commit closes that: the
existing unit-tests job now builds and runs the suite in Release as well,
alongside the Debug coverage build.

## Two ungated tests

Found while checking the fix was safe in a non-GL build. The drivers are
compiled from the shell target's own source list, so they already follow its
backend gating -- but the test subdirectories did not. `EglProcessResolver`
exists only with a GL backend and `PresentLayerSequencer` only in a Wayland
build, so a software-only build with unit tests failed on both. No CI leg
configures that combination, which is why it survived.

## The engine entry point

`FlutterEngineSendSemanticsAction` is resolved optionally at load time,
because the vendored header declaring it says nothing about what the deployed
engine exports and the deployment floor is older than the header. The decision
that follows had three outcomes and no test, since two are only reachable
against an engine nobody has to hand.

Extracting it as a pure function reaches them without one. The engine makes
exactly the same choice -- the switch routes through the function the tests
drive, so this is the decision that runs rather than a copy of it.

The outcome worth having under test is the refusal: an older engine cannot
address a view, so sending a multiview action through the deprecated entry
point lands it on the implicit view -- a different control than the caller
named, activated silently, and reported as success. A `static_assert` pins it,
so removing the refusal fails the build rather than a test run.

Worth saying what this is *not*: it does not run against a 3.38.3 engine. The
struct-shape degradation paths already are executed -- `accessibility_tree`
covers the concrete deployed case, and those tests segfault when the gate is
ablated, without a sanitizer -- so the remaining gap was this one decision,
not the version handling generally. A CI leg that fetches and runs an old
engine is a separate, heavier piece of work.

## The CI leg, and why its flags are minimal

The Release step uses the default backend set on purpose, and that is the part
worth not "improving". Measured against this very defect:

| Configuration | Failed targets |
| --- | --- |
| Every backend on | **0** |
| Default backend set | 16 |
| wayland-egl alone | 19 |

With everything enabled some other consumer names libGLESv2 early enough to
keep it, and the check silently stops checking. Adding backends to that step
would switch it off without any sign that it had.

It runs inside the existing unit-tests job rather than as a new one, so it
costs a build rather than a runner; coverage stays on the Debug build, which
needs it. It carries the same protocol-header step the accesskit job does, for
the same missing scanner dependency -- without it a fresh build directory
races and the first ninja pass fails with compile errors that vanish on a
second run.

## Verification

Two configurations that previously could not complete a build now do:
wayland-egl with MCP runs 29 of 29, software-only 19 of 19. Ablating the GL
declaration reproduces exactly the 19 failures; ablating the multiview refusal
fails to compile. The new CI step was checked in both directions: green with
the fix (21 of 21) and 16 failed targets with it reverted.
