### PR TITLE
docs: on_touch pointer_data_size is the total, not a stride

### DIFF
--- a/shared/include/ihs/platform_view.h
+++ b/shared/include/ihs/platform_view.h
@@ -405,10 +405,16 @@ typedef struct IhsPvGrant {
  *                                    for crisp output. Position and z-order come
  *                                    from the Flutter layer, not a callback.
  *   on_touch                         a pointer/touch sequence hit the view;
- *                                    @pointer_data is @point_count contacts of
- *                                    @pointer_data_size doubles, coordinates in
- *                                    view-local logical pixels (a plugin remaps
- *                                    to its own space, e.g. a CarPlay dongle's).
+ *                                    @pointer_data holds @point_count contacts
+ *                                    in @pointer_data_size doubles *in total*,
+ *                                    so one contact's stride is
+ *                                    @pointer_data_size / @point_count -- the
+ *                                    size is the whole buffer, not the stride.
+ *                                    Within a contact, x sits at offset 7 and y
+ *                                    at offset 8 (raw Flutter PointerCoords
+ *                                    order), in view-local logical pixels (a
+ *                                    plugin remaps to its own space, e.g. a
+ *                                    CarPlay dongle's).
  *   accept_gesture/reject_gesture    gesture-arena arbitration for a sequence
  *                                    already delivered to the view.
  *   set_suspended                    the view left (1) or re-entered (0) the
@@ -432,6 +438,8 @@ typedef struct IhsPvGrant {
 typedef struct IhsPvCallbacks {
   size_t struct_size;
   void (*resize)(void* user_data, double width, double height);
+  /* pointer_data_size is the total number of doubles in pointer_data across
+   * all contacts, not a per-contact stride; divide by point_count for that. */
   void (*on_touch)(void* user_data,
                    int32_t action,
                    int32_t point_count,


### PR DESCRIPTION
Fixes #364.

## Problem

`platform_view.h` described `on_touch`'s buffer as:

```
 *   on_touch    @pointer_data is @point_count contacts of
 *               @pointer_data_size doubles
```

That reads as `point_count` rows, each `pointer_data_size` doubles wide, so a plugin computes contact *i* at `pointer_data + i * pointer_data_size` and mis-strides through multi-touch data.

## What is actually passed

The total length, unchanged all the way to the plugin:

```cpp
// platform_views_handler.cc
registry_->OnTouch(touch.getId(), touch.getAction(),
                   touch.getPointerCount(),
                   touch.getRawPointerCoords().size(),   // <-- whole buffer
                   touch.getRawPointerCoords().data());
```

`PlatformViewRegistry::OnTouch` forwards it verbatim to `listener->on_touch`, and `ListenerOnTouch` forwards it verbatim to `view->callbacks.on_touch`. Nothing divides it along the way. A contact's stride is `pointer_data_size / point_count`.

## Which side to change

The description, not the call site:

- the parameter is named for a size, and reads naturally as one
- the implementation has always passed the whole buffer, so this is documentation catching up with shipped behavior
- changing what is passed would silently break any out-of-tree plugin that already worked to the real behavior -- a wrong doc is fixable by reading, a changed ABI is not

## Change

Reword the callback table entry to say the size is the whole buffer and give the stride formula explicitly.

Also record where x and y sit inside a contact, offsets 7 and 8. The stride alone does not tell a plugin where to look, and those offsets are currently only discoverable by reading `getX()`/`getY()` and `PlatformViewTouch::Print()` in the shell.

The declaration gets a short note too, so the correction is visible at the point of use rather than only in the table 30 lines up.

## Checks

- header compiles clean as C11 and C++17, `-Wall -Wextra -fsyntax-only`, against a stubbed `ihs_export.h`
- no new lines over 80 columns; the file's five existing over-length lines are untouched
- comment-only, no generated code or ABI change
