### PR TITLE
test: make the MCP drive fixture read its results, and cover several applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ packages/*/.dart_tool/
 packages/*/pubspec.lock
 packages/*/.packages
 test/integration/*/build/
+# Assembled bundles: the READMEs tell you to build one here, and it holds an
+# engine shared object and icudtl, so it is tens of megabytes of build output.
+test/integration/*/bundle/
 test/integration/*/pubspec.lock
 
 # Python bytecode from the fixture drivers.

--- a/test/integration/mcp_drive_test/README.md
+++ b/test/integration/mcp_drive_test/README.md
@@ -42,10 +42,28 @@ layout that breaks the first time a font or a screen size changes.
 | --- | --- | --- |
 | C1 | tree | The app is described: status, Save, Locked and Destination are present, and Save offers `tap`. Checked first and separately — an empty tree means semantics never came up, which is a different fault from a dispatch not working |
 | C2 | dispatch | `ui_tap` invokes **the widget's own handler**. This is the claim the mock-host tests cannot make: they end where the shell begins |
-| C3 | set_text | `ui_set_text` reaches the field's editing connection and replaces its contents. This is plan R-9's stated exit criterion, and nothing else in the suite covers it |
+| C3 | set_text | `ui_set_text` reaches the field's editing connection and replaces its contents. Nothing else in the suite covers it |
 | C4a | exclusion | The `ExcludeSemantics` region is absent from the tree, so `ui_tap` has nothing to address |
-| C4b | pointer | `ui_tap_at` at that region's rect reaches it anyway. C4a and C4b together are the DR-7 contrast, demonstrated rather than argued |
+| C4b | pointer | `ui_tap_at` at that region's rect reaches it anyway. C4a and C4b together show the contrast a dispatch cannot cross but a pointer can, demonstrated rather than argued |
 | C5 | enabled gate | A disabled control is refused **and never reaches the widget** — the framework drops such an action silently, so a client would otherwise see success and no effect |
+| C6 | flow | A multi-step flow driven only by what an agent can see: a control found by role and offered action, moved twice, then a custom action invoked by its label. Each step is verified from the action's own reply rather than by re-reading the tree |
+| C7 | app tool | A tool the application declared, with its schema. The semantics verbs cannot express this — an agent names the value it wants instead of working out how many increments reach it |
+
+C8–C11 run only when more than one application is live, because addressing is
+the thing they cover and it does not exist with one:
+
+| # | Check | What it validates |
+| --- | --- | --- |
+| C8 | addressing | Every application has its own tree resource, under a distinct name. Two sharing a name would leave neither addressable |
+| C9 | routing | An action naming one application reaches **only** it. Both run the same bundle, so both have a node of the same id — the collision that makes an unaddressed dispatch land in the wrong place |
+| C10 | refusal | An action naming no application is refused, and the refusal says a view was needed. An agent that omitted the argument has to be able to learn it exists |
+| C11 | spanning read | A read naming none searches every application and says which one each result came from, since an agent hunting for a control does not yet know who owns it |
+
+The names are the shell's own, not this fixture's: it derives them from the
+bundle directory, disambiguating a collision with an index. That is why these
+checks discover them instead of asserting them — the unit tests cover the
+addressing logic with names they chose, and the derivation is the part only a
+real shell can show.
 
 ## The app must be composited, or nothing works
 
@@ -86,7 +104,7 @@ cmake -B build/mcp -GNinja \
 ninja -C build/mcp
 
 emb -v cross . --backend software --build      # or your usual bundle step
-./build/mcp/shell/ivi-homescreen -b <bundle> --enable-mcp
+./build/mcp/shell/homescreen -b <bundle> --enable-mcp
 ```
 
 Then, in another terminal:
@@ -99,12 +117,32 @@ It prints one line per check and exits non-zero if any failed. The socket
 defaults to `$XDG_RUNTIME_DIR/ivi-homescreen/mcp.sock`; pass `--socket` to
 point at another, including one forwarded from a board over ssh.
 
+### With more than one application
+
+`--bundle` is repeatable, and each one gets its own engine and its own tree, so
+the same bundle twice is enough to exercise addressing — and it is the harder
+case, because both then derive the same name and the shell has to disambiguate:
+
+```bash
+./build/mcp/shell/homescreen -b <bundle> -b <bundle> --enable-mcp
+```
+
+The driver discovers how many are running and adapts: with one it leaves the
+view argument off, which is the case the shell allows to go unqualified; with
+several it names one for C1–C7 and adds C8–C11. No extra flag.
+
+Two surfaces make the presentation problem above sharper rather than milder.
+Under a headless compositor only one is generally composited, so checks against
+the other time out with its status frozen — the failure looks identical to a
+broken dispatch. Confirm both are presenting before reading a two-view failure
+as a defect: tap one control twice and watch `events` climb.
+
 ## Why the driver keys on label and role, not identifier
 
 The app sets `identifier` on every control, and the driver prefers it when the
 engine reports one — but it matches on label and role first.
 
-Flutter **3.38.3**, the deployment floor this port targets (plan §2.2), never
+Flutter **3.38.3**, the oldest engine this port must run against, never
 writes `identifier` at all. A fixture keyed on it would pass against a
 development engine and fail against every shipping target, which is the
 opposite of what an integration test is for.
@@ -115,6 +153,18 @@ The checks drive the semantics and pointer paths. They do not exercise
 `ui_scroll_to`, the AccessKit bridge, or notification delivery under load —
 those have unit coverage and, for AccessKit, verification over a real AT-SPI
 bus, but not against a real engine here.
+
+Two gaps are specific to running several applications, both found by C8–C11 and
+neither fixed here:
+
+- **`ui_tap_at` cannot be aimed.** The host's pointer-tap seam takes a view and
+  the shell discards it, so a synthetic tap goes wherever the ordinary input
+  path sends it regardless of which application the caller named. C4b is
+  therefore not meaningful with more than one running.
+- **Tools an application declares are first-come.** The prefix is claimed
+  process-wide, so a second application registering the same one is refused and
+  its tools never appear. Semantics trees are addressed per application; these
+  are not.
 
 C4b depends on the region being unobscured. If the app grows a layout where
 something overlaps it, that check will correctly start failing — a pointer

--- a/test/integration/mcp_drive_test/tools/drive.py
+++ b/test/integration/mcp_drive_test/tools/drive.py
@@ -91,18 +91,56 @@ def call_tool(path, name, arguments=None, request_id=1):
     return not reply["result"].get("isError", False), json.loads(content)
 
 
-def read_tree(path):
+def list_trees(path):
+    """Every application's tree resource, sorted.
+
+    The resources live under `result`, like every other JSON-RPC reply this
+    driver reads. Taking them off the envelope instead finds nothing and
+    reports it as "no application is running", which looks like a shell fault
+    rather than a driver one -- so this reads the same place `resources/read`
+    below reads.
+    """
     listing = rpc(path, "resources/list", {}, request_id=2)
-    trees = [
-        r["uri"]
-        for r in listing.get("resources", [])
+    if "error" in listing:
+        raise Failure(f"resources/list: {listing['error']}")
+    resources = listing.get("result", {}).get("resources", [])
+    return sorted(
+        r["uri"] for r in resources
         if r.get("uri", "").startswith(TREE_URI_PREFIX)
-    ]
-    if len(trees) != 1:
-        raise SystemExit(
-            f"expected exactly one application's tree, found {len(trees)}: {trees}"
-        )
-    reply = rpc(path, "resources/read", {"uri": trees[0]}, request_id=3)
+    )
+
+
+def view_names(path):
+    """The name of every running application, from its tree's URI.
+
+    Discovered rather than configured: the shell derives these names itself,
+    so a driver that assumed them would test its own assumption.
+    """
+    prefix = len(TREE_URI_PREFIX)
+    return [uri[prefix:].removesuffix("/tree") for uri in list_trees(path)]
+
+
+def read_tree(path, view=None):
+    """One application's tree. `view` names it, and is required when more than
+    one is running -- picking one would be arbitrary, and the shell refuses an
+    unqualified action for the same reason."""
+    trees = list_trees(path)
+    if not trees:
+        raise Failure(
+            "no application published a semantics tree. Either semantics never "
+            "came up, or nothing is being composited -- see the README on "
+            "presentation before suspecting the tool under test")
+    if view is not None:
+        uri = f"{TREE_URI_PREFIX}{view}/tree"
+        if uri not in trees:
+            raise Failure(f"no tree for view {view!r}; running: {trees}")
+    elif len(trees) == 1:
+        uri = trees[0]
+    else:
+        raise Failure(
+            f"{len(trees)} applications are running and no view was named: "
+            f"{trees}")
+    reply = rpc(path, "resources/read", {"uri": uri}, request_id=3)
     if "error" in reply:
         raise Failure(f"resources/read: {reply['error']}")
     return json.loads(reply["result"]["contents"][0]["text"])
@@ -113,7 +151,7 @@ def find(tree, label=None, role=None, identifier=None):
     engine reports one.
 
     Label and role are the primary key on purpose. Flutter 3.38.3 -- the
-    deployment floor this port targets (plan section 2.2) -- never writes
+    oldest engine this port must run against -- never writes
     `identifier`, so a fixture keyed on it would pass on a development engine
     and fail on every shipping target. The app still sets identifiers, which
     a newer engine will use for a more exact match.
@@ -131,11 +169,11 @@ def find(tree, label=None, role=None, identifier=None):
     return None
 
 
-def status_fields(path):
+def status_fields(path, view=None):
     """The app's status node, parsed into a dict. Values are space separated
     key=value pairs, which survives a round trip through a semantics value
     without needing the app to embed JSON in a label."""
-    tree = read_tree(path)
+    tree = read_tree(path, view)
     node = find(tree, label="status", identifier="status")
     if node is None:
         raise Failure("the app published no status node; is it the right app?")
@@ -149,7 +187,7 @@ def status_fields(path):
     return fields
 
 
-def wait_for(path, predicate, timeout, what):
+def wait_for(path, predicate, timeout, what, view=None):
     """Polls the status node until the app reports what was expected.
 
     Polled rather than driven by a notification because the check is about a
@@ -160,29 +198,64 @@ def wait_for(path, predicate, timeout, what):
     deadline = time.time() + timeout
     last = {}
     while time.time() < deadline:
-        last = status_fields(path)
+        last = status_fields(path, view)
         if predicate(last):
             return last
         time.sleep(0.05)
     raise Failure(f"timed out waiting for {what}; status was {last}")
 
 
-def query(path, **selectors):
+def viewed(arguments, view):
+    """Adds the view argument when one is named.
+
+    Omitted rather than defaulted when there is a single application, because
+    that is the case the shell allows to go unqualified -- sending it anyway
+    would stop this driver from covering it.
+    """
+    if view is None:
+        return arguments
+    return {**arguments, "view": view}
+
+
+def query(path, view=None, **selectors):
     """ui_query with any of its selectors. Returns the decoded result."""
-    ok, doc = call_tool(path, "ui_query", selectors, request_id=7)
+    ok, doc = call_tool(path, "ui_query", viewed(selectors, view), request_id=7)
     if not ok:
         raise Failure(f"ui_query {selectors}: {doc}")
     return doc
 
 
-def act(path, tool, arguments, what):
+def matches(doc):
+    """The matched nodes from a ui_query result, in either shape it arrives in.
+
+    A read that names a view answers about that view directly. A read that
+    names none spans every application and reports each under `views`, so the
+    counts and nodes sit one level down. Which shape comes back depends on how
+    many applications are running rather than on what the caller asked, so a
+    driver has to handle both -- reading `match_count` off the spanning shape
+    finds nothing and looks exactly like an app that published no such node.
+
+    Each returned node carries the view it came from, which is the whole point
+    of the spanning shape: an agent searching for a control it has not found
+    yet needs to know which application answered.
+    """
+    if "views" in doc:
+        found = []
+        for entry in doc.get("views") or []:
+            for node in (entry.get("result") or {}).get("nodes", []):
+                found.append({**node, "view": entry.get("view")})
+        return found
+    return [dict(node) for node in doc.get("nodes", [])]
+
+
+def act(path, tool, arguments, what, view=None):
     """Invokes an action tool and returns its verify-after-act result.
 
-    The point of DR-8 is that this is enough on its own: the caller does not
-    re-read the tree to find out what happened, because the response already
-    carries the node as it stands afterwards.
+    The response carries the node as it stands after the action, so a caller
+    does not have to re-read the tree to find out what happened. Checking that
+    is the point: it is what lets an agent act without a second round trip.
     """
-    ok, doc = call_tool(path, tool, arguments, request_id=8)
+    ok, doc = call_tool(path, tool, viewed(arguments, view), request_id=8)
     if not ok:
         raise Failure(f"{tool} ({what}) was refused: {doc}")
     if not doc.get("dispatched"):
@@ -215,6 +288,22 @@ def main():
                         help="seconds to wait for the app to react")
     args = parser.parse_args()
 
+    # Which applications are running, discovered from the shell rather than
+    # configured here. With one, actions go unqualified -- that is the case the
+    # shell allows and this driver has always covered. With several, every
+    # action must name its view, so the checks below name the first one and the
+    # multi-view checks cover the addressing itself.
+    views = view_names(args.socket)
+    if not views:
+        raise Failure(
+            "no application published a semantics tree. Either semantics never "
+            "came up, or nothing is being composited -- see the README on "
+            "presentation before suspecting the tool under test")
+    view = views[0] if len(views) > 1 else None
+    if view is not None:
+        print(f"{len(views)} applications running: {', '.join(views)}")
+        print(f"single-application checks run against {view!r}\n")
+
     results = []
 
     def check(name, description, fn):
@@ -232,7 +321,7 @@ def main():
     # not annotated or semantics never came up, which is a different problem
     # from a dispatch not working.
     def c1():
-        tree = read_tree(args.socket)
+        tree = read_tree(args.socket, view)
         for label, role in (("status", None), ("Save", "button"),
                             ("Locked", "button"), ("Destination", None)):
             if find(tree, label=label, role=role) is None:
@@ -245,34 +334,37 @@ def main():
     # C2 -- a dispatch invokes the widget's own handler. This is the claim the
     # mock-host tests cannot make: they end where the shell begins.
     def c2():
-        before = status_fields(args.socket)
-        node = find(read_tree(args.socket), label="Save", role="button",
+        before = status_fields(args.socket, view)
+        node = find(read_tree(args.socket, view), label="Save", role="button",
                     identifier="save")
-        ok, doc = call_tool(args.socket, "ui_tap", {"node_id": node["id"]}, 10)
+        ok, doc = call_tool(args.socket, "ui_tap",
+                            viewed({"node_id": node["id"]}, view), 10)
         if not ok:
             raise Failure(f"ui_tap refused: {doc}")
         after = wait_for(
             args.socket,
             lambda f: f.get("last") == "tap:save"
             and f.get("events") != before.get("events"),
-            args.timeout, "the Save handler to run")
+            args.timeout, "the Save handler to run", view)
         del after
 
-    # C3 -- plan R-9's exit criterion: the text actually lands in the field.
+    # C3 -- the text actually lands in the field, which nothing else in the
+    # suite covers.
     def c3():
-        node = find(read_tree(args.socket), label="Destination",
+        node = find(read_tree(args.socket, view), label="Destination",
                     identifier="destination")
         ok, doc = call_tool(args.socket, "ui_set_text",
-                            {"node_id": node["id"], "text": "Sarah Connor"}, 11)
+                            viewed({"node_id": node["id"], "text": "Sarah Connor"}, view), 11)
         if not ok:
             raise Failure(f"ui_set_text refused: {doc}")
         wait_for(args.socket,
                  lambda f: f.get("text") == "Sarah Connor",
-                 args.timeout, "the field to take the new text")
+                 args.timeout, "the field to take the new text", view)
 
-    # C4 -- the DR-7 contrast, in both directions.
+    # C4 -- in both directions: a dispatch cannot reach what the tree does not
+    # describe, and a pointer tap can.
     def c4_no_node():
-        tree = read_tree(args.socket)
+        tree = read_tree(args.socket, view)
         for node in tree.get("nodes", []):
             if (node.get("label") or "") == "unannotated region":
                 raise Failure("the excluded region appeared in the tree; "
@@ -280,29 +372,30 @@ def main():
                               "contrast this fixture exists to show is gone")
 
     def c4_pointer_reaches():
-        fields = status_fields(args.socket)
+        fields = status_fields(args.socket, view)
         geometry = fields.get("opaque", "")
         try:
             left, top, width, height = (float(v) for v in geometry.split(","))
         except ValueError as exc:
             raise Failure(f"app did not report its geometry: {geometry!r}") from exc
-        before = status_fields(args.socket)
+        before = status_fields(args.socket, view)
         ok, doc = call_tool(args.socket, "ui_tap_at",
-                            {"x": left + width / 2, "y": top + height / 2}, 12)
+                            viewed({"x": left + width / 2, "y": top + height / 2}, view), 12)
         if not ok:
             raise Failure(f"ui_tap_at refused: {doc}")
         wait_for(
             args.socket,
             lambda f: f.get("last") == "tap:opaque"
             and f.get("events") != before.get("events"),
-            args.timeout, "the unannotated region to receive a pointer tap")
+            args.timeout, "the unannotated region to receive a pointer tap", view)
 
     # C5 -- a disabled control is refused rather than dispatched into silence.
     def c5():
-        node = find(read_tree(args.socket), label="Locked", role="button",
+        node = find(read_tree(args.socket, view), label="Locked", role="button",
                     identifier="locked")
-        before = status_fields(args.socket)
-        ok, doc = call_tool(args.socket, "ui_tap", {"node_id": node["id"]}, 13)
+        before = status_fields(args.socket, view)
+        ok, doc = call_tool(args.socket, "ui_tap",
+                            viewed({"node_id": node["id"]}, view), 13)
         if ok:
             raise Failure("ui_tap on a disabled control was accepted")
         # The refusal has to say why. A bare "refused" leaves an agent unable
@@ -310,7 +403,7 @@ def main():
         if "disabled" not in json.dumps(doc):
             raise Failure(f"the refusal did not say why: {doc}")
         time.sleep(0.2)
-        after = status_fields(args.socket)
+        after = status_fields(args.socket, view)
         if after.get("events") != before.get("events"):
             raise Failure("a refused tap still reached the widget")
 
@@ -319,29 +412,30 @@ def main():
     # response rather than by re-reading the tree.
     #
     # No node ids are carried in from outside and no identifiers are used:
-    # identifiers are empty at the 3.38.3 deployment floor (plan section 2.2),
+    # identifiers are empty on the oldest engine this port must run against,
     # so a flow that depended on them would pass here and fail on a target.
     def c6_multi_step_flow():
         # Step 1: find the control by role and the action it offers, which is
         # how an agent picks a target it was not told about.
-        found = query(args.socket, role="slider", action="increase")
-        if found.get("match_count", 0) < 1:
+        found = matches(query(args.socket, view, role="slider",
+                              action="increase"))
+        if not found:
             raise Failure("no slider offering increase; the app did not "
                           "publish one, or the selectors did not match it")
-        slider = found["nodes"][0]
+        slider = found[0]
         if slider.get("label") != "Temperature":
             raise Failure(f"found the wrong slider: {slider.get('label')!r}")
 
         start = numeric(slider.get("value"))
         if start is None:
             raise Failure(f"slider reports no numeric value: {slider!r}")
-        app_start = numeric(status_fields(args.socket).get("temp"))
+        app_start = numeric(status_fields(args.socket, view).get("temp"))
         if app_start is None:
             raise Failure("the app did not report its temperature")
 
         # Step 2: act, and read the outcome out of the action's own reply.
         first = act(args.socket, "ui_increase", {"node_id": slider["id"]},
-                    "raise the temperature")
+            "raise the temperature", view)
         if first.get("mode") != "semantics":
             raise Failure(f"expected a semantics dispatch: {first}")
         after = first.get("node_after")
@@ -357,7 +451,7 @@ def main():
         # Step 3: again, to show the flow accumulates rather than each step
         # being read against a stale baseline.
         second = act(args.socket, "ui_increase", {"node_id": slider["id"]},
-                     "raise it again")
+            "raise it again", view)
         twice = numeric((second.get("node_after") or {}).get("value"))
         if twice is None or twice <= raised:
             raise Failure(f"second step did not advance: {raised} -> {twice}")
@@ -365,20 +459,21 @@ def main():
         # Step 4: a custom action, found and invoked by its label. These are
         # the application's own verbs -- there is no fixed set, and the label
         # is the only handle an agent has on one.
-        climate = query(args.socket, custom_action="Set to Auto")
-        if climate.get("match_count", 0) < 1:
+        climate = matches(query(args.socket, view,
+                               custom_action="Set to Auto"))
+        if not climate:
             raise Failure("no node declares the custom action 'Set to Auto'")
-        node = climate["nodes"][0]
+        node = climate[0]
         act(args.socket, "ui_custom_action",
             {"node_id": node["id"], "action": "Set to Auto"},
-            "switch the climate mode")
+            "switch the climate mode", view)
 
         # The custom action's effect is app state rather than node state, so
         # this one step is confirmed through the status line -- which is also
         # the proof the widget's own closure ran, not merely that the dispatch
         # was accepted.
         fields = wait_for(args.socket, lambda f: f.get("mode") == "auto",
-                          args.timeout, "the custom action's handler to run")
+                          args.timeout, "the custom action's handler to run", view)
 
         # And the slider's movement reached the app's own state, not just the
         # semantics node.
@@ -426,7 +521,7 @@ def main():
         fields = wait_for(
             args.socket,
             lambda f: f.get("last") == "tool:set_temp",
-            args.timeout, "the application's tool handler to run")
+            args.timeout, "the application's tool handler to run", view)
         reported = numeric(fields.get("temp"))
         if reported is None or abs(reported - 24.5) > 0.01:
             raise Failure(
@@ -445,16 +540,103 @@ def main():
         if missing:
             raise Failure("a call to a tool that does not exist was accepted")
 
+    # C8-C11 -- addressing, which only exists once more than one application is
+    # running. Every other MCP multi-view test uses a mock host with names it
+    # chose; these run against the names the shell derives for itself, which is
+    # the part no unit test can reach.
+    def c8_each_view_is_addressable():
+        trees = list_trees(args.socket)
+        if len(trees) != len(views):
+            raise Failure(f"{len(views)} applications but {len(trees)} trees")
+        if len(set(views)) != len(views):
+            raise Failure(
+                f"two applications share a name, so neither can be addressed "
+                f"unambiguously: {views}")
+        for name in views:
+            tree = read_tree(args.socket, name)
+            if find(tree, label="status", identifier="status") is None:
+                raise Failure(f"view {name!r} published no status node")
+
+    def c9_an_action_goes_to_the_view_it_names():
+        other = views[1]
+        before = {name: status_fields(args.socket, name) for name in views}
+        node = find(read_tree(args.socket, other), label="Save", role="button",
+                    identifier="save")
+        ok, doc = call_tool(args.socket, "ui_tap",
+                            {"node_id": node["id"], "view": other}, 30)
+        if not ok:
+            raise Failure(f"ui_tap naming {other!r} was refused: {doc}")
+        wait_for(args.socket,
+                 lambda f: f.get("last") == "tap:save"
+                 and f.get("events") != before[other].get("events"),
+                 args.timeout, f"the Save handler in {other!r} to run", other)
+        # The other applications must be untouched. Both run the same bundle
+        # and so have a node of the same id -- which is exactly the collision
+        # that makes an unaddressed dispatch land in the wrong application.
+        for name in views:
+            if name == other:
+                continue
+            if status_fields(args.socket, name).get("events") != \
+                    before[name].get("events"):
+                raise Failure(
+                    f"tapping {other!r} also reached {name!r}; the action was "
+                    f"delivered by node id rather than by the view named")
+
+    def c10_an_unqualified_action_is_refused():
+        before = {name: status_fields(args.socket, name) for name in views}
+        node = find(read_tree(args.socket, views[0]), label="Save",
+                    role="button", identifier="save")
+        ok, doc = call_tool(args.socket, "ui_tap", {"node_id": node["id"]}, 31)
+        if ok:
+            raise Failure(
+                "an action naming no view was accepted while several "
+                "applications were running; one of them received it")
+        # The refusal has to name what is missing, or an agent cannot learn
+        # that the argument exists.
+        if "view" not in json.dumps(doc):
+            raise Failure(f"the refusal did not say a view was needed: {doc}")
+        time.sleep(0.2)
+        for name in views:
+            if status_fields(args.socket, name).get("events") != \
+                    before[name].get("events"):
+                raise Failure(f"the refused action still reached {name!r}")
+
+    def c11_an_unqualified_read_spans_every_view():
+        # A read is the opposite case from an action: an agent hunting for a
+        # control does not yet know which application owns it, so searching all
+        # of them and saying where each hit came from is the useful answer.
+        found = matches(query(args.socket, None, label="Save"))
+        if len(found) < len(views):
+            raise Failure(
+                f"an unqualified read found {len(found)} matches across "
+                f"{len(views)} applications, each of which has a Save: "
+                f"{found}")
+        attributed = {node.get("view") for node in found}
+        missing = [name for name in views if name not in attributed]
+        if missing:
+            raise Failure(
+                f"the result does not say which view these came from, so an "
+                f"agent cannot act on them: {missing} absent from {attributed}")
+
     check("C1", "the tree describes the app", c1)
     check("C2", "ui_tap invokes the widget's own handler", c2)
-    check("C3", "ui_set_text reaches the field (R-9)", c3)
+    check("C3", "ui_set_text reaches the field", c3)
     check("C4a", "the unannotated region is absent from the tree", c4_no_node)
-    check("C4b", "ui_tap_at reaches it anyway (DR-7)", c4_pointer_reaches)
+    check("C4b", "ui_tap_at reaches it anyway", c4_pointer_reaches)
     check("C5", "a disabled control is refused before dispatch", c5)
     check("C6", "a multi-step flow by role, label and custom-action name",
           c6_multi_step_flow)
     check("C7", "a tool the application declared, with its schema",
           c7_app_declared_tool)
+    if len(views) > 1:
+        check("C8", "every application has its own addressable tree",
+              c8_each_view_is_addressable)
+        check("C9", "an action goes only to the view it names",
+              c9_an_action_goes_to_the_view_it_names)
+        check("C10", "an action naming no view is refused",
+              c10_an_unqualified_action_is_refused)
+        check("C11", "a read naming no view spans every one",
+              c11_an_unqualified_read_spans_every_view)
 
     width = max(len(d) for _, d, _, _ in results)
     failed = 0


### PR DESCRIPTION
Stacked on #480 — the two-view checks here cannot pass without that fix. Base it back to `v3.0` once #480 merges.

## None of this fixture's checks had ever passed

The driver took the resource list off the JSON-RPC envelope rather than out of `result`, so it always found no trees and exited with `expected exactly one application's tree, found 0` before running anything. Two lines below, the read of a tree unwraps `result` correctly — which is what the list should have done.

Confirmed against a shell with a **single** application, where exactly one tree exists and the driver still reported none. So this was never a multi-view problem.

## Two more defects were unreachable behind that one

- **`ui_query` has two shapes.** A read naming a view answers with a document; a read naming none answers with the same document per view, under `views`. The multi-step check read `match_count` off the top level, where the second shape has none. Which shape arrives depends on how many applications are running rather than on what was asked, so both are now handled.
- **Nothing carried a view.** With several applications every action must name one, so the driver would have failed against such a shell even once it could read.

## What it covers now

The driver discovers what is running and adapts — no new flag. With one application it leaves the argument off, which is the case the shell allows to go unqualified. With several it names one for C1–C7 and adds four:

| # | Check |
| --- | --- |
| C8 | every application has its own addressable tree, under a distinct name |
| C9 | an action reaches **only** the application it names — both run the same bundle, so both have a node of the same id |
| C10 | an action naming none is refused, and the refusal says a view was needed |
| C11 | a read naming none spans every application and attributes its results |

The names these use are the shell's own, derived from the bundle directory and disambiguated with an index. The hub tests cover the addressing logic with names they chose; the derivation is the part only a real shell shows. Running the same bundle twice exercises it, and is the harder case because both then start from the same name.

## Results

**8/8 against one application** — the first time any of them has passed.

Against two, the four new checks pass and three existing ones do not. Those depend on the application being composited, and a headless compositor generally presents only one of two surfaces: one view's `events` climbed 1→2→3 on repeated taps while the other stayed at 1. `ui_set_text` and `ui_increase` both work on the presented view in isolation. That confound is documented rather than papered over, because its symptom is a frozen status line, which looks exactly like a dispatch that never arrived.

## Gaps this exposed, recorded not fixed

- **`ui_tap_at` cannot be aimed.** The host's pointer-tap seam takes a view and the shell discards it, so a synthetic tap goes wherever the ordinary input path sends it. C4b is not meaningful with more than one application running.
- **App-declared tool prefixes are process-wide.** A second application claiming the same prefix is refused and its tools never appear. Semantics trees are addressed per application; these are not.

## Housekeeping

The assembled `bundle/` directory is now ignored — the instructions here tell you to build one in the tree, and it holds an engine shared object and icudtl, so it was tens of megabytes of untracked build output next to the source. The run instructions also named a binary that is not what the build produces.