### PR TITLE
feat: let a second instance of an application keep its tools

### DIFF
--- a/packages/ihs_mcp_app_tools/lib/ihs_mcp_app_tools.dart
+++ b/packages/ihs_mcp_app_tools/lib/ihs_mcp_app_tools.dart
@@ -96,7 +96,11 @@ final class _AppToolsDesc extends ffi.Struct {
   external ffi.Pointer<ffi.Void> userData;
   @ffi.Uint32()
   external int callTimeoutMs;
+  external ffi.Pointer<Utf8> view;
 }
+
+typedef _PrefixNative = ffi.Pointer<Utf8> Function(ffi.Pointer<ffi.Void>);
+typedef _PrefixDart = ffi.Pointer<Utf8> Function(ffi.Pointer<ffi.Void>);
 
 typedef _InvokeNative = ffi.Void Function(
   ffi.Pointer<ffi.Void>,
@@ -124,6 +128,8 @@ class _Bindings {
             'ihs_mcp_app_tools_register'),
         complete = library.lookupFunction<_CompleteNative, _CompleteDart>(
             'ihs_mcp_app_tools_complete'),
+        prefixOf = library.lookupFunction<_PrefixNative, _PrefixDart>(
+            'ihs_mcp_app_tools_prefix'),
         unregister = library.lookupFunction<_UnregisterNative, _UnregisterDart>(
             'ihs_mcp_app_tools_unregister');
 
@@ -146,6 +152,7 @@ class _Bindings {
 
   final _RegisterDart register;
   final _CompleteDart complete;
+  final _PrefixDart prefixOf;
   final _UnregisterDart unregister;
 }
 
@@ -158,12 +165,14 @@ const int _errPrefixTaken = -2;
 
 /// A live registration. Tools stay advertised until [unregister].
 class McpAppTools {
-  McpAppTools._(this._handle, this._callable, this._allocations, this._tools);
+  McpAppTools._(this._handle, this._callable, this._allocations, this._tools,
+      this._prefix);
 
   final ffi.Pointer<ffi.Void> _handle;
   final ffi.NativeCallable<_InvokeNative> _callable;
   final List<ffi.Pointer<ffi.NativeType>> _allocations;
   final Map<String, McpTool> _tools;
+  final String _prefix;
   bool _released = false;
 
   /// Registers [tools] under [prefix] (a bare identifier prefix, `hvac_`).
@@ -171,9 +180,40 @@ class McpAppTools {
   /// Throws [StateError] if the prefix is already claimed by another
   /// application or by the shell's own tools, and [ArgumentError] for a
   /// malformed registration.
+  /// Reads the view this application is running as out of the entrypoint
+  /// arguments the shell passes to `main`, or null when it is not there.
+  ///
+  /// An application cannot work this out for itself -- every instance of a
+  /// bundle runs the same code -- and it matters as soon as two instances run
+  /// at once, because both would otherwise claim the same tool namespace and
+  /// the second would lose. Pass the result to [register] as `view`.
+  ///
+  /// The same name addresses this view's semantics tree, so an agent reading a
+  /// tree and calling a tool sees one identity.
+  static String? viewFromArgs(List<String> args) {
+    const String flag = '--ihs-view=';
+    for (final String arg in args) {
+      if (arg.startsWith(flag)) {
+        final String value = arg.substring(flag.length);
+        return value.isEmpty ? null : value;
+      }
+    }
+    return null;
+  }
+
+  /// The prefix the tools are actually advertised under.
+  ///
+  /// Usually [prefix] as asked for. When another application had already
+  /// claimed it and a [view] was given, it is that prefix qualified by the
+  /// view -- so the tools are reachable, under a name that says which view
+  /// they act on. Worth logging: it is the difference between tools an agent
+  /// can find and tools that are there under another name.
+  String get prefix => _prefix;
+
   static McpAppTools register({
     required String prefix,
     required List<McpTool> tools,
+    String? view,
     Duration timeout = const Duration(seconds: 5),
   }) {
     final Map<String, McpTool> byName = <String, McpTool>{
@@ -222,7 +262,8 @@ class McpAppTools {
       ..toolCount = tools.length
       ..invoke = callable.nativeFunction
       ..userData = ffi.nullptr
-      ..callTimeoutMs = timeout.inMilliseconds;
+      ..callTimeoutMs = timeout.inMilliseconds
+      ..view = view == null ? ffi.nullptr : allocate(view);
 
     final ffi.Pointer<ffi.Pointer<ffi.Void>> out = calloc<ffi.Pointer<ffi.Void>>();
     final int status = _abi.register(desc, out);
@@ -241,8 +282,12 @@ class McpAppTools {
       throw ArgumentError('registration was refused (status $status)');
     }
 
+    // Read back rather than assumed: the shell may have qualified it, and an
+    // application that logs the prefix it asked for would be reporting a name
+    // no agent will see.
+    final String effective = _abi.prefixOf(handle).toDartString();
     final McpAppTools registration =
-        McpAppTools._(handle, callable, allocations, byName);
+        McpAppTools._(handle, callable, allocations, byName, effective);
     _live[callable.nativeFunction.address] = registration;
     return registration;
   }

--- a/shared/include/ihs/ihs_mcp_app_tools.h
+++ b/shared/include/ihs/ihs_mcp_app_tools.h
@@ -141,6 +141,26 @@ typedef struct IhsMcpAppToolsDesc {
    * one still working.
    */
   uint32_t call_timeout_ms;
+
+  /*
+   * Which view this application is, when the shell is running more than one.
+   * NULL or empty when it does not know, which is every single-view case.
+   *
+   * Only used to break a tie. Two instances of one bundle ask for the same
+   * prefix -- the same application on two displays is an ordinary arrangement,
+   * and without this the second registration is refused and its tools are
+   * simply absent, reported nowhere the agent can see. Given a view, the second
+   * claimant falls back to "<view>.<prefix>" instead of failing.
+   *
+   * The first claimant keeps the bare prefix, so an application running alone
+   * advertises exactly the names it always did, and a second one starting later
+   * cannot rename the tools an agent has already discovered.
+   *
+   * The shell passes this to the application as --ihs-view=<name>, and it is
+   * the same name that addresses the view's semantics tree, so an agent sees
+   * one identity rather than two.
+   */
+  const char* view;
 } IhsMcpAppToolsDesc;
 
 /*
@@ -169,6 +189,17 @@ IHS_EXPORT int ihs_mcp_app_tools_complete(uint64_t call_id,
                                           bool ok,
                                           const char* result_json,
                                           size_t result_length);
+
+/*
+ * The prefix the tools are actually advertised under, which is what an agent
+ * sees in front of every tool name. Usually the requested one; the view's
+ * qualified form when another application had already claimed it. Valid until
+ * the handle is unregistered, and "" for NULL.
+ *
+ * Worth logging at startup: it is the difference between an application whose
+ * tools an agent can find and one whose tools are there under another name.
+ */
+IHS_EXPORT const char* ihs_mcp_app_tools_prefix(const IhsMcpAppTools* handle);
 
 /*
  * Unregisters. Any call still outstanding is failed before this returns, and

--- a/shared/src/mcp_app_tools.cc
+++ b/shared/src/mcp_app_tools.cc
@@ -29,6 +29,7 @@
 #include <cerrno>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -75,7 +76,11 @@ struct PendingCall {
 };
 
 struct Registration {
+  // The prefix actually claimed, which is what the tools are advertised under.
+  // Not necessarily the one asked for: see the registration fallback below.
   std::string prefix;
+  // The view this application is, or "" when it did not say.
+  std::string view;
   std::vector<OwnedTool> tools;
   // Rebuilt whenever `tools` changes: the registry borrows this array and
   // reads the pointers out of it, so it has to outlive the list_tools call.
@@ -257,9 +262,17 @@ int ihs_mcp_app_tools_register(const IhsMcpAppToolsDesc* desc,
     return IHS_MCP_ERR_INVALID;
   }
 
+  // Appended after the struct's initial layout, so a caller built against the
+  // older header reports a smaller size and has no member here. The bounds
+  // check is what makes reading it safe rather than a guess.
+  constexpr size_t kViewNeeded =
+      offsetof(IhsMcpAppToolsDesc, view) + sizeof(desc->view);
+  const char* view = (desc->struct_size >= kViewNeeded) ? desc->view : nullptr;
+
   auto handle = std::make_unique<IhsMcpAppTools>();
   Registration& reg = handle->reg;
   reg.prefix = desc->tool_prefix;
+  reg.view = (view != nullptr) ? view : "";
   reg.invoke = desc->invoke;
   reg.user_data = desc->user_data;
   reg.timeout_ms = desc->call_timeout_ms != 0 ? desc->call_timeout_ms
@@ -296,7 +309,11 @@ int ihs_mcp_app_tools_register(const IhsMcpAppToolsDesc* desc,
 
   IhsMcpProviderDesc provider{};
   provider.struct_size = sizeof(provider);
-  provider.name = "app";
+  // Named for the view when there is one, so two applications are two
+  // providers rather than two things both called "app".
+  const std::string provider_name =
+      reg.view.empty() ? std::string("app") : ("app:" + reg.view);
+  provider.name = provider_name.c_str();
   provider.tool_prefix = reg.prefix.c_str();
   // No resource scheme: this provider serves tools only, and claiming one
   // would collide with a provider that actually publishes resources.
@@ -309,7 +326,26 @@ int ihs_mcp_app_tools_register(const IhsMcpAppToolsDesc* desc,
   provider.callbacks.call_tool = CallTool;
   provider.callbacks.read_resource = ReadResource;
 
-  const int status = ihs_mcp_provider_register(&provider, &reg.provider);
+  int status = ihs_mcp_provider_register(&provider, &reg.provider);
+
+  // The same application on two displays asks for the same prefix, and that is
+  // an ordinary arrangement rather than a mistake. Qualify with the view and
+  // try once more, so the second instance's tools are reachable under a name
+  // that says which one they act on.
+  //
+  // Only the loser qualifies. The application that got there first keeps the
+  // bare prefix, so a second instance starting later cannot rename tools an
+  // agent has already discovered -- and an application running alone advertises
+  // exactly what it always did.
+  if (status == IHS_MCP_ERR_PREFIX_TAKEN && !reg.view.empty()) {
+    const std::string qualified = reg.view + "." + reg.prefix;
+    Log(IHS_LEVEL_INFO, "prefix '" + reg.prefix + "' is taken; retrying as '" +
+                            qualified + "'");
+    reg.prefix = qualified;
+    provider.tool_prefix = reg.prefix.c_str();
+    status = ihs_mcp_provider_register(&provider, &reg.provider);
+  }
+
   if (status != IHS_MCP_OK) {
     if (reg.notify_fd >= 0) {
       ::close(reg.notify_fd);
@@ -358,6 +394,12 @@ int ihs_mcp_app_tools_complete(const uint64_t call_id,
   }
   call->cv.notify_one();
   return IHS_MCP_OK;
+}
+
+const char* ihs_mcp_app_tools_prefix(const IhsMcpAppTools* handle) {
+  // Fixed once registration returns, so this needs no lock: the fallback runs
+  // before the handle is handed out.
+  return handle != nullptr ? handle->reg.prefix.c_str() : "";
 }
 
 void ihs_mcp_app_tools_unregister(IhsMcpAppTools* handle) {

--- a/shell/app.cc
+++ b/shell/app.cc
@@ -251,6 +251,45 @@ void App::WatchDisplayOutputs(const std::shared_ptr<IDisplay>& display) {
                   provider->EnumerateOutputs().size());
 }
 
+std::string App::NameForView(const Configuration::Config& config) const {
+  // The bundle's own directory, which is what a person configuring the shell
+  // named it, so an outside reader recognizes it. A bundle laid out as
+  // <app>/bundle would be called "bundle" and say nothing, so that one name
+  // defers to the directory holding it.
+  std::filesystem::path path = config.view.bundle_path;
+  while (!path.empty() && (path.filename() == "bundle" ||
+                           path.filename() == "." || path.filename() == "/")) {
+    path = path.parent_path();
+  }
+  std::string base = path.filename().string();
+  if (base.empty()) {
+    base = "view";
+  }
+
+  // Unique among live views, because the name addresses one: a repeated name
+  // would leave two trees indistinguishable to anything naming them, which is
+  // the failure the whole addressing scheme exists to prevent. Two instances of
+  // one bundle is an ordinary arrangement -- the same application on two
+  // displays -- so this disambiguates rather than refusing.
+  const auto taken = [this](const std::string& candidate) {
+    return std::any_of(m_views.begin(), m_views.end(),
+                       [&candidate](const std::unique_ptr<FlutterView>& v) {
+                         return v->GetName() == candidate;
+                       });
+  };
+  if (!taken(base)) {
+    return base;
+  }
+  // Suffixed from the index rather than a counter, so a name is stable for a
+  // given view rather than depending on what started before it.
+  for (size_t n = m_views.size();; n++) {
+    std::string candidate = base + "-" + std::to_string(n);
+    if (!taken(candidate)) {
+      return candidate;
+    }
+  }
+}
+
 FlutterView* App::AddView(const Configuration::Config& config) {
   const size_t display_count_before = m_displays.size();
   auto display = DisplayForContext(config);
@@ -276,7 +315,8 @@ FlutterView* App::AddView(const Configuration::Config& config) {
   // Index continues the constructor's sequence: it is the engine index that
   // shows up in the logs, and a duplicate would make two engines
   // indistinguishable there.
-  auto view = std::make_unique<FlutterView>(config, m_views.size(), display);
+  auto view = std::make_unique<FlutterView>(config, m_views.size(),
+                                            NameForView(config), display);
   // Initialize() runs the engine. Doing it here, one view at a time, is the
   // whole point of this entry point.
   //
@@ -323,7 +363,10 @@ App::App(const std::vector<Configuration::Config>& configs) {
   size_t index = 0;
   m_views.reserve(configs.size());
   for (auto const& cfg : configs) {
-    auto view = std::make_unique<FlutterView>(cfg, index, view_display[index]);
+    // m_views grows as this loop runs, so each name is checked against the
+    // views already built -- the same rule AddView applies later.
+    auto view = std::make_unique<FlutterView>(cfg, index, NameForView(cfg),
+                                              view_display[index]);
     if (!view->Initialize()) {
       // Fatal on this path only: the constructor runs before anything is up, so
       // there is no running system for a failed view to spare.

--- a/shell/app.h
+++ b/shell/app.h
@@ -81,6 +81,11 @@ class App final {
    *
    * @relation flutter, osgi
    */
+  // This view's identity: derived from its bundle and unique among live
+  // views. Names the view's semantics tree and is handed to the application.
+  [[nodiscard]] std::string NameForView(
+      const Configuration::Config& config) const;
+
   FlutterView* AddView(const Configuration::Config& config);
 
   /**

--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -128,6 +128,7 @@ extern "C" void EngineThreadPrioritySetter(FlutterThreadPriority prio) {
 
 Engine::Engine(FlutterView* view,
                const size_t index,
+               std::string view_name,
                const std::vector<const char*>& command_line_args_c,
                const std::vector<const char*>& dart_entrypoint_args_c,
                const std::string& bundle_path,
@@ -138,6 +139,7 @@ Engine::Engine(FlutterView* view,
                const bool mcp_tools_narrowed)
     : m_index(index),
       m_bundle_name(std::filesystem::path(bundle_path).filename().string()),
+      m_view_name(std::move(view_name)),
       m_running(false),
       m_backend(view->GetBackend()),
       m_view(view),
@@ -1069,32 +1071,20 @@ void Engine::InstallSemanticsHost() {
     return engine->SendSyntheticTap(x, y);
   };
 
-  // A name an outside reader can recognise: the bundle's own directory, which
-  // is what a person configuring the shell named it. The index disambiguates
-  // the case two bundles share a basename, which registration would otherwise
-  // refuse -- and refusing would take semantics away from the second view
-  // rather than merely naming it awkwardly.
-  std::string name = m_bundle_name;
-  if (name.empty()) {
-    name = "view";
-  }
-
+  // App assigned this name and keeps it unique among live views, so there is
+  // nothing to fall back to here. It was derived before the engine started
+  // because the application is told it too -- one name, decided once, for the
+  // tree an agent reads and the tools it calls.
   IhsSemanticsSourceDesc desc{};
   desc.struct_size = sizeof(desc);
-  desc.name = name.c_str();
+  desc.name = m_view_name.c_str();
   desc.host = host;
   if (ihs_semantics_source_register(&desc, &m_semantics_source) !=
       IHS_SEMANTICS_OK) {
-    const std::string unique = name + "-" + std::to_string(m_index);
-    desc.name = unique.c_str();
-    if (ihs_semantics_source_register(&desc, &m_semantics_source) !=
-        IHS_SEMANTICS_OK) {
-      ihs::log::error(
-          "({}) semantics source registration failed; this view "
-          "publishes no tree",
-          m_index);
-      m_semantics_source = nullptr;
-    }
+    ihs::log::error(
+        "({}) semantics source '{}' was refused; this view publishes no tree",
+        m_index, m_view_name);
+    m_semantics_source = nullptr;
   }
 
   // The publish callback reaches the source through the engine state, which is

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -70,6 +70,7 @@ class Engine {
    */
   Engine(FlutterView* view,
          size_t index,
+         std::string view_name,
          const std::vector<const char*>& command_line_args_c,
          const std::vector<const char*>& dart_entrypoint_args_c,
          const std::string& bundle_path,
@@ -483,6 +484,8 @@ class Engine {
   // what a person configuring the shell called this application, so it is what
   // an outside reader should see addressing its tree.
   std::string m_bundle_name;
+  // Assigned by App: this view's identity, unique among live views.
+  std::string m_view_name;
 
 #if BUILD_ACCESSIBILITY
   // This engine's hub registration. Each engine is an independent publisher --

--- a/shell/view/flutter_view.cc
+++ b/shell/view/flutter_view.cc
@@ -177,8 +177,12 @@ std::shared_ptr<Backend> Backend::Create(
 
 FlutterView::FlutterView(Configuration::Config config,
                          const size_t index,
+                         std::string name,
                          const std::shared_ptr<IDisplay>& display)
-    : m_display(display), m_config(std::move(config)), m_index(index) {
+    : m_display(display),
+      m_config(std::move(config)),
+      m_index(index),
+      m_name(std::move(name)) {
   m_backend = Backend::Create(m_config, display);
 
   IHS_DEBUG("Width: {}, Height: {}",
@@ -536,8 +540,17 @@ bool FlutterView::Initialize() {
 
   // Arguments to the Dart entrypoint main(List<String>) -> dart_entrypoint_argv
   // (no argv[0] convention).
+  //
+  // The view's own name goes in ahead of the configured ones. An application
+  // cannot work out which view it is -- every instance of a bundle runs the
+  // same code -- and it needs to, because two instances otherwise claim the
+  // same namespace for the tools they declare and the second one loses. This
+  // is the same name that addresses the view's semantics tree, so an agent
+  // reading a tree and calling a tool sees one identity rather than two.
+  const std::string view_arg = "--ihs-view=" + m_name;
   std::vector<const char*> m_dart_entrypoint_args_c;
-  m_dart_entrypoint_args_c.reserve(m_config.view.dart_args.size());
+  m_dart_entrypoint_args_c.reserve(m_config.view.dart_args.size() + 1);
+  m_dart_entrypoint_args_c.push_back(view_arg.c_str());
   for (const auto& arg : m_config.view.dart_args) {
     m_dart_entrypoint_args_c.push_back(arg.c_str());
   }
@@ -548,7 +561,7 @@ bool FlutterView::Initialize() {
 #endif
 
   m_flutter_engine = std::make_shared<Engine>(
-      this, m_index, m_command_line_args_c, m_dart_entrypoint_args_c,
+      this, m_index, m_name, m_command_line_args_c, m_dart_entrypoint_args_c,
       m_config.view.bundle_path,
       m_config.view.accessibility_features.value_or(0),
       m_config.view.merge_render_platform.value_or(false),

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -76,9 +76,19 @@ class TaskRunner;
 
 class FlutterView {
  public:
+  /**
+   * @param name  This view's identity, assigned by App and unique among live
+   *              views. It names the view's semantics tree and is handed to the
+   *              application so its tools can say which view they act on, so
+   *              one view is one name everywhere it is addressed from.
+   */
   FlutterView(Configuration::Config config,
               size_t index,
+              std::string name,
               const std::shared_ptr<IDisplay>& display);
+
+  /// This view's identity; see the constructor.
+  [[nodiscard]] const std::string& GetName() const { return m_name; }
   ~FlutterView();
 
   /**
@@ -406,6 +416,8 @@ class FlutterView {
   const Configuration::Config m_config;
   std::shared_ptr<PlatformChannel> m_platform_channel;
   size_t m_index;
+  // Assigned by App; see the constructor.
+  std::string m_name;
 
   std::unique_ptr<FlutterDesktopViewControllerState> m_state;
 

--- a/test/integration/mcp_drive_test/lib/main.dart
+++ b/test/integration/mcp_drive_test/lib/main.dart
@@ -23,7 +23,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:ihs_mcp_app_tools/ihs_mcp_app_tools.dart';
 
-void main() {
+// The shell passes --ihs-view=<name> so an instance can tell which view it is.
+// Held here because the tool registration needs it and initState has no access
+// to the entrypoint arguments.
+String? _viewName;
+
+void main(List<String> args) {
+  _viewName = McpAppTools.viewFromArgs(args);
   runApp(const McpDriveTestApp());
 }
 
@@ -94,6 +100,10 @@ class _DriveTestPageState extends State<DriveTestPage> {
     try {
       _appTools = McpAppTools.register(
         prefix: 'fixture_',
+        // Only breaks a tie: with one instance this changes nothing, and with
+        // two the second is advertised under its view instead of losing its
+        // tools entirely.
+        view: _viewName,
         tools: <McpTool>[
           McpTool(
             name: 'set_temp',

--- a/test/unit_test/mcp_app_tools-test/test_case_mcp_app_tools.cc
+++ b/test/unit_test/mcp_app_tools-test/test_case_mcp_app_tools.cc
@@ -302,6 +302,58 @@ TEST_F(McpAppToolsTest, ACollidingPrefixIsRefused) {
   EXPECT_EQ(second, nullptr);
 }
 
+// Two instances of one application ask for the same prefix -- the same app on
+// two displays is an ordinary arrangement, not a mistake. Given a view, the
+// second is advertised under it instead of losing its tools entirely.
+TEST_F(McpAppToolsTest, ASecondInstanceFallsBackToItsViewsPrefix) {
+  ASSERT_EQ(RegisterOne("hvac_"), IHS_MCP_OK);
+  // The first claimant keeps the bare prefix: an application running alone
+  // advertises what it always did, and a second one starting later must not
+  // rename tools an agent has already discovered.
+  EXPECT_STREQ(ihs_mcp_app_tools_prefix(handle_), "hvac_");
+
+  std::vector<IhsMcpAppTool> more = {Tool("set_temp", kTempSchema)};
+  IhsMcpAppToolsDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.tool_prefix = "hvac_";
+  desc.tools = more.data();
+  desc.tool_count = more.size();
+  desc.invoke = OnInvoke;
+  desc.view = "cluster";
+  IhsMcpAppTools* second = nullptr;
+  ASSERT_EQ(ihs_mcp_app_tools_register(&desc, &second), IHS_MCP_OK)
+      << "a second instance lost its tools rather than falling back";
+  ASSERT_NE(second, nullptr);
+  EXPECT_STREQ(ihs_mcp_app_tools_prefix(second), "cluster.hvac_");
+
+  // Reachable is the point: a name nothing can call would be no better than
+  // the refusal this replaces.
+  IhsMcpPayload out{};
+  EXPECT_EQ(ihs_mcp_registry_call_tool("cluster.hvac_set_temp", "{}", 2, &out),
+            IHS_MCP_OK);
+  ihs_mcp_registry_release_payload(&out);
+
+  ihs_mcp_app_tools_unregister(second);
+}
+
+// Without a view there is nothing to qualify with, so the refusal stands and
+// stays distinguishable from a plain decline.
+TEST_F(McpAppToolsTest, ASecondInstanceWithNoViewIsStillRefused) {
+  ASSERT_EQ(RegisterOne("hvac_"), IHS_MCP_OK);
+
+  std::vector<IhsMcpAppTool> more = {Tool("other", kTempSchema)};
+  IhsMcpAppToolsDesc desc{};
+  desc.struct_size = sizeof(desc);
+  desc.tool_prefix = "hvac_";
+  desc.tools = more.data();
+  desc.tool_count = more.size();
+  desc.invoke = OnInvoke;
+  IhsMcpAppTools* second = nullptr;
+  EXPECT_EQ(ihs_mcp_app_tools_register(&desc, &second),
+            IHS_MCP_ERR_PREFIX_TAKEN);
+  EXPECT_EQ(second, nullptr);
+}
+
 // Unregistering has to leave nothing behind: the tools go, and a call already
 // waiting is failed rather than left to time out against a callback that no
 // longer exists.


### PR DESCRIPTION
First of three. The other two are the DRM multi-output semantics gap and the pointer tap that goes with it.

## The problem

The same application on two displays is an ordinary arrangement. The second instance **lost the tools it declares**: both ask for the same prefix, the registry refused the duplicate, and the refusal reached nobody an agent could see. The tools were simply absent — the application learned about it only through its own error path, which is where I first saw it:

```
last=tools:unavailable:Bad state: the tool prefix 'fixture_' is already claimed
```

## Why the shell has to be the one to say

An application cannot tell which instance it is — every instance runs the same code. So the shell tells it.

Each view already needs a name for the semantics tree that addresses it. That name is now decided **once, up front**, and passed to the application as `--ihs-view=<name>`. Registration takes it and, **only when the prefix it wanted is already claimed**, falls back to `<view>.<prefix>`.

**The first claimant keeps the bare prefix.** An application running alone advertises exactly the names it always did, and a second one starting later cannot rename tools an agent has already discovered.

## Naming moved to App, and stopped saying "bundle"

Deriving the name in the engine was too late — the application has to be told it before the engine starts. It now happens in `App`, which is the part that knows what else is running, and the try-then-fall-back dance at source registration goes away.

It also stops calling everything `bundle`. A bundle laid out as `<app>/bundle` took its directory name, so every view was `bundle`:

| | before | after |
|---|---|---|
| tree | `ui://semantics/bundle/tree` | `ui://semantics/mcp_drive_test/tree` |
| second tree | `ui://semantics/bundle-1/tree` | `ui://semantics/mcp_drive_test-1/tree` |

## Verified against a real shell

Two views:

```
trees: ui://semantics/mcp_drive_test/tree, ui://semantics/mcp_drive_test-1/tree
tools: fixture_set_temp, mcp_drive_test-1.fixture_set_temp
```

The qualifier is the same name that addresses that view's tree, so an agent reading a tree and calling a tool sees one identity rather than two.

One view is unchanged (`fixture_set_temp`), and the integration suite still passes **8 of 8** against it. The two-view run is 8 of 12 — the same set as before this change; the four failures are the documented presentation confound, where a headless compositor presents only one of two surfaces.

## Tests

Two, and the first **fails with the fallback reverted** (checked): a second instance with a view is advertised under it *and is callable there*, and one without a view is still refused with the status that distinguishes "this namespace is taken" from a plain decline.

29/29 unit suites, clang-tidy clean on the changed sources, clang-format last.

One note: `mcp_semantics_provider` failed once under `ctest` with `Subprocess terminated`, then passed on re-run and 3/3 standalone. I could not reproduce it and have not established whether it predates this branch — flagging rather than assuming it is noise.

## Compatibility

`view` is appended to `IhsMcpAppToolsDesc` behind a `struct_size` bounds check, so a caller built against the older header is unaffected and behaves exactly as before.
