### PR TITLE
fix: take the core wayland.xml from the sysroot, not the build host

### DIFF
--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -42,6 +42,29 @@ if (BUILD_BACKEND_WAYLAND_EGL)
     pkg_check_modules(WAYLAND_CXX_EGL REQUIRED IMPORTED_TARGET wayland-egl)
 endif ()
 
+# pkg_get_variable() hands back the variable exactly as the .pc file spells it.
+# Unlike the -I/-L flags in the cflags/libs, it is never sysroot-prefixed, so
+# when cross-compiling a pkgdatadir such as /usr/share/wayland resolves against
+# the *build host* rather than the sysroot. Feeding host XML to the scanner
+# generates bindings for the host's libwayland while the code links the
+# sysroot's, and the *_SINCE_VERSION guards in the shell then test one version's
+# macros against the other version's structs.
+#
+# Prefer the sysroot copy whenever there is one. The host path usually exists
+# too -- that is precisely the failure -- so this cannot be an "only if missing"
+# fallback; under CMAKE_SYSROOT the sysroot wins. When the value already points
+# inside the sysroot (pkg-config does apply PKG_CONFIG_SYSROOT_DIR when it finds
+# the .pc there) the prefixed path does not exist and the value is left alone.
+function(_wlcxx_prefer_sysroot var subpath)
+    if (NOT CMAKE_SYSROOT)
+        return()
+    endif ()
+    set(_candidate "${CMAKE_SYSROOT}${${var}}")
+    if (EXISTS "${_candidate}/${subpath}")
+        set(${var} "${_candidate}" PARENT_SCOPE)
+    endif ()
+endfunction()
+
 # Protocol XML base — xdg-shell + presentation-time ship with wayland-protocols.
 #
 # Surface builds only: a lease-only build reads nothing from wayland-protocols.
@@ -54,14 +77,20 @@ endif ()
 if (IVI_WAYLAND_SURFACE_BACKENDS)
     pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.20)
     pkg_get_variable(_wlcxx_proto_base wayland-protocols pkgdatadir)
+    _wlcxx_prefer_sysroot(_wlcxx_proto_base "stable/xdg-shell/xdg-shell.xml")
     set(IVI_WL_PROTOCOLS_BASE "${_wlcxx_proto_base}" CACHE INTERNAL "wayland-protocols pkgdatadir")
 endif ()
 
 # Core Wayland protocol XML (wl_seat / wl_keyboard / …) ships with
 # wayland-scanner. The generated wayland_client.hpp backs wl::KeyboardHandler;
 # its core wl_interface tables come from libwayland (no --emit-interface-tables).
+# Settable: an integrator whose sysroot layout defeats the probe above can point
+# this straight at the right XML. It must describe the libwayland actually being
+# linked -- a mismatch is silent when the XML is older (events are compiled out
+# with no diagnostic) and a compile error when it is newer.
 pkg_get_variable(_wlcxx_core_base wayland-scanner pkgdatadir)
-set(IVI_WL_CORE_XML "${_wlcxx_core_base}/wayland.xml" CACHE INTERNAL "core wayland.xml")
+_wlcxx_prefer_sysroot(_wlcxx_core_base "wayland.xml")
+set(IVI_WL_CORE_XML "${_wlcxx_core_base}/wayland.xml" CACHE FILEPATH "core wayland.xml")
 
 # --- Shell client options --------------------------------------------------
 # xdg + agl on by default; ivi + simple are opt-in.


### PR DESCRIPTION
Fixes #488.

## What was wrong

`pkg_get_variable()` returns a `.pc` variable exactly as written. Unlike the `-I`/`-L` flags in cflags/libs it is never sysroot-prefixed, so `pkgdatadir` came back as a bare `/usr/share/wayland` and resolved against the build host. The scanner was generating core bindings from the host's XML while everything it produces links the sysroot's libwayland.

Observed on a Yocto kirkstone build (container wayland 1.22, sysroot 1.20.0) — the core XML escapes while the wayland-protocols XMLs next to it resolve correctly:

```
/usr/share/wayland/wayland.xml                                    <-- build host
.../recipe-sysroot/usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml
.../recipe-sysroot/usr/share/wayland-protocols/unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml
```

Because the generated headers carry the `*_SINCE_VERSION` macros, the listener guards in `shell/wayland` compare one wayland version's macros against another's structs. Both directions are broken, and the quiet one is worse:

| sysroot vs host | result |
|---|---|
| older | compile error — guards true, struct members absent |
| newer | **silent** — guards false, listener members omitted, those events never arrive |
| equal | correct, by coincidence |

## The change

`_wlcxx_prefer_sysroot()` re-roots a pkg-config directory under `CMAKE_SYSROOT` when the expected file is present there.

This deliberately is **not** an "only if the host path is missing" fallback. The host path almost always exists — that is the entire failure — so under `CMAKE_SYSROOT` the sysroot wins outright. Where the value already points into the sysroot, as `wayland-protocols` `pkgdatadir` does when pkg-config finds that `.pc` inside it, the prefixed candidate does not exist and the value is left untouched.

`IVI_WL_CORE_XML` also becomes a real cache entry. It was `CACHE INTERNAL`, and `INTERNAL` implies `FORCE`, so `-D IVI_WL_CORE_XML=...` was overwritten on every configure and there was no way to correct the path from outside the project. Note this makes the value sticky across reconfigures in one build directory, which is ordinary cache behavior but a change from the previous refresh-every-time semantics.

The helper is applied to the `wayland-protocols` lookup too. That path resolves correctly today, so it is a no-op there — but it depends on which sysroot pkg-config happens to find the `.pc` in, and the same class of failure applies if that ever shifts.

## Verification

The helper was exercised directly with `cmake -P` over a fixture reproducing the kirkstone layout:

| case | result |
|---|---|
| cross, host **and** sysroot copies exist | sysroot wins ✅ (the failing case) |
| value already inside the sysroot | unchanged, no double prefix ✅ |
| native build, no `CMAKE_SYSROOT` | unchanged ✅ |
| cross, no copy in sysroot | unchanged, degrades to previous behavior ✅ |

`cmake -P cmake/wayland_cxx.cmake` parses and runs clean; a deliberately unbalanced `if()` appended to the same file is rejected, so the check is meaningful rather than vacuous.

Not yet run through a full cross build — worth a kirkstone (1.20) and a current-master (1.26) build before merge, since those are the two directions the table above describes.