### PR TITLE
ci: stop writing one augment cache entry per matrix job

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -330,6 +330,12 @@ jobs:
       # accesskit-c) sit behind BUILD_CRASH_HANDLER / BUILD_ACCESSKIT, which
       # this workflow never passes.
       #
+      # The exact key is the complete set, written only by a green build. The
+      # first restore-key repeats it as a prefix, which is what reaches the
+      # `-partial-<run id>` entries a failed run leaves behind: preferred in
+      # that order, so a partial never shadows a complete one however recently
+      # it was written.
+      #
       # Restore and save are separate so the save can run after a failed
       # build. actions/cache skips saving when the job fails, which for a
       # cache whose whole purpose is to stop a flaky download would be a
@@ -354,6 +360,9 @@ jobs:
       # a pure cache hit (no download/extract). Host build tools (cmake, ninja,
       # meson, wayland-scanner) are baked too; only the augment libs rebuild.
       - name: Build ${{ matrix.backend }}
+        # id: the save steps below key off whether this succeeded, which is
+        # what tells a complete set of fetched archives from a partial one.
+        id: build
         working-directory: ivi-homescreen
         # Container jobs default to dash (sh); pipefail/SECONDS need bash.
         shell: bash
@@ -417,32 +426,32 @@ jobs:
               | sed -E 's/^[[:space:]]*[^A-Za-z]*/- /' || true
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # always(): the point is to keep what a failed run managed to fetch.
-      # The key carries a run id so a partial set never claims to be the
-      # complete one; restore-keys above picks up the newest either way.
+      # Two saves, because "what a run fetched" and "everything that has to be
+      # fetched" are not the same thing and must not share a key.
       #
-      # It carries the OS, and nothing else. The archives do not vary by board
-      # or backend, so those two multiplied one entry per OS into thirteen
-      # identical ones apiece. That is not merely untidy: the repository cache
-      # is a fixed budget with least-recently-used eviction, so the duplicates
-      # evict the entries this workflow depends on, including each other.
+      # The key is the manifest hash and the OS -- nothing more. Board and
+      # backend do not change what gets fetched, so carrying them turned one
+      # entry per OS into thirteen identical ones apiece. A run id does not
+      # belong here either: it is unique per run, so it would mint two fresh
+      # entries every single run and re-upload archives the cache already
+      # holds, which is the churn this is meant to remove. bookworm and trixie
+      # each own exactly one entry, for as long as the manifest is unchanged.
       #
-      # The OS stays because bookworm and trixie genuinely differ -- see the
-      # restore step above: bookworm fetches libdisplay-info on top of the
-      # scanner, trixie fetches the scanner alone. Collapsing them too would
-      # let whichever job saved first decide what the whole matrix restores,
-      # and a trixie job winning that race leaves every bookworm job in the
-      # next run re-downloading libdisplay-info with no way to cache it.
+      # A stable key cannot be overwritten, though -- actions/cache/save
+      # refuses a key that exists -- so a partial set saved by a failed run
+      # would own it until the manifest hash changed, and the flaky download
+      # the cache exists to absorb would be the one thing never cached. Hence
+      # the split: a green build means emb fetched everything, so that set
+      # claims the stable key; anything less is kept under a run-scoped key
+      # that the restore step reaches only as a fallback. Failure runs churn;
+      # green runs do not.
       #
-      # pios precedes the run id so the restore step's prefix still matches:
-      # restore-keys are prefixes, and a run id in front of the OS would hide
-      # it from them.
-      #
-      # The thirteen jobs sharing an OS now write the same key. The first wins
+      # The thirteen jobs sharing an OS all write the same key. The first wins
       # and the rest log "unable to reserve cache", which is the expected
-      # outcome rather than a failure -- they were writing identical archives.
+      # outcome rather than a failure -- they were writing identical archives,
+      # and the oras cache in this workflow already behaves this way.
       - name: Save augment sources
-        if: always()
+        if: steps.build.outcome == 'success'
         uses: actions/cache/save@v6
         with:
           path: |
@@ -451,7 +460,22 @@ jobs:
             /emb/.config/flutter_workspace/overlay-src/*.tar.bz2
             /emb/.config/flutter_workspace/overlay-src/*.tgz
             /emb/.config/flutter_workspace/overlay-src/*.zip
-          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ matrix.pios }}-${{ github.run_id }}
+          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ matrix.pios }}
+
+      # always(): the point is to keep what a failed run managed to fetch, so
+      # each attempt leaves the next one better off. Run-scoped so it never
+      # claims the stable key above.
+      - name: Save partial augment sources
+        if: always() && steps.build.outcome != 'success'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            /emb/.config/flutter_workspace/overlay-src/*.tar.gz
+            /emb/.config/flutter_workspace/overlay-src/*.tar.xz
+            /emb/.config/flutter_workspace/overlay-src/*.tar.bz2
+            /emb/.config/flutter_workspace/overlay-src/*.tgz
+            /emb/.config/flutter_workspace/overlay-src/*.zip
+          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ matrix.pios }}-partial-${{ github.run_id }}
 
       - name: Upload homescreen binary
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -312,8 +312,24 @@ jobs:
       # for wayland-cxx-scanner and failed the build, and emb's own four
       # retries had already been spent. Keyed on the augment definitions, so a
       # new or bumped source misses and refetches; every other run stays off
-      # the network entirely. Not keyed on the OS -- the sources are the same
-      # archives for every target, so one entry serves the whole matrix.
+      # the network entirely.
+      #
+      # Keyed on the OS too, because bookworm and trixie do not fetch the same
+      # set. bookworm cross-builds libdisplay-info 0.2.0 -- it ships 0.1.1 and
+      # drm-cxx needs >= 0.2.0 -- while trixie takes libdisplay-info-dev from
+      # apt and declares `augment: [*augment_scanner]` alone. Two archives
+      # against one. This comment used to claim the opposite, and the claim was
+      # wrong in a way the restore-keys fallback below acts on: a bookworm job
+      # matching a trixie entry starts one archive short of what it needs.
+      # The OS-specific prefix is tried first for that reason; the bare
+      # `emb-augment-src-` below stays as a last resort, where restoring the
+      # one shared archive still beats restoring nothing.
+      #
+      # Board and backend are genuinely uniform. Every board aliases the same
+      # augment list, and the only backend-sensitive augments (sentry-native,
+      # accesskit-c) sit behind BUILD_CRASH_HANDLER / BUILD_ACCESSKIT, which
+      # this workflow never passes.
+      #
       # Restore and save are separate so the save can run after a failed
       # build. actions/cache skips saving when the job fails, which for a
       # cache whose whole purpose is to stop a flaky download would be a
@@ -329,8 +345,9 @@ jobs:
             /emb/.config/flutter_workspace/overlay-src/*.tar.bz2
             /emb/.config/flutter_workspace/overlay-src/*.tgz
             /emb/.config/flutter_workspace/overlay-src/*.zip
-          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}
+          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ matrix.pios }}
           restore-keys: |
+            emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ matrix.pios }}
             emb-augment-src-
 
       # The image bakes the toolchain + sysroot at /emb, so -w /emb resolves as
@@ -404,17 +421,26 @@ jobs:
       # The key carries a run id so a partial set never claims to be the
       # complete one; restore-keys above picks up the newest either way.
       #
-      # It carries nothing else. The archives do not vary by board, OS or
-      # backend -- the restore above says as much, and is keyed on the manifest
-      # alone -- so adding the matrix dimensions here multiplied one entry per
-      # run into twenty-six identical ones. That is not merely untidy: the
-      # repository cache is a fixed budget with least-recently-used eviction,
-      # so the duplicates evict the entries this workflow depends on, including
-      # each other.
+      # It carries the OS, and nothing else. The archives do not vary by board
+      # or backend, so those two multiplied one entry per OS into thirteen
+      # identical ones apiece. That is not merely untidy: the repository cache
+      # is a fixed budget with least-recently-used eviction, so the duplicates
+      # evict the entries this workflow depends on, including each other.
       #
-      # Every job in a run now writes the same key. The first wins and the rest
-      # log "unable to reserve cache", which is the expected outcome rather
-      # than a failure -- they were all writing identical archives.
+      # The OS stays because bookworm and trixie genuinely differ -- see the
+      # restore step above: bookworm fetches libdisplay-info on top of the
+      # scanner, trixie fetches the scanner alone. Collapsing them too would
+      # let whichever job saved first decide what the whole matrix restores,
+      # and a trixie job winning that race leaves every bookworm job in the
+      # next run re-downloading libdisplay-info with no way to cache it.
+      #
+      # pios precedes the run id so the restore step's prefix still matches:
+      # restore-keys are prefixes, and a run id in front of the OS would hide
+      # it from them.
+      #
+      # The thirteen jobs sharing an OS now write the same key. The first wins
+      # and the rest log "unable to reserve cache", which is the expected
+      # outcome rather than a failure -- they were writing identical archives.
       - name: Save augment sources
         if: always()
         uses: actions/cache/save@v6
@@ -425,7 +451,7 @@ jobs:
             /emb/.config/flutter_workspace/overlay-src/*.tar.bz2
             /emb/.config/flutter_workspace/overlay-src/*.tgz
             /emb/.config/flutter_workspace/overlay-src/*.zip
-          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ github.run_id }}
+          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ matrix.pios }}-${{ github.run_id }}
 
       - name: Upload homescreen binary
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -403,6 +403,18 @@ jobs:
       # always(): the point is to keep what a failed run managed to fetch.
       # The key carries a run id so a partial set never claims to be the
       # complete one; restore-keys above picks up the newest either way.
+      #
+      # It carries nothing else. The archives do not vary by board, OS or
+      # backend -- the restore above says as much, and is keyed on the manifest
+      # alone -- so adding the matrix dimensions here multiplied one entry per
+      # run into twenty-six identical ones. That is not merely untidy: the
+      # repository cache is a fixed budget with least-recently-used eviction,
+      # so the duplicates evict the entries this workflow depends on, including
+      # each other.
+      #
+      # Every job in a run now writes the same key. The first wins and the rest
+      # log "unable to reserve cache", which is the expected outcome rather
+      # than a failure -- they were all writing identical archives.
       - name: Save augment sources
         if: always()
         uses: actions/cache/save@v6
@@ -413,7 +425,7 @@ jobs:
             /emb/.config/flutter_workspace/overlay-src/*.tar.bz2
             /emb/.config/flutter_workspace/overlay-src/*.tgz
             /emb/.config/flutter_workspace/overlay-src/*.zip
-          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ github.run_id }}-${{ matrix.board }}-${{ matrix.pios }}-${{ matrix.backend }}
+          key: emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ github.run_id }}
 
       - name: Upload homescreen binary
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The augment **save** key carried the board, OS, backend and run id:

```
emb-augment-src-<hash>-${{ github.run_id }}-${{ matrix.board }}-${{ matrix.pios }}-${{ matrix.backend }}
```

All **26 build jobs wrote their own entry, every run** — and because `run_id`
is unique per run, none of those entries was ever reused by key. The key is now
the manifest hash and the OS:

```
emb-augment-src-<hash>-${{ matrix.pios }}
```

**Two entries total**, for as long as the manifest is unchanged, instead of 26
more per run.

## Why the OS stays and board/backend go

bookworm and trixie do not fetch the same set:

```yaml
augment: &augment_bookworm
  - pkg: libdisplay-info        # 0.2.0 tarball
  - &augment_scanner
    pkg: wayland-cxx-scanner
...
rpi5-trixie:  augment: [*augment_scanner]
```

bookworm cross-builds libdisplay-info 0.2.0 (it ships 0.1.1 and drm-cxx needs
`>= 0.2.0`); trixie takes `libdisplay-info-dev` from apt and declares the
scanner alone. Two archives against one. Collapsing the OS as well would let
whichever job saved first decide what the whole matrix restores, and a trixie
job winning that race leaves every bookworm job re-downloading libdisplay-info
with no way to cache it.

Board and backend are uniform: every board aliases the same augment list, and
the only backend-sensitive augments (`sentry-native`, `accesskit-c`) sit behind
`BUILD_CRASH_HANDLER` / `BUILD_ACCESSKIT`, which this workflow never passes.

## Why the save splits in two

A stable key cannot be overwritten — `actions/cache/save` refuses a key that
exists — and the save runs under `always()`, so the first write could be the
partial set left by a run whose download failed. That set would then own the key
until the manifest hash changed, and the flaky download this cache exists to
absorb would be the one thing it never held.

So a green build (emb fetched everything) claims the stable key, and anything
less is written under `-partial-<run id>`. The restore step tries the exact key
first and reaches the partials only through its prefix fallback, so a partial
never shadows a complete set however recently it was written. Failure runs
churn; green runs do not.

## Corrections to the first draft of this PR

- **The run id.** Removing the matrix dimensions still left `github.run_id`,
  which is unique per run — so the "one entry per run" version still minted two
  fresh entries every run and re-uploaded archives the cache already had. That
  is the churn this was supposed to remove.
- **The OS.** The first version dropped `matrix.pios` too, on the strength of
  the restore step's comment that "the sources are the same archives for every
  target". That comment was wrong, and with `restore-keys` in play it was wrong
  in a way the workflow acted on. It is corrected here rather than cited.
- **The eviction argument was overstated.** These archives are small (the
  scanner tarball is 428 KB), so 26 duplicates per run were not meaningfully
  crowding out the multi-GB `emb-store` entries. The honest cost is entry churn
  and uploading the same bytes 26 times a run.

## Not touched

`emb-store` (2 entries, keyed on `pios` in the publish job) and the two `oras`
binary caches are correctly scoped and left alone.