### PR TITLE
shared: make ihs_pv_assets_path a weak import for plugins

### DIFF
--- a/shared/include/ihs/platform_view.h
+++ b/shared/include/ihs/platform_view.h
@@ -57,6 +57,34 @@
 
 #include "ihs/ihs_export.h"
 
+/*
+ * An entry point a plugin may be built against but run without.
+ *
+ * A plugin links libihs_shared and is dlopen'd by the shell it finds at run
+ * time, which is not always the one it was built against. A normal reference
+ * to a symbol the running shell lacks fails the relocation, and the loader
+ * rejects the whole plugin -- so an entry point documented as "NULL on an
+ * older shell" could never actually report that, because nothing of the plugin
+ * ran. Declaring the import weak makes the address NULL instead, which the
+ * plugin can test.
+ *
+ * Consumers only: inside the library the definition stays strong.
+ *
+ * The test is on the symbol, not the return value, and both matter:
+ *
+ *     if (ihs_pv_assets_path) {
+ *       const char* p = ihs_pv_assets_path();   // may still be NULL
+ *     }
+ *
+ * Calling through the null address instead of testing it is a crash, so a
+ * plugin that skips the guard is worse off than before.
+ */
+#if defined(__GNUC__) && !defined(ihs_shared_EXPORTS)
+#define IHS_WEAK_IMPORT __attribute__((weak))
+#else
+#define IHS_WEAK_IMPORT
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -215,16 +243,22 @@ IHS_EXPORT int ihs_pv_query_capabilities(IhsPvCapabilities* out);
 
 /*
  * Absolute path to the running bundle's flutter_assets directory, or NULL if
- * the shell is older than this entry point, has no host installed, or has not
- * resolved a bundle. Borrowed: owned by the shell and valid for the engine's
- * lifetime; copy it if you need to outlive the call.
+ * the shell has no host installed or has not resolved a bundle. Borrowed:
+ * owned by the shell and valid for the engine's lifetime; copy it if you need
+ * to outlive the call.
  *
  * A plugin that resolves its own assets by relative path needs this. The
  * compositor-surface path receives the directory as an initialize() argument;
  * the platform-view path had no equivalent, so such a plugin had nothing to
  * resolve against.
+ *
+ * Added after 1.0, so a shell can predate it. IHS_WEAK_IMPORT (see above)
+ * makes that case a null symbol rather than a failed load; test the symbol
+ * before calling it:
+ *
+ *     const char* p = ihs_pv_assets_path ? ihs_pv_assets_path() : NULL;
  */
-IHS_EXPORT const char* ihs_pv_assets_path(void);
+IHS_EXPORT IHS_WEAK_IMPORT const char* ihs_pv_assets_path(void);
 
 /*
  * The backend's Vulkan objects, offered to a plugin that renders on a Vulkan


### PR DESCRIPTION
`ihs_pv_assets_path` documents:

> or NULL if **the shell is older than this entry point**, has no host
> installed, or has not resolved a bundle

A plugin could never observe the first case. A plugin links libihs_shared and
is `dlopen`'d by whatever shell it finds at run time, which need not be the one
it was built against. An ordinary reference to a symbol the running shell lacks
fails the relocation, so an older shell does not hand the plugin a NULL — the
loader rejects the plugin whole, before any of its code runs.

## Reproduction

Two libraries with the same SONAME, one exporting the symbol and one not; a
plugin built against the first, then loaded with each on the path:

```
=== NEW shell (symbol present) ===
plugin_strong.so:   assets=/bundle/flutter_assets   dlopen ok
plugin_weak.so:     assets=/bundle/flutter_assets   dlopen ok

=== OLD shell (symbol absent) ===
plugin_strong.so:   dlopen FAILED: undefined symbol: ihs_pv_assets_path
plugin_weak.so:     assets=(null -- older shell, took the documented path)  dlopen ok
```

## The change

`IHS_WEAK_IMPORT` applies to consumers only, keyed on `ihs_shared_EXPORTS`, so
the definition inside the library stays strong. Confirmed on a real build of
`shared/`:

| side | symbol |
|---|---|
| `libihs_shared.so.1.0.0` | `FUNC GLOBAL DEFAULT 4 ihs_pv_assets_path` |
| consumer object | `NOTYPE WEAK DEFAULT UND ihs_pv_assets_path` |

The exported ABI is unchanged.

## The part that needs saying out loud

Weak linkage nulls the **symbol**, not the return value, so the guard is on the
symbol:

```c
const char* p = ihs_pv_assets_path ? ihs_pv_assets_path() : NULL;
```

A plugin that skips the guard and calls through the null address crashes —
strictly worse than the failed load it replaces. Both the macro comment and the
entry point state that and show the idiom, and the "older shell" clause moves
out of the return-value description, since it is now a property of the symbol
rather than of the value.

`IHS_WEAK_IMPORT` is written to be reusable: any entry point added after 1.0
that a plugin should tolerate the absence of can take it.

The consumer-side fix in fluorite (guarding its one call site) follows
separately; that plugin is the reason this surfaced — an older shell killed it
outright instead of letting it log "no asset root from the shell" and carry on.