### PR TITLE
fix: find the sysroot when CMAKE_SYSROOT is not set

### DIFF
--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -56,13 +56,24 @@ endif ()
 # inside the sysroot (pkg-config does apply PKG_CONFIG_SYSROOT_DIR when it finds
 # the .pc there) the prefixed path does not exist and the value is left alone.
 function(_wlcxx_prefer_sysroot var subpath)
-    if (NOT CMAKE_SYSROOT)
-        return()
-    endif ()
-    set(_candidate "${CMAKE_SYSROOT}${${var}}")
-    if (EXISTS "${_candidate}/${subpath}")
-        set(${var} "${_candidate}" PARENT_SCOPE)
-    endif ()
+    # CMAKE_SYSROOT is the obvious root, but a cross toolchain need not set it.
+    # OpenEmbedded's cmake class began emitting it in 4.0 (kirkstone); 3.1
+    # (dunfell) names the sysroot through CMAKE_FIND_ROOT_PATH alone. Returning
+    # early there left the caller holding an unprefixed pkg-config path -- the
+    # build host's copy -- with no diagnostic, which for the core wayland.xml
+    # means generating bindings against a libwayland that is not the one being
+    # linked. Try every root that could name a sysroot, most specific first.
+    set(_roots "${CMAKE_SYSROOT}" ${CMAKE_FIND_ROOT_PATH} "${CMAKE_STAGING_PREFIX}")
+    foreach (_root IN LISTS _roots)
+        if (NOT _root)
+            continue()
+        endif ()
+        set(_candidate "${_root}${${var}}")
+        if (EXISTS "${_candidate}/${subpath}")
+            set(${var} "${_candidate}" PARENT_SCOPE)
+            return()
+        endif ()
+    endforeach ()
 endfunction()
 
 # Protocol XML base — xdg-shell + presentation-time ship with wayland-protocols.


### PR DESCRIPTION
`_wlcxx_prefer_sysroot()` opens with `if (NOT CMAKE_SYSROOT) return()`. On a cross toolchain that does not set that variable the function does nothing, and the caller keeps the path `pkg_get_variable()` produced — which is un-sysroot-prefixed, i.e. the build host's.

For the core `wayland.xml` that means generating bindings against a different libwayland than the one being linked.

## How it shows up

Silent when the host's XML is **older** — the extra events are simply compiled out, no diagnostic. A compile error when it is **newer**:

```
display.cc:427:54: error: excess elements in struct initializer
                                             display_handle_name,
```

`wl_output`'s `name` and `description` events arrived in wayland 1.20, so an older sysroot has four `wl_output_listener` members against the six the host's XML describes. The `#if defined(WL_OUTPUT_NAME_SINCE_VERSION)` guard around those two handlers passes, because the macro comes from the generated header while the struct comes from the sysroot — the two disagree precisely because the XML was taken from the wrong place.

## Where it bites

OpenEmbedded began emitting `CMAKE_SYSROOT` in 4.0 (kirkstone). 3.1 (dunfell) names the sysroot through `CMAKE_FIND_ROOT_PATH` alone, and that is where this was found — building the embedder against a 1.18 sysroot while the container had a modern wayland. The build log named the file it used, with no sysroot prefix:

```
/usr/share/wayland/wayland.xml
```

## The change

Try each root that could name a sysroot rather than only `CMAKE_SYSROOT`, most specific first, stopping at the first that actually holds the file:

```cmake
set(_roots "${CMAKE_SYSROOT}" ${CMAKE_FIND_ROOT_PATH} "${CMAKE_STAGING_PREFIX}")
```

Behaviour is unchanged wherever `CMAKE_SYSROOT` is set — it is still tried first. A native build has none of these set and still falls through to the pkg-config path, as before.

The existing `IVI_WL_CORE_XML` override remains the escape hatch for a layout this probe still cannot see; this just stops the common cross case needing it.