### PR TITLE
fix: aim a synthesized tap at the view it was asked for

### DIFF
--- a/shell/engine.cc
+++ b/shell/engine.cc
@@ -837,7 +837,8 @@ void Engine::CoalesceMouseEvent(const FlutterPointerSignalKind signal,
                                 const double scroll_delta_x,
                                 const double scroll_delta_y,
                                 const int64_t buttons,
-                                const uint64_t timestamp_us) {
+                                const uint64_t timestamp_us,
+                                const int64_t view_id) {
   // 0 = no high-resolution source; stamp with the arrival time (the engine
   // clock is CLOCK_MONOTONIC, so a caller-supplied kernel input timestamp in
   // the same domain slots in directly and predates this by the input path's
@@ -870,6 +871,10 @@ void Engine::CoalesceMouseEvent(const FlutterPointerSignalKind signal,
   e.scroll_delta_y = scroll_delta_y * m_pointer_scale;
   e.device_kind = kFlutterPointerDeviceKindMouse;
   e.buttons = buttons;
+  // Which view receives it. Zero is the implicit view, which is what every
+  // caller but a synthesized tap on an additional view means -- and what this
+  // was before the member was set at all.
+  e.view_id = view_id;
   e.pan_x = 0;
   e.pan_y = 0;
   e.scale = 0;
@@ -1073,10 +1078,13 @@ void Engine::InstallSemanticsHost() {
                                            data_length);
   };
 
+  // The source is the view, so its own id is used rather than the one the hub
+  // passes through -- the same rule dispatch follows. This source is the
+  // engine's implicit view.
   host.send_pointer_tap = [](void* user_data, const int64_t /* view_id */,
                              const double x, const double y) -> int {
     auto* engine = static_cast<Engine*>(user_data);
-    return engine->SendSyntheticTap(x, y);
+    return engine->SendSyntheticTap(0, x, y);
   };
 
   // App assigned this name and keeps it unique among live views, so there is
@@ -1104,39 +1112,44 @@ void Engine::InstallSemanticsHost() {
   }
 }
 
-int Engine::SendSyntheticTap(const double x, const double y) {
+int Engine::SendSyntheticTap(const int64_t view_id,
+                             const double x,
+                             const double y) {
   if (m_flutter_engine == nullptr) {
     return IHS_SEMANTICS_ERR_UNAVAILABLE;
   }
 
   // Posted rather than sent here: the coalescing buffer is drained on the
   // platform thread, and a caller may be on any thread.
-  asio::post(*m_platform_task_runner->GetStrandContext(), [this, x, y]() {
-    if (m_flutter_engine == nullptr) {
-      return;
-    }
-    // Add, then down, then up -- the sequence a real seat produces. Sent
-    // through the ordinary coalescing path rather than around it, so a
-    // synthesized tap is hit-tested, scaled and batched exactly as a physical
-    // one is; anything else would make the fallback behave unlike the input
-    // it stands in for.
-    CoalesceMouseEvent(kFlutterPointerSignalKindNone, kAdd, x, y, 0.0, 0.0, 0,
-                       0);
-    CoalesceMouseEvent(kFlutterPointerSignalKindNone, kDown, x, y, 0.0, 0.0,
-                       kFlutterPointerButtonMousePrimary, 0);
-    SendPointerEvents();
-    // Release in a later task, not the same batch. A down and an up delivered
-    // in one packet are one frame's worth of input with no interval between
-    // them, which is not a gesture any recognizer is looking for.
-    asio::post(*m_platform_task_runner->GetStrandContext(), [this, x, y]() {
-      if (m_flutter_engine == nullptr) {
-        return;
-      }
-      CoalesceMouseEvent(kFlutterPointerSignalKindNone, kUp, x, y, 0.0, 0.0,
-                         kFlutterPointerButtonMousePrimary, 0);
-      SendPointerEvents();
-    });
-  });
+  asio::post(
+      *m_platform_task_runner->GetStrandContext(), [this, view_id, x, y]() {
+        if (m_flutter_engine == nullptr) {
+          return;
+        }
+        // Add, then down, then up -- the sequence a real seat produces. Sent
+        // through the ordinary coalescing path rather than around it, so a
+        // synthesized tap is hit-tested, scaled and batched exactly as a
+        // physical one is; anything else would make the fallback behave unlike
+        // the input it stands in for.
+        CoalesceMouseEvent(kFlutterPointerSignalKindNone, kAdd, x, y, 0.0, 0.0,
+                           0, 0, view_id);
+        CoalesceMouseEvent(kFlutterPointerSignalKindNone, kDown, x, y, 0.0, 0.0,
+                           kFlutterPointerButtonMousePrimary, 0, view_id);
+        SendPointerEvents();
+        // Release in a later task, not the same batch. A down and an up
+        // delivered in one packet are one frame's worth of input with no
+        // interval between them, which is not a gesture any recognizer is
+        // looking for.
+        asio::post(*m_platform_task_runner->GetStrandContext(), [this, view_id,
+                                                                 x, y]() {
+          if (m_flutter_engine == nullptr) {
+            return;
+          }
+          CoalesceMouseEvent(kFlutterPointerSignalKindNone, kUp, x, y, 0.0, 0.0,
+                             kFlutterPointerButtonMousePrimary, 0, view_id);
+          SendPointerEvents();
+        });
+      });
 
   // Accepted for delivery. Whether anything was under the point is not
   // knowable here, and reporting success as though it were would be the
@@ -1303,7 +1316,7 @@ void Engine::PublishSemanticsUpdate(const FlutterSemanticsUpdate2* update) {
     host.send_pointer_tap = [](void* user_data, const int64_t /* view_id */,
                                const double x, const double y) -> int {
       auto* view = static_cast<ViewSemantics*>(user_data);
-      return view->engine->SendSyntheticTap(x, y);
+      return view->engine->SendSyntheticTap(view->view_id, x, y);
     };
 
     // Named from the view it belongs to, so a reader can see which output it

--- a/shell/engine.h
+++ b/shell/engine.h
@@ -322,7 +322,8 @@ class Engine {
                           double scroll_delta_x,
                           double scroll_delta_y,
                           int64_t buttons,
-                          uint64_t timestamp_us = 0);
+                          uint64_t timestamp_us = 0,
+                          int64_t view_id = 0);
 
   /**
    * @brief Coalesce touch event
@@ -389,7 +390,15 @@ class Engine {
    * does not describe. Rides the ordinary input path, so it is hit-tested
    * like a real tap rather than invoking a node's handler by id.
    */
-  int SendSyntheticTap(double x, double y);
+  /**
+   * @brief Synthesize a tap, on a named view.
+   *
+   * @param[in] view_id Which of this engine's views to aim at. One engine can
+   *                    drive several, and a tap is hit-tested against the view
+   *                    it is delivered to, so aiming at the wrong one silently
+   *                    misses -- there is no node id here to catch it.
+   */
+  int SendSyntheticTap(int64_t view_id, double x, double y);
 
   /**
    * @brief Get backend of view

--- a/test/integration/mcp_drive_test/README.md
+++ b/test/integration/mcp_drive_test/README.md
@@ -154,17 +154,17 @@ The checks drive the semantics and pointer paths. They do not exercise
 those have unit coverage and, for AccessKit, verification over a real AT-SPI
 bus, but not against a real engine here.
 
-Two gaps are specific to running several applications, both found by C8–C11 and
-neither fixed here:
+An earlier version of this file said `ui_tap_at` could not be aimed, and that a
+tap landed somewhere arbitrary "regardless of which application the caller
+named". The second half was wrong. A tap has always reached the right
+application: the tool resolves the view argument to a source, and the hub calls
+that source's own host.
 
-- **`ui_tap_at` cannot be aimed.** The host's pointer-tap seam takes a view and
-  the shell discards it, so a synthetic tap goes wherever the ordinary input
-  path sends it regardless of which application the caller named. C4b is
-  therefore not meaningful with more than one running.
-- **Tools an application declares are first-come.** The prefix is claimed
-  process-wide, so a second application registering the same one is refused and
-  its tools never appear. Semantics trees are addressed per application; these
-  are not.
+What was lost is narrower, and is fixed now: one engine can drive several
+Flutter views, and the view *within* the engine was dropped on the way to the
+pointer event, so a tap meant for an extra output arrived at the implicit one.
+It travels with the coordinate now, because a coordinate only means anything
+against a view.
 
 C4b depends on the region being unobscured. If the app grows a layout where
 something overlaps it, that check will correctly start failing — a pointer

--- a/test/integration/mcp_drive_test/lib/main.dart
+++ b/test/integration/mcp_drive_test/lib/main.dart
@@ -18,6 +18,8 @@
 // assertion channel for the write path: if either direction is broken the
 // checks cannot pass by accident.
 
+import 'dart:ui' show FlutterView;
+
 import 'package:flutter/material.dart';
 // CustomSemanticsAction is not exported by material.dart.
 import 'package:flutter/semantics.dart';
@@ -30,7 +32,12 @@ String? _viewName;
 
 void main(List<String> args) {
   _viewName = McpAppTools.viewFromArgs(args);
-  runApp(const McpDriveTestApp());
+  // runWidget rather than runApp: one engine can be driving several views --
+  // the DRM backend attaches one per extra output on the same card -- and
+  // runApp renders into the implicit view alone. The others would exist,
+  // produce no semantics, and publish nothing, which looks from the outside
+  // exactly like a shell that dropped them.
+  runWidget(const McpDriveTestApp());
 }
 
 class McpDriveTestApp extends StatelessWidget {
@@ -38,16 +45,33 @@ class McpDriveTestApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      title: 'mcp_drive_test',
-      debugShowCheckedModeBanner: false,
-      home: DriveTestPage(),
+    final List<FlutterView> views =
+        WidgetsBinding.instance.platformDispatcher.views.toList();
+    return ViewCollection(
+      views: <Widget>[
+        for (final FlutterView view in views)
+          View(
+            view: view,
+            // A separate page per view, so each keeps its own state. That is
+            // what makes routing checkable: acting on one view has to leave
+            // the other's status line alone, and it cannot if they share one.
+            child: MaterialApp(
+              title: 'mcp_drive_test',
+              debugShowCheckedModeBanner: false,
+              home: DriveTestPage(viewId: view.viewId),
+            ),
+          ),
+      ],
     );
   }
 }
 
 class DriveTestPage extends StatefulWidget {
-  const DriveTestPage({super.key});
+  const DriveTestPage({super.key, this.viewId = 0});
+
+  /// Which of the engine's views this page is rendering into. Reported in the
+  /// status line so a driver can tell one view's page from another's.
+  final int viewId;
 
   @override
   State<DriveTestPage> createState() => _DriveTestPageState();
@@ -183,8 +207,12 @@ class _DriveTestPageState extends State<DriveTestPage> {
     // chose, and the realistic case for set_text has a space in it. A
     // separator the payload can contain makes the fixture pass only for
     // inputs that avoid it, which is the wrong way round.
+    // view is reported so a driver can tell which of the engine's views
+    // answered. With one view it is always 0 and says nothing; with several it
+    // is the only thing distinguishing two otherwise identical pages.
     return 'last=$_last; events=$_events; text=${_destination.text}; '
-        'temp=${_temperature.toStringAsFixed(1)}; mode=$_mode; $geometry';
+        'temp=${_temperature.toStringAsFixed(1)}; mode=$_mode; '
+        'view=${widget.viewId}; $geometry';
   }
 
   @override


### PR DESCRIPTION
Re-opens #485 against `v3.0` (it merged into the stale stack base), plus the fixture change that makes it verifiable — and **it is now verified on hardware**.

## Verified on a Pi 4 driving two outputs

The limitation I flagged on #484 and #485 is closed. One engine, HDMI-A-1 and DSI-1 on the same card, `drm-kms-egl`:

```
[FlutterView] view 0 is on output 'HDMI-A-1'
[FlutterView] AddView id=1 800x480 result=0
(0) view 1 publishes as 'mcp-drive-test.1'

trees: ui://semantics/mcp-drive-test/tree
       ui://semantics/mcp-drive-test.1/tree
       (status.view=0 and status.view=1 respectively)

ui_tap    Save on view 1  ->  view 1 events 0->1,  view 0 unchanged
ui_tap_at on view 1       ->  view 1 last=tap:opaque, view 0 untouched
```

The pointer line is the one that matters here. Before this change `view_id` was dropped and `FlutterPointerEvent.view_id` was left at 0, so that tap would have landed on the HDMI panel rather than the DSI one it named.

Both displays were confirmed rendering.

## Why the fixture had to change too

The fixture called `runApp`, which renders into the implicit view alone. On an engine driving several views the others existed, produced no semantics and published nothing — indistinguishable from a shell that dropped them, so the fixture could not have told the two apart.

It now uses `runWidget` with a view per `FlutterView`, a separate page in each so they keep their own state (sharing one would make an action on either look like an action on both), and the status line reports which view answered.

## What it does

`FlutterPointerEvent.view_id` was never set and the host seam dropped the view it was handed, so every synthesized tap arrived at view zero whatever the caller named. Each source now aims at the view it belongs to rather than the id passed through it — the rule dispatch already follows, so reading a tree and acting on what was read reach the same place.

A tap carries no node id and is hit-tested, so aiming at the wrong view did not fail, it *missed* — and missing is a legitimate outcome for a coordinate, so nothing reported it.

The view defaults to zero through the coalescing path, so a real seat, touch and scroll are unchanged.

## Also corrects a claim I committed

`test/integration/mcp_drive_test/README.md` said a tap landed arbitrarily "regardless of which application the caller named". Wrong — a tap has always reached the right application; the tool resolves the view argument to a source and the hub calls that source's host. What was lost was the Flutter view *within* one engine.

## Other verification

- x86 single-view integration suite **8 of 8**, unchanged by the fixture change
- 29/29 unit suites, clang-tidy clean, clang-format last
