### PR TITLE
fix: aim a synthesized tap at the view it was asked for

### DIFF
--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -837,7 +837,8 @@ void Engine::CoalesceMouseEvent(const FlutterPointerSignalKind signal,
                                 const double scroll_delta_x,
                                 const double scroll_delta_y,
                                 const int64_t buttons,
-                                const uint64_t timestamp_us) {
+                                const uint64_t timestamp_us,
+                                const int64_t view_id) {
   // 0 = no high-resolution source; stamp with the arrival time (the engine
   // clock is CLOCK_MONOTONIC, so a caller-supplied kernel input timestamp in
   // the same domain slots in directly and predates this by the input path's
@@ -870,6 +871,10 @@ void Engine::CoalesceMouseEvent(const FlutterPointerSignalKind signal,
   e.scroll_delta_y = scroll_delta_y * m_pointer_scale;
   e.device_kind = kFlutterPointerDeviceKindMouse;
   e.buttons = buttons;
+  // Which view receives it. Zero is the implicit view, which is what every
+  // caller but a synthesized tap on an additional view means -- and what this
+  // was before the member was set at all.
+  e.view_id = view_id;
   e.pan_x = 0;
   e.pan_y = 0;
   e.scale = 0;
@@ -1073,10 +1078,13 @@ void Engine::InstallSemanticsHost() {
                                            data_length);
   };
 
+  // The source is the view, so its own id is used rather than the one the hub
+  // passes through -- the same rule dispatch follows. This source is the
+  // engine's implicit view.
   host.send_pointer_tap = [](void* user_data, const int64_t /* view_id */,
                              const double x, const double y) -> int {
     auto* engine = static_cast<Engine*>(user_data);
-    return engine->SendSyntheticTap(x, y);
+    return engine->SendSyntheticTap(0, x, y);
   };
 
   // App assigned this name and keeps it unique among live views, so there is
@@ -1104,39 +1112,44 @@ void Engine::InstallSemanticsHost() {
   }
 }
 
-int Engine::SendSyntheticTap(const double x, const double y) {
+int Engine::SendSyntheticTap(const int64_t view_id,
+                             const double x,
+                             const double y) {
   if (m_flutter_engine == nullptr) {
     return IHS_SEMANTICS_ERR_UNAVAILABLE;
   }
 
   // Posted rather than sent here: the coalescing buffer is drained on the
   // platform thread, and a caller may be on any thread.
-  asio::post(*m_platform_task_runner->GetStrandContext(), [this, x, y]() {
-    if (m_flutter_engine == nullptr) {
-      return;
-    }
-    // Add, then down, then up -- the sequence a real seat produces. Sent
-    // through the ordinary coalescing path rather than around it, so a
-    // synthesized tap is hit-tested, scaled and batched exactly as a physical
-    // one is; anything else would make the fallback behave unlike the input
-    // it stands in for.
-    CoalesceMouseEvent(kFlutterPointerSignalKindNone, kAdd, x, y, 0.0, 0.0, 0,
-                       0);
-    CoalesceMouseEvent(kFlutterPointerSignalKindNone, kDown, x, y, 0.0, 0.0,
-                       kFlutterPointerButtonMousePrimary, 0);
-    SendPointerEvents();
-    // Release in a later task, not the same batch. A down and an up delivered
-    // in one packet are one frame's worth of input with no interval between
-    // them, which is not a gesture any recognizer is looking for.
-    asio::post(*m_platform_task_runner->GetStrandContext(), [this, x, y]() {
-      if (m_flutter_engine == nullptr) {
-        return;
-      }
-      CoalesceMouseEvent(kFlutterPointerSignalKindNone, kUp, x, y, 0.0, 0.0,
-                         kFlutterPointerButtonMousePrimary, 0);
-      SendPointerEvents();
-    });
-  });
+  asio::post(
+      *m_platform_task_runner->GetStrandContext(), [this, view_id, x, y]() {
+        if (m_flutter_engine == nullptr) {
+          return;
+        }
+        // Add, then down, then up -- the sequence a real seat produces. Sent
+        // through the ordinary coalescing path rather than around it, so a
+        // synthesized tap is hit-tested, scaled and batched exactly as a
+        // physical one is; anything else would make the fallback behave unlike
+        // the input it stands in for.
+        CoalesceMouseEvent(kFlutterPointerSignalKindNone, kAdd, x, y, 0.0, 0.0,
+                           0, 0, view_id);
+        CoalesceMouseEvent(kFlutterPointerSignalKindNone, kDown, x, y, 0.0, 0.0,
+                           kFlutterPointerButtonMousePrimary, 0, view_id);
+        SendPointerEvents();
+        // Release in a later task, not the same batch. A down and an up
+        // delivered in one packet are one frame's worth of input with no
+        // interval between them, which is not a gesture any recognizer is
+        // looking for.
+        asio::post(*m_platform_task_runner->GetStrandContext(), [this, view_id,
+                                                                 x, y]() {
+          if (m_flutter_engine == nullptr) {
+            return;
+          }
+          CoalesceMouseEvent(kFlutterPointerSignalKindNone, kUp, x, y, 0.0, 0.0,
+                             kFlutterPointerButtonMousePrimary, 0, view_id);
+          SendPointerEvents();
+        });
+      });
 
   // Accepted for delivery. Whether anything was under the point is not
   // knowable here, and reporting success as though it were would be the
@@ -1303,7 +1316,7 @@ void Engine::PublishSemanticsUpdate(const FlutterSemanticsUpdate2* update) {
     host.send_pointer_tap = [](void* user_data, const int64_t /* view_id */,
                                const double x, const double y) -> int {
       auto* view = static_cast<ViewSemantics*>(user_data);
-      return view->engine->SendSyntheticTap(x, y);
+      return view->engine->SendSyntheticTap(view->view_id, x, y);
     };
 
     // Named from the view it belongs to, so a reader can see which output it

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -322,7 +322,8 @@ class Engine {
                           double scroll_delta_x,
                           double scroll_delta_y,
                           int64_t buttons,
-                          uint64_t timestamp_us = 0);
+                          uint64_t timestamp_us = 0,
+                          int64_t view_id = 0);
 
   /**
    * @brief Coalesce touch event
@@ -389,7 +390,15 @@ class Engine {
    * does not describe. Rides the ordinary input path, so it is hit-tested
    * like a real tap rather than invoking a node's handler by id.
    */
-  int SendSyntheticTap(double x, double y);
+  /**
+   * @brief Synthesize a tap, on a named view.
+   *
+   * @param[in] view_id Which of this engine's views to aim at. One engine can
+   *                    drive several, and a tap is hit-tested against the view
+   *                    it is delivered to, so aiming at the wrong one silently
+   *                    misses -- there is no node id here to catch it.
+   */
+  int SendSyntheticTap(int64_t view_id, double x, double y);
 
   /**
    * @brief Get backend of view

--- a/test/integration/mcp_drive_test/README.md
+++ b/test/integration/mcp_drive_test/README.md
@@ -154,17 +154,17 @@ The checks drive the semantics and pointer paths. They do not exercise
 those have unit coverage and, for AccessKit, verification over a real AT-SPI
 bus, but not against a real engine here.
 
-Two gaps are specific to running several applications, both found by C8–C11 and
-neither fixed here:
+An earlier version of this file said `ui_tap_at` could not be aimed, and that a
+tap landed somewhere arbitrary "regardless of which application the caller
+named". The second half was wrong. A tap has always reached the right
+application: the tool resolves the view argument to a source, and the hub calls
+that source's own host.
 
-- **`ui_tap_at` cannot be aimed.** The host's pointer-tap seam takes a view and
-  the shell discards it, so a synthetic tap goes wherever the ordinary input
-  path sends it regardless of which application the caller named. C4b is
-  therefore not meaningful with more than one running.
-- **Tools an application declares are first-come.** The prefix is claimed
-  process-wide, so a second application registering the same one is refused and
-  its tools never appear. Semantics trees are addressed per application; these
-  are not.
+What was lost is narrower, and is fixed now: one engine can drive several
+Flutter views, and the view *within* the engine was dropped on the way to the
+pointer event, so a tap meant for an extra output arrived at the implicit one.
+It travels with the coordinate now, because a coordinate only means anything
+against a view.
 
 C4b depends on the region being unobscured. If the app grows a layout where
 something overlaps it, that check will correctly start failing — a pointer


### PR DESCRIPTION
Third of three. Stacked on #484 — it aims the taps at the views that PR gives each source.

## The defect

A tap synthesized for one of an engine's additional views went to the implicit one. The host seam is handed a view and the shell dropped it:

```cpp
host.send_pointer_tap = [](void* user_data, const int64_t /* view_id */, ...)
```

and `FlutterPointerEvent.view_id` was never set, so every synthesized tap arrived at view zero whatever the caller named.

## Why this one is quiet

A tap is hit-tested against the view it is delivered to, and it carries **no node id**, so aiming at the wrong view does not fail — it *misses*. Nothing reports that, because missing is a legitimate outcome for a coordinate: `ui_tap_at` exists precisely to reach what the tree does not describe, and it cannot tell a point with nothing under it from a point delivered to the wrong screen.

## The fix

The coordinate is only meaningful against a view, so it now travels with one. Each source aims at the view it belongs to rather than the id passed through it — the rule dispatch already follows, so reading a tree and acting on what was read reach the same place.

The view defaults to zero through the coalescing path, so every other caller (a real seat, touch, scroll) is unchanged, and so is the implicit view every Wayland configuration uses.

## Verification, and its limit

The integration suite passes **8 of 8** on Wayland, including **C4b**, the check that drives exactly this path: a pointer tap reaching a region the semantics tree deliberately does not describe. That is real coverage of the implicit-view case this change threads a value through.

29/29 unit suites, clang-tidy clean, clang-format last.

**Aiming at an additional view was not run.** It needs a card with two outputs. As with #484, the multi-view branch is reviewed but unexercised end to end.

## Correcting the record

I earlier described this as "`ui_tap_at` cannot be aimed at a view, regardless of which application the caller named," and committed that wording to `test/integration/mcp_drive_test/README.md`. The second half was wrong: `ui_tap_at` already routes to the right **application**, because the provider passes the resolved source and the hub calls that source's host. What was lost is the **Flutter view within one engine**, which is what this fixes. The README paragraph is corrected here.
