### PR TITLE
fix: stop DrmSession waking 5x/s on an idle system

### DIFF
--- a/shell/backend/drm_kms_egl/drm_session.cc
+++ b/shell/backend/drm_kms_egl/drm_session.cc
@@ -120,6 +120,10 @@ DrmSession::DrmSession(drm::session::Seat seat) : seat_(std::move(seat)) {
 
 DrmSession::~DrmSession() {
   stop_.store(true, std::memory_order_release);
+  // Store the flag, then wake. That order closes the lost-wake window: the
+  // eventfd stays readable across the dispatcher's check/block boundary, so a
+  // Wake() landing between its stop_ check and its poll() is still seen.
+  waker_.Wake();
   if (thread_.joinable()) {
     thread_.join();
   }
@@ -172,17 +176,33 @@ void DrmSession::DispatchLoop() {
     return;
   }
   int hp_fd = hotplug_ ? hotplug_->fd() : -1;
+  const int wake_fd = waker_.fd();
   constexpr short kErr = POLLERR | POLLHUP | POLLNVAL;
 
+  // Block indefinitely. Both the seat and the hotplug fd are readable exactly
+  // when there is something to dispatch, so a timeout would only serve to
+  // re-check stop_ -- and stop_ changes once, at teardown, where the
+  // destructor wakes us instead. Degraded mode (eventfd() unavailable, fd()
+  // is -1) keeps the old cap so teardown is still observed promptly.
+  const int timeout_ms = wake_fd >= 0 ? -1 : kPollTimeoutMs;
+
   while (!stop_.load(std::memory_order_acquire)) {
-    pollfd pfds[2];
-    pfds[0] = {seat_fd, POLLIN, 0};
-    nfds_t nfds = 1;
+    // Indices rather than fixed slots: hotplug can be dropped mid-loop on a
+    // bad fd, and the waker is absent in degraded mode, so the set is rebuilt
+    // each iteration and the slots move.
+    pollfd pfds[3];
+    nfds_t nfds = 0;
+    const int seat_idx = static_cast<int>(nfds);
+    pfds[nfds++] = {seat_fd, POLLIN, 0};
+    const int hp_idx = hp_fd >= 0 ? static_cast<int>(nfds) : -1;
     if (hp_fd >= 0) {
-      pfds[1] = {hp_fd, POLLIN, 0};
-      nfds = 2;
+      pfds[nfds++] = {hp_fd, POLLIN, 0};
     }
-    const int r = poll(pfds, nfds, kPollTimeoutMs);
+    const int wake_idx = wake_fd >= 0 ? static_cast<int>(nfds) : -1;
+    if (wake_fd >= 0) {
+      pfds[nfds++] = {wake_fd, POLLIN, 0};
+    }
+    const int r = poll(pfds, nfds, timeout_ms);
     if (r < 0) {
       if (errno == EINTR) {
         continue;
@@ -191,25 +211,31 @@ void DrmSession::DispatchLoop() {
       break;
     }
     if (r > 0) {
-      if ((pfds[0].revents & kErr) != 0) {
+      // Drain first: the only writer is the destructor, so a readable waker
+      // means stop_ is already set and the loop condition will end us. Drain
+      // regardless so a spurious wake cannot spin the loop.
+      if (wake_idx >= 0 && (pfds[wake_idx].revents & POLLIN) != 0) {
+        waker_.Drain();
+      }
+      if ((pfds[seat_idx].revents & kErr) != 0) {
         ihs::log::error("[DrmSession] seat fd error (revents={:#x}); exiting",
-                        static_cast<unsigned>(pfds[0].revents));
+                        static_cast<unsigned>(pfds[seat_idx].revents));
         break;
       }
-      if ((pfds[0].revents & POLLIN) != 0) {
+      if ((pfds[seat_idx].revents & POLLIN) != 0) {
         seat_.dispatch();
       }
-      if (nfds == 2) {
-        if ((pfds[1].revents & kErr) != 0) {
+      if (hp_idx >= 0) {
+        if ((pfds[hp_idx].revents & kErr) != 0) {
           // Drop the hotplug monitor and keep serving the seat. A bad
           // hotplug fd shouldn't silently busy-loop the seat dispatcher.
           ihs::log::warn(
               "[DrmSession] hotplug fd error (revents={:#x}); disabling "
               "monitor",
-              static_cast<unsigned>(pfds[1].revents));
+              static_cast<unsigned>(pfds[hp_idx].revents));
           hotplug_.reset();
           hp_fd = -1;
-        } else if ((pfds[1].revents & POLLIN) != 0) {
+        } else if ((pfds[hp_idx].revents & POLLIN) != 0) {
           if (auto rc = hotplug_->dispatch(); !rc) {
             ihs::log::warn("[DrmSession] hotplug dispatch: {}",
                            rc.error().message());

--- a/shell/backend/drm_kms_egl/drm_session.h
+++ b/shell/backend/drm_kms_egl/drm_session.h
@@ -25,6 +25,8 @@
 #include <thread>
 #include <vector>
 
+#include "input/wake_event_fd.h"
+
 #include <drm-cxx/display/hotplug_monitor.hpp>
 #include <drm-cxx/input/seat.hpp>
 #include <drm-cxx/session/seat.hpp>
@@ -126,6 +128,10 @@ class DrmSession {
   std::vector<ResumeFn> resume_handlers_;
   std::thread thread_;
   std::atomic<bool> stop_{false};
+  // Breaks the dispatch loop out of its indefinite poll at teardown. Without
+  // it the loop needs a timeout purely to re-check stop_, which costs a wakeup
+  // several times a second on a system that is doing nothing.
+  input::WakeEventFd waker_;
 };
 
 }  // namespace homescreen


### PR DESCRIPTION
Fixes #304.

## Problem

`DrmSession::DispatchLoop` polled with a 200 ms cap:

```cpp
const int r = poll(pfds, nfds, kPollTimeoutMs);   // kPollTimeoutMs = 200
```

Both fds it watches — the libseat fd and the hotplug fd — are readable exactly when there is something to dispatch. The timeout served only to re-evaluate `while (!stop_.load(...))`, a flag that changes once, at teardown. The thread paid five wakeups a second, forever, on a fully idle system.

## Change

Give the loop a `WakeEventFd` and block indefinitely (`timeout_ms = -1`). The destructor stores `stop_`, then wakes:

```cpp
DrmSession::~DrmSession() {
  stop_.store(true, std::memory_order_release);
  waker_.Wake();
  if (thread_.joinable()) { thread_.join(); }
```

Store-then-wake closes the lost-wake window — the eventfd stays readable across the dispatcher's check/block boundary, so a `Wake()` landing between its flag check and its `poll()` is still seen. That reasoning is documented on `WakeEventFd` itself.

This reuses `shell/input/wake_event_fd.h` rather than introducing a mechanism: `drm_seat` and `software_seat` already drive their loops this way, which is what #284 established.

**Degraded mode is preserved.** When `eventfd()` is unavailable `fd()` returns -1 and the loop falls back to the old 200 ms cap, so teardown is still observed promptly. `kPollTimeoutMs` stays, now purely as that fallback.

### Why the poll set moved to explicit indices

Not cosmetic. The old loop hard-coded `pfds[0]`/`pfds[1]` and tested `if (nfds == 2)` to decide whether the hotplug slot was populated. Hotplug can be dropped mid-loop on a bad fd (`hotplug_.reset(); hp_fd = -1;`), so once a third entry exists the waker slides from slot 2 into slot 1 — and `nfds == 2` would then read the waker as the hotplug fd and call `hotplug_->dispatch()` on a reset monitor.

The set is now rebuilt each iteration with `seat_idx` / `hp_idx` / `wake_idx`, matching `software_seat`.

## Verified on a Raspberry Pi 5

Cross-built with `emb` and run on the device against the real DRM-KMS-EGL backend.

Pi 5 Model B Rev 1.0, kernel `6.18.33+rpt-rpi-2712`, PiOS trixie arm64, `vc4`.

```
emb -v cross . --target rpi5-trixie --build --backend drm-kms-egl \
    --app test/integration/scroll_bench -m release \
    --deploy joel@raspberrypi.local --run
```

Builds clean for aarch64, and the shell reports its own provenance on startup:

```
SHEL: jw/drm-session-waker @ 5f684f3
[backend] resolved '<unset>' -> 'drm-kms-egl'
[drm] auto-selected first card with a connected display: /dev/dri/card0
[DrmDisplay] libseat session active
[DrmDisplay] opened /dev/dri/card0 via libseat (fd=7)
[DrmBackend] connector=35 crtc=94 mode=1280x1440@60Hz
[DrmBackend] driver='vc4' compositor=planes modeset=atomic explicit-sync=yes
```

So this is a real libseat session on a real DRM master — the exact fd the loop services, not a stand-in.

### The loop really does block indefinitely

The `DrmSession` thread is unnamed, so it is identified by its syscall rather than by `comm` (`li-drm-dispatch` is `DrmSeat`, set in `shell/input/drm_seat.cc`). On aarch64:

```
DrmSession thread: syscall=73 (ppoll)  arg2 (timespec*) = 0x0
```

A NULL `timespec` is an indefinite block. Unpatched, glibc would pass a pointer to a 200 ms `timespec` here, so this is kernel-side confirmation the change is in effect rather than an inference from the source.

### Idle wakeups

Context switches for that thread across 20 s of idle:

```
  start:          vol=19  nonvol=0
  after 20s idle: vol=19  nonvol=0
  DELTA:          voluntary=0  nonvoluntary=0
```

Zero. Unpatched this would be ~100 voluntary (5/s x 20 s). The thread blocks once and stays blocked.

### Teardown

`SIGTERM -> exit in 231 ms`, with no hang in `thread_.join()` — the specific runtime risk of moving to an indefinite poll.

## Also checked

Slot assignment was proven separately in a standalone harness mirroring the construction verbatim, since it is the part most likely to go wrong:

| hotplug | waker | nfds | seat | hp | wake |
| --- | --- | --- | --- | --- | --- |
| present | present | 3 | 0 | 1 | 2 |
| absent/dropped | present | 2 | 0 | -1 | 1 |
| present | absent (degraded) | 2 | 0 | 1 | -1 |
| absent | absent | 1 | 0 | -1 | -1 |

Each case asserts every populated slot holds the fd it claims, that no two indices alias, and that `nfds <= 3`. A dispatch harness on the same hardware serviced 150/150 events sub-millisecond across all three fd configurations, including after dropping hotplug mid-loop.

`clang-format --dry-run -Werror` clean; no lines over 80 columns.

## Not covered

Only the DRM-KMS-EGL backend was built and run. A VT switch (libseat pause/resume) and a live connector plug/unplug were not exercised — both drive `DrmSession` through paths this run left idle.