### PR TITLE
ci: run the push-triggered workflows on the default branch

### DIFF
--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [v2.0]
+    branches: [v3.0]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [v2.0]
+    branches: [v3.0]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/oss-codeql.yml
+++ b/.github/workflows/oss-codeql.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 'v2.0' ]
+    branches: [ 'v3.0' ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ 'main' ]

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -20,7 +20,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [v2.0]
+    branches: [v3.0]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -361,10 +361,17 @@ jobs:
             # -v streams the toolchain/compile output line-prefixed into the
             # log (tee'd) so every build leaves a full record, not just
             # spinners.
+            #
+            # 2>&1 before the pipe, because the grep below reads this file and
+            # emb reports a failed augment download on stderr. Without it the
+            # message reached the console -- both streams land there -- but
+            # never the file, so the retry decided every download failure was
+            # "something other than a download" and gave up on the first
+            # attempt. The retry has therefore never once fired.
             if emb -v cross . \
                  --target "${{ matrix.board }}-${{ matrix.pios }}" \
                  --build --backend "${{ matrix.backend }}" \
-                 --no-verify -w /emb | tee /tmp/emb-build.log; then
+                 --no-verify -w /emb 2>&1 | tee /tmp/emb-build.log; then
               break
             fi
             if ! grep -q "augment: download failed" /tmp/emb-build.log; then


### PR DESCRIPTION
The augment source cache has never been warm, and this is why.

## The cause

Four workflows still trigger on pushes to **v2.0** — which stopped being the
default branch, and has had no commit since November. So none of them has run
on a push since the move to v3.0. Only on pull requests.

That matters for caching specifically, because of how GitHub scopes it: a run
can restore caches created on **its own ref or on the default branch**, and
nothing else. A cache saved by one pull request is scoped to that pull request
and is invisible to every other one.

`pios.yml` saves correctly and restores correctly — `restore-keys` prefix
fallback and an `if: always()` save so a failed run still keeps what it
fetched. Both halves are right. There has simply never been a default-branch
entry for them to find, so **every pull request re-downloads libdisplay-info**
from gitlab.freedesktop.org and wears whatever that origin is doing at the
time. Today that is a run of 504s.

## And the retry has never once fired

Reading the failing logs on this PR turned up a second, independent bug. The
retry loop reads `/tmp/emb-build.log` and gives up unless it finds
`augment: download failed` there — but only stdout was piped into `tee`, and
emb reports that on stderr. The message reached the console, where both
streams land, and never the file. So every download failure was classified as
"something other than a download" and failed on the first attempt:

```
augment: download failed (…libdisplay-info-0.2.0.tar.gz): 504
##[error]build failed for a reason other than a source download
```

Those two lines contradict each other, and the second is the loop misreading an
empty file. `2>&1` before the pipe fixes it. A 504 now costs three attempts
over about ninety seconds rather than failing immediately — which is what the
loop was written to do, and was worth having today when the origin returned 504
for every job in the matrix.

## Two more consequences, not about caching

- **CodeQL has not analysed the default branch** since the move. Default-branch
  runs are what populate the security tab; a per-PR run annotates the PR and
  little else.
- **lint and drm-kms have not gated a direct push to v3.0.** Pull requests
  still ran them so nothing wrong has merged, but the branch itself was
  unchecked.

## What this does not change

The retry loop and backoff in `pios.yml` are left alone deliberately. They
exist for an origin that blips, and widening them would trade CI time against a
problem fixed here at the cause: the first push to v3.0 after this lands saves
the archives, and every pull request from then on restores them rather than
touching the network at all.

v2.0 is dropped rather than kept alongside — it is dormant, and listing a
branch nothing pushes to is exactly what produced this.

## Note on sequencing

This is self-healing but not instant: the shared cache exists only once
something lands on v3.0. Merging this first means the next merge warms it for
everything after.
