### PR TITLE
ci: describe the published image as the build env it is

### DIFF
--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -1,15 +1,36 @@
 ---
-# Cross-compiled PiOS (aarch64) artifacts via emb + a prebuilt toolchain image.
+# Cross-compiled PiOS (aarch64) artifacts via emb + a prebuilt build-env image.
 #
 # Two phases:
-#   publish-<os>  (per PiOS variant) — emb resolves the toolchain + sysroot and
-#                 publishes a content-addressed OCI image to GHCR. The emb cross
-#                 sandbox is cached, and `emb cross --publish` skips the build
-#                 when the image (keyed by the manifest's sysroot_key) already
-#                 exists, so this is a near-no-op once warm.
-#   build-...     (per board x os x backend) — runs INSIDE the published image,
-#                 where `emb cross --build -w /emb` is a pure cache hit on the
-#                 baked toolchain + sysroot. No per-run toolchain/sysroot fetch.
+#   publish-<os>  (per PiOS variant) — emb resolves the toolchain + sysroot,
+#                 pushes them to the content-addressed store (oras/OCI), and
+#                 publishes a build-env image to GHCR. `emb cross --publish`
+#                 skips the image build when the tag (keyed by the manifest's
+#                 sysroot_key plus the toolset) already exists, so this is a
+#                 near-no-op once warm.
+#   build-...     (per board x os x backend) — runs INSIDE the published image
+#                 and builds one backend.
+#
+# What that image is, precisely, because it is easy to assume otherwise: a
+# build *environment* and nothing more. `emb cross --dockerfile` emits
+# `FROM debian:bookworm-slim` plus cmake/ninja/meson/build-essential and the
+# codegen tools, with an empty build context -- see ToolchainImage.dockerfile
+# in emb_cli, which states it outright: "The cross toolchain and sysroot are
+# fetched from the shared cache / resolved at build time, not baked in."
+#
+# So three separate things are cached here, at three layers, and only the first
+# is the image:
+#   1. the image itself (GHCR)          -- host build tooling
+#   2. the store (oras/OCI)             -- resolved sysroot + toolchain, pulled
+#                                          per build job
+#   3. the augment sources (actions/cache) -- see the restore step below
+#
+# The augment libraries (libdisplay-info, wayland-cxx-scanner) are in none of
+# them: emb rebuilds them into the sysroot at consume time, so all 26 build
+# jobs repeat that work every run. Publishing the prepared overlay alongside
+# the store would remove both the source fetch and the rebuild, and would make
+# layer 3 deletable. Until then the source cache is what keeps the fetch off
+# the network.
 #
 # Runs on x86_64 runners: the pinned ARM toolchains cross-compile aarch64 (no
 # emulation). Hardware facts live in emb's board library; this repo's
@@ -356,9 +377,11 @@ jobs:
             emb-augment-src-${{ hashFiles('ivi-homescreen/.emb/base.emb.yaml', 'ivi-homescreen/.emb/raspberry-pi.emb.yaml') }}-${{ matrix.pios }}
             emb-augment-src-
 
-      # The image bakes the toolchain + sysroot at /emb, so -w /emb resolves as
-      # a pure cache hit (no download/extract). Host build tools (cmake, ninja,
-      # meson, wayland-scanner) are baked too; only the augment libs rebuild.
+      # -w /emb resolves as a cache hit because emb oras-pulls the sysroot +
+      # toolchain from EMB_CACHE_REGISTRY as part of this step, not because the
+      # image carries them -- the image is host build tooling only (see the
+      # header). The augment libs are cross-built here too, in every one of the
+      # 26 jobs.
       - name: Build ${{ matrix.backend }}
         # id: the save steps below key off whether this succeeded, which is
         # what tells a complete set of fetched archives from a partial one.


### PR DESCRIPTION
Comments only. No workflow behavior changes.

## The claim that was wrong

The header said the build jobs run

> INSIDE the published image, where `emb cross --build -w /emb` is a pure cache
> hit on the **baked toolchain + sysroot**. No per-run toolchain/sysroot fetch.

and the Build step repeated it. Nothing is baked. `emb cross --dockerfile`
emits:

```dockerfile
FROM debian:bookworm-slim
RUN apt-get install -y cmake ninja-build meson build-essential pkg-config hwdata \
      tar xz-utils rsync ca-certificates libwayland-bin git curl <host_dev_packages>
ENV FLUTTER_WORKSPACE=/emb
```

with an empty build context — `ToolchainImage.dockerignore()` exists so that
nothing is copied in. Its own doc comment states it: *"The cross toolchain and
sysroot are fetched from the shared cache / resolved at build time, not baked
in."*

## What actually happens

Three cache layers, where the comments described one:

| Layer | Holds | Fetched by |
|---|---|---|
| GHCR image | host build tooling | `container:` on the build job |
| oras/OCI store | resolved sysroot + toolchain | emb, during the Build step |
| actions/cache | augment source archives | the restore step |

## Why it matters rather than being pedantry

The augment libraries are in **none** of the three. emb rebuilds them into the
sysroot at consume time, so all 26 build jobs fetch the same two archives and
cross-build libdisplay-info and the wayland-cxx-scanner, every run. The source
cache tuned in #477 removes the download and nothing else.

Reading the old comments, that arrangement looks far more optimized than it is
— which is exactly the confusion that made #477 need three passes. The header
now names the three layers, says the augments sit outside all of them, and
records that publishing the prepared overlay alongside the store would remove
the rebuild as well and make the source cache deletable.