### PR TITLE
ci: install apt packages through a local action

### DIFF
--- a/.github/actions/apt-packages/action.yml
+++ b/.github/actions/apt-packages/action.yml
@@ -1,0 +1,87 @@
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Install apt packages
+description: >-
+  Refreshes the apt index and installs packages, retrying a transient failure.
+  Local on purpose: a remote action is fetched during "Set up job", before any
+  step runs and with no way to retry it, so an outage at the registry fails
+  every leg of the matrix before a compiler is reached. This one arrives with
+  the checkout.
+
+inputs:
+  packages:
+    description: >-
+      Packages to install, separated by whitespace. A YAML folded scalar is
+      fine: newlines collapse to spaces before this sees them.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install apt packages
+      shell: bash
+      # Through the environment rather than interpolated into the script. The
+      # package list is often built from a matrix value, and a value that
+      # reached the script body would be shell rather than data.
+      env:
+        IHS_APT_PACKAGES: ${{ inputs.packages }}
+      run: |
+        set -euo pipefail
+
+        # Package names are literals. Word splitting is what turns the input
+        # into an argument list, so globbing is disabled around it rather than
+        # left to chance -- 'libc++-19-dev' is harmless, but a list is not the
+        # place to let the filesystem have an opinion.
+        set -f
+        # shellcheck disable=SC2206
+        packages=(${IHS_APT_PACKAGES})
+        set +f
+
+        if [ "${#packages[@]}" -eq 0 ]; then
+          echo "::error::no packages given"
+          exit 1
+        fi
+
+        # Unprivileged on a runner, root in a container. Both are used here.
+        sudo=""
+        if [ "$(id -u)" -ne 0 ]; then
+          sudo="sudo"
+        fi
+
+        # An apt mirror serving a 5xx, or a lock still held by the image's own
+        # unattended-upgrade, is a wait rather than a failure. Backs off so a
+        # slow release of the lock is not three failures in three seconds.
+        retry() {
+          local attempt=1 attempts=4 delay=5
+          until "$@"; do
+            if [ "${attempt}" -ge "${attempts}" ]; then
+              echo "::error::failed after ${attempts} attempts: $*"
+              return 1
+            fi
+            echo "::warning::attempt ${attempt} of ${attempts} failed," \
+                 "retrying in ${delay}s: $*"
+            sleep "${delay}"
+            attempt=$((attempt + 1))
+            delay=$((delay * 2))
+          done
+        }
+
+        # The index is refreshed here, every time, and that is load-bearing.
+        # The runner image ships a stale one, and once Ubuntu supersedes a
+        # revision the old .deb leaves the mirror -- so installing against the
+        # shipped index fetches a version that is no longer there and 404s.
+        export DEBIAN_FRONTEND=noninteractive
+        retry ${sudo} apt-get update
+        retry ${sudo} apt-get install -y "${packages[@]}"

--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -35,17 +35,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
-
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             ninja-build
@@ -55,7 +46,6 @@ jobs:
             libxcursor-dev
             libglib2.0-dev
             ${{ matrix.extra_pkgs }}
-          version: 1.0
 
       - name: Setup libdisplay-info (system or from-source)
         uses: ./.github/actions/setup-libdisplay-info
@@ -96,17 +86,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
-
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             ninja-build
@@ -116,7 +97,6 @@ jobs:
             libxcursor-dev
             libglib2.0-dev
             clang-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
-          version: 1.0
 
       - name: Setup libdisplay-info (system or from-source)
         uses: ./.github/actions/setup-libdisplay-info

--- a/.github/workflows/ihs-logging-compat-matrix.yml
+++ b/.github/workflows/ihs-logging-compat-matrix.yml
@@ -80,17 +80,8 @@ jobs:
 
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
 
-      - name: Update apt package index
-        if: ${{ steps.install.outputs.packages != '' }}
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         if: ${{ steps.install.outputs.packages != '' }}
         with:
           packages: >-
@@ -125,7 +116,9 @@ jobs:
     name: "Clang-12 C++17"
     steps:
       - name: Add git + ninja
-        # NOTE: DO NOT use the cache-apt-pkgs-action here
+        # Inline, not ./.github/actions/apt-packages: this runs before the
+        # checkout, because it is what installs the git that does the checkout,
+        # so a local action is not on disk yet.
         run: |
           set -eux
           apt-get update
@@ -184,17 +177,8 @@ jobs:
 
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
 
-      - name: Update apt package index
-        if: ${{ steps.install.outputs.packages != '' }}
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         if: ${{ steps.install.outputs.packages != '' }}
         with:
           packages: >-

--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -40,16 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             cmake ninja-build g++
@@ -112,16 +104,8 @@ jobs:
       - name: Fetch fmt submodule (raw-fmt reference)
         run: git submodule update --init --depth 1 third_party/fmt
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             cmake ninja-build g++
@@ -147,16 +131,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             cmake ninja-build g++ abigail-tools
@@ -216,16 +192,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             cmake ninja-build gcc g++ dlt-daemon dlt-tools

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,17 +55,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # Refresh the index before cache-apt-pkgs-action resolves versions, so
-        # it pins the revision currently on the mirror rather than a stale one
-        # the runner image still lists (a dropped .deb 404s and aborts install).
-        run: sudo apt-get update
-
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev libpugixml-dev ${{ matrix.extra_pkgs }}
-          version: 1.0
 
       - name: Configure
         env:
@@ -94,17 +87,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # Refresh the index before cache-apt-pkgs-action resolves versions, so
-        # it pins the revision currently on the mirror rather than a stale one
-        # the runner image still lists (a dropped .deb 404s and aborts install).
-        run: sudo apt-get update
-
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev libpugixml-dev libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev libxcursor-dev clang-19 clang-tidy-19 clang-format-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
-          version: 1.0
 
       - name: Setup libdisplay-info (system or from-source)
         uses: ./.github/actions/setup-libdisplay-info
@@ -164,17 +150,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # Refresh the index before cache-apt-pkgs-action resolves versions, so
-        # it pins the revision currently on the mirror rather than a stale one
-        # the runner image still lists (a dropped .deb 404s and aborts install).
-        run: sudo apt-get update
-
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: ninja-build clang-format-19
-          version: 1.0
 
       - name: clang-format
         run: scripts/format.sh --check
@@ -199,14 +178,20 @@ jobs:
       contents: read
 
     steps:
-      - name: Update apt package index
-        run: sudo apt-get update
+      # This job's workspace comes from the build artifact below rather than a
+      # checkout, so ./.github/actions would not be on disk. Fetch just that
+      # path: sparse and shallow, and it lands before the tarball is unpacked
+      # over it, so what the artifact carries still wins.
+      - name: Checkout the local actions
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
 
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev libpugixml-dev libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev libxcursor-dev clang-19 clang-tidy-19 clang-format-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
-          version: 1.0
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/oss-codeql.yml
+++ b/.github/workflows/oss-codeql.yml
@@ -31,16 +31,8 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: recursive
-    - name: Update apt package index
-      # cache-apt-pkgs-action resolves package versions before it runs its
-      # own apt update, so it pins whatever the runner image's stale index
-      # lists. When Ubuntu supersedes a revision and drops the old .deb from
-      # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-      # and aborts the whole install. Refresh the index up front so it pins
-      # the version currently on the mirror.
-      run: sudo apt-get update
     - name: Install packages
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      uses: ./.github/actions/apt-packages
       with:
         packages: >-
           build-essential cmake ninja-build pkg-config

--- a/.github/workflows/oss-integration.yaml
+++ b/.github/workflows/oss-integration.yaml
@@ -29,16 +29,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build + test deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             build-essential cmake ninja-build pkg-config git python3
@@ -114,16 +106,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build + test deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             build-essential cmake ninja-build pkg-config git python3
@@ -165,7 +149,7 @@ jobs:
           ./scripts/watchdog_integration.sh
 
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             libsystemd-dev

--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -22,16 +22,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             ninja-build
@@ -140,16 +132,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             ninja-build
@@ -192,12 +176,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # See the accessibility job: the cache action pins versions from the
-        # runner's stale index, which 404s once a revision is superseded.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             ninja-build
@@ -330,16 +310,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             build-essential cmake ninja-build pkg-config git python3
@@ -421,16 +393,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             build-essential cmake ninja-build pkg-config git python3
@@ -489,7 +453,7 @@ jobs:
           path: ~/.cache/emb/store/engine
           key: emb-engine-x86_64-${{ github.run_id }}
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             libsystemd-dev
@@ -521,32 +485,18 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Update apt package index
-        # Refresh the index before cache-apt-pkgs-action resolves versions, so
-        # it pins the revision currently on the mirror rather than a stale one
-        # the runner image still lists (a dropped .deb 404s and aborts install).
-        run: sudo apt-get update
-
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: ninja-build libwayland-dev wayland-protocols libxkbcommon-dev mesa-common-dev libegl1-mesa-dev libgles2-mesa-dev mesa-utils libglib2.0-dev libpugixml-dev libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev libxcursor-dev clang-19 clang-tidy-19 clang-format-19 llvm-19 lld-19 libc++-19-dev libc++abi-19-dev
-          version: 1.0
-
-      - name: Update apt package index
-        # Refresh the index before cache-apt-pkgs-action resolves versions, so
-        # it pins the revision currently on the mirror rather than a stale one
-        # the runner image still lists (a dropped .deb 404s and aborts install).
-        run: sudo apt-get update
 
       - name: Install extra dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: >-
             libdrm-dev libgbm-dev
             libinput-dev libudev-dev libseat-dev libxcursor-dev
             libsystemd-dev libpugixml-dev libcurl4-openssl-dev
-          version: 1.0-extra
 
       - name: Setup libdisplay-info
         uses: ./.github/actions/setup-libdisplay-info
@@ -577,10 +527,9 @@ jobs:
         run: ninja -C .
 
       - name: Install unit test deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./.github/actions/apt-packages
         with:
           packages: lcov
-          version: 1.0-unit_test
 
       - name: Run unit tests (CTest)
         working-directory: ${{github.workspace}}/build/unit-tests

--- a/.github/workflows/pios.yml
+++ b/.github/workflows/pios.yml
@@ -83,16 +83,11 @@ jobs:
           path: ivi-homescreen
           submodules: recursive
 
-      - name: Update apt package index
-        # cache-apt-pkgs-action resolves package versions before it runs its
-        # own apt update, so it pins whatever the runner image's stale index
-        # lists. When Ubuntu supersedes a revision and drops the old .deb from
-        # the mirror (e.g. libinput 1.25.0-1ubuntu3.4), that pinned fetch 404s
-        # and aborts the whole install. Refresh the index up front so it pins
-        # the version currently on the mirror.
-        run: sudo apt-get update
+      # Path includes the checkout directory: a local action resolves against
+      # the workspace root, and this job checks out into a subdirectory because
+      # it clones emb alongside.
       - name: Install build deps
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: ./ivi-homescreen/.github/actions/apt-packages
         with:
           packages: >-
             tar xz-utils rsync curl ca-certificates


### PR DESCRIPTION
## Why

A remote action is fetched during **"Set up job"** — before any step runs, and with no way to retry it. When the registry serving it is unhappy, every leg of every matrix fails in ~90 seconds without reaching a compiler.

That is what happened across all workflows today. `codeload.github.com` answered **429** and **503** for the apt install action, and a re-run hit the same wall:

```
##[warning]Failed to download action 'https://codeload.github.com/awalsh128/...'.
  Error: Response status code does not indicate success: 429 (Too Many Requests).
##[error]Failed to download archive '...' after 3 attempts.
```

I reproduced the throttling from a workstation too, so it was not specific to the runners.

## What this does

Replaces it with a composite action in this repository. It arrives with the checkout, so it cannot fail to download. It refreshes the index, installs, and retries a transient failure with a growing delay — an apt mirror serving a 5xx, or a lock still held by the image's own unattended-upgrade, is a wait rather than a failure.

**It also removes a workaround.** The old action resolved package versions before running its own update, pinning whatever the runner image's stale index listed; once Ubuntu superseded a revision and the old `.deb` left the mirror, the pinned fetch 404'd and aborted the install. **Twenty-one steps existed only to refresh the index in front of it**, each carrying a copy of that explanation. Refreshing is now part of installing, so they are gone — hence 204 deletions against 128 insertions.

## Three call sites that are not uniform, and say why

| Site | Treatment |
|---|---|
| `ihs-logging-compat-matrix` clang-12 | Stays inline — it installs the git that performs the checkout, so it runs before anything is on disk |
| `pios::publish` | Checks out into a subdirectory, so the path names it: `./ivi-homescreen/.github/actions/apt-packages` |
| `lint::lint-tidy-shard` | Takes its workspace from a build artifact rather than a checkout, so it now sparse-checks-out the actions directory alone, before the tarball unpacks over it |

## Security

The package list travels through the environment rather than the script body. It is often built from a matrix value, and a value interpolated into a shell script is no longer data.

## Trade-off

What is given up is the package cache the old action kept. Installing without it costs each job some seconds; a matrix that cannot start costs all of them. If the install time turns out to matter on a specific leg, caching can come back on that leg deliberately rather than everywhere by default.

## Verification

- every workflow parses
- **all 26 call sites resolved against the checkout each job actually performs** — this is how the `pios` subdirectory case turned up, which a grep would have missed and CI would have found the slow way
- the install script exercised for whitespace-folded package lists, an empty list (refused), and a failure that recovers on retry
- globbing disabled around the word-splitting that builds the argument list

Independent of #480 and #481 — this touches only `.github/`.