### PR TITLE
fix: publish a tree per Flutter view rather than merging them

### DIFF
--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -355,6 +355,14 @@ void Engine::Shutdown() {
       m_engine_state->semantics_source = nullptr;
     }
   }
+  // Additional views go with it, for the same reason and at the same point.
+  for (auto& [view_id, view] : m_extra_views) {
+    if (view->source != nullptr) {
+      ihs_semantics_source_unregister(view->source);
+      view->source = nullptr;
+    }
+  }
+  m_extra_views.clear();
 #endif
   // Deinitialize stops new frame work; Shutdown joins the platform, UI and
   // rasterizer threads. After this returns nothing in the engine touches the
@@ -1092,6 +1100,7 @@ void Engine::InstallSemanticsHost() {
   // together, because publishing one without the other is the defect.
   if (m_engine_state != nullptr) {
     m_engine_state->semantics_source = m_semantics_source;
+    m_engine_state->engine = this;
   }
 }
 
@@ -1221,21 +1230,106 @@ void Engine::onSemanticsUpdateCallback(const FlutterSemanticsUpdate2* update,
   FlutterDesktopEngineState const* engine_state =
       static_cast<FlutterDesktopEngineState*>(user_data);
 
-  auto* accessibility_tree = engine_state->accessibility_tree;
   IHS_TRACE(
       "[onSemanticsUpdateCallback] struct_size: {}, node_count: {} "
       "custom_action_count: {}",
       update->struct_size, update->node_count, update->custom_action_count);
 
-  accessibility_tree->HandleFlutterUpdate(update);
+  if (engine_state->engine == nullptr) {
+    return;
+  }
+  engine_state->engine->PublishSemanticsUpdate(update);
+}
 
-  // Hand the refreshed tree to the semantics hub. Publication is whole-tree
-  // and happens here, at the batch boundary, because that is the only point at
-  // which the mirror is known consistent.
-  const int status = accessibility::PublishTree(*accessibility_tree,
-                                                engine_state->semantics_source);
+void Engine::PublishSemanticsUpdate(const FlutterSemanticsUpdate2* update) {
+  // Which view this batch describes. Appended to the struct after its initial
+  // layout, so an engine older than the member reports a smaller size and every
+  // batch is the implicit view -- which is what such an engine can produce.
+  constexpr size_t kViewIdNeeded =
+      offsetof(FlutterSemanticsUpdate2, view_id) + sizeof(update->view_id);
+  const int64_t view_id =
+      update->struct_size >= kViewIdNeeded ? update->view_id : 0;
+
+  // The implicit view keeps the tree and source already in place. Every
+  // Wayland configuration is one view per engine and never reaches the branch
+  // below.
+  if (view_id == 0) {
+    auto* tree = m_engine_state->accessibility_tree;
+    if (tree == nullptr) {
+      return;
+    }
+    tree->HandleFlutterUpdate(update);
+    // Whole-tree publication, at the batch boundary, because that is the only
+    // point at which the mirror is known consistent.
+    const int status =
+        accessibility::PublishTree(*tree, m_engine_state->semantics_source);
+    if (status != IHS_SEMANTICS_OK) {
+      ihs::log::warn("({}) failed to publish semantics snapshot: {}", m_index,
+                     status);
+    }
+    return;
+  }
+
+  auto& slot = m_extra_views[view_id];
+  if (slot == nullptr) {
+    slot = std::make_unique<ViewSemantics>();
+    slot->engine = this;
+    slot->view_id = view_id;
+
+    IhsSemanticsHost host{};
+    host.struct_size = sizeof(host);
+    host.user_data = slot.get();
+    // Semantics is an engine-wide switch, so every view on this engine asks
+    // the same question of it. Repeating it is harmless and simpler than
+    // tracking which view spoke first.
+    host.set_semantics_enabled = [](void* user_data, const bool enabled) {
+      auto* view = static_cast<ViewSemantics*>(user_data);
+      if (view->engine->m_flutter_engine == nullptr) {
+        return;
+      }
+      LibFlutterEngine->UpdateSemanticsEnabled(view->engine->m_flutter_engine,
+                                               enabled);
+    };
+    // The view is the source, so its own id is used rather than the one the
+    // hub passes through. That is what makes an action come back to the view
+    // whose tree it was read from.
+    host.dispatch = [](void* user_data, int64_t /* view_id */,
+                       const int32_t node_id, const uint64_t action,
+                       const uint8_t* data, const size_t data_length) -> int {
+      auto* view = static_cast<ViewSemantics*>(user_data);
+      return view->engine->DispatchSemanticsAction(view->view_id, node_id,
+                                                   action, data, data_length);
+    };
+    host.send_pointer_tap = [](void* user_data, const int64_t /* view_id */,
+                               const double x, const double y) -> int {
+      auto* view = static_cast<ViewSemantics*>(user_data);
+      return view->engine->SendSyntheticTap(x, y);
+    };
+
+    // Named from the view it belongs to, so a reader can see which output it
+    // is looking at and which engine it came from.
+    const std::string name = m_view_name + "." + std::to_string(view_id);
+    IhsSemanticsSourceDesc desc{};
+    desc.struct_size = sizeof(desc);
+    desc.name = name.c_str();
+    desc.host = host;
+    if (ihs_semantics_source_register(&desc, &slot->source) !=
+        IHS_SEMANTICS_OK) {
+      ihs::log::error(
+          "({}) semantics source '{}' was refused; that view "
+          "publishes no tree",
+          m_index, name);
+      slot->source = nullptr;
+    } else {
+      ihs::log::info("({}) view {} publishes as '{}'", m_index, view_id, name);
+    }
+  }
+
+  slot->tree.HandleFlutterUpdate(update);
+  const int status = accessibility::PublishTree(slot->tree, slot->source);
   if (status != IHS_SEMANTICS_OK) {
-    ihs::log::warn("Failed to publish semantics snapshot: {}", status);
+    ihs::log::warn("({}) failed to publish semantics for view {}: {}", m_index,
+                   view_id, status);
   }
 }
 #endif

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -488,6 +488,33 @@ class Engine {
   std::string m_view_name;
 
 #if BUILD_ACCESSIBILITY
+  // One engine can drive several Flutter views -- the DRM backend attaches an
+  // additional view per extra output on the same card. Each has its own root
+  // and numbers its nodes from it, and Flutter gives every root id 0, so the
+  // views cannot share a mirror: the second root would overwrite the first and
+  // whatever was unreachable from the survivor would simply be dropped.
+  //
+  // So each view gets its own tree and its own hub source, and is addressed by
+  // its own name. Actions come back through the source they were read from,
+  // which is what stops a dispatch aimed at one output landing on another.
+  //
+  // The implicit view (id 0) is deliberately absent here: it keeps the tree and
+  // source that were already in place, so a shell with one view per engine --
+  // every Wayland configuration -- behaves exactly as before.
+  struct ViewSemantics {
+    AccessibilityTree tree;
+    IhsSemanticsSource* source = nullptr;
+    Engine* engine = nullptr;
+    int64_t view_id = 0;
+  };
+  std::map<int64_t, std::unique_ptr<ViewSemantics>> m_extra_views;
+
+  // Routes one batch to the view it belongs to, registering that view's source
+  // the first time it publishes. Platform thread only, like every publish.
+  void PublishSemanticsUpdate(const FlutterSemanticsUpdate2* update);
+#endif
+
+#if BUILD_ACCESSIBILITY
   // This engine's hub registration. Each engine is an independent publisher --
   // its own tree, its own node id space -- so a shared host would mean the
   // last engine to start receiving every engine's actions.

--- a/shell/platform/homescreen/flutter_desktop_engine_state.h
+++ b/shell/platform/homescreen/flutter_desktop_engine_state.h
@@ -99,6 +99,11 @@ struct FlutterDesktopEngineState {
 
   AccessibilityTree* accessibility_tree = nullptr;
 
+  // The engine that owns this state. Semantics batches arrive on a static
+  // callback that is handed only this struct, and routing one to the view it
+  // describes needs the per-view state the engine holds.
+  Engine* engine = nullptr;
+
   // The hub registration this engine publishes its tree to, travelling beside
   // the tree because the two are only meaningful together: publishing without
   // it means the last engine to run owns the only tree there is.

--- a/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
+++ b/test/unit_test/accessibility_tree-test/test_case_accessibility_tree.cc
@@ -751,3 +751,41 @@ TEST_F(AccessibilityTreeTest, DumpTreeEmitsCustomActionsInIdOrder) {
   EXPECT_EQ(doc["nodes"][0]["custom_actions"][1].GetInt(), 1);
   EXPECT_EQ(doc["nodes"][0]["custom_actions"][2].GetInt(), 5);
 }
+
+// Why one engine driving several views cannot share a mirror.
+//
+// Each view has its own root and numbers its nodes from it, and Flutter gives
+// every root id 0 -- SemanticsNode.root() is defined that way. Two views
+// applied to one tree therefore write over each other at id 0, and the loser's
+// subtree becomes unreachable from the root that survived. The publisher walks
+// from id 0 and drops what it cannot reach, so that view's nodes do not merely
+// come out wrong, they come out absent.
+//
+// This is the constraint that makes a tree per view the only workable shape,
+// so it is asserted rather than left as a remark in a commit message.
+TEST_F(AccessibilityTreeTest, TwoViewsInOneTreeOverwriteEachOther) {
+  AccessibilityTree shared;
+
+  NodeBuilder first_root(0, {1}, "cluster root");
+  NodeBuilder first_child(1, {}, "Speed");
+  Apply(shared, {&first_root.node, &first_child.node});
+  ASSERT_NE(FindById(shared, 1), nullptr);
+
+  // The second view's batch, with the root Flutter gives it: also 0.
+  NodeBuilder second_root(0, {2}, "radio root");
+  NodeBuilder second_child(2, {}, "Volume");
+  Apply(shared, {&second_root.node, &second_child.node});
+
+  const AccessibilityNode* root = FindById(shared, 0);
+  ASSERT_NE(root, nullptr);
+  EXPECT_STREQ(root->GetLabel(), "radio root")
+      << "the roots did not collide, so this test no longer shows anything";
+
+  // And the first view's node is gone outright: replacing the root's children
+  // detaches it, and a detached node is pruned rather than kept. So the loser
+  // does not come out stale or misparented, it comes out absent -- with nothing
+  // anywhere reporting that a view stopped being described.
+  ASSERT_EQ(root->NumberOfChildren(), 1u);
+  EXPECT_EQ(root->GetChild(0), 2);
+  EXPECT_EQ(FindById(shared, 1), nullptr);
+}


### PR DESCRIPTION
Second of three. #483 has merged, so this is rebased onto `v3.0` and stands alone.

## The defect

One engine can drive several Flutter views: the DRM backend attaches an additional view per extra output on the same card (`flutter_view.cc`, `Engine::AddView`). Their semantics were merged into one mirror, and **the merge destroyed them**.

Every view's root is node 0 — the framework defines it that way (`SemanticsNode.root()`). Two views applied to one tree write over each other at the root. Replacing the root's children detaches the previous view's subtree, and a detached node is **pruned rather than kept**. The publisher then walks from node 0 and emits what it can reach.

So the losing view's nodes do not come out stale or misparented. They come out **absent**, with nothing anywhere reporting that a view stopped being described.

The batch already said which view it belonged to. `onSemanticsUpdateCallback` discarded it.

## The fix

Each view gets its own tree and its own hub source, named for the view it belongs to, registered the first time that view publishes.

Actions come back through the source they were read from: an extra view's host **carries its own id and uses that** rather than the one passed through it, which is what stops a dispatch aimed at one output landing on another.

The implicit view keeps the tree and source already in place, so a shell with one view per engine — every Wayland configuration — takes the same path it always did. Reading the view id is gated on `struct_size`, so an engine older than that member reports every batch as the implicit view, which is what such an engine can produce.

## The test corrected me

I asserted the first view's node would be left behind but unreachable. It is removed outright — `Update()` prunes detached children. The test now asserts what actually happens, which is the more destructive of the two.

It exists because this is invisible without two outputs attached, and it is the constraint that makes a tree per view the only workable shape.

## Verification, and its limit

Verified on **Wayland**, where the behavior must not change:

- integration suite **8 of 8**
- two bundles still publish two trees
- 29/29 unit suites, clang-tidy clean, clang-format last

**The DRM path that reaches the new branch was not run.** It needs a card with two outputs, which this environment does not have. The routing, the lazy source registration and the per-view dispatch id are therefore reviewed-but-unexercised end to end — worth a reviewer's attention on hardware before this is relied on.

