### PR TITLE
DIAGNOSTIC: print what the cross image actually baked (do not merge)

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -320,6 +320,34 @@ jobs:
       # deadlock: the archives only land after a green build, and the build
       # cannot go green while the download keeps failing. Saving whatever did
       # arrive means each attempt leaves the next one better off.
+      # DIAGNOSTIC — remove before merging.
+      #
+      # Every build job re-resolves the cross toolchain for 90-110 seconds,
+      # which across the matrix is roughly 40 minutes of CI per run. The image
+      # this job runs in is supposed to have it baked at /emb, and the publish
+      # job reports the content it would build is "already published --
+      # skipping resolve", so both sides agree on what the toolchain should be.
+      #
+      # What is not known is whether the mutable :${{ matrix.pios }} tag this
+      # container comes from actually carries that content, and whether it is
+      # baked under the path and profile hash the build then asks for. This
+      # prints exactly that, and nothing else, so the answer comes from the
+      # container rather than from reasoning about it.
+      - name: Diagnose baked toolchain
+        continue-on-error: true
+        run: |
+          echo "::group::what the image baked"
+          ls -la /emb/.config/flutter_workspace/ 2>&1 || echo "MISSING: /emb/.config/flutter_workspace"
+          echo "--- cross profiles present ---"
+          ls -d /emb/.config/flutter_workspace/cross-* 2>&1 || echo "none"
+          echo "--- size of each ---"
+          du -sh /emb/.config/flutter_workspace/cross-* 2>&1 || true
+          echo "--- overlay-src (augment archives) ---"
+          ls -la /emb/.config/flutter_workspace/overlay-src/ 2>&1 | head -20 || echo "none"
+          echo "--- what /emb looks like at the top ---"
+          ls -la /emb/ 2>&1 | head -10
+          echo "::endgroup::"
+
       - name: Restore augment sources
         uses: actions/cache/restore@v6
         with:


### PR DESCRIPTION
**Draft, and not for merging.** One `continue-on-error` step that prints what is
present at `/emb` inside the build container, to settle a question I cannot
answer from outside the registry.

## What is measured

Every build job re-resolves the cross toolchain:

| job | resolve |
|---|---|
| `build-rpi4-bookworm-software` | 91.8s |
| `build-rpi5-bookworm-software` | 108.8s |
| `build-rpi-zero-2w-bookworm-software` | 97.3s |

About forty minutes of CI per run, on a toolchain the container is supposed to
have baked.

## What is known

- `publish` does not rebuild it: `…:86fcab4da34b-d75b32b4db3d already published — skipping resolve.`
- `86fcab4da34b` is exactly the profile hash the build then resolves to, so both
  sides agree on *what* the toolchain should be.
- The `oras:pull … not found` lines are a separate, harmless thing: nothing has
  ever pushed to `emb-cache`, and the resolve happens regardless of them.

## What is not known

The build's container is the **mutable** `:<pios>` tag. Whether that tag carries
the content publish computed, and whether it is baked under the path and profile
hash the build asks for, needs looking inside the image. My token lacks
`read:packages`, so this step looks from within instead.

The asymmetry worth ruling in or out: publish resolves into `-w "$EMB_WS"` on the
runner, while build reads `-w /emb`.

## Already rejected

Publish bakes only `--target rpi5-*`, so a board mismatch would have made rpi5
fast and the others slow. rpi5 is the slowest of the three — so that is not it.
I would rather post a falsified hypothesis than a plausible patch.