### PR TITLE
fix: include the standard headers these declarations need

### DIFF
--- a/shell/app.h
+++ b/shell/app.h
@@ -19,9 +19,11 @@
 #include <EGL/egl.h>
 #include <chrono>
 #include <memory>
+#include <string>
 #include <string_view>
 
 #include <unordered_map>
+#include <vector>
 #include "config/common.h"  // ENABLE_DLT — keep before logger.hpp / member decl
 
 #include "configuration/configuration.h"

--- a/shell/backend/register_backends.h
+++ b/shell/backend/register_backends.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <string>
 #include <vector>
 
 #include "backend/backend_registry.h"

--- a/shell/backend/software/drm_dumb_sink.h
+++ b/shell/backend/software/drm_dumb_sink.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <functional>

--- a/shell/backend/wayland_egl/egl.h
+++ b/shell/backend/wayland_egl/egl.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <array>
 #include <vector>
 
 #include <EGL/egl.h>

--- a/shell/backend/wayland_vulkan/wayland_vulkan.h
+++ b/shell/backend/wayland_vulkan/wayland_vulkan.h
@@ -21,6 +21,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <ctime>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <vector>

--- a/shell/display/software_display.h
+++ b/shell/display/software_display.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "display/idisplay.h"
 

--- a/shell/osgi/app_bundle_host.h
+++ b/shell/osgi/app_bundle_host.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <mutex>
+#include <string>
 
 #include "bundle_host.h"
 #include "vsync_coordinator.h"

--- a/shell/platform/homescreen/flutter_desktop_engine_state.h
+++ b/shell/platform/homescreen/flutter_desktop_engine_state.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <asio/io_context_strand.hpp>
+#include <string>
 
 #include "config/common.h"
 

--- a/shell/platform/homescreen/flutter_desktop_view_controller_state.h
+++ b/shell/platform/homescreen/flutter_desktop_view_controller_state.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "flutter_desktop_view.h"
 #include "keyboard_hook_handler.h"

--- a/shell/platform/homescreen/platform_views/platform_view_touch.h
+++ b/shell/platform/homescreen/platform_views/platform_view_touch.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <flutter/encodable_value.h>
+#include <vector>
 
 #include "engine.h"
 

--- a/shell/task_runner.h
+++ b/shell/task_runner.h
@@ -18,6 +18,8 @@
 
 #include <future>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "asio/executor_work_guard.hpp"
 #include "asio/io_context.hpp"

--- a/shell/utils.h
+++ b/shell/utils.h
@@ -11,8 +11,10 @@
 #include <unistd.h>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 #include <flutter/encodable_value.h>
+#include <vector>
 
 #include "config/common.h"
 #include "logging/logging.h"

--- a/shell/view/compositor_surface.h
+++ b/shell/view/compositor_surface.h
@@ -7,6 +7,7 @@
 
 #include <EGL/egl.h>
 #include <wayland-client.h>
+#include <string>
 
 #include "compositor_surface_api.h"
 #include "config/common.h"

--- a/shell/view/flutter_view.h
+++ b/shell/view/flutter_view.h
@@ -17,6 +17,7 @@
 #include "config/common.h"
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -33,6 +34,7 @@
 #endif
 
 #include <flutter_homescreen.h>
+#include <vector>
 
 #ifdef ENABLE_PLUGIN_COMP_SURF
 #include "compositor_surface.h"

--- a/shell/wayland/display.h
+++ b/shell/wayland/display.h
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <ctime>
 #include <list>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>


### PR DESCRIPTION
## Problem

`shell/platform/homescreen/flutter_desktop_view_controller_state.h` includes `<memory>` but uses `std::vector`, so the type is visible only through the forward declaration in `<iosfwd>`. On a libc++ that does not pull `<vector>` in transitively, the build stops:

```
flutter_desktop_view_controller_state.h:48:7: error: implicit instantiation of
  undefined template 'std::vector<std::unique_ptr<flutter::KeyboardHookHandler>>'
      keyboard_hook_handlers;
      ^
/usr/include/c++/v1/iosfwd:260:28: note: template is declared here
class _LIBCPP_TEMPLATE_VIS vector;
```

Hit building ivi-homescreen v3 on Yocto dunfell, on **both riscv64 and armv7** (`key_event_handler.cc.o`). Newer toolchains happen to include enough for it to compile, which is the only reason this has not surfaced before.

## Scope

Sweeping the tree for the same shape -- a `std::` type used in a header that does not include its own standard header -- found fourteen more:

| header | added |
| --- | --- |
| `shell/app.h` | `<string>`, `<vector>` |
| `shell/task_runner.h` | `<string>`, `<vector>` |
| `shell/utils.h` | `<string>`, `<vector>` |
| `shell/view/flutter_view.h` | `<map>`, `<vector>` |
| `shell/wayland/display.h` | `<map>` |
| `shell/view/compositor_surface.h` | `<string>` |
| `shell/platform/homescreen/flutter_desktop_engine_state.h` | `<string>` |
| `shell/platform/homescreen/flutter_desktop_view_controller_state.h` | `<vector>` |
| `shell/platform/homescreen/platform_views/platform_view_touch.h` | `<vector>` |
| `shell/osgi/app_bundle_host.h` | `<string>` |
| `shell/display/software_display.h` | `<string>` |
| `shell/backend/register_backends.h` | `<string>` |
| `shell/backend/wayland_vulkan/wayland_vulkan.h` | `<functional>` |
| `shell/backend/wayland_egl/egl.h` | `<array>` |
| `shell/backend/software/drm_dumb_sink.h` | `<array>` |

Only the first breaks a build today. The rest are each one toolchain away from it, and cost nothing to fix now rather than one at a time as they surface.

Matches were taken from comment-stripped source, so a type named only in prose does not count.

## Checks

- **19 insertions, 0 deletions** -- every changed line is an added `#include`
- the sweep re-run afterwards reports nothing remaining
- `scripts/format.sh --check` (clang-format-19, as CI runs it) is clean. Include ordering is whatever `format.sh` produced rather than hand-placed: my first attempt inserted `<string>` into the wrong group in `shell/utils.h` and `shell/view/compositor_surface.h`, which those files' C-header groups made obvious once the project's own checker ran
