### PR TITLE
fix: give GetDmabuf a tri-state so a reused view stops freezing

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2559,7 +2559,23 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       ICompositorSurface::Dmabuf db{};
       const bool is_new =
           scene_->find_by_identity_tag(surface.get()) == nullptr;
-      const bool have_db = surface->GetDmabuf(&db);
+      const auto db_state = surface->GetDmabuf(&db);
+      const bool have_db = db_state == ICompositorSurface::DmabufState::kFrame;
+      // A reused layer with new content that cannot be scanned out. Holding the
+      // plane here -- which is what a bare "no dma-buf" answer used to mean --
+      // freezes the view on its last scannable frame while the producer goes on
+      // emitting content the plane path cannot carry (a format switch, or a
+      // producer that moved to a GL-only surface). Composite the frame through
+      // GL instead; the view returns to its plane on the next frame the plane
+      // can take.
+      //
+      // Only for a reused layer: an is_new view has nothing latched in the
+      // scene to go stale, and the branch below deliberately keeps a
+      // not-yet-ready producer on the plane path to avoid startup flicker.
+      if (!is_new &&
+          db_state == ICompositorSurface::DmabufState::kNotScanoutCapable) {
+        return PresentViaGlFallback(layers, layer_count);
+      }
       if (is_new && !have_db) {
         // New platform view with no dma-buf to place this present.
         //

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -2574,6 +2574,14 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
       // not-yet-ready producer on the plane path to avoid startup flicker.
       if (!is_new &&
           db_state == ICompositorSurface::DmabufState::kNotScanoutCapable) {
+        // Rare by construction -- a producer that submits a frame the plane
+        // path cannot carry. Log it: without this the fallback is
+        // indistinguishable from any other GL present, and this branch is the
+        // one a producer-side regression would silently stop reaching.
+        ihs::log::debug(
+            "[DrmCompositor] pv {}: new frame is not scanout-capable; "
+            "compositing this present through GL",
+            static_cast<const void*>(surface.get()));
         return PresentViaGlFallback(layers, layer_count);
       }
       if (is_new && !have_db) {

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -418,19 +418,25 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   // correct, just not zero-copy) until it resubmits. Retaining the dma-buf
   // across a GL import so a static producer returns to scanout is part of the
   // dynamic-producer follow-up.
-  [[nodiscard]] bool GetDmabuf(Dmabuf* out) const override {
+  [[nodiscard]] DmabufState GetDmabuf(Dmabuf* out) const override {
     const std::lock_guard<std::mutex> lock(mutex);
+    // Nothing submitted yet. Not "cannot scan out" -- this producer is simply
+    // not ready, and its plane lights up on its first submit.
     if (out == nullptr || !pending_egl.valid) {
-      return false;
+      return DmabufState::kNoNewFrame;
     }
     // Hand each submitted frame to the scanout path at most once — the reuse
     // branch polls this every present but only wants a fresh buffer.
     if (dmabuf_delivered_seq == submit_seq) {
-      return false;
+      return DmabufState::kNoNewFrame;
     }
     const IhsFrame& f = pending_egl.frame;
+    // From here on there *is* a new frame, so every remaining bail-out is a
+    // frame that cannot be scanned out rather than an absent one. Saying so
+    // lets the compositor GL-composite the new content instead of holding the
+    // plane on the last scannable frame.
     if (f.plane_count == 0 || f.plane_fd[0] < 0) {
-      return false;
+      return DmabufState::kNotScanoutCapable;
     }
     // Per-plane fds. A single-handle frame (v4l2/libcamera/Chromium) repeats
     // one fd across planes with distinct offsets; a multi-handle frame (e.g.
@@ -441,7 +447,8 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     const uint32_t np = f.plane_count < 4 ? f.plane_count : 4;
     for (uint32_t i = 0; i < np; ++i) {
       if (f.plane_fd[i] < 0) {
-        return false;  // a plane without a handle can't be scanned out
+        // A plane without a handle can't be scanned out.
+        return DmabufState::kNotScanoutCapable;
       }
     }
     int duped[4] = {-1, -1, -1, -1};
@@ -451,7 +458,12 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
         for (uint32_t j = 0; j < i; ++j) {
           ::close(duped[j]);
         }
-        return false;
+        // Transient (fd exhaustion), not a property of the frame -- and the
+        // frame is not marked delivered, so the next present retries the dup on
+        // the same buffer. Report it as "no new frame" so the plane holds for
+        // one present and self-heals, rather than dropping the whole frame to
+        // GL over a failure that is likely gone by the next commit.
+        return DmabufState::kNoNewFrame;
       }
     }
     for (uint32_t i = 0; i < np; ++i) {
@@ -493,7 +505,7 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
       }
     }
     dmabuf_delivered_seq = submit_seq;
-    return true;
+    return DmabufState::kFrame;
   }
 #endif
 

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -250,20 +250,54 @@ class ICompositorSurface {
   };
 
   /**
+   * @brief Why a present has no dma-buf for the plane, or that it has one.
+   *
+   * @c GetDmabuf used to answer with a bool, which conflated three cases the
+   * compositor has to treat differently. @c kNoNewFrame means keep whatever is
+   * already on the plane; @c kNotScanoutCapable means there *is* new content
+   * but it cannot go on a plane, so GL-composite it rather than leaving the
+   * plane showing a stale frame.
+   */
+  enum class DmabufState : uint8_t {
+    /// No fresh content this present. A reused layer keeps its current source;
+    /// a view whose producer has not delivered its first frame yet is simply
+    /// not ready. Nothing to do.
+    kNoNewFrame = 0,
+    /// New content exists but is not expressible as a scanout dma-buf -- a
+    /// GL-only surface, a frame with per-plane handles the layout cannot carry,
+    /// or a transient failure to dup the producer's fds. The compositor must
+    /// route this view through GL for the present; holding the plane would
+    /// freeze it on the last scannable frame.
+    kNotScanoutCapable,
+    /// @p out is filled and the caller owns every populated @c fd.
+    kFrame,
+  };
+
+  /**
    * @brief Expose the surface's latest frame as a dma-buf for direct scanout.
    *
-   * A surface that produced a frame into a dma-buf (a video decoder, a camera,
-   * a Vulkan/GL plugin that exported its image) fills @p out and returns true;
-   * the compositor then routes it onto a KMS overlay plane (the FlutterLayer
-   * geometry drives the Layer Crtc and Src rects, which drive the plane)
-   * instead of GL-compositing it. Returns false (default) for GL-only surfaces,
-   * or when no dma-buf frame is ready this present — the compositor falls back
-   * to the @c GetGlTextureName / @c GetVulkanImage path. The returned @c fd is
-   * owned by the caller (an implementation may dup its internal handle to make
-   * it robust against a concurrent producer superseding the frame); the caller
-   * closes it once it has imported the buffer.
+   * Fills @p out and returns @c kFrame when a fresh frame is ready to be placed
+   * on a KMS overlay plane; the compositor then routes it onto a plane (the
+   * FlutterLayer geometry drives the Layer Crtc and Src rects) instead of
+   * GL-compositing it. Otherwise nothing is written to @p out and the state
+   * says which of the two no-frame cases applies -- see @c DmabufState, and
+   * note that only @c kNoNewFrame is safe to answer by keeping the plane as it
+   * is.
+   *
+   * Deliver-once: a frame is handed to the scanout path at most once, so a
+   * reused layer polling every present sees @c kNoNewFrame until the producer
+   * submits again. The returned @c fd is owned by the caller (an implementation
+   * may dup its internal handle to make it robust against a concurrent producer
+   * superseding the frame); the caller closes each one once it has imported the
+   * buffer.
+   *
+   * The default is @c kNotScanoutCapable: a surface that does not override this
+   * has no dma-buf path at all, and its content only reaches the screen through
+   * @c GetGlTextureName / @c GetVulkanImage.
    */
-  [[nodiscard]] virtual bool GetDmabuf(Dmabuf* /*out*/) const { return false; }
+  [[nodiscard]] virtual DmabufState GetDmabuf(Dmabuf* /*out*/) const {
+    return DmabufState::kNotScanoutCapable;
+  }
 
   /**
    * @brief The surface's current HDR static metadata, if its content is HDR.


### PR DESCRIPTION
First half of #332.

## Problem

`ICompositorSurface::GetDmabuf` answered with a `bool`, and the compositor's reuse path read `false` as "no new frame this present, keep the source already on the plane":

```cpp
// GetDmabuf is deliver-once: a valid descriptor here means a fresh frame this
// present. When it's empty (fd < 0 — the producer had no new frame), don't
// submit; the pool holds the last buffer until the next arrives.
```

That reading is correct for a producer between frames and wrong for a producer whose new frame cannot be scanned out — a format switch to per-plane handles, or a move to a GL-only surface. The view then freezes on its last scannable frame while the producer goes on emitting content nobody composites.

## Change

A scoped enum replaces the bool:

| state | meaning |
| --- | --- |
| `kNoNewFrame` | nothing fresh; the plane keeps what it has |
| `kNotScanoutCapable` | new content exists but cannot go on a plane |
| `kFrame` | `out` is filled; the caller owns every populated `fd` |

`enum class` does not convert to `bool`, so every call site had to be revisited rather than silently keeping the old meaning.

**That mattered.** I originally wrote that there was "exactly one call site and one override". Wrong — there is one call site, but a **second override lives out-of-tree** in `ivi-homescreen-plugins`, which I missed by searching only this tree. It surfaced as a hard compile error the first time the plugin was built against this branch:

```
layer_playground_view_plugin.h:143: error: conflicting return type specified for
  'virtual bool ...LayerPlaygroundViewPlugin::GetDmabuf(ICompositorSurface::Dmabuf*) const'
```

which is exactly what the scoped enum is for. **This PR therefore requires toyota-connected/ivi-homescreen-plugins#266 to land with it**, or enabling `layer-playground-view` breaks the build. Worth noting that plugin carries both of the cases the bool conflated — a permanent gate and a temporary pre-layout extent — so it is independent evidence the split is the right shape.

The compositor now GL-composites a **reused** view reporting `kNotScanoutCapable` instead of holding its plane. Only a reused one: an `is_new` view has nothing latched in the scene to go stale, and that branch deliberately keeps a not-yet-ready producer on the plane path to avoid startup flicker.

### A side effect worth noting

The old code documented an ambiguity it could not act on:

> Such a producer also exposes a GL-fallback texture, so a `GetGlTextureName()!=0` test can't tell it apart from a genuine GL-only surface

Those two cases are now distinguishable — a not-yet-ready producer is `kNoNewFrame`, a surface with no dma-buf path at all is `kNotScanoutCapable` (the default for anything that does not override). I did not change the `is_new` branch to exploit that, to keep this change to the freeze.

### The dup() case

A failed `dup()` of the producer's fds stays `kNoNewFrame`, not `kNotScanoutCapable`. It is transient (fd exhaustion), not a property of the frame, and the frame is not marked delivered — so the next present retries the same buffer. Holding the plane for one present self-heals; dropping the whole frame to GL over it would not.

## Not in this change

The import-failure retry — case (2) in the issue. `GetDmabuf` still marks the frame delivered when it hands out the descriptor, so a frame whose `ExternalDmaBufSource::create` / `replace_source` later fails is already consumed and a static producer can stay on the GL path. Fixing that means moving the delivered bookkeeping into an ack the compositor calls only once import *and* scanout have succeeded, which changes the failure semantics at five call sites (`submit_pv_pool` x3, `make_pv_pool` x2) and can strand a producer if any path forgets to ack. It wants its own review, so it is a separate change. The issue stays open.

## Verified

Cross-built for aarch64 / drm-kms-egl with `emb`:

```
emb cross . --target rpi5-trixie --build --backend drm-kms-egl
  drm-kms-egl: built
  build : 1 backend(s) in 6.2s
```

Clean, no warnings. `clang-format --dry-run -Werror` clean on all three files; no lines over 80 columns introduced.

A debug log was added at the new branch: it is rare by construction, and without it the fallback is indistinguishable from any other GL present.

## Hardware status

Built and **run on a Pi 5** (trixie arm64, `vc4`, real DRM master) with the plugin and the `layer_playground` app: embedder, plugin and app all build for aarch64 and the shell starts clean, so there is no startup regression.

The behaviour itself is **not yet exercised**. Two obstacles, both worth recording:

1. **No producer in-tree can reach the new branch.** The bcm2835 V4L2 path only ever yields `kNoNewFrame` or `kFrame`, exactly as the issue says. `layer_playground_view` is the only dma-buf platform-view producer available, and it needs `IVI_PV_DMABUF=1` plus a layer to exist.
2. **The `layer_playground` app is from 2023** (`sdk: '>=2.19.0 <3.0.0'`) and only creates the view on user interaction, so a headless run instantiates nothing. It needs its SDK constraint relaxed and a seeded layer to be usable as a fixture.

So reaching `kNotScanoutCapable` deliberately still needs a scripted producer — either a fake `ICompositorSurface` registered through `Backend::RegisterCompositorSurface`, or a test plugin that submits `plane_count = 0` after N good frames. Until then this change rests on review plus the compile-time enforcement, not on observed behaviour.