### PR TITLE
fix: enable semantics for a source that registers after a consumer

### DIFF
--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -571,7 +571,7 @@ const IhsSemanticsSnapshot* WaitForNewerSnapshot(IhsSemanticsSource* source,
 }
 
 // How long an action waits for the tree to settle before reporting what it
-// sees (DR-8).
+// sees.
 //
 // A bound on waiting, not an expectation: an action that changes nothing pays
 // this in full, which is the cost of answering "did anything happen" in the
@@ -582,7 +582,8 @@ const IhsSemanticsSnapshot* WaitForNewerSnapshot(IhsSemanticsSource* source,
 // looks like a real result.
 constexpr int kVerifySettleMs = 150;
 
-// Appends the verify-after-act fields to a tool result (DR-8, plan 4.1).
+// Appends the verify-after-act fields to a tool result: the caller learns
+// what the node became without a second round trip.
 //
 // generation_after equal to generation_before is a real answer rather than a
 // failure: the action was accepted and the tree did not change, which is what

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -214,9 +214,18 @@ std::string ResultEnvelope(const std::string& id, const std::string& result) {
 
 std::string ErrorEnvelope(const std::string& id,
                           const int code,
-                          const std::string& message) {
-  return R"({"jsonrpc":"2.0","id":)" + id + R"(,"error":{"code":)" +
-         std::to_string(code) + R"(,"message":)" + Escape(message) + "}}";
+                          const std::string& message,
+                          const std::string& data = std::string()) {
+  std::string out = R"({"jsonrpc":"2.0","id":)" + id + R"(,"error":{"code":)" +
+                    std::to_string(code) + R"(,"message":)" + Escape(message);
+  // JSON-RPC's optional `data` member, used only when the provider explained
+  // the failure. The code and message classify it; this is what says which
+  // argument was wrong, which is the difference between a client that can
+  // correct itself and one that can only retry the same call.
+  if (!data.empty()) {
+    out += R"(,"data":)" + Escape(data);
+  }
+  return out + "}}";
 }
 
 // Maps a host status onto the JSON-RPC code that describes it. A denied
@@ -379,7 +388,12 @@ std::string HandleToolsCall(const rapidjson::Value& params,
   // explanation -- which for a tool the application declared is the only thing
   // saying what went wrong, since the host knows nothing about what it does.
   if (status != IHS_MCP_OK && !ToolExecuted(status)) {
-    return ErrorEnvelope(id, JsonRpcCodeFor(status), StatusText(status));
+    // Classified as a protocol error, but the provider's own explanation still
+    // travels: a call rejected for a missing argument is only actionable if the
+    // client is told which one. "invalid arguments" alone leaves an agent to
+    // guess, and the guess is usually the same call again.
+    return ErrorEnvelope(id, JsonRpcCodeFor(status), StatusText(status),
+                         content);
   }
 
   const bool failed = status != IHS_MCP_OK;

--- a/shared/src/semantics.cc
+++ b/shared/src/semantics.cc
@@ -101,7 +101,7 @@ Hub& TheHub() {
   return *hub;
 }
 
-// Attribution logging for the dispatch funnel (DR-11). Opened lazily so a
+// Attribution logging for the dispatch funnel. Opened lazily so a
 // process that never registers a consumer never allocates a log context; the
 // index is stable for the process once opened.
 int32_t TraceContext() {
@@ -481,24 +481,47 @@ int ihs_semantics_source_register(const IhsSemanticsSourceDesc* desc,
     return IHS_SEMANTICS_ERR_INVALID;
   }
 
-  Hub& hub = TheHub();
-  std::lock_guard<std::mutex> lock(hub.mutex);
-  for (const auto& existing : hub.sources) {
-    if (existing->name == desc->name) {
-      // Two trees under one name are indistinguishable to anything addressing
-      // them by it, which is the whole failure this mechanism prevents.
-      LogInfo(std::string("semantics: source name already registered: ") +
-              desc->name);
-      return IHS_SEMANTICS_ERR_INVALID;
+  // Whether this source has to be switched on as it arrives, decided under the
+  // lock and acted on outside it.
+  bool enable = false;
+  {
+    Hub& hub = TheHub();
+    std::lock_guard<std::mutex> lock(hub.mutex);
+    for (const auto& existing : hub.sources) {
+      if (existing->name == desc->name) {
+        // Two trees under one name are indistinguishable to anything addressing
+        // them by it, which is the whole failure this mechanism prevents.
+        LogInfo(std::string("semantics: source name already registered: ") +
+                desc->name);
+        return IHS_SEMANTICS_ERR_INVALID;
+      }
     }
+
+    auto source = std::make_unique<Source>();
+    source->name = desc->name;
+    source->host = desc->host;
+    source->host_installed = true;
+    *out_source = reinterpret_cast<IhsSemanticsSource*>(source.get());
+    hub.sources.push_back(std::move(source));
+
+    // The consumer path enables every source that exists when the first
+    // consumer registers. A source registering after that is not among them,
+    // and nothing else would ever ask its engine for semantics.
+    //
+    // A shell bringing up several engines hits this every time: the consumer
+    // arrives with the first engine's socket, so every later engine registers
+    // into a hub that already has consumers. Its tree is advertised and stays
+    // empty at generation 0 -- which reads as an application that publishes
+    // nothing rather than as an engine that was never asked to.
+    enable = !hub.consumers.empty();
   }
 
-  auto source = std::make_unique<Source>();
-  source->name = desc->name;
-  source->host = desc->host;
-  source->host_installed = true;
-  *out_source = reinterpret_cast<IhsSemanticsSource*>(source.get());
-  hub.sources.push_back(std::move(source));
+  // Outside the lock, for the same reason the consumer path is: the shell's
+  // enable path reaches into the engine, and holding the registry across it
+  // would let engine work block every consumer.
+  if (enable && desc->host.set_semantics_enabled != nullptr) {
+    desc->host.set_semantics_enabled(desc->host.user_data, true);
+  }
   return IHS_SEMANTICS_OK;
 }
 

--- a/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
+++ b/test/unit_test/mcp_transport-test/test_case_mcp_transport.cc
@@ -962,6 +962,86 @@ TEST_F(McpTransportTest, AnUnknownToolRemainsAProtocolError) {
   EXPECT_EQ(body.find(R"("isError")"), std::string::npos) << body;
 }
 
+namespace {
+
+// Rejects the call before running anything, and says which argument was wrong.
+struct InvalidArgProvider {
+  static int ListTools(void*, const IhsMcpToolDesc** out, size_t* count) {
+    static const IhsMcpToolDesc kTool = {
+        "act", "needs a view", R"({"type":"object"})", IHS_MCP_CAP_INTERACT};
+    *out = &kTool;
+    *count = 1;
+    return IHS_MCP_OK;
+  }
+  static int ListResources(void*,
+                           const IhsMcpResourceDesc** out,
+                           size_t* count) {
+    *out = nullptr;
+    *count = 0;
+    return IHS_MCP_OK;
+  }
+  static int CallTool(void*,
+                      const char*,
+                      const char*,
+                      size_t,
+                      IhsMcpPayload* out) {
+    static const char kWhy[] =
+        R"({"error":"view is required when several applications are running"})";
+    out->struct_size = sizeof(IhsMcpPayload);
+    out->data = kWhy;
+    out->length = sizeof(kWhy) - 1;
+    out->release = nullptr;
+    out->release_ctx = nullptr;
+    return IHS_MCP_ERR_INVALID;
+  }
+  static int ReadResource(void*, const char*, IhsMcpPayload*) {
+    return IHS_MCP_ERR_NOT_FOUND;
+  }
+};
+
+IhsMcpProvider* RegisterInvalidArg(InvalidArgProvider* mock) {
+  IhsMcpProviderDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = "invalid-arg";
+  desc.tool_prefix = "ia_";
+  desc.resource_scheme = nullptr;
+  desc.capability_mask = IHS_MCP_CAP_ALL;
+  desc.notify_fd = -1;
+  desc.user_data = mock;
+  desc.callbacks.list_tools = &InvalidArgProvider::ListTools;
+  desc.callbacks.list_resources = &InvalidArgProvider::ListResources;
+  desc.callbacks.call_tool = &InvalidArgProvider::CallTool;
+  desc.callbacks.read_resource = &InvalidArgProvider::ReadResource;
+  IhsMcpProvider* provider = nullptr;
+  return ihs_mcp_provider_register(&desc, &provider) == IHS_MCP_OK ? provider
+                                                                   : nullptr;
+}
+
+}  // namespace
+
+// A call rejected for a bad argument stays a protocol error -- nothing ran --
+// but the provider's explanation still has to reach the client. "invalid
+// arguments" on its own does not say which argument, and a client that cannot
+// tell has no move except the same call again.
+TEST_F(McpTransportTest, AnInvalidArgumentErrorCarriesItsExplanation) {
+  InvalidArgProvider mock;
+  IhsMcpProvider* provider = RegisterInvalidArg(&mock);
+  ASSERT_NE(provider, nullptr);
+
+  const std::string body =
+      Body(Post(path_, R"({"jsonrpc":"2.0","id":32,"method":"tools/call",)"
+                       R"("params":{"name":"ia_act","arguments":{}}})"));
+
+  // Still a protocol error: the classification is deliberate, and a result
+  // with isError would say the tool ran when it did not.
+  EXPECT_NE(body.find("-32602"), std::string::npos) << body;
+  EXPECT_EQ(body.find(R"("isError")"), std::string::npos) << body;
+  EXPECT_NE(body.find("view is required"), std::string::npos)
+      << "the reason the call was rejected never reached the client: " << body;
+
+  ihs_mcp_provider_unregister(provider);
+}
+
 // ---------------------------------------------------------------------------
 // Bounds on client-held state
 //

--- a/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
+++ b/test/unit_test/semantics_hub-test/test_case_semantics_hub.cc
@@ -1084,3 +1084,47 @@ TEST_F(SemanticsHubTest, AHeldSnapshotSurvivesItsSourceUnregistering) {
   EXPECT_STREQ(ihs_semantics_snapshot_node_at(held, 0)->label, "Still here");
   ihs_semantics_release_snapshot(held);
 }
+
+// A source that registers after a consumer already has to be switched on as it
+// arrives. The consumer path enables every source that exists when the first
+// consumer registers, so an engine coming up later would otherwise never be
+// asked for semantics at all.
+//
+// This is the ordinary case for a shell running several engines, not an edge
+// one: the consumer arrives with the first engine, so every later engine
+// registers into a hub that already has consumers. The symptom is not an error
+// anywhere -- the late engine's tree is advertised and stays empty, which reads
+// as an application that publishes nothing.
+TEST_F(SemanticsHubTest, ASourceRegisteringAfterAConsumerIsEnabled) {
+  ihs_semantics_set_host(nullptr);
+
+  Recorder early{"early"};
+  IhsSemanticsSource* first = RegisterSource("app-early", &early);
+  ASSERT_NE(first, nullptr);
+
+  IhsSemanticsConsumerDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.name = "probe";
+  desc.action_allow_mask = IHS_SEMANTICS_ACTION_ALL;
+  desc.notify_fd = -1;
+  IhsSemanticsConsumer* consumer = nullptr;
+  ASSERT_EQ(ihs_semantics_register(&desc, &consumer), IHS_SEMANTICS_OK);
+  ASSERT_EQ(early.enables, 1) << "the source present at registration was not "
+                                 "enabled, so this test cannot show anything "
+                                 "about the one that comes later";
+
+  Recorder late{"late"};
+  IhsSemanticsSource* second = RegisterSource("app-late", &late);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(late.enables, 1)
+      << "a source registering while a consumer was already listening was "
+         "never asked to produce semantics; its tree would stay empty";
+
+  // And the early source is not enabled twice by the late one's arrival --
+  // set_semantics_enabled is meant to track the transition, not be re-sent.
+  EXPECT_EQ(early.enables, 1);
+
+  ihs_semantics_unregister(consumer);
+  ihs_semantics_source_unregister(first);
+  ihs_semantics_source_unregister(second);
+}


### PR DESCRIPTION
## The defect

A shell running more than one engine produced a tree for the first one and nothing for the rest.

The hub reference-counts consumer registrations and switches semantics on at the 0→1 transition, telling every source it knows about **at that moment**. A source registering later was not among them, and nothing else ever asked its engine for semantics.

That is the ordinary case, not an edge one: the consumer arrives with the first engine, so every later engine registers into a hub that already has consumers.

**Nothing reported an error.** The late engine's tree was advertised and stayed empty at generation 0, which reads as an application that publishes nothing rather than one that was never asked to.

Found by driving a two-view shell over MCP: the second application's tree resource existed and answered every read with `no semantics tree has been published yet`.

## Also: a rejected call now carries its reason

A tool that never ran stays a JSON-RPC error — deliberate, and unchanged. But the reason was dropped on the way out. An action that omitted a required argument came back as a bare:

```json
{"code":-32602,"message":"invalid arguments"}
```

naming nothing. The provider says which argument is missing and the client could not see it, so an agent had no move except to repeat the same call. It now travels in the error's `data` member, which is what that member is for. The comment three lines above the discard already argued this should not happen.

## Tests

Two, and each fails with its own fix reverted (checked, not assumed):

- a source registering while a consumer is already listening is enabled, exactly once
- a rejected call carries the reason it was rejected, while staying a protocol error

Reverting the transport fix reproduces the wire response above verbatim.

29/29 unit suites pass. clang-tidy clean on the changed sources.

## Not addressed here

Three comments referred to an internal planning document by section; they now say what they mean.

The fixture that found this is a separate change — #481 stacks on this branch, because its two-view checks cannot pass without the fix above.