### PR TITLE
semantics: make multi-view first class, and fix acting on the wrong application

### DIFF
--- a/docs/mcp-security.md
+++ b/docs/mcp-security.md
@@ -11,13 +11,15 @@ That is the feature. Everything below is about who gets to.
 
 | | |
 | --- | --- |
-| **Read** | The entire semantics tree — every label, value, role and screen rectangle the application publishes for accessibility |
+| **Read** | The entire semantics tree of every running application — every label, value, role and screen rectangle each publishes for accessibility. One resource per application, `ui://semantics/{view}/tree` |
 | **Act** | Any semantics action the application offers on any node: taps, text entry, scrolling, and the application's own custom actions |
 | **Coordinates** | `ui_tap_at` synthesizes a hit-tested tap at a point, reaching what the tree does not describe |
 | **Application tools** | Whatever an application declares through `ihs_mcp_app_tools.h`, under its own prefix |
 
 Treat the tree as **everything on screen**. An agent that can read it can read
-the user's destination, their media, and any text a field displays.
+the user's destination, their media, and any text a field displays — and where
+the shell runs several applications, it can read all of them. There is no
+per-application access control: admitting a client admits it to every view.
 
 ## What stops it
 

--- a/scripts/mcp_inspector.py
+++ b/scripts/mcp_inspector.py
@@ -40,7 +40,11 @@ import socket
 import sys
 import time
 
-TREE_URI = "ui://semantics/tree"
+# The tree URIs are discovered rather than hardcoded: there is one per running
+# application, named for it, and which are present depends on what the shell
+# was configured with. A client that assumes a single fixed URI works until a
+# second application appears and then reads the wrong one, or nothing.
+TREE_URI_PREFIX = "ui://semantics/"
 
 # Roles worth telling apart at a glance. Anything unlisted renders plain,
 # which keeps an unfamiliar role visible rather than mis-coloured.
@@ -115,8 +119,29 @@ def rpc(path, method, params=None, request_id=1):
     return reply["result"]
 
 
-def read_tree(path):
-    result = rpc(path, "resources/read", {"uri": TREE_URI}, request_id=2)
+def tree_uris(path):
+    """Every semantics tree the server is serving, in listed order."""
+    result = rpc(path, "resources/list", {}, request_id=2)
+    return [
+        r["uri"]
+        for r in result.get("resources", [])
+        if r.get("uri", "").startswith(TREE_URI_PREFIX)
+    ]
+
+
+def read_tree(path, uri=None):
+    """One application's tree. With no uri, the only one -- and it says so
+    rather than guessing when there are several, because picking one would
+    silently show a different application than the caller meant."""
+    if uri is None:
+        found = tree_uris(path)
+        if not found:
+            raise ServerGone("no application is publishing a UI")
+        if len(found) > 1:
+            names = ", ".join(found)
+            raise ServerGone(f"several applications are running; name one: {names}")
+        uri = found[0]
+    result = rpc(path, "resources/read", {"uri": uri}, request_id=3)
     return json.loads(result["contents"][0]["text"])
 
 

--- a/shared/include/ihs/ihs_semantics.h
+++ b/shared/include/ihs/ihs_semantics.h
@@ -515,6 +515,67 @@ IHS_EXPORT int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
                                       void* user_data);
 
 /*
+ * ---------------------------------------------------------------------------
+ * Sources (ABI 1.4)
+ * ---------------------------------------------------------------------------
+ *
+ * A source is one independent publisher of a tree. In this port that is one
+ * Flutter engine: each bundle gets an engine of its own, each with its own
+ * node id space starting at the root.
+ *
+ * Before this existed the hub held a single tree and a single host, so a
+ * second engine overwrote the first's tree and redirected the first's actions
+ * to itself. A client could read one application's tree and have its tap
+ * delivered to another -- silently, and to a real but unrelated control, since
+ * the two id spaces overlap. Keying by source is what makes reading and acting
+ * refer to the same application.
+ *
+ * Two trees are not one document. They are merged nowhere: a consumer asks a
+ * source for its tree and dispatches back to that same source, and the pairing
+ * is what the type system now enforces.
+ */
+typedef struct IhsSemanticsSource IhsSemanticsSource;
+
+/* How many sources are registered, and the one at `index`, or NULL. Together
+ * these let a consumer enumerate what it can address. */
+IHS_EXPORT size_t ihs_semantics_source_count(void);
+IHS_EXPORT IhsSemanticsSource* ihs_semantics_source_at(size_t index);
+
+/* The registered name, or "" for the implicit source ihs_semantics_set_host
+ * creates. Valid until that source is unregistered. */
+IHS_EXPORT const char* ihs_semantics_source_name(
+    const IhsSemanticsSource* source);
+
+/* This source's current tree, or NULL when it has published none. Release with
+ * ihs_semantics_release_snapshot, as for any snapshot. */
+IHS_EXPORT const IhsSemanticsSnapshot* ihs_semantics_acquire_snapshot_from(
+    IhsSemanticsSource* source);
+
+/*
+ * As ihs_semantics_dispatch, against a named source. The node id is resolved
+ * in that source's tree and the action reaches that source's host.
+ *
+ * Prefer this wherever the snapshot the node came from is known, which is
+ * everywhere a consumer acts on something it read.
+ */
+IHS_EXPORT int ihs_semantics_dispatch_from(IhsSemanticsConsumer* consumer,
+                                           IhsSemanticsSource* source,
+                                           int64_t view_id,
+                                           int32_t node_id,
+                                           uint64_t action,
+                                           const uint8_t* data,
+                                           size_t data_length,
+                                           IhsSemanticsDoneCallback done,
+                                           void* user_data);
+
+/* As ihs_semantics_send_pointer_tap, against a named source. */
+IHS_EXPORT int ihs_semantics_send_pointer_tap_to(IhsSemanticsConsumer* consumer,
+                                                 IhsSemanticsSource* source,
+                                                 int64_t view_id,
+                                                 double x,
+                                                 double y);
+
+/*
  * Semantics capability sub-table (IhsApi::semantics), added in ABI 1.2.
  *
  * The flat entry points above are the same functions and remain supported.

--- a/shared/include/ihs/ihs_semantics.h
+++ b/shared/include/ihs/ihs_semantics.h
@@ -633,6 +633,37 @@ typedef struct IhsSemanticsApi {
                           int64_t view_id,
                           double x,
                           double y);
+
+  /*
+   * Source addressing, appended in ABI 1.4. Read only when struct_size reaches
+   * them; a plugin built against 1.3 has neither these nor the size to reach
+   * them.
+   *
+   * They are not optional extras where the shell runs several applications:
+   * the calls above resolve to a single unambiguous source, so with more than
+   * one registered acquire_snapshot returns NULL and dispatch fails. A plugin
+   * that wants to work in that configuration has to address a view, and these
+   * are how.
+   */
+  size_t (*source_count)(void);
+  IhsSemanticsSource* (*source_at)(size_t index);
+  const char* (*source_name)(const IhsSemanticsSource* source);
+  const IhsSemanticsSnapshot* (*acquire_snapshot_from)(
+      IhsSemanticsSource* source);
+  int (*dispatch_from)(IhsSemanticsConsumer* consumer,
+                       IhsSemanticsSource* source,
+                       int64_t view_id,
+                       int32_t node_id,
+                       uint64_t action,
+                       const uint8_t* data,
+                       size_t data_length,
+                       IhsSemanticsDoneCallback done,
+                       void* user_data);
+  int (*send_pointer_tap_to)(IhsSemanticsConsumer* consumer,
+                             IhsSemanticsSource* source,
+                             int64_t view_id,
+                             double x,
+                             double y);
 } IhsSemanticsApi;
 
 #ifdef __cplusplus

--- a/shared/include/ihs/ihs_semantics_host.h
+++ b/shared/include/ihs/ihs_semantics_host.h
@@ -105,12 +105,56 @@ typedef struct IhsSemanticsHost {
 } IhsSemanticsHost;
 
 /*
- * Install the host. Exactly one per process, at engine bring-up and before the
- * first publish. Pass NULL to uninstall during teardown, after which dispatch
- * fails with IHS_SEMANTICS_ERR_UNAVAILABLE rather than calling into a shell
- * that is going away. The struct is copied; it need not outlive the call.
+ * Install the host for the implicit source, at bring-up and before the first
+ * publish. Pass NULL to uninstall during teardown, after which dispatch fails
+ * with IHS_SEMANTICS_ERR_UNAVAILABLE rather than calling into a shell that is
+ * going away. The struct is copied; it need not outlive the call.
+ *
+ * For one publisher this is all that is needed. **A shell running more than
+ * one engine must use ihs_semantics_source_register instead** (ABI 1.4): this
+ * call installs a single host, so a second caller replaces the first and its
+ * actions -- including actions read from the first engine's tree -- are
+ * delivered to the second.
  */
 IHS_EXPORT void ihs_semantics_set_host(const IhsSemanticsHost* host);
+
+/*
+ * Registering a source is the multi-publisher form of set_host (ABI 1.4),
+ * and lives here rather than beside the addressing calls in ihs_semantics.h
+ * because it carries a host: creating a publisher is a producer operation,
+ * and only the shell has one to offer.
+ */
+typedef struct IhsSemanticsSourceDesc {
+  size_t struct_size; /* sizeof(IhsSemanticsSourceDesc) */
+
+  /*
+   * Stable name, unique among registered sources. It addresses this tree from
+   * outside -- an MCP resource URI is built from it -- so it should be
+   * meaningful to someone who did not configure the shell, and should not
+   * change across a restart of the same application.
+   */
+  const char* name;
+
+  /* Where this source's dispatches go. Copied; not retained by pointer. */
+  IhsSemanticsHost host;
+} IhsSemanticsSourceDesc;
+
+/*
+ * Registers a publisher. Fails with IHS_SEMANTICS_ERR_INVALID for a malformed
+ * desc or a name already taken -- a duplicate name would make two trees
+ * indistinguishable to anything addressing them by it, which is the failure
+ * this whole mechanism exists to prevent.
+ */
+IHS_EXPORT int ihs_semantics_source_register(const IhsSemanticsSourceDesc* desc,
+                                             IhsSemanticsSource** out_source);
+
+/*
+ * Drops the source and releases its tree. Safe with NULL. Any snapshot a
+ * consumer still holds stays valid: snapshots are refcounted independently of
+ * the source that published them, so a consumer mid-read does not fault
+ * because an engine went away.
+ */
+IHS_EXPORT void ihs_semantics_source_unregister(IhsSemanticsSource* source);
 
 /*
  * One node as the shell hands it over. Distinct from IhsSemanticsNode -- this
@@ -197,6 +241,19 @@ typedef struct IhsSemanticsPublishInfo {
 
   const IhsSemanticsPublishCustomAction* custom_actions;
   size_t custom_action_count;
+
+  /*
+   * Which publisher this tree belongs to (ABI 1.4). NULL publishes to the
+   * implicit source ihs_semantics_set_host creates, which is what a caller
+   * that knows nothing of sources gets.
+   *
+   * A shell running more than one engine must set this. Without it the last
+   * engine to publish owns the only tree there is, and the last to install a
+   * host owns every dispatch -- so a consumer reads one application and acts
+   * on another. Read is gated on struct_size, so a caller built against 1.3
+   * is unaffected.
+   */
+  struct IhsSemanticsSource* source;
 } IhsSemanticsPublishInfo;
 
 /*

--- a/shared/include/ihs/ihs_version.h
+++ b/shared/include/ihs/ihs_version.h
@@ -29,7 +29,7 @@
  * ihs_get_api().
  */
 #define IHS_SHARED_ABI_MAJOR 1u
-#define IHS_SHARED_ABI_MINOR 3u
+#define IHS_SHARED_ABI_MINOR 4u
 #define IHS_SHARED_ABI_VERSION \
   ((IHS_SHARED_ABI_MAJOR << 16) | IHS_SHARED_ABI_MINOR)
 

--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -72,11 +72,24 @@ struct ToolEntry {
 // only ids must still be able to act.
 constexpr char kNodeSchema[] =
     R"({"type":"object","properties":{)"
-    R"("node_id":{"type":"integer","description":"Semantics tree id."},)"
-    R"("identifier":{"type":"string","description":"Application-assigned identifier, when the app sets one."})"
+    R"("node_id":{"type":"integer","description":"Semantics tree id. Unique only within a view -- two applications number from their own roots."},)"
+    R"("identifier":{"type":"string","description":"Application-assigned identifier, when the app sets one."},)"
+    R"("view":{"type":"string","description":"Which application's UI, as named by ui://semantics/{view}/tree. Required when more than one is running."})"
     R"(},"anyOf":[{"required":["node_id"]},{"required":["identifier"]}]})";
 
 constexpr char kEmptySchema[] = R"({"type":"object","properties":{}})";
+
+// The view argument, spelled the same wherever it appears. Its name is the
+// source name, which is what ui://semantics/{view}/tree carries and what
+// ui_query reports on every node it returns -- so an agent that found a node
+// already holds what it needs to act on it.
+constexpr char kViewProperty[] =
+    R"("view":{"type":"string","description":"Which application's UI, as named by ui://semantics/{view}/tree. Required when more than one is running; may be omitted when there is exactly one."})";
+
+constexpr char kSnapshotSchema[] =
+    R"({"type":"object","properties":{)"
+    R"("view":{"type":"string","description":"Which application's UI. Omitted, every one is returned, each tagged with its view."})"
+    R"(}})";
 
 constexpr char kQuerySchema[] =
     R"({"type":"object","properties":{)"
@@ -86,14 +99,16 @@ constexpr char kQuerySchema[] =
     R"("action":{"type":"string","description":"Only nodes offering this action, named as the tree reports it."},)"
     R"("custom_action":{"type":"string","description":"Only nodes declaring a custom action with this label."},)"
     R"("enabled":{"type":"string","enum":["true","false","not_applicable"],"description":"Enabled tristate, spelled as the tree reports it; not_applicable means enablement is meaningless for the node."},)"
-    R"("limit":{"type":"integer","description":"Cap on returned nodes. match_count and truncated always report the full total."})"
+    R"("limit":{"type":"integer","description":"Cap on returned nodes. match_count and truncated always report the full total."},)"
+    R"("view":{"type":"string","description":"Restrict to one application's UI. Omitted, every view is searched and each match reports the view it is in."})"
     R"(}})";
 
 constexpr char kSetTextSchema[] =
     R"({"type":"object","properties":{)"
     R"("node_id":{"type":"integer"},)"
     R"("identifier":{"type":"string"},)"
-    R"("text":{"type":"string","description":"Replacement text for the field."})"
+    R"("text":{"type":"string","description":"Replacement text for the field."},)"
+    R"("view":{"type":"string"})"
     R"(},"required":["text"]})";
 
 constexpr char kScrollToSchema[] =
@@ -101,7 +116,8 @@ constexpr char kScrollToSchema[] =
     R"("node_id":{"type":"integer"},)"
     R"("identifier":{"type":"string"},)"
     R"("dx":{"type":"number","description":"Horizontal offset in logical pixels."},)"
-    R"("dy":{"type":"number","description":"Vertical offset in logical pixels."})"
+    R"("dy":{"type":"number","description":"Vertical offset in logical pixels."},)"
+    R"("view":{"type":"string"})"
     R"(}})";
 
 constexpr char kCustomActionSchema[] =
@@ -109,13 +125,15 @@ constexpr char kCustomActionSchema[] =
     R"("node_id":{"type":"integer"},)"
     R"("identifier":{"type":"string"},)"
     R"("action":{"type":"string","description":"Custom action label, exactly as the tree reports it."},)"
-    R"("action_id":{"type":"integer","description":"Custom action id, as an alternative to the label."})"
+    R"("action_id":{"type":"integer","description":"Custom action id, as an alternative to the label."},)"
+    R"("view":{"type":"string"})"
     R"(}})";
 
 constexpr char kTapAtSchema[] =
     R"({"type":"object","properties":{)"
     R"("x":{"type":"number","description":"Screen x, in the same coordinates as a node rect."},)"
-    R"("y":{"type":"number","description":"Screen y, in the same coordinates as a node rect."})"
+    R"("y":{"type":"number","description":"Screen y, in the same coordinates as a node rect."},)"
+    R"("view":{"type":"string","description":"Which application's screen. Required when more than one is running."})"
     R"(},"required":["x","y"]})";
 
 const ToolEntry kTools[] = {
@@ -533,10 +551,12 @@ class Arguments {
 // server is waiting for.
 constexpr int kFocusSettleMs = 400;
 
-const IhsSemanticsSnapshot* WaitForNewerSnapshot(const uint64_t generation,
+const IhsSemanticsSnapshot* WaitForNewerSnapshot(IhsSemanticsSource* source,
+                                                 const uint64_t generation,
                                                  const int timeout_ms) {
   for (int waited = 0; waited <= timeout_ms; waited += 10) {
-    const IhsSemanticsSnapshot* candidate = ihs_semantics_acquire_snapshot();
+    const IhsSemanticsSnapshot* candidate =
+        ihs_semantics_acquire_snapshot_from(source);
     if (candidate != nullptr &&
         ihs_semantics_snapshot_generation(candidate) > generation) {
       return candidate;
@@ -570,17 +590,18 @@ constexpr int kVerifySettleMs = 150;
 // looks like. Reporting it as an error would make a client retry an action
 // that already happened.
 void WriteOutcome(rapidjson::Writer<rapidjson::StringBuffer>& w,
+                  IhsSemanticsSource* source,
                   const char* mode,
                   const uint64_t generation_before,
                   const int32_t node_id,
                   const bool report_node) {
   const IhsSemanticsSnapshot* after =
-      WaitForNewerSnapshot(generation_before, kVerifySettleMs);
+      WaitForNewerSnapshot(source, generation_before, kVerifySettleMs);
   if (after == nullptr) {
     // Nothing newer arrived. Read the current tree anyway rather than assuming
     // it still matches: the wait can only end early on a newer generation, so
     // this is the same tree, and looking is cheaper than reasoning about it.
-    after = ihs_semantics_acquire_snapshot();
+    after = ihs_semantics_acquire_snapshot_from(source);
   }
 
   w.Key("mode");
@@ -641,7 +662,14 @@ struct Provider {
   IhsSemanticsConsumer* consumer = nullptr;
   std::vector<IhsMcpToolDesc> tools;
   std::vector<std::string> names;  // prefix-free names, owned
-  IhsMcpResourceDesc resources[1]{};
+
+  // One resource per source, rebuilt whenever the set of sources changes. A
+  // tree belongs to a publisher and the URI says which -- there is no
+  // unqualified "the tree", because what it would name depends on how many
+  // applications happen to be running, which is not something a client can
+  // see or an identifier should depend on.
+  std::vector<IhsMcpResourceDesc> resources;
+  std::vector<std::string> resource_uris;  // owned; the descs point at these
 };
 
 Provider& TheProvider() {
@@ -658,22 +686,78 @@ int ListTools(void* /* user_data */,
   return IHS_MCP_OK;
 }
 
+// The resource URI naming `source`'s tree.
+std::string TreeUriFor(IhsSemanticsSource* source) {
+  return std::string("ui://semantics/") + ihs_semantics_source_name(source) +
+         "/tree";
+}
+
+// Rebuilds the resource list from the hub's current sources. Called on every
+// listing rather than cached at start: an application can come and go while
+// the shell runs, and a list that went stale would advertise a tree nobody
+// publishes and omit one somebody does.
+void RefreshResourcesLocked(Provider& p) {
+  const size_t count = ihs_semantics_source_count();
+  p.resource_uris.clear();
+  p.resources.clear();
+  p.resource_uris.reserve(count);
+  p.resources.reserve(count);
+  for (size_t i = 0; i < count; i++) {
+    IhsSemanticsSource* source = ihs_semantics_source_at(i);
+    if (source == nullptr) {
+      continue;
+    }
+    p.resource_uris.push_back(TreeUriFor(source));
+  }
+  // Pointed at after the vector has stopped growing; a c_str() taken during
+  // the loop would dangle on the next reallocation.
+  for (const std::string& uri : p.resource_uris) {
+    IhsMcpResourceDesc desc{};
+    desc.uri = uri.c_str();
+    desc.name = "semantics tree";
+    desc.description = "One application's UI as a semantics tree.";
+    desc.mime_type = "application/json";
+    p.resources.push_back(desc);
+  }
+}
+
 int ListResources(void* /* user_data */,
                   const IhsMcpResourceDesc** out_resources,
                   size_t* out_count) {
   Provider& p = TheProvider();
-  *out_resources = p.resources;
-  *out_count = 1;
+  const std::lock_guard<std::mutex> lock(p.mutex);
+  RefreshResourcesLocked(p);
+  *out_resources = p.resources.empty() ? nullptr : p.resources.data();
+  *out_count = p.resources.size();
   return IHS_MCP_OK;
+}
+
+// The source a resource URI names, or NULL. Resolved by comparing against the
+// URI each live source would produce, so there is exactly one place that
+// decides what a tree is called.
+IhsSemanticsSource* SourceForUri(const char* uri) {
+  if (uri == nullptr) {
+    return nullptr;
+  }
+  const size_t count = ihs_semantics_source_count();
+  for (size_t i = 0; i < count; i++) {
+    IhsSemanticsSource* source = ihs_semantics_source_at(i);
+    if (source != nullptr && TreeUriFor(source) == uri) {
+      return source;
+    }
+  }
+  return nullptr;
 }
 
 int ReadResource(void* /* user_data */,
                  const char* uri,
                  IhsMcpPayload* out_content) {
-  if (std::strcmp(uri, "ui://semantics/tree") != 0) {
+  IhsSemanticsSource* source = SourceForUri(uri);
+  if (source == nullptr) {
     return IHS_MCP_ERR_NOT_FOUND;
   }
-  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  const IhsSemanticsSnapshot* snapshot =
+      ihs_semantics_acquire_snapshot_from(source);
   if (snapshot == nullptr) {
     // Semantics has not produced a tree yet. An empty document says so
     // without pretending the UI has no nodes.
@@ -683,6 +767,93 @@ int ReadResource(void* /* user_data */,
   FillPayload(out_content, SerializeTree(snapshot));
   ihs_semantics_release_snapshot(snapshot);
   return IHS_MCP_OK;
+}
+
+std::string RunQuery(const IhsSemanticsSnapshot* snapshot,
+                     const Arguments& arguments);
+
+// Runs a read across every application, grouped by view.
+//
+// Grouped rather than flattened: two applications number their nodes from
+// their own roots, so a flat list of matches would carry ids that collide and
+// mean different things. The grouping is what makes each id usable -- an agent
+// reads a match, takes the view it is under, and has both halves of what an
+// action needs.
+std::string ReadEveryView(const char* tool, const Arguments& arguments) {
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> w(buffer);
+  w.StartObject();
+  w.Key("views");
+  w.StartArray();
+
+  const size_t count = ihs_semantics_source_count();
+  for (size_t i = 0; i < count; i++) {
+    IhsSemanticsSource* source = ihs_semantics_source_at(i);
+    if (source == nullptr) {
+      continue;
+    }
+    const IhsSemanticsSnapshot* snapshot =
+        ihs_semantics_acquire_snapshot_from(source);
+    if (snapshot == nullptr) {
+      continue;  // registered but has published nothing yet
+    }
+    w.StartObject();
+    w.Key("view");
+    w.String(ihs_semantics_source_name(source));
+    w.Key("result");
+    // Re-emitted rather than composed: each helper already produces a complete
+    // document, and reparsing it here would be a second place that has to know
+    // their shapes.
+    const std::string body = std::strcmp(tool, "snapshot") == 0
+                                 ? SerializeTree(snapshot)
+                                 : RunQuery(snapshot, arguments);
+    w.RawValue(body.c_str(), body.size(), rapidjson::kObjectType);
+    w.EndObject();
+    ihs_semantics_release_snapshot(snapshot);
+  }
+
+  w.EndArray();
+  w.EndObject();
+  return buffer.GetString();
+}
+
+// The source a `view` argument names.
+//
+// Absent, and exactly one application is running, that one is meant and saying
+// so would be noise. Absent with several running, there is no right answer:
+// choosing one is how a client ends up acting on an application it never read,
+// which is the defect sources exist to prevent, so it refuses instead. The
+// error names what it wanted, because an agent that omitted the argument needs
+// to know the argument exists.
+//
+// `found` distinguishes "no such view" from "ambiguous", which are different
+// mistakes: the first is a wrong name, the second a missing one.
+IhsSemanticsSource* ResolveView(const Arguments& arguments,
+                                std::string* out_error) {
+  std::string wanted;
+  const bool named = arguments.String("view", &wanted);
+
+  const size_t count = ihs_semantics_source_count();
+  if (!named) {
+    if (count == 1) {
+      return ihs_semantics_source_at(0);
+    }
+    *out_error = count == 0
+                     ? "no application is publishing a UI"
+                     : "view is required: " + std::to_string(count) +
+                           " applications are running. Name one, as listed by "
+                           "resources/list.";
+    return nullptr;
+  }
+
+  for (size_t i = 0; i < count; i++) {
+    IhsSemanticsSource* source = ihs_semantics_source_at(i);
+    if (source != nullptr && wanted == ihs_semantics_source_name(source)) {
+      return source;
+    }
+  }
+  *out_error = "no view named '" + wanted + "'";
+  return nullptr;
 }
 
 // Resolves an action name to its bit, using the same table WriteActions
@@ -822,7 +993,31 @@ int CallTool(void* /* user_data */,
   // promise.
   const Arguments arguments(arguments_json, arguments_length);
 
-  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  // Reading may span applications; acting may not. An agent looking for a
+  // control has no reason to know which application owns it -- that is what it
+  // is trying to find out -- so an unqualified read searches everything and
+  // reports where each result came from. An unqualified *action* has no such
+  // defensible reading, and is refused below.
+  const bool reads_only =
+      std::strcmp(name, "snapshot") == 0 || std::strcmp(name, "query") == 0;
+  std::string requested_view;
+  if (reads_only && !arguments.String("view", &requested_view)) {
+    FillPayload(out_result, ReadEveryView(name, arguments));
+    return IHS_MCP_OK;
+  }
+
+  // Which application this call is about, decided before anything is read or
+  // dispatched. Every path below uses this one source, so a call cannot read
+  // one application's tree and act on another's.
+  std::string view_error;
+  IhsSemanticsSource* source = ResolveView(arguments, &view_error);
+  if (source == nullptr) {
+    FillPayload(out_result, ErrorJson(view_error.c_str(), 0));
+    return IHS_MCP_ERR_INVALID;
+  }
+
+  const IhsSemanticsSnapshot* snapshot =
+      ihs_semantics_acquire_snapshot_from(source);
   if (snapshot == nullptr) {
     FillPayload(out_result, ErrorJson("no semantics tree has been published "
                                       "yet",
@@ -859,7 +1054,7 @@ int CallTool(void* /* user_data */,
 
     Provider& provider = TheProvider();
     const int tap_status =
-        ihs_semantics_send_pointer_tap(provider.consumer, 0, x, y);
+        ihs_semantics_send_pointer_tap_to(provider.consumer, source, 0, x, y);
     if (tap_status != IHS_SEMANTICS_OK) {
       FillPayload(out_result, ErrorJson("pointer tap refused", generation_now));
       return IHS_MCP_ERR_REFUSED;
@@ -881,7 +1076,7 @@ int CallTool(void* /* user_data */,
     tap_writer.Double(x);
     tap_writer.Key("y");
     tap_writer.Double(y);
-    WriteOutcome(tap_writer, "pointer", generation_now, 0,
+    WriteOutcome(tap_writer, source, "pointer", generation_now, 0,
                  /*report_node=*/false);
     tap_writer.EndObject();
     FillPayload(out_result, tap_buffer.GetString());
@@ -952,9 +1147,10 @@ int CallTool(void* /* user_data */,
     std::memcpy(payload.data(), &action_id, sizeof(action_id));
 
     Provider& provider = TheProvider();
-    const int custom_status = ihs_semantics_dispatch(
-        provider.consumer, 0, target, IHS_SEMANTICS_ACTION_CUSTOM_ACTION,
-        payload.data(), payload.size(), nullptr, nullptr);
+    const int custom_status = ihs_semantics_dispatch_from(
+        provider.consumer, source, 0, target,
+        IHS_SEMANTICS_ACTION_CUSTOM_ACTION, payload.data(), payload.size(),
+        nullptr, nullptr);
     if (custom_status != IHS_SEMANTICS_OK) {
       FillPayload(out_result, ErrorJson("dispatch refused", generation));
       return IHS_MCP_ERR_REFUSED;
@@ -969,7 +1165,7 @@ int CallTool(void* /* user_data */,
     custom_writer.Int(target);
     custom_writer.Key("action_id");
     custom_writer.Int(action_id);
-    WriteOutcome(custom_writer, "semantics", generation, target,
+    WriteOutcome(custom_writer, source, "semantics", generation, target,
                  /*report_node=*/true);
     custom_writer.EndObject();
     FillPayload(out_result, custom_buffer.GetString());
@@ -999,9 +1195,10 @@ int CallTool(void* /* user_data */,
     ihs_semantics_release_snapshot(snapshot);
 
     Provider& focus_provider = TheProvider();
-    if (ihs_semantics_dispatch(focus_provider.consumer, 0, focus_id,
-                               IHS_SEMANTICS_ACTION_FOCUS, nullptr, 0, nullptr,
-                               nullptr) != IHS_SEMANTICS_OK) {
+    if (ihs_semantics_dispatch_from(focus_provider.consumer, source, 0,
+                                    focus_id, IHS_SEMANTICS_ACTION_FOCUS,
+                                    nullptr, 0, nullptr,
+                                    nullptr) != IHS_SEMANTICS_OK) {
       FillPayload(out_result,
                   ErrorJson("could not focus the field before setting text",
                             generation));
@@ -1011,7 +1208,7 @@ int CallTool(void* /* user_data */,
     // Focusing takes effect on a frame, so the tree that advertises SetText is
     // the next one. Bounded so a field that never gains focus fails as a
     // refusal rather than hanging the caller.
-    snapshot = WaitForNewerSnapshot(generation, kFocusSettleMs);
+    snapshot = WaitForNewerSnapshot(source, generation, kFocusSettleMs);
     if (snapshot == nullptr) {
       FillPayload(out_result,
                   ErrorJson("field did not report focus in time", generation));
@@ -1068,9 +1265,9 @@ int CallTool(void* /* user_data */,
 
   Provider& p = TheProvider();
   const int status =
-      ihs_semantics_dispatch(p.consumer, 0, node_id, tool->action,
-                             argument.empty() ? nullptr : argument.data(),
-                             argument.size(), nullptr, nullptr);
+      ihs_semantics_dispatch_from(p.consumer, source, 0, node_id, tool->action,
+                                  argument.empty() ? nullptr : argument.data(),
+                                  argument.size(), nullptr, nullptr);
   if (status != IHS_SEMANTICS_OK) {
     FillPayload(out_result, ErrorJson("dispatch refused", generation));
     return IHS_MCP_ERR_REFUSED;
@@ -1083,7 +1280,8 @@ int CallTool(void* /* user_data */,
   w.Bool(true);
   w.Key("node_id");
   w.Int(node_id);
-  WriteOutcome(w, "semantics", generation, node_id, /*report_node=*/true);
+  WriteOutcome(w, source, "semantics", generation, node_id,
+               /*report_node=*/true);
   w.EndObject();
   FillPayload(out_result, buffer.GetString());
   return IHS_MCP_OK;
@@ -1182,10 +1380,7 @@ int ihs_mcp_semantics_provider_start_with(const IhsMcpSemanticsConfig* config) {
                             std::to_string(kToolCount) + ": " + offered_names);
   }
 
-  p.resources[0].uri = "ui://semantics/tree";
-  p.resources[0].name = "semantics tree";
-  p.resources[0].description = "The current UI as a semantics tree.";
-  p.resources[0].mime_type = "application/json";
+  RefreshResourcesLocked(p);
 
   // Register with the hub first: an MCP client can call the moment the
   // provider is visible, and answering with "no tree" because we had not

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -1100,11 +1100,47 @@ bool TryOpenEventStream(const int fd,
 
 // Serves one connection. Returns true when the descriptor has become an event
 // stream and must stay open; the caller closes it otherwise.
+// Closes a connection we are refusing, without losing the reason.
+//
+// A close with the peer's request still sitting unread discards both
+// directions, so the response we just wrote can vanish and the client sees an
+// empty reply rather than the refusal. Consuming what it sent first is what
+// makes the answer reliably arrive.
+//
+// The drain is bounded in both bytes and time: this runs before any
+// authorisation has succeeded, so a peer that keeps sending must not be able
+// to hold the accept thread. Whatever is left when the bound is reached is
+// abandoned -- at that point the response has had every chance to land, and
+// the peer is misbehaving anyway.
+void CloseRefused(const int fd) {
+  static constexpr size_t kMaxDrainBytes = 64 * 1024;
+  static constexpr int kDrainTimeoutMs = 50;
+
+  ::shutdown(fd, SHUT_WR);
+  size_t drained = 0;
+  while (drained < kMaxDrainBytes) {
+    pollfd poll_fd = {fd, POLLIN, 0};
+    if (::poll(&poll_fd, 1, kDrainTimeoutMs) <= 0) {
+      break;
+    }
+    char discard[4096];
+    const ssize_t got = ::recv(fd, discard, sizeof(discard), 0);
+    if (got <= 0) {
+      break;  // EOF, or an error that makes further reading pointless
+    }
+    drained += static_cast<size_t>(got);
+  }
+  ::close(fd);
+}
+
 bool ServeConnection(const int fd, const size_t max_body) {
   if (!PeerIsOwner(fd)) {
     Log(IHS_LEVEL_WARN, "mcp: refused a connection from another user");
     WriteAll(fd, HttpResponse(403, "Forbidden", R"({"error":"forbidden"})"));
-    return false;
+    // Returning true means "the descriptor is handled": this closes it itself,
+    // because a plain close here races the response away.
+    CloseRefused(fd);
+    return true;
   }
 
   // Peeked rather than read: a GET opens an event stream and a POST carries a

--- a/shared/src/semantics.cc
+++ b/shared/src/semantics.cc
@@ -970,6 +970,12 @@ const IhsSemanticsApi* semantics_api() noexcept {
       &ihs_semantics_unregister,
       &ihs_semantics_dispatch,
       &ihs_semantics_send_pointer_tap,
+      &ihs_semantics_source_count,
+      &ihs_semantics_source_at,
+      &ihs_semantics_source_name,
+      &ihs_semantics_acquire_snapshot_from,
+      &ihs_semantics_dispatch_from,
+      &ihs_semantics_send_pointer_tap_to,
   };
   return &api;
 }

--- a/shared/src/semantics.cc
+++ b/shared/src/semantics.cc
@@ -21,6 +21,7 @@
 #include "ihs/ihs_semantics.h"
 #include "ihs/ihs_semantics_host.h"
 
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <cmath>
@@ -66,6 +67,17 @@ struct Consumer {
   int notify_fd = -1;
 };
 
+// One publisher: its tree, and where its actions go. Two engines are two of
+// these, and keeping the pair together is the point -- a tree read from one
+// source dispatches back to that source's host, so reading and acting cannot
+// drift onto different applications.
+struct Source {
+  std::string name;
+  IhsSemanticsHost host{};
+  bool host_installed = false;
+  Snapshot* current = nullptr;  // owns one reference
+};
+
 // One process-wide hub. A mutex rather than a lock-free protocol: it is held
 // only to swap a pointer or touch the registry, never across consumer work or
 // a host call, so no consumer can stall the platform thread or another
@@ -73,11 +85,12 @@ struct Consumer {
 // sake would buy nothing and cost a reclamation scheme.
 struct Hub {
   std::mutex mutex;
-  Snapshot* current = nullptr;  // owns one reference
+  // Generations are hub-wide rather than per-source, so a consumer watching
+  // several trees can order what it saw. Per-source counters would make two
+  // publishes from different engines indistinguishable by number.
   uint64_t next_generation = 1;
+  std::vector<std::unique_ptr<Source>> sources;
   std::vector<std::unique_ptr<Consumer>> consumers;
-  IhsSemanticsHost host{};
-  bool host_installed = false;
 };
 
 Hub& TheHub() {
@@ -140,6 +153,37 @@ void Own(std::vector<std::string>& pool, const char* s) {
 // byte both just mean "generation changed, go look". EAGAIN means a previous
 // wake has not been drained yet, which is exactly the coalescing the contract
 // promises, so it is success rather than an error.
+// The source an unkeyed call means.
+//
+// Two answers are correct and a third is not. The implicit source that
+// set_host creates is what a caller predating sources gets. Failing that, a
+// single registered source is unambiguous and answering with it is what keeps
+// a consumer working while a shell migrates. More than one, and there is no
+// right answer -- returning any of them is how a client ends up reading one
+// application and acting on another, which is the defect sources exist to fix,
+// so it returns nothing and the caller gets a clean failure instead.
+//
+// Called with the hub lock held.
+Source* DefaultSourceLocked(Hub& hub) {
+  for (const auto& source : hub.sources) {
+    if (source->name.empty()) {
+      return source.get();
+    }
+  }
+  return hub.sources.size() == 1 ? hub.sources.front().get() : nullptr;
+}
+
+// Whether `source` is still registered. A consumer may hold a pointer across
+// an engine going away, and dereferencing it then would be a use-after-free
+// rather than the "that application is gone" the caller can act on.
+// Called with the hub lock held.
+bool SourceIsLiveLocked(Hub& hub, const Source* source) {
+  return std::any_of(hub.sources.begin(), hub.sources.end(),
+                     [source](const std::unique_ptr<Source>& candidate) {
+                       return candidate.get() == source;
+                     });
+}
+
 void Notify(int fd) {
   if (fd < 0) {
     return;
@@ -362,13 +406,14 @@ const IhsSemanticsCustomAction* ihs_semantics_find_custom_action(
 const IhsSemanticsSnapshot* ihs_semantics_acquire_snapshot(void) {
   Hub& hub = TheHub();
   std::lock_guard<std::mutex> lock(hub.mutex);
-  if (hub.current == nullptr) {
+  Source* source = DefaultSourceLocked(hub);
+  if (source == nullptr || source->current == nullptr) {
     return nullptr;
   }
   // Under the lock, so this cannot race the publisher dropping the last
   // reference: the retire in publish happens with the lock held too.
-  Retain(hub.current);
-  return reinterpret_cast<const IhsSemanticsSnapshot*>(hub.current);
+  Retain(source->current);
+  return reinterpret_cast<const IhsSemanticsSnapshot*>(source->current);
 }
 
 void ihs_semantics_release_snapshot(const IhsSemanticsSnapshot* snapshot) {
@@ -378,22 +423,155 @@ void ihs_semantics_release_snapshot(const IhsSemanticsSnapshot* snapshot) {
   Release(const_cast<Snapshot*>(reinterpret_cast<const Snapshot*>(snapshot)));
 }
 
+// The implicit source: created on demand by set_host, named "" so
+// DefaultSourceLocked can find it and so ihs_semantics_source_name reports
+// something a caller can recognise as unnamed rather than invented.
+// Called with the hub lock held. Static: it sits inside the extern "C" block
+// beside its only callers, where an unmangled external name would be one more
+// symbol than this needs.
+static Source* ImplicitSourceLocked(Hub& hub) {
+  for (const auto& source : hub.sources) {
+    if (source->name.empty()) {
+      return source.get();
+    }
+  }
+  hub.sources.push_back(std::make_unique<Source>());
+  return hub.sources.back().get();
+}
+
 void ihs_semantics_set_host(const IhsSemanticsHost* host) {
   Hub& hub = TheHub();
+  Snapshot* retired = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(hub.mutex);
+    if (host == nullptr || host->struct_size < sizeof(IhsSemanticsHost)) {
+      // Uninstalling drops the implicit source entirely rather than leaving it
+      // present with no host: a source that cannot dispatch is not a source,
+      // and leaving it registered would keep DefaultSourceLocked answering
+      // with it in preference to a real one.
+      for (auto it = hub.sources.begin(); it != hub.sources.end(); ++it) {
+        if ((*it)->name.empty()) {
+          retired = (*it)->current;
+          hub.sources.erase(it);
+          break;
+        }
+      }
+    } else {
+      Source* source = ImplicitSourceLocked(hub);
+      source->host = *host;
+      source->host_installed = true;
+    }
+  }
+  Release(retired);
+}
+
+int ihs_semantics_source_register(const IhsSemanticsSourceDesc* desc,
+                                  IhsSemanticsSource** out_source) {
+  if (desc == nullptr || out_source == nullptr ||
+      desc->struct_size < sizeof(IhsSemanticsSourceDesc) ||
+      desc->name == nullptr || desc->name[0] == '\0' ||
+      desc->host.struct_size < sizeof(IhsSemanticsHost)) {
+    return IHS_SEMANTICS_ERR_INVALID;
+  }
+
+  Hub& hub = TheHub();
   std::lock_guard<std::mutex> lock(hub.mutex);
-  if (host == nullptr || host->struct_size < sizeof(IhsSemanticsHost)) {
-    hub.host = IhsSemanticsHost{};
-    hub.host_installed = false;
+  for (const auto& existing : hub.sources) {
+    if (existing->name == desc->name) {
+      // Two trees under one name are indistinguishable to anything addressing
+      // them by it, which is the whole failure this mechanism prevents.
+      LogInfo(std::string("semantics: source name already registered: ") +
+              desc->name);
+      return IHS_SEMANTICS_ERR_INVALID;
+    }
+  }
+
+  auto source = std::make_unique<Source>();
+  source->name = desc->name;
+  source->host = desc->host;
+  source->host_installed = true;
+  *out_source = reinterpret_cast<IhsSemanticsSource*>(source.get());
+  hub.sources.push_back(std::move(source));
+  return IHS_SEMANTICS_OK;
+}
+
+void ihs_semantics_source_unregister(IhsSemanticsSource* source) {
+  if (source == nullptr) {
     return;
   }
-  hub.host = *host;
-  hub.host_installed = true;
+  Hub& hub = TheHub();
+  Snapshot* retired = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(hub.mutex);
+    auto* target = reinterpret_cast<Source*>(source);
+    for (auto it = hub.sources.begin(); it != hub.sources.end(); ++it) {
+      if (it->get() == target) {
+        retired = target->current;
+        hub.sources.erase(it);
+        break;
+      }
+    }
+  }
+  // Outside the lock, and only the publisher's reference: a consumer still
+  // reading this tree keeps it alive until it releases.
+  Release(retired);
+}
+
+size_t ihs_semantics_source_count(void) {
+  Hub& hub = TheHub();
+  std::lock_guard<std::mutex> lock(hub.mutex);
+  return hub.sources.size();
+}
+
+IhsSemanticsSource* ihs_semantics_source_at(const size_t index) {
+  Hub& hub = TheHub();
+  std::lock_guard<std::mutex> lock(hub.mutex);
+  if (index >= hub.sources.size()) {
+    return nullptr;
+  }
+  return reinterpret_cast<IhsSemanticsSource*>(hub.sources[index].get());
+}
+
+const char* ihs_semantics_source_name(const IhsSemanticsSource* source) {
+  if (source == nullptr) {
+    return "";
+  }
+  Hub& hub = TheHub();
+  std::lock_guard<std::mutex> lock(hub.mutex);
+  const auto* target = reinterpret_cast<const Source*>(source);
+  return SourceIsLiveLocked(hub, target) ? target->name.c_str() : "";
+}
+
+const IhsSemanticsSnapshot* ihs_semantics_acquire_snapshot_from(
+    IhsSemanticsSource* source) {
+  if (source == nullptr) {
+    return nullptr;
+  }
+  Hub& hub = TheHub();
+  std::lock_guard<std::mutex> lock(hub.mutex);
+  auto* target = reinterpret_cast<Source*>(source);
+  if (!SourceIsLiveLocked(hub, target) || target->current == nullptr) {
+    return nullptr;
+  }
+  Retain(target->current);
+  return reinterpret_cast<const IhsSemanticsSnapshot*>(target->current);
 }
 
 int ihs_semantics_publish(const IhsSemanticsPublishInfo* info) {
-  if (info == nullptr || info->struct_size < sizeof(IhsSemanticsPublishInfo)) {
+  // Only the members through custom_action_count are required: `source` was
+  // appended in ABI 1.4 and a caller built against 1.3 supplies neither it nor
+  // the size to reach it.
+  constexpr size_t kSourceEnd =
+      offsetof(IhsSemanticsPublishInfo, source) + sizeof(void*);
+  constexpr size_t kRequired =
+      offsetof(IhsSemanticsPublishInfo, custom_action_count) + sizeof(size_t);
+  static_assert(kRequired <= sizeof(IhsSemanticsPublishInfo),
+                "required publish members overrun IhsSemanticsPublishInfo");
+  if (info == nullptr || info->struct_size < kRequired) {
     return IHS_SEMANTICS_ERR_INVALID;
   }
+  IhsSemanticsSource* requested =
+      info->struct_size >= kSourceEnd ? info->source : nullptr;
 
   Hub& hub = TheHub();
 
@@ -412,8 +590,31 @@ int ihs_semantics_publish(const IhsSemanticsPublishInfo* info) {
   Snapshot* retired = nullptr;
   {
     std::lock_guard<std::mutex> lock(hub.mutex);
-    retired = hub.current;
-    hub.current = built;
+    Source* target = nullptr;
+    if (requested != nullptr) {
+      target = reinterpret_cast<Source*>(requested);
+      // A named source that has gone away. The built tree is dropped rather
+      // than published somewhere arbitrary.
+      if (!SourceIsLiveLocked(hub, target)) {
+        Release(built);
+        return IHS_SEMANTICS_ERR_UNAVAILABLE;
+      }
+    } else {
+      target = DefaultSourceLocked(hub);
+      if (target == nullptr) {
+        // Publishing without ever installing a host is legitimate and always
+        // has been: the tree is readable, and only dispatch needs somewhere to
+        // send an action. Creating the implicit source here keeps that true,
+        // rather than making a publish depend on a host it does not use.
+        //
+        // This cannot silently pick a wrong source: DefaultSourceLocked
+        // already refused to guess between several, so reaching here means
+        // there are none.
+        target = ImplicitSourceLocked(hub);
+      }
+    }
+    retired = target->current;
+    target->current = built;
     notify_fds.reserve(hub.consumers.size());
     for (const auto& consumer : hub.consumers) {
       notify_fds.push_back(consumer->notify_fd);
@@ -431,14 +632,19 @@ int ihs_semantics_publish(const IhsSemanticsPublishInfo* info) {
 
 void ihs_semantics_clear(void) {
   Hub& hub = TheHub();
-  Snapshot* retired = nullptr;
+  std::vector<Snapshot*> retired;
   {
     std::lock_guard<std::mutex> lock(hub.mutex);
-    retired = hub.current;
-    hub.current = nullptr;
+    retired.reserve(hub.sources.size());
+    for (const auto& source : hub.sources) {
+      retired.push_back(source->current);
+      source->current = nullptr;
+    }
     hub.next_generation = 1;
   }
-  Release(retired);
+  for (Snapshot* snapshot : retired) {
+    Release(snapshot);
+  }
 }
 
 size_t ihs_semantics_consumer_count(void) {
@@ -462,13 +668,19 @@ int ihs_semantics_register(const IhsSemanticsConsumerDesc* desc,
 
   Consumer* raw = consumer.get();
   bool first = false;
-  IhsSemanticsHost host{};
+  // Every source, not one host: the registration count is hub-wide, but each
+  // engine has its own semantics switch and a consumer wants all of their
+  // trees. Telling only one would leave the others producing nothing.
+  std::vector<IhsSemanticsHost> hosts;
   {
     Hub& hub = TheHub();
     std::lock_guard<std::mutex> lock(hub.mutex);
     first = hub.consumers.empty();
     hub.consumers.push_back(std::move(consumer));
-    host = hub.host;
+    hosts.reserve(hub.sources.size());
+    for (const auto& source : hub.sources) {
+      hosts.push_back(source->host);
+    }
   }
 
   LogInfo("consumer '" + raw->name + "' registered, mask 0x" +
@@ -476,8 +688,12 @@ int ihs_semantics_register(const IhsSemanticsConsumerDesc* desc,
 
   // Outside the lock: the shell's enable path reaches into the engine, and
   // holding the registry across it would let engine work block every consumer.
-  if (first && host.set_semantics_enabled != nullptr) {
-    host.set_semantics_enabled(host.user_data, true);
+  if (first) {
+    for (const IhsSemanticsHost& host : hosts) {
+      if (host.set_semantics_enabled != nullptr) {
+        host.set_semantics_enabled(host.user_data, true);
+      }
+    }
   }
 
   *out_consumer = reinterpret_cast<IhsSemanticsConsumer*>(raw);
@@ -491,7 +707,7 @@ void ihs_semantics_unregister(IhsSemanticsConsumer* consumer) {
   auto* raw = reinterpret_cast<Consumer*>(consumer);
 
   bool last = false;
-  IhsSemanticsHost host{};
+  std::vector<IhsSemanticsHost> hosts;
   std::unique_ptr<Consumer> owned;
   {
     Hub& hub = TheHub();
@@ -507,7 +723,10 @@ void ihs_semantics_unregister(IhsSemanticsConsumer* consumer) {
       return;  // not registered, or already unregistered
     }
     last = hub.consumers.empty();
-    host = hub.host;
+    hosts.reserve(hub.sources.size());
+    for (const auto& source : hub.sources) {
+      hosts.push_back(source->host);
+    }
   }
 
   LogInfo("consumer '" + owned->name + "' unregistered");
@@ -515,8 +734,12 @@ void ihs_semantics_unregister(IhsSemanticsConsumer* consumer) {
   // Dispatch is synchronous through to the host, so removal from the registry
   // under the lock is itself the drain: no dispatch for this consumer can be
   // in flight once we are here, and none can start.
-  if (last && host.set_semantics_enabled != nullptr) {
-    host.set_semantics_enabled(host.user_data, false);
+  if (last) {
+    for (const IhsSemanticsHost& host : hosts) {
+      if (host.set_semantics_enabled != nullptr) {
+        host.set_semantics_enabled(host.user_data, false);
+      }
+    }
   }
 }
 
@@ -524,6 +747,14 @@ int ihs_semantics_send_pointer_tap(IhsSemanticsConsumer* consumer,
                                    const int64_t view_id,
                                    const double x,
                                    const double y) {
+  return ihs_semantics_send_pointer_tap_to(consumer, nullptr, view_id, x, y);
+}
+
+int ihs_semantics_send_pointer_tap_to(IhsSemanticsConsumer* consumer,
+                                      IhsSemanticsSource* source,
+                                      const int64_t view_id,
+                                      const double x,
+                                      const double y) {
   int status = IHS_SEMANTICS_OK;
   std::string name;
 
@@ -549,7 +780,15 @@ int ihs_semantics_send_pointer_tap(IhsSemanticsConsumer* consumer,
     } else {
       name = raw->name;
       allow_mask = raw->action_allow_mask;
-      host = hub.host;
+      // A coordinate means nothing without knowing whose screen it is on, so
+      // an ambiguous default is refused here exactly as it is for dispatch.
+      Source* target = source != nullptr ? reinterpret_cast<Source*>(source)
+                                         : DefaultSourceLocked(hub);
+      if (target == nullptr || !SourceIsLiveLocked(hub, target)) {
+        status = IHS_SEMANTICS_ERR_UNAVAILABLE;
+      } else {
+        host = target->host;
+      }
     }
   }
 
@@ -588,8 +827,23 @@ int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
                            size_t data_length,
                            IhsSemanticsDoneCallback done,
                            void* user_data) {
+  return ihs_semantics_dispatch_from(consumer, nullptr, view_id, node_id,
+                                     action, data, data_length, done,
+                                     user_data);
+}
+
+int ihs_semantics_dispatch_from(IhsSemanticsConsumer* consumer,
+                                IhsSemanticsSource* source,
+                                int64_t view_id,
+                                int32_t node_id,
+                                uint64_t action,
+                                const uint8_t* data,
+                                size_t data_length,
+                                IhsSemanticsDoneCallback done,
+                                void* user_data) {
   int status = IHS_SEMANTICS_OK;
   std::string name;
+  std::string source_name;
 
   if (consumer == nullptr || action == 0) {
     status = IHS_SEMANTICS_ERR_INVALID;
@@ -597,6 +851,10 @@ int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
 
   IhsSemanticsHost host{};
   uint64_t allow_mask = 0;
+  // Resolved under the same lock that validates the consumer, and held as a
+  // pointer only for the snapshot lookup below -- which re-checks liveness,
+  // because an engine may go away between the two.
+  Source* target = nullptr;
   if (status == IHS_SEMANTICS_OK) {
     auto* raw = reinterpret_cast<Consumer*>(consumer);
     Hub& hub = TheHub();
@@ -613,7 +871,19 @@ int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
     } else {
       name = raw->name;
       allow_mask = raw->action_allow_mask;
-      host = hub.host;
+      target = source != nullptr ? reinterpret_cast<Source*>(source)
+                                 : DefaultSourceLocked(hub);
+      if (target == nullptr || !SourceIsLiveLocked(hub, target)) {
+        // Either the named engine is gone, or there is no unambiguous default
+        // because more than one is registered. Both are the caller addressing
+        // something that does not exist, and both must fail rather than
+        // pick one.
+        status = IHS_SEMANTICS_ERR_UNAVAILABLE;
+        target = nullptr;
+      } else {
+        source_name = target->name;
+        host = target->host;
+      }
     }
   }
 
@@ -625,7 +895,12 @@ int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
   }
 
   if (status == IHS_SEMANTICS_OK) {
-    const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+    // This source's tree, not whichever published last. Resolving the node in
+    // the same tree the caller read is the entire point: the id spaces of two
+    // engines overlap, so looking it up anywhere else finds a real but
+    // unrelated control.
+    const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot_from(
+        reinterpret_cast<IhsSemanticsSource*>(target));
     if (snapshot == nullptr) {
       status = IHS_SEMANTICS_ERR_UNAVAILABLE;
     } else {
@@ -655,9 +930,9 @@ int ihs_semantics_dispatch(IhsSemanticsConsumer* consumer,
   // Attribution is the point of the funnel: every action that reaches the UI
   // is traceable to a named actor, and so is every one that was refused.
   LogInfo("dispatch consumer='" +
-          (name.empty() ? std::string("<unregistered>") : name) +
-          "' node=" + std::to_string(node_id) + " action=0x" + ToHex(action) +
-          " status=" + std::to_string(status));
+          (name.empty() ? std::string("<unregistered>") : name) + "' source='" +
+          source_name + "' node=" + std::to_string(node_id) + " action=0x" +
+          ToHex(action) + " status=" + std::to_string(status));
 
   if (done != nullptr) {
     done(status, user_data);

--- a/shared/src/semantics.cc
+++ b/shared/src/semantics.cc
@@ -71,6 +71,9 @@ struct Consumer {
 // these, and keeping the pair together is the point -- a tree read from one
 // source dispatches back to that source's host, so reading and acting cannot
 // drift onto different applications.
+// What set_host's source is called. Addressable like any other name.
+constexpr const char* kImplicitSourceName = "default";
+
 struct Source {
   std::string name;
   IhsSemanticsHost host{};
@@ -166,7 +169,7 @@ void Own(std::vector<std::string>& pool, const char* s) {
 // Called with the hub lock held.
 Source* DefaultSourceLocked(Hub& hub) {
   for (const auto& source : hub.sources) {
-    if (source->name.empty()) {
+    if (source->name == kImplicitSourceName) {
       return source.get();
     }
   }
@@ -423,19 +426,23 @@ void ihs_semantics_release_snapshot(const IhsSemanticsSnapshot* snapshot) {
   Release(const_cast<Snapshot*>(reinterpret_cast<const Snapshot*>(snapshot)));
 }
 
-// The implicit source: created on demand by set_host, named "" so
-// DefaultSourceLocked can find it and so ihs_semantics_source_name reports
-// something a caller can recognise as unnamed rather than invented.
+// The implicit source: created on demand by set_host and named "default",
+// which is both how DefaultSourceLocked finds it and what addresses its tree
+// from outside. A real name rather than an empty one because it is addressable
+// like any other -- ui://semantics/default/tree -- and an empty segment would
+// produce a URI with a hole in it.
 // Called with the hub lock held. Static: it sits inside the extern "C" block
 // beside its only callers, where an unmangled external name would be one more
 // symbol than this needs.
 static Source* ImplicitSourceLocked(Hub& hub) {
   for (const auto& source : hub.sources) {
-    if (source->name.empty()) {
+    if (source->name == kImplicitSourceName) {
       return source.get();
     }
   }
-  hub.sources.push_back(std::make_unique<Source>());
+  auto created = std::make_unique<Source>();
+  created->name = kImplicitSourceName;
+  hub.sources.push_back(std::move(created));
   return hub.sources.back().get();
 }
 
@@ -450,7 +457,7 @@ void ihs_semantics_set_host(const IhsSemanticsHost* host) {
       // and leaving it registered would keep DefaultSourceLocked answering
       // with it in preference to a real one.
       for (auto it = hub.sources.begin(); it != hub.sources.end(); ++it) {
-        if ((*it)->name.empty()) {
+        if ((*it)->name == kImplicitSourceName) {
           retired = (*it)->current;
           hub.sources.erase(it);
           break;

--- a/shell/accessibility/semantics_publisher.cc
+++ b/shell/accessibility/semantics_publisher.cc
@@ -303,7 +303,7 @@ FlutterSemanticsAction ToFlutterSemanticsAction(const uint64_t ihs_action) {
   }
 }
 
-int PublishTree(const AccessibilityTree& tree) {
+int PublishTree(const AccessibilityTree& tree, IhsSemanticsSource* source) {
   const AccessibilityNode* root = tree.FindNode(0);
   if (root == nullptr) {
     // No root yet: Flutter sends it in the first update, and until it arrives
@@ -426,6 +426,7 @@ int PublishTree(const AccessibilityTree& tree) {
   info.custom_actions =
       custom_actions.empty() ? nullptr : custom_actions.data();
   info.custom_action_count = custom_actions.size();
+  info.source = source;
   return ihs_semantics_publish(&info);
 }
 

--- a/shell/accessibility/semantics_publisher.h
+++ b/shell/accessibility/semantics_publisher.h
@@ -82,7 +82,13 @@ FlutterSemanticsAction ToFlutterSemanticsAction(uint64_t ihs_action);
 // is the root and that every child index resolves, and an orphan satisfies
 // neither. Returns the hub status, or IHS_SEMANTICS_OK when the tree has no
 // root yet and there is nothing to say.
-int PublishTree(const AccessibilityTree& tree);
+/*
+ * Publishes to `source`, the hub registration belonging to this engine. NULL
+ * publishes to the implicit source, which is correct only where there is one
+ * engine: with several, an unkeyed publish means the last one to run owns the
+ * only tree there is.
+ */
+int PublishTree(const AccessibilityTree& tree, IhsSemanticsSource* source);
 
 }  // namespace accessibility
 

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -137,6 +137,7 @@ Engine::Engine(FlutterView* view,
                std::vector<std::string> mcp_allowed_tools,
                const bool mcp_tools_narrowed)
     : m_index(index),
+      m_bundle_name(std::filesystem::path(bundle_path).filename().string()),
       m_running(false),
       m_backend(view->GetBackend()),
       m_view(view),
@@ -338,6 +339,19 @@ void Engine::Shutdown() {
     // standing on. Stop guarantees nothing is in flight when it returns.
     ihs_mcp_transport_stop();
     ihs_mcp_semantics_provider_stop();
+  }
+#endif
+#if BUILD_ACCESSIBILITY
+  // After the consumers above are gone, so nothing is mid-read of this tree,
+  // and before the engine is torn down, so no publish can arrive for a source
+  // that no longer exists. A snapshot a consumer still holds stays valid
+  // regardless -- snapshots are refcounted independently of the source.
+  if (m_semantics_source != nullptr) {
+    ihs_semantics_source_unregister(m_semantics_source);
+    m_semantics_source = nullptr;
+    if (m_engine_state != nullptr) {
+      m_engine_state->semantics_source = nullptr;
+    }
   }
 #endif
   // Deinitialize stops new frame work; Shutdown joins the platform, UI and
@@ -1055,7 +1069,40 @@ void Engine::InstallSemanticsHost() {
     return engine->SendSyntheticTap(x, y);
   };
 
-  ihs_semantics_set_host(&host);
+  // A name an outside reader can recognise: the bundle's own directory, which
+  // is what a person configuring the shell named it. The index disambiguates
+  // the case two bundles share a basename, which registration would otherwise
+  // refuse -- and refusing would take semantics away from the second view
+  // rather than merely naming it awkwardly.
+  std::string name = m_bundle_name;
+  if (name.empty()) {
+    name = "view";
+  }
+
+  IhsSemanticsSourceDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = name.c_str();
+  desc.host = host;
+  if (ihs_semantics_source_register(&desc, &m_semantics_source) !=
+      IHS_SEMANTICS_OK) {
+    const std::string unique = name + "-" + std::to_string(m_index);
+    desc.name = unique.c_str();
+    if (ihs_semantics_source_register(&desc, &m_semantics_source) !=
+        IHS_SEMANTICS_OK) {
+      ihs::log::error(
+          "({}) semantics source registration failed; this view "
+          "publishes no tree",
+          m_index);
+      m_semantics_source = nullptr;
+    }
+  }
+
+  // The publish callback reaches the source through the engine state, which is
+  // what it already has: the tree and the source it belongs to travel
+  // together, because publishing one without the other is the defect.
+  if (m_engine_state != nullptr) {
+    m_engine_state->semantics_source = m_semantics_source;
+  }
 }
 
 int Engine::SendSyntheticTap(const double x, const double y) {
@@ -1195,7 +1242,8 @@ void Engine::onSemanticsUpdateCallback(const FlutterSemanticsUpdate2* update,
   // Hand the refreshed tree to the semantics hub. Publication is whole-tree
   // and happens here, at the batch boundary, because that is the only point at
   // which the mirror is known consistent.
-  const int status = accessibility::PublishTree(*accessibility_tree);
+  const int status = accessibility::PublishTree(*accessibility_tree,
+                                                engine_state->semantics_source);
   if (status != IHS_SEMANTICS_OK) {
     ihs::log::warn("Failed to publish semantics snapshot: {}", status);
   }

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -43,6 +43,14 @@ class Backend;
 class FlutterView;
 struct FlutterDesktopEngineState;
 
+#if BUILD_ACCESSIBILITY
+// Forward-declared rather than including the hub header: engine.h is widely
+// included and this is only ever held as a pointer.
+extern "C" {
+struct IhsSemanticsSource;
+}
+#endif
+
 class Engine {
  public:
   /**
@@ -470,6 +478,18 @@ class Engine {
 
  private:
   size_t m_index;
+
+  // The bundle's directory name, kept for the semantics source's name: it is
+  // what a person configuring the shell called this application, so it is what
+  // an outside reader should see addressing its tree.
+  std::string m_bundle_name;
+
+#if BUILD_ACCESSIBILITY
+  // This engine's hub registration. Each engine is an independent publisher --
+  // its own tree, its own node id space -- so a shared host would mean the
+  // last engine to start receiving every engine's actions.
+  IhsSemanticsSource* m_semantics_source = nullptr;
+#endif
   bool m_running;
 
   Backend* m_backend;

--- a/shell/platform/homescreen/flutter_desktop_engine_state.h
+++ b/shell/platform/homescreen/flutter_desktop_engine_state.h
@@ -46,6 +46,11 @@ using FlutterDesktopMessengerReferenceOwner =
 using UniqueAotDataPtr = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;
 /// Maintains one ref on the FlutterDesktopMessenger's internal reference count.
 
+extern "C" {
+// Held only as a pointer; the hub header is not needed here.
+struct IhsSemanticsSource;
+}
+
 // Struct for storing state of a Flutter engine instance.
 struct FlutterDesktopEngineState {
   // The handle to the Flutter engine instance.
@@ -93,6 +98,11 @@ struct FlutterDesktopEngineState {
 #endif
 
   AccessibilityTree* accessibility_tree = nullptr;
+
+  // The hub registration this engine publishes its tree to, travelling beside
+  // the tree because the two are only meaningful together: publishing without
+  // it means the last engine to run owns the only tree there is.
+  IhsSemanticsSource* semantics_source = nullptr;
 
   // The controller associated with this engine instance, if any.
   // This will always be null for a headless engine.

--- a/test/integration/mcp_drive_test/tools/drive.py
+++ b/test/integration/mcp_drive_test/tools/drive.py
@@ -39,7 +39,8 @@ import socket
 import sys
 import time
 
-TREE_URI = "ui://semantics/tree"
+# Discovered, not assumed: one tree per running application, named for it.
+TREE_URI_PREFIX = "ui://semantics/"
 
 
 class Failure(Exception):
@@ -91,7 +92,17 @@ def call_tool(path, name, arguments=None, request_id=1):
 
 
 def read_tree(path):
-    reply = rpc(path, "resources/read", {"uri": TREE_URI}, request_id=2)
+    listing = rpc(path, "resources/list", {}, request_id=2)
+    trees = [
+        r["uri"]
+        for r in listing.get("resources", [])
+        if r.get("uri", "").startswith(TREE_URI_PREFIX)
+    ]
+    if len(trees) != 1:
+        raise SystemExit(
+            f"expected exactly one application's tree, found {len(trees)}: {trees}"
+        )
+    reply = rpc(path, "resources/read", {"uri": trees[0]}, request_id=3)
     if "error" in reply:
         raise Failure(f"resources/read: {reply['error']}")
     return json.loads(reply["result"]["contents"][0]["text"])

--- a/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
+++ b/test/unit_test/mcp_semantics_provider-test/test_case_mcp_semantics_provider.cc
@@ -375,8 +375,9 @@ TEST_F(McpSemanticsProviderTest, ResourceReturnsTheTree) {
   ASSERT_EQ(tree.Publish(), IHS_SEMANTICS_OK);
 
   IhsMcpPayload payload{};
-  ASSERT_EQ(ihs_mcp_registry_read_resource("ui://semantics/tree", &payload),
-            IHS_MCP_OK);
+  ASSERT_EQ(
+      ihs_mcp_registry_read_resource("ui://semantics/default/tree", &payload),
+      IHS_MCP_OK);
   const std::string body(payload.data, payload.length);
   EXPECT_TRUE(Contains(body, "\"nodes\""));
   ihs_mcp_registry_release_payload(&payload);
@@ -1170,4 +1171,218 @@ TEST_F(McpSemanticsProviderTest, ANarrowedPolicyStillAllowsWhatItsToolsNeed) {
   EXPECT_EQ(status, IHS_MCP_OK)
       << "custom_action was offered but the mask does not carry its action: "
       << body;
+}
+
+// ---------------------------------------------------------------------------
+// Multi-view
+//
+// Two applications, two trees, two id spaces. Reading may span them because an
+// agent looking for a control does not yet know which application owns it.
+// Acting may not: an unqualified action has no defensible reading, and
+// choosing one is how a client acts on something it never looked at.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct ViewHost {
+  const char* name;
+  int dispatches = 0;
+  int32_t last_node = 0;
+};
+
+int OnViewDispatch(void* user_data,
+                   int64_t,
+                   int32_t node_id,
+                   uint64_t,
+                   const uint8_t*,
+                   size_t) {
+  auto* h = static_cast<ViewHost*>(user_data);
+  h->dispatches++;
+  h->last_node = node_id;
+  return IHS_SEMANTICS_OK;
+}
+
+IhsSemanticsSource* AddView(const char* name, ViewHost* host_data) {
+  IhsSemanticsHost host{};
+  host.struct_size = sizeof(host);
+  host.user_data = host_data;
+  host.set_semantics_enabled = [](void*, bool) {};
+  host.dispatch = OnViewDispatch;
+
+  IhsSemanticsSourceDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = name;
+  desc.host = host;
+  IhsSemanticsSource* source = nullptr;
+  return ihs_semantics_source_register(&desc, &source) == IHS_SEMANTICS_OK
+             ? source
+             : nullptr;
+}
+
+// One tappable node, published to a named view.
+void PublishOne(IhsSemanticsSource* source, int32_t id, const char* label) {
+  IhsSemanticsPublishNode node{};
+  node.id = id;
+  node.label = label;
+  node.role = IHS_SEMANTICS_ROLE_BUTTON;
+  node.enabled = IHS_SEMANTICS_TRISTATE_NONE;
+  node.actions = IHS_SEMANTICS_ACTION_TAP;
+  IhsSemanticsPublishInfo info{};
+  info.struct_size = sizeof(info);
+  info.nodes = &node;
+  info.node_count = 1;
+  info.source = source;
+  ASSERT_EQ(ihs_semantics_publish(&info), IHS_SEMANTICS_OK);
+}
+
+}  // namespace
+
+// Each application's tree is addressable, and the URI says which. There is no
+// unqualified "the tree": what it would name depends on how many applications
+// happen to be running, which a client cannot see.
+TEST_F(McpSemanticsProviderTest, EachViewHasItsOwnResource) {
+  ihs_semantics_set_host(nullptr);
+  ViewHost a{"a"};
+  ViewHost b{"b"};
+  IhsSemanticsSource* cluster = AddView("cluster", &a);
+  IhsSemanticsSource* radio = AddView("radio", &b);
+  ASSERT_NE(cluster, nullptr);
+  ASSERT_NE(radio, nullptr);
+  PublishOne(cluster, 1, "Speed");
+  PublishOne(radio, 1, "Volume");
+
+  std::vector<std::string> uris;
+  ihs_mcp_registry_for_each_resource(
+      [](const IhsMcpRegistryResource* resource, void* user_data) {
+        static_cast<std::vector<std::string>*>(user_data)->emplace_back(
+            resource->uri);
+      },
+      &uris);
+  EXPECT_NE(std::find(uris.begin(), uris.end(), "ui://semantics/cluster/tree"),
+            uris.end());
+  EXPECT_NE(std::find(uris.begin(), uris.end(), "ui://semantics/radio/tree"),
+            uris.end());
+
+  IhsMcpPayload payload{};
+  ASSERT_EQ(
+      ihs_mcp_registry_read_resource("ui://semantics/radio/tree", &payload),
+      IHS_MCP_OK);
+  const std::string body(payload.data, payload.length);
+  EXPECT_TRUE(Contains(body, "Volume"));
+  EXPECT_FALSE(Contains(body, "Speed")) << "a view's resource returned another "
+                                           "application's tree: "
+                                        << body;
+  ihs_mcp_registry_release_payload(&payload);
+
+  ihs_semantics_source_unregister(cluster);
+  ihs_semantics_source_unregister(radio);
+}
+
+// The defect, at the surface an agent actually uses: two applications with the
+// same node id, act on one, and the other must not receive it.
+TEST_F(McpSemanticsProviderTest, AnActionGoesToTheViewItNames) {
+  ihs_semantics_set_host(nullptr);
+  ViewHost cluster_host{"cluster"};
+  ViewHost radio_host{"radio"};
+  IhsSemanticsSource* cluster = AddView("cluster", &cluster_host);
+  IhsSemanticsSource* radio = AddView("radio", &radio_host);
+  ASSERT_NE(cluster, nullptr);
+  ASSERT_NE(radio, nullptr);
+  PublishOne(cluster, 7, "Trip reset");
+  PublishOne(radio, 7, "Mute");
+
+  int status = 0;
+  const std::string body =
+      CallTool("ui_tap", R"({"view":"radio","node_id":7})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_EQ(radio_host.dispatches, 1);
+  EXPECT_EQ(cluster_host.dispatches, 0)
+      << "the action reached an application the call did not name";
+
+  ihs_semantics_source_unregister(cluster);
+  ihs_semantics_source_unregister(radio);
+}
+
+// An action that names no view, with several running, is refused. Choosing one
+// is precisely the defect; the error says what is missing, because an agent
+// that omitted the argument needs to learn it exists.
+TEST_F(McpSemanticsProviderTest, AnUnqualifiedActionIsRefused) {
+  ihs_semantics_set_host(nullptr);
+  ViewHost a{"a"};
+  ViewHost b{"b"};
+  IhsSemanticsSource* first = AddView("cluster", &a);
+  IhsSemanticsSource* second = AddView("radio", &b);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  PublishOne(first, 7, "One");
+  PublishOne(second, 7, "Two");
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":7})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_INVALID) << body;
+  EXPECT_TRUE(Contains(body, "view is required")) << body;
+  EXPECT_EQ(a.dispatches, 0);
+  EXPECT_EQ(b.dispatches, 0);
+
+  ihs_semantics_source_unregister(first);
+  ihs_semantics_source_unregister(second);
+}
+
+// A read that names no view searches every one and reports where each result
+// came from -- which is what an agent hunting for a control needs, since it
+// does not yet know which application owns it.
+TEST_F(McpSemanticsProviderTest, AnUnqualifiedReadSpansEveryView) {
+  ihs_semantics_set_host(nullptr);
+  ViewHost a{"a"};
+  ViewHost b{"b"};
+  IhsSemanticsSource* cluster = AddView("cluster", &a);
+  IhsSemanticsSource* radio = AddView("radio", &b);
+  ASSERT_NE(cluster, nullptr);
+  ASSERT_NE(radio, nullptr);
+  PublishOne(cluster, 1, "Speed");
+  PublishOne(radio, 2, "Volume");
+
+  const std::string body = CallTool("ui_query", R"({"label":"o"})", nullptr);
+  EXPECT_TRUE(Contains(body, "\"views\"")) << body;
+  EXPECT_TRUE(Contains(body, "cluster")) << body;
+  EXPECT_TRUE(Contains(body, "radio")) << body;
+  EXPECT_TRUE(Contains(body, "Volume")) << body;
+
+  ihs_semantics_source_unregister(cluster);
+  ihs_semantics_source_unregister(radio);
+}
+
+// Naming a view that does not exist is a different mistake from omitting one,
+// and says so.
+TEST_F(McpSemanticsProviderTest, AnUnknownViewNameIsRejected) {
+  ihs_semantics_set_host(nullptr);
+  ViewHost a{"a"};
+  IhsSemanticsSource* only = AddView("cluster", &a);
+  ASSERT_NE(only, nullptr);
+  PublishOne(only, 1, "Speed");
+
+  int status = 0;
+  const std::string body =
+      CallTool("ui_tap", R"({"view":"nosuch","node_id":1})", &status);
+  EXPECT_EQ(status, IHS_MCP_ERR_INVALID) << body;
+  EXPECT_TRUE(Contains(body, "no view named")) << body;
+
+  ihs_semantics_source_unregister(only);
+}
+
+// One application is unambiguous, so naming it is optional -- the argument
+// exists to remove ambiguity, not as ceremony.
+TEST_F(McpSemanticsProviderTest, OneViewNeedsNoNaming) {
+  ihs_semantics_set_host(nullptr);
+  ViewHost only_host{"only"};
+  IhsSemanticsSource* only = AddView("cockpit", &only_host);
+  ASSERT_NE(only, nullptr);
+  PublishOne(only, 4, "Play");
+
+  int status = 0;
+  const std::string body = CallTool("ui_tap", R"({"node_id":4})", &status);
+  EXPECT_EQ(status, IHS_MCP_OK) << body;
+  EXPECT_EQ(only_host.dispatches, 1);
+
+  ihs_semantics_source_unregister(only);
 }

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -643,9 +643,9 @@ TEST_F(McpTransportTest, NotificationsGoOnlyToStreamsThatSubscribed) {
 
   // Subscribed to the concrete resource, not the scheme the registry will
   // report -- which is exactly the mismatch a naive equality check drops.
-  ASSERT_NE(
-      Body(Subscribe(path_, a, "ui://semantics/tree")).find(R"("result")"),
-      std::string::npos);
+  ASSERT_NE(Body(Subscribe(path_, a, "ui://semantics/default/tree"))
+                .find(R"("result")"),
+            std::string::npos);
   ASSERT_NE(Body(Subscribe(path_, b, "other://elsewhere")).find(R"("result")"),
             std::string::npos);
 

--- a/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
+++ b/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
@@ -841,3 +841,238 @@ TEST_F(SemanticsHubTest, UsableEntirelyThroughTheTable) {
                                      nullptr, 0, nullptr, nullptr),
             IHS_SEMANTICS_ERR_INVALID);
 }
+
+// ---------------------------------------------------------------------------
+// Sources
+//
+// One hub, several publishers. Before sources existed the hub held a single
+// tree and a single host, so a second engine overwrote the first's tree and
+// captured the first's dispatches. A client could read one application and
+// have its tap delivered to another -- to a real but unrelated control, since
+// two engines' id spaces overlap.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// A second recorder, so a test can tell which engine a dispatch reached
+// rather than only that one did.
+struct Recorder {
+  const char* name;
+  int dispatches = 0;
+  int32_t last_node = 0;
+  int enables = 0;
+};
+
+int OnRecorderDispatch(void* user_data,
+                       int64_t,
+                       int32_t node_id,
+                       uint64_t,
+                       const uint8_t*,
+                       size_t) {
+  auto* r = static_cast<Recorder*>(user_data);
+  r->dispatches++;
+  r->last_node = node_id;
+  return IHS_SEMANTICS_OK;
+}
+
+void OnRecorderEnable(void* user_data, bool enabled) {
+  if (enabled) {
+    static_cast<Recorder*>(user_data)->enables++;
+  }
+}
+
+IhsSemanticsSource* RegisterSource(const char* name, Recorder* recorder) {
+  IhsSemanticsHost host{};
+  host.struct_size = sizeof(host);
+  host.user_data = recorder;
+  host.set_semantics_enabled = OnRecorderEnable;
+  host.dispatch = OnRecorderDispatch;
+
+  IhsSemanticsSourceDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = name;
+  desc.host = host;
+
+  IhsSemanticsSource* source = nullptr;
+  return ihs_semantics_source_register(&desc, &source) == IHS_SEMANTICS_OK
+             ? source
+             : nullptr;
+}
+
+// Publishes a one-node tree to a named source.
+int PublishTo(IhsSemanticsSource* source, int32_t id, const char* label) {
+  IhsSemanticsPublishNode node{};
+  node.id = id;
+  node.label = label;
+  node.role = IHS_SEMANTICS_ROLE_BUTTON;
+  node.enabled = IHS_SEMANTICS_TRISTATE_NONE;
+  node.actions = IHS_SEMANTICS_ACTION_TAP;
+
+  IhsSemanticsPublishInfo info{};
+  info.struct_size = sizeof(info);
+  info.nodes = &node;
+  info.node_count = 1;
+  info.source = source;
+  return ihs_semantics_publish(&info);
+}
+
+}  // namespace
+
+// The defect this exists for, in one test. Two engines publish trees whose
+// node ids overlap -- which they do, because each engine numbers from its own
+// root. A client reads one tree and acts on what it read, and the action must
+// reach the engine it read from.
+TEST_F(SemanticsHubTest, AnActionReachesTheSourceItsTreeCameFrom) {
+  // The fixture installed a host; drop it so neither source is "the default"
+  // and every call below has to be explicit about which it means.
+  ihs_semantics_set_host(nullptr);
+
+  Recorder engine_a{"A"};
+  Recorder engine_b{"B"};
+  IhsSemanticsSource* a = RegisterSource("app-a", &engine_a);
+  IhsSemanticsSource* b = RegisterSource("app-b", &engine_b);
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+
+  // Same node id in both trees, different controls.
+  ASSERT_EQ(PublishTo(a, 10, "A: Play"), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTo(b, 10, "B: Navigate"), IHS_SEMANTICS_OK);
+
+  IhsSemanticsConsumerDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = "probe";
+  desc.action_allow_mask = IHS_SEMANTICS_ACTION_ALL;
+  desc.notify_fd = -1;
+  IhsSemanticsConsumer* consumer = nullptr;
+  ASSERT_EQ(ihs_semantics_register(&desc, &consumer), IHS_SEMANTICS_OK);
+
+  // Read A's tree, and check it is A's rather than whichever published last.
+  const IhsSemanticsSnapshot* from_a = ihs_semantics_acquire_snapshot_from(a);
+  ASSERT_NE(from_a, nullptr);
+  EXPECT_STREQ(ihs_semantics_snapshot_node_at(from_a, 0)->label, "A: Play");
+  ihs_semantics_release_snapshot(from_a);
+
+  EXPECT_EQ(
+      ihs_semantics_dispatch_from(consumer, a, 0, 10, IHS_SEMANTICS_ACTION_TAP,
+                                  nullptr, 0, nullptr, nullptr),
+      IHS_SEMANTICS_OK);
+
+  EXPECT_EQ(engine_a.dispatches, 1) << "the action did not reach the engine "
+                                       "whose tree the node was read from";
+  EXPECT_EQ(engine_b.dispatches, 0)
+      << "the action reached a different application's engine";
+  EXPECT_EQ(engine_a.last_node, 10);
+
+  ihs_semantics_unregister(consumer);
+  ihs_semantics_source_unregister(a);
+  ihs_semantics_source_unregister(b);
+}
+
+// Each source keeps its own tree. Publishing to one leaves the other's alone,
+// which is what makes "read A, act on A" meaningful at all.
+TEST_F(SemanticsHubTest, SourcesDoNotOverwriteEachOther) {
+  ihs_semantics_set_host(nullptr);
+  Recorder a_rec{"A"};
+  Recorder b_rec{"B"};
+  IhsSemanticsSource* a = RegisterSource("app-a", &a_rec);
+  IhsSemanticsSource* b = RegisterSource("app-b", &b_rec);
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+
+  ASSERT_EQ(PublishTo(a, 1, "A one"), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTo(b, 1, "B one"), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTo(a, 1, "A two"), IHS_SEMANTICS_OK);
+
+  const IhsSemanticsSnapshot* sa = ihs_semantics_acquire_snapshot_from(a);
+  const IhsSemanticsSnapshot* sb = ihs_semantics_acquire_snapshot_from(b);
+  ASSERT_NE(sa, nullptr);
+  ASSERT_NE(sb, nullptr);
+  EXPECT_STREQ(ihs_semantics_snapshot_node_at(sa, 0)->label, "A two");
+  EXPECT_STREQ(ihs_semantics_snapshot_node_at(sb, 0)->label, "B one");
+  ihs_semantics_release_snapshot(sa);
+  ihs_semantics_release_snapshot(sb);
+
+  ihs_semantics_source_unregister(a);
+  ihs_semantics_source_unregister(b);
+}
+
+// With more than one source there is no unambiguous default, so an unkeyed
+// call refuses rather than choosing. Answering with either one is precisely
+// how a client ends up acting on the wrong application.
+TEST_F(SemanticsHubTest, AnUnkeyedCallRefusesWhenSeveralSourcesExist) {
+  ihs_semantics_set_host(nullptr);
+  Recorder a_rec{"A"};
+  Recorder b_rec{"B"};
+  IhsSemanticsSource* a = RegisterSource("app-a", &a_rec);
+  IhsSemanticsSource* b = RegisterSource("app-b", &b_rec);
+  ASSERT_NE(a, nullptr);
+  ASSERT_NE(b, nullptr);
+  ASSERT_EQ(PublishTo(a, 5, "A"), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTo(b, 5, "B"), IHS_SEMANTICS_OK);
+
+  EXPECT_EQ(ihs_semantics_acquire_snapshot(), nullptr)
+      << "an unkeyed read picked one of two trees";
+
+  IhsSemanticsConsumerDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = "probe";
+  desc.action_allow_mask = IHS_SEMANTICS_ACTION_ALL;
+  desc.notify_fd = -1;
+  IhsSemanticsConsumer* consumer = nullptr;
+  ASSERT_EQ(ihs_semantics_register(&desc, &consumer), IHS_SEMANTICS_OK);
+  EXPECT_EQ(ihs_semantics_dispatch(consumer, 0, 5, IHS_SEMANTICS_ACTION_TAP,
+                                   nullptr, 0, nullptr, nullptr),
+            IHS_SEMANTICS_ERR_UNAVAILABLE)
+      << "an unkeyed dispatch chose one of two engines";
+  EXPECT_EQ(a_rec.dispatches, 0);
+  EXPECT_EQ(b_rec.dispatches, 0);
+
+  ihs_semantics_unregister(consumer);
+  ihs_semantics_source_unregister(a);
+  ihs_semantics_source_unregister(b);
+}
+
+// A single source is unambiguous, so the pre-sources entry points keep working
+// against it -- which is what lets a consumer migrate after the shell does.
+TEST_F(SemanticsHubTest, OneSourceStillAnswersUnkeyedCalls) {
+  ihs_semantics_set_host(nullptr);
+  Recorder only{"only"};
+  IhsSemanticsSource* s = RegisterSource("app", &only);
+  ASSERT_NE(s, nullptr);
+  ASSERT_EQ(PublishTo(s, 3, "Solo"), IHS_SEMANTICS_OK);
+
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  ASSERT_NE(snapshot, nullptr);
+  EXPECT_STREQ(ihs_semantics_snapshot_node_at(snapshot, 0)->label, "Solo");
+  ihs_semantics_release_snapshot(snapshot);
+  ihs_semantics_source_unregister(s);
+}
+
+// A duplicate name would make two trees indistinguishable to anything
+// addressing them by it, which is the failure the whole mechanism prevents.
+TEST_F(SemanticsHubTest, ADuplicateSourceNameIsRefused) {
+  ihs_semantics_set_host(nullptr);
+  Recorder one{"one"};
+  Recorder two{"two"};
+  IhsSemanticsSource* first = RegisterSource("same", &one);
+  ASSERT_NE(first, nullptr);
+  EXPECT_EQ(RegisterSource("same", &two), nullptr);
+  ihs_semantics_source_unregister(first);
+}
+
+// A snapshot outlives the engine that published it: a consumer mid-read must
+// not fault because an application went away.
+TEST_F(SemanticsHubTest, AHeldSnapshotSurvivesItsSourceUnregistering) {
+  ihs_semantics_set_host(nullptr);
+  Recorder rec{"gone"};
+  IhsSemanticsSource* s = RegisterSource("app", &rec);
+  ASSERT_NE(s, nullptr);
+  ASSERT_EQ(PublishTo(s, 9, "Still here"), IHS_SEMANTICS_OK);
+
+  const IhsSemanticsSnapshot* held = ihs_semantics_acquire_snapshot_from(s);
+  ASSERT_NE(held, nullptr);
+  ihs_semantics_source_unregister(s);
+
+  EXPECT_STREQ(ihs_semantics_snapshot_node_at(held, 0)->label, "Still here");
+  ihs_semantics_release_snapshot(held);
+}

--- a/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
+++ b/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
@@ -810,6 +810,14 @@ TEST(SemanticsCapabilityTable, SubTableAliasesFlatEntryPoints) {
   EXPECT_EQ(api->semantics->register_consumer, &ihs_semantics_register);
   EXPECT_EQ(api->semantics->unregister_consumer, &ihs_semantics_unregister);
   EXPECT_EQ(api->semantics->dispatch, &ihs_semantics_dispatch);
+  EXPECT_EQ(api->semantics->source_count, &ihs_semantics_source_count);
+  EXPECT_EQ(api->semantics->source_at, &ihs_semantics_source_at);
+  EXPECT_EQ(api->semantics->source_name, &ihs_semantics_source_name);
+  EXPECT_EQ(api->semantics->acquire_snapshot_from,
+            &ihs_semantics_acquire_snapshot_from);
+  EXPECT_EQ(api->semantics->dispatch_from, &ihs_semantics_dispatch_from);
+  EXPECT_EQ(api->semantics->send_pointer_tap_to,
+            &ihs_semantics_send_pointer_tap_to);
   EXPECT_EQ(api->semantics->send_pointer_tap, &ihs_semantics_send_pointer_tap);
 }
 

--- a/test/unit_test/semantics_publisher-test/test_case_semantics_publisher.cc
+++ b/test/unit_test/semantics_publisher-test/test_case_semantics_publisher.cc
@@ -198,7 +198,7 @@ TEST_F(SemanticsPublisherTest, PublishWithNoRootIsANoOp) {
   NodeBuilder orphan(5, {}, "orphan");
   Apply(tree, {&orphan.node});
 
-  EXPECT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  EXPECT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   EXPECT_EQ(ihs_semantics_acquire_snapshot(), nullptr);
 }
 
@@ -213,7 +213,7 @@ TEST_F(SemanticsPublisherTest, ChildRectsAreComposedToScreenSpace) {
   child.node.rect = {0.0, 0.0, 5.0, 5.0};
   Apply(tree, {&root.node, &child.node});
 
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
 
@@ -236,7 +236,7 @@ TEST_F(SemanticsPublisherTest, RootIsPublishedFirstInTraversalOrder) {
   // Deliberately not root-first in the update.
   Apply(tree, {&second.node, &first.node, &root.node});
 
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
 
@@ -261,7 +261,7 @@ TEST_F(SemanticsPublisherTest, TristatesArePublishedNotFlattened) {
   NodeBuilder plain(2, {}, "Label");  // enablement does not apply
 
   Apply(tree, {&root.node, &disabled.node, &plain.node});
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
 
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
@@ -282,7 +282,7 @@ TEST_F(SemanticsPublisherTest, ActionsAndIdentifierReachTheSnapshot) {
       kFlutterSemanticsActionIncrease | kFlutterSemanticsActionDecrease);
   Apply(tree, {&root.node, &slider.node});
 
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
   const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
@@ -304,7 +304,7 @@ TEST_F(SemanticsPublisherTest, ObscuredIsReportedForPasswordFields) {
       kFlutterSemanticsFlagIsTextField | kFlutterSemanticsFlagIsObscured);
   Apply(tree, {&root.node, &password.node});
 
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
   const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
@@ -328,7 +328,7 @@ TEST_F(SemanticsPublisherTest, ScrollableCarriesANumericValue) {
   list.node.scroll_extent_max = 400.0;
   Apply(tree, {&root.node, &list.node});
 
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
   const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
@@ -355,7 +355,7 @@ TEST_F(SemanticsPublisherTest, NonScrollableHasNoNumericValue) {
   button.node.actions = kFlutterSemanticsActionTap;
   Apply(tree, {&root.node, &button.node});
 
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
   const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
@@ -381,7 +381,7 @@ TEST_F(SemanticsPublisherTest, UnboundedScrollableReportsNoNumericValue) {
   infinite.node.scroll_extent_max = std::numeric_limits<double>::infinity();
   Apply(tree, {&root.node, &infinite.node});
 
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
   const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
@@ -404,7 +404,7 @@ TEST_F(SemanticsPublisherTest, OverscrollClampsIntoRange) {
   list.node.scroll_extent_max = 400.0;
   Apply(tree, {&root.node, &list.node});
 
-  ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+  ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
   const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
   ASSERT_NE(snapshot, nullptr);
   const IhsSemanticsNode* out = ihs_semantics_snapshot_node_by_id(snapshot, 1);
@@ -428,7 +428,7 @@ TEST_F(SemanticsPublisherTest, RepeatedPublishesAgreeOnOrder) {
   std::vector<std::string> first;
   std::vector<std::string> second;
   for (int pass = 0; pass < 2; pass++) {
-    ASSERT_EQ(PublishTree(tree), IHS_SEMANTICS_OK);
+    ASSERT_EQ(PublishTree(tree, nullptr), IHS_SEMANTICS_OK);
     const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
     ASSERT_NE(snapshot, nullptr);
     auto& into = pass == 0 ? first : second;


### PR DESCRIPTION
Makes multi-view a first-class configuration, and fixes the correctness defect
that was sitting under it.

## The defect

Each bundle gets an engine of its own, each with its own semantics tree and its
own node id space. The hub held **one** tree and **one** host for the process,
so the last engine to publish owned the only tree there was and the last to
install a host owned every dispatch -- and those are not the same engine.

A client could read one application's tree and have its action delivered to
another. Not as a failure: two engines number from their own roots, so the id
lands on a real but unrelated control, and the caller is told it succeeded.
Reachable with `-b appA -b appB` plus `BUILD_ACCESSIBILITY`; nothing guarded it.

Demonstrated before fixing, against the real library:

```
engine A publishes; client reads: node 10 "A: Play"
engine B publishes; client reads: node 20 "B: Navigate"
engine A republishes; client reads: node 10 "A: Play"
client taps node 10, which it just read from A:
  -> delivered to engine-B
```

## The fix

A **source** is one publisher: its tree and the host its actions go to, kept
together. A consumer asks a source for a tree and dispatches back to that same
source, so reading and acting cannot drift apart.

Two trees are never merged. They have separate id spaces and separate
lifetimes, and pretending otherwise is what produced this.

Additive, ABI 1.4: a trailing `source` on `IhsSemanticsPublishInfo` behind its
struct_size, a registration entry point in the host header, addressing calls
beside the existing ones, and the same six appended to the capability
sub-table. Compatibility is an implicit source named `default`; where several
exist there is no unambiguous default, so an unkeyed call **fails rather than
choosing** -- answering with either is exactly how a client acts on the wrong
application.

## The surface

Every tree is its own resource, `ui://semantics/{view}/tree`, named for the
application. There is deliberately **no unqualified alias**: what it would name
depends on how many applications happen to be running, which a client cannot
see and an identifier must not depend on. Keeping one would also move the
breakage to whenever a second application appears, which is the worse moment.

Reading and acting are treated differently because the honest default differs:

- **Reads may span.** An agent hunting for a control does not know which
  application owns it -- that is what it is trying to find out -- so
  `ui_snapshot` and `ui_query` with no view search every one and **group by
  view**. Grouped rather than flattened, because two applications' ids collide
  and mean different things; the grouping is what makes an id usable, since an
  agent reads a match and takes the view it sits under.
- **Actions may not.** With several running, an action naming no view is
  refused, and the error names the argument so an agent that omitted it learns
  it exists. With exactly one, the argument is optional: it removes ambiguity,
  it is not ceremony.

Both in-tree clients now discover trees through `resources/list` rather than
assuming a fixed URI -- which is what an MCP client should do, and what keeps
them correct as applications come and go.

## A second defect, found by a flake

`AnotherUserIsRefusedOnceTheModeIsWrong` began failing about one run in six,
with an **empty** response rather than a wrong one -- so a real bug, not a
flaky test. A refused connection got its 403 written and the socket closed with
the peer's request still unread, and closing with unconsumed input discards
both directions.

`docs/mcp-security.md` claims the surface "refuses, and says so rather than
hanging up silently", which was true only sometimes. Fixed with a drain bounded
in bytes and time, since this runs before any authorisation has succeeded. 25
consecutive clean runs after.

## Known gap: AccessKit

**AccessKit still uses the unkeyed calls, so in a multi-view configuration it
gets nothing.** Before this branch it saw one arbitrary, flickering tree; now
it sees none. "Nothing" is better than "wrong", but for a screen reader neither
is acceptable, and accessibility is why this subsystem exists.

It is not fixed here because `BUILD_ACCESSKIT` is off by default and needs an
unpacked accesskit-c release that is not available in this environment -- I
could not compile it, and writing untested code into that adapter is the exact
failure this repository has recorded before. The fix shape is small and
mechanical: enumerate sources and expose each as its own AccessKit tree, since
a screen reader legitimately wants the whole desktop.

Worth deciding whether that blocks merging or follows it.

## Also worth a decision

`mcp_allowed_tools` is image-wide. With multi-view first-class that reads
differently: admitting a client admits it to **every** application, and there is
no per-view policy. Recorded in the security review rather than assumed away.

## Verification

29 of 29 across repeated runs. Six hub tests led by the defect itself -- two
trees with the same node id, read one, act, assert which engine received it --
and six provider tests covering per-view resources, an action reaching only the
view it names, an unqualified action refused, an unqualified read spanning, an
unknown view name rejected as a different mistake from an omitted one, and a
single application still needing no naming.
