### PR TITLE
accesskit: show every application, not one

### DIFF
--- a/shell/accessibility/accesskit_consumer.cc
+++ b/shell/accessibility/accesskit_consumer.cc
@@ -21,9 +21,13 @@
 #include <sys/eventfd.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdint>
 #include <cstring>
+#include <map>
+#include <mutex>
+#include <string>
 #include <vector>
 
 #include "ihs/ihs_semantics.h"
@@ -182,8 +186,75 @@ void AddActions(accesskit_node* node,
 // flattened: a screen reader announces "unchecked" and "not checkable" very
 // differently, and collapsing them would make every container sound like an
 // unchecked checkbox.
+namespace {
+
+// AccessKit addresses nodes with one 64-bit id across the whole tree, while
+// each application numbers its own nodes from its own root -- so two
+// applications both have a node 1. The id carries the application in its high
+// half and the node in its low half, which makes it unique without asking the
+// applications to coordinate.
+//
+// The slot is assigned per source name on first sight and never reused, so an
+// id a screen reader is holding cannot come to mean a different application
+// because something else started or stopped. Index in the hub's list would
+// have been the obvious key and is exactly wrong: it shifts when a source
+// unregisters.
+//
+// The first application seen gets slot 0, so with one application the ids are
+// its node ids unchanged.
+constexpr uint64_t kSyntheticRootId = UINT64_MAX;
+
+}  // namespace
+
+uint32_t SlotForSourceName(const std::string& name) {
+  static std::mutex mutex;
+  static std::map<std::string, uint32_t> slots;
+  static uint32_t next = 0;
+  const std::lock_guard<std::mutex> lock(mutex);
+  const auto it = slots.find(name);
+  if (it != slots.end()) {
+    return it->second;
+  }
+  const uint32_t assigned = next++;
+  slots.emplace(name, assigned);
+  return assigned;
+}
+
+accesskit_node_id ComposeNodeId(const uint32_t slot, const int32_t node_id) {
+  return (static_cast<uint64_t>(slot) << 32) | static_cast<uint32_t>(node_id);
+}
+
+uint32_t SlotOfNodeId(const accesskit_node_id id) {
+  return static_cast<uint32_t>(id >> 32);
+}
+
+int32_t NodeOfNodeId(const accesskit_node_id id) {
+  return static_cast<int32_t>(static_cast<uint32_t>(id & 0xffffffffu));
+}
+
+namespace {
+
+uint32_t SlotForSource(IhsSemanticsSource* source) {
+  return SlotForSourceName(ihs_semantics_source_name(source));
+}
+
+// The source a composed id belongs to, or NULL if that application has gone.
+IhsSemanticsSource* SourceForSlot(const uint32_t slot) {
+  const size_t count = ihs_semantics_source_count();
+  for (size_t i = 0; i < count; i++) {
+    IhsSemanticsSource* source = ihs_semantics_source_at(i);
+    if (source != nullptr && SlotForSource(source) == slot) {
+      return source;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
 accesskit_node* BuildNode(const IhsSemanticsNode* node,
-                          const IhsSemanticsSnapshot* snapshot) {
+                          const IhsSemanticsSnapshot* snapshot,
+                          const uint32_t slot) {
   const accesskit_role role = ToAccessKitRole(node->role);
   accesskit_node* out = accesskit_node_new(role);
 
@@ -191,7 +262,7 @@ accesskit_node* BuildNode(const IhsSemanticsNode* node,
     const IhsSemanticsNode* child =
         ihs_semantics_snapshot_node_at(snapshot, node->child_indices[i]);
     if (child != nullptr) {
-      accesskit_node_push_child(out, static_cast<accesskit_node_id>(child->id));
+      accesskit_node_push_child(out, ComposeNodeId(slot, child->id));
     }
   }
 
@@ -335,36 +406,105 @@ accesskit_node* BuildNode(const IhsSemanticsNode* node,
 
 namespace {
 
-// Builds a full tree update from a snapshot. The caller owns the result.
-accesskit_tree_update* BuildTreeUpdate(const IhsSemanticsSnapshot* snapshot) {
-  const size_t count = ihs_semantics_snapshot_node_count(snapshot);
-  if (count == 0) {
+// Builds a tree update spanning every application. The caller owns the result.
+//
+// A screen reader wants the desktop, not one window of it, so every source
+// contributes. AccessKit's tree has a single root and each application has one
+// of its own, so with more than one a synthetic root parents them; with one it
+// stays the root, leaving the single-application tree exactly as it was.
+accesskit_tree_update* BuildTreeUpdate() {
+  struct Contribution {
+    IhsSemanticsSource* source;
+    const IhsSemanticsSnapshot* snapshot;
+    uint32_t slot;
+    size_t count;
+  };
+
+  std::vector<Contribution> contributions;
+  size_t total = 0;
+  const size_t sources = ihs_semantics_source_count();
+  for (size_t i = 0; i < sources; i++) {
+    IhsSemanticsSource* source = ihs_semantics_source_at(i);
+    if (source == nullptr) {
+      continue;
+    }
+    const IhsSemanticsSnapshot* snapshot =
+        ihs_semantics_acquire_snapshot_from(source);
+    if (snapshot == nullptr) {
+      continue;  // registered but has published nothing yet
+    }
+    const size_t count = ihs_semantics_snapshot_node_count(snapshot);
+    if (count == 0) {
+      ihs_semantics_release_snapshot(snapshot);
+      continue;
+    }
+    contributions.push_back({source, snapshot, SlotForSource(source), count});
+    total += count;
+  }
+
+  if (contributions.empty()) {
     return nullptr;
   }
 
-  // Focus follows whichever node reports it; the root is the fallback, since
-  // AccessKit requires the focus id to name a node that exists in the update.
-  accesskit_node_id focus = 0;
-  for (size_t i = 0; i < count; i++) {
-    const IhsSemanticsNode* node = ihs_semantics_snapshot_node_at(snapshot, i);
-    if (node != nullptr && node->focused == IHS_SEMANTICS_TRISTATE_TRUE) {
-      focus = static_cast<accesskit_node_id>(node->id);
+  const bool synthetic_root = contributions.size() > 1;
+  const accesskit_node_id root =
+      synthetic_root ? kSyntheticRootId
+                     : ComposeNodeId(contributions.front().slot,
+                                     ihs_semantics_snapshot_node_at(
+                                         contributions.front().snapshot, 0)
+                                         ->id);
+
+  // Focus follows whichever node reports it, across every application; the
+  // root is the fallback, since AccessKit requires the focus id to name a node
+  // present in the update.
+  accesskit_node_id focus = root;
+  for (const Contribution& c : contributions) {
+    bool found = false;
+    for (size_t i = 0; i < c.count; i++) {
+      const IhsSemanticsNode* node =
+          ihs_semantics_snapshot_node_at(c.snapshot, i);
+      if (node != nullptr && node->focused == IHS_SEMANTICS_TRISTATE_TRUE) {
+        focus = ComposeNodeId(c.slot, node->id);
+        found = true;
+        break;
+      }
+    }
+    if (found) {
       break;
     }
   }
 
-  accesskit_tree_update* update =
-      accesskit_tree_update_with_capacity_and_focus(count, focus);
-  accesskit_tree_update_set_tree(update, accesskit_tree_new(0));
+  accesskit_tree_update* update = accesskit_tree_update_with_capacity_and_focus(
+      total + (synthetic_root ? 1 : 0), focus);
+  accesskit_tree_update_set_tree(update, accesskit_tree_new(root));
 
-  for (size_t i = 0; i < count; i++) {
-    const IhsSemanticsNode* node = ihs_semantics_snapshot_node_at(snapshot, i);
-    if (node == nullptr) {
-      continue;
+  if (synthetic_root) {
+    // A container whose children are the applications' own roots. Given the
+    // window role because that is what it is to a screen reader: several
+    // applications sharing one screen.
+    accesskit_node* container = accesskit_node_new(ACCESSKIT_ROLE_WINDOW);
+    for (const Contribution& c : contributions) {
+      const IhsSemanticsNode* app_root =
+          ihs_semantics_snapshot_node_at(c.snapshot, 0);
+      if (app_root != nullptr) {
+        accesskit_node_push_child(container,
+                                  ComposeNodeId(c.slot, app_root->id));
+      }
     }
-    accesskit_tree_update_push_node(update,
-                                    static_cast<accesskit_node_id>(node->id),
-                                    BuildNode(node, snapshot));
+    accesskit_tree_update_push_node(update, kSyntheticRootId, container);
+  }
+
+  for (const Contribution& c : contributions) {
+    for (size_t i = 0; i < c.count; i++) {
+      const IhsSemanticsNode* node =
+          ihs_semantics_snapshot_node_at(c.snapshot, i);
+      if (node == nullptr) {
+        continue;
+      }
+      accesskit_tree_update_push_node(update, ComposeNodeId(c.slot, node->id),
+                                      BuildNode(node, c.snapshot, c.slot));
+    }
+    ihs_semantics_release_snapshot(c.snapshot);
   }
   return update;
 }
@@ -373,15 +513,10 @@ accesskit_tree_update* BuildTreeUpdate(const IhsSemanticsSnapshot* snapshot) {
 // This runs on AccessKit's thread, which is safe now only because it reads a
 // snapshot rather than the shell's mutable tree.
 accesskit_tree_update* ActivationHandler(void* /* user_data */) {
-  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
-  if (snapshot == nullptr) {
-    // Nothing published yet. Returning null tells AccessKit there is no tree
-    // to show, and the next publish will push one.
-    return nullptr;
-  }
-  accesskit_tree_update* update = BuildTreeUpdate(snapshot);
-  ihs_semantics_release_snapshot(snapshot);
-  return update;
+  // Every application, not one: an assistive technology attaching wants the
+  // whole screen. Null when nothing has published yet, which tells AccessKit
+  // there is no tree to show; the next publish pushes one.
+  return BuildTreeUpdate();
 }
 
 // A screen reader asked for something. Everything the framework can act on
@@ -416,10 +551,11 @@ void ActionHandler(accesskit_action_request* request, void* user_data) {
       const double value = request->data.value.numeric_value;
       bool horizontal = false;
       if (const IhsSemanticsSnapshot* snapshot =
-              ihs_semantics_acquire_snapshot();
+              ihs_semantics_acquire_snapshot_from(
+                  SourceForSlot(SlotOfNodeId(request->target_node)));
           snapshot != nullptr) {
         if (const IhsSemanticsNode* node = ihs_semantics_snapshot_node_by_id(
-                snapshot, static_cast<int32_t>(request->target_node));
+                snapshot, NodeOfNodeId(request->target_node));
             node != nullptr) {
           const bool vertical =
               (node->actions & (IHS_SEMANTICS_ACTION_SCROLL_UP |
@@ -469,8 +605,14 @@ void ActionHandler(accesskit_action_request* request, void* user_data) {
     }
   }
 
-  const int status = ihs_semantics_dispatch(
-      consumer, 0, static_cast<int32_t>(request->target_node), action,
+  // Back to the application the id came from. Its high half names which, and
+  // the low half is that application's own node id -- so an action reaches the
+  // control the screen reader was reading, not whichever application happens
+  // to have a node of the same number.
+  IhsSemanticsSource* source =
+      SourceForSlot(SlotOfNodeId(request->target_node));
+  const int status = ihs_semantics_dispatch_from(
+      consumer, source, 0, NodeOfNodeId(request->target_node), action,
       argument.empty() ? nullptr : argument.data(), argument.size(), nullptr,
       nullptr);
   if (status != IHS_SEMANTICS_OK) {
@@ -602,23 +744,44 @@ void AccessKitConsumer::PollLoop() {
       got = ::read(notify_fd_, &token, sizeof(token));
     } while (got < 0 && errno == EINTR);
 
-    const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
-    if (snapshot == nullptr) {
-      continue;
-    }
-    PushSnapshot(snapshot);
-    ihs_semantics_release_snapshot(snapshot);
+    PushSnapshot();
   }
 }
 
-void AccessKitConsumer::PushSnapshot(const IhsSemanticsSnapshot* snapshot) {
-  const uint64_t generation = ihs_semantics_snapshot_generation(snapshot);
-  if (generation == last_generation_) {
-    return;  // a wake with nothing newer behind it
+namespace {
+
+// The newest generation any application has published. The hub's counter is
+// process-wide rather than per-source, so one number orders publishes from
+// different applications and is enough to tell whether anything changed since
+// the last push.
+uint64_t NewestGeneration() {
+  uint64_t newest = 0;
+  const size_t count = ihs_semantics_source_count();
+  for (size_t i = 0; i < count; i++) {
+    IhsSemanticsSource* source = ihs_semantics_source_at(i);
+    if (source == nullptr) {
+      continue;
+    }
+    if (const IhsSemanticsSnapshot* snapshot =
+            ihs_semantics_acquire_snapshot_from(source);
+        snapshot != nullptr) {
+      newest = std::max(newest, ihs_semantics_snapshot_generation(snapshot));
+      ihs_semantics_release_snapshot(snapshot);
+    }
+  }
+  return newest;
+}
+
+}  // namespace
+
+void AccessKitConsumer::PushSnapshot() {
+  const uint64_t generation = NewestGeneration();
+  if (generation == 0 || generation == last_generation_) {
+    return;  // nothing published, or a wake with nothing newer behind it
   }
   last_generation_ = generation;
 
-  accesskit_tree_update* update = BuildTreeUpdate(snapshot);
+  accesskit_tree_update* update = BuildTreeUpdate();
   if (update == nullptr) {
     return;
   }

--- a/shell/accessibility/accesskit_consumer.h
+++ b/shell/accessibility/accesskit_consumer.h
@@ -19,6 +19,8 @@
 
 #include <accesskit.h>
 
+#include <string>
+
 #include <atomic>
 #include <cstdint>
 #include <thread>
@@ -46,8 +48,38 @@ uint64_t ToIhsAction(accesskit_action action);
 //
 // `snapshot` resolves the node's children and custom-action declarations, so
 // it must be the snapshot the node came from. Caller owns the result.
+/*
+ * `slot` is the application this node belongs to; child ids are composed from
+ * it so two applications' node 1 do not collide in AccessKit's single id
+ * space. Defaulted because the first application seen is slot 0, which leaves
+ * its ids exactly as they were.
+ */
 accesskit_node* BuildNode(const IhsSemanticsNode* node,
-                          const IhsSemanticsSnapshot* snapshot);
+                          const IhsSemanticsSnapshot* snapshot,
+                          uint32_t slot = 0);
+
+/*
+ * Node id composition, exposed for the same reason BuildNode is: it is only
+ * exercised with an assistive technology attached and several applications
+ * running, and every way of getting it wrong is silent. A collision hands a
+ * screen reader two different controls under one id; an unstable slot makes an
+ * id it is already holding come to mean a different application.
+ *
+ * AccessKit addresses the whole tree with one 64-bit id while each application
+ * numbers its nodes from its own root, so the id carries the application in
+ * its high half and the node in its low half.
+ */
+accesskit_node_id ComposeNodeId(uint32_t slot, int32_t node_id);
+uint32_t SlotOfNodeId(accesskit_node_id id);
+int32_t NodeOfNodeId(accesskit_node_id id);
+
+/*
+ * The slot for a source name: assigned on first sight and never reused, so an
+ * id survives other applications starting and stopping. Index in the hub's
+ * list would have been the obvious key and is exactly wrong -- it shifts when
+ * a source unregisters, silently remapping ids already in use.
+ */
+uint32_t SlotForSourceName(const std::string& name);
 
 // Bridges the semantics hub to a platform screen reader through AccessKit.
 //
@@ -86,7 +118,9 @@ class AccessKitConsumer {
   void PollLoop();
 
   // Publishes `snapshot` as a full AccessKit tree update.
-  void PushSnapshot(const IhsSemanticsSnapshot* snapshot);
+  // Rebuilds and pushes the tree spanning every application, if anything has
+  // published since the last push.
+  void PushSnapshot();
 
   IhsSemanticsConsumer* consumer_ = nullptr;
   int notify_fd_ = -1;    // eventfd the hub writes on publish

--- a/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
+++ b/test/unit_test/accesskit_consumer-test/test_case_accesskit_consumer.cc
@@ -408,3 +408,103 @@ TEST(AccessKitConsumer, ScrollOffsetActionMapsToScrollToOffset) {
 TEST(AccessKitConsumer, SetValueIsNotMappedByTagAlone) {
   EXPECT_EQ(ToIhsAction(ACCESSKIT_ACTION_SET_VALUE), 0u);
 }
+
+// ---------------------------------------------------------------------------
+// Multi-application addressing
+//
+// AccessKit addresses the whole tree with one 64-bit id, while each
+// application numbers its nodes from its own root -- so two applications both
+// have a node 1. Every way of getting this wrong is silent with no assistive
+// technology attached: a collision hands a screen reader two different
+// controls under one id, and an unstable slot makes an id it is already
+// holding come to mean a different application.
+// ---------------------------------------------------------------------------
+
+TEST(AccessKitMultiView, IdsFromDifferentApplicationsDoNotCollide) {
+  // The case that matters: the same node id in two applications.
+  EXPECT_NE(accessibility::ComposeNodeId(0, 1),
+            accessibility::ComposeNodeId(1, 1));
+  EXPECT_NE(accessibility::ComposeNodeId(0, 0),
+            accessibility::ComposeNodeId(1, 0));
+}
+
+TEST(AccessKitMultiView, AnIdCarriesBackWhatWentIn) {
+  for (const uint32_t slot : {0u, 1u, 7u, 4294967295u}) {
+    for (const int32_t node :
+         {int32_t{0}, int32_t{1}, int32_t{-1}, INT32_MAX, INT32_MIN}) {
+      const accesskit_node_id id = accessibility::ComposeNodeId(slot, node);
+      EXPECT_EQ(accessibility::SlotOfNodeId(id), slot);
+      EXPECT_EQ(accessibility::NodeOfNodeId(id), node)
+          << "node id " << node << " did not survive slot " << slot;
+    }
+  }
+}
+
+// The first application seen keeps its own node ids, so a single-application
+// tree is addressed exactly as it was before any of this existed.
+TEST(AccessKitMultiView, TheFirstApplicationKeepsItsIdsUnchanged) {
+  EXPECT_EQ(accessibility::ComposeNodeId(0, 42), 42u);
+  EXPECT_EQ(accessibility::ComposeNodeId(0, 0), 0u);
+}
+
+// The reason slots are keyed by name rather than by position in the hub's
+// list: a position shifts when an application stops, which would silently
+// remap every id a screen reader is holding onto a different application.
+TEST(AccessKitMultiView, ASlotSurvivesOtherApplicationsComingAndGoing) {
+  const uint32_t cluster = accessibility::SlotForSourceName("cluster");
+  const uint32_t radio = accessibility::SlotForSourceName("radio");
+  const uint32_t nav = accessibility::SlotForSourceName("nav");
+  EXPECT_NE(cluster, radio);
+  EXPECT_NE(radio, nav);
+
+  // Asking again is asking about the same application, whatever happened to
+  // the others in between.
+  EXPECT_EQ(accessibility::SlotForSourceName("cluster"), cluster);
+  EXPECT_EQ(accessibility::SlotForSourceName("nav"), nav);
+
+  // And a name seen for the first time never reuses a slot, even if the
+  // application that had one is gone.
+  const uint32_t fresh = accessibility::SlotForSourceName("media");
+  EXPECT_NE(fresh, cluster);
+  EXPECT_NE(fresh, radio);
+  EXPECT_NE(fresh, nav);
+}
+
+// A node's children are addressed in its own application, not in whichever
+// happens to have a node of that number.
+TEST(AccessKitMultiView, ChildIdsAreComposedWithTheirOwnApplication) {
+  std::vector<IhsSemanticsPublishNode> nodes(2);
+  static const int32_t kChildren[] = {5};
+  nodes[0].id = 1;
+  nodes[0].label = "Root";
+  nodes[0].role = IHS_SEMANTICS_ROLE_PANE;
+  nodes[0].enabled = IHS_SEMANTICS_TRISTATE_NONE;
+  nodes[0].child_ids = kChildren;
+  nodes[0].child_count = 1;
+  nodes[1].id = 5;
+  nodes[1].label = "Child";
+  nodes[1].role = IHS_SEMANTICS_ROLE_BUTTON;
+  nodes[1].enabled = IHS_SEMANTICS_TRISTATE_NONE;
+
+  IhsSemanticsPublishInfo info{};
+  info.struct_size = sizeof(info);
+  info.nodes = nodes.data();
+  info.node_count = nodes.size();
+  ASSERT_EQ(ihs_semantics_publish(&info), IHS_SEMANTICS_OK);
+
+  const IhsSemanticsSnapshot* snapshot = ihs_semantics_acquire_snapshot();
+  ASSERT_NE(snapshot, nullptr);
+  const IhsSemanticsNode* root = ihs_semantics_snapshot_node_at(snapshot, 0);
+  ASSERT_NE(root, nullptr);
+
+  accesskit_node* built = accessibility::BuildNode(root, snapshot, /*slot=*/3);
+  ASSERT_NE(built, nullptr);
+  const accesskit_node_ids children = accesskit_node_children(built);
+  ASSERT_EQ(children.length, 1u);
+  EXPECT_EQ(children.values[0], accessibility::ComposeNodeId(3, 5))
+      << "a child was addressed in the wrong application";
+
+  accesskit_node_free(built);
+  ihs_semantics_release_snapshot(snapshot);
+  ihs_semantics_clear();
+}


### PR DESCRIPTION
Closes the gap #473 left open and flagged.

## The regression

#473 keyed the semantics hub by source. This consumer kept calling the unkeyed
entry points, which by design answer with nothing when more than one
application is registered — so **a screen reader got no tree at all** in
exactly the configuration that change made first class.

Before #473 it saw one arbitrary, flickering tree. After, none. "Nothing" beats
"wrong", but neither is acceptable on the accessibility path, which is the
reason the hub exists.

## What it does now

A screen reader wants the desktop, not one window of it, so every source
contributes to one tree. AccessKit has a single root and each application has
one of its own, so with several a synthetic window node parents them; with one,
that application's root stays the root and the single-application tree is
exactly as it was.

## The problem underneath was addressing

AccessKit names nodes with one 64-bit id across the whole tree, while each
application numbers from its own root — so two applications both have a node 1.
The id now carries the application in its high half and the node in its low
half. That makes it unique without asking applications to coordinate, and it is
what lets an action be routed back to the application its id came from rather
than to whichever happens to have a node of that number.

**The slot in the high half is keyed by source name, assigned on first sight,
never reused.** Position in the hub's list would have been the obvious key and
is exactly wrong: it shifts when an application stops, silently remapping every
id a screen reader is currently holding onto a different application. The first
application seen gets slot 0, so its ids are unchanged.

## Tests

Five, and the header says why they exist: every way of getting this wrong is
silent without an assistive technology attached *and* several applications
running.

- Ids from different applications do not collide
- The id round-trips at the range edges, including `INT32_MIN`
- The first application keeps its ids unchanged
- A slot survives other applications coming and going
- A node's children are addressed in their own application — this one fails
  against the previous code

## A correction

I said in #473 that this could not be built or tested here. That was wrong: the
accesskit-c release was already unpacked under
`.config/flutter_workspace/overlay-src/accesskit-c-0.22.3` with a
`linux/x86_64` static library, and configuring with `-D BUILD_ACCESSKIT=ON -D
CMAKE_PREFIX_PATH=<that>` builds and runs the adapter's own suite. I checked
before writing anything this time.

30 of 30 with the adapter compiled in, 29 of 29 without.
