### PR TITLE
logging: make the per-thread ring depth configurable

### DIFF
--- a/.github/workflows/ihs-logging-compat-matrix.yml
+++ b/.github/workflows/ihs-logging-compat-matrix.yml
@@ -19,6 +19,7 @@ on:
       - 'cmake/cxx_compat.cmake'
       - 'cmake/logging_helpers.cmake'
       - 'shell/logging/**'
+      - 'shared/src/logging/**'
       - '.github/workflows/ihs-logging-compat-matrix.yml'
   push:
     branches:
@@ -28,6 +29,7 @@ on:
       - 'cmake/cxx_compat.cmake'
       - 'cmake/logging_helpers.cmake'
       - 'shell/logging/**'
+      - 'shared/src/logging/**'
       - '.github/workflows/ihs-logging-compat-matrix.yml'
   workflow_dispatch:
 

--- a/shared/src/logging/thread_ring.cpp
+++ b/shared/src/logging/thread_ring.cpp
@@ -3,8 +3,10 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <memory>
 
 namespace {
 
@@ -17,9 +19,74 @@ std::uint64_t now_realtime_ns() noexcept {
          static_cast<std::uint64_t>(ts.tv_nsec);
 }
 
+// Smallest power of two at or above v, never below kMinRingCapacity.
+std::size_t round_up_pow2(const std::size_t v) noexcept {
+  std::size_t p = ihs::dlt::kMinRingCapacity;
+  while (p < v) {
+    p <<= 1;
+  }
+  return p;
+}
+
+std::size_t resolve_ring_capacity() noexcept {
+  const char* spec = std::getenv("IHS_LOG_RING_CAPACITY");
+  if (spec == nullptr || *spec == '\0') {
+    return ihs::dlt::kDefaultRingCapacity;
+  }
+  // strtoull silently wraps a leading '-' (so "-1" would read as the maximum,
+  // i.e. the largest allocation this accepts). Reject it before parsing.
+  if (*spec == '-') {
+    std::fprintf(stderr,
+                 "[ihs_log] IHS_LOG_RING_CAPACITY=\"%s\" is not a positive "
+                 "integer; using %zu slots\n",
+                 spec, ihs::dlt::kDefaultRingCapacity);
+    return ihs::dlt::kDefaultRingCapacity;
+  }
+  char* end = nullptr;
+  const unsigned long long v = std::strtoull(spec, &end, 10);
+  if (end == nullptr || *end != '\0' || v == 0) {
+    std::fprintf(stderr,
+                 "[ihs_log] IHS_LOG_RING_CAPACITY=\"%s\" is not a positive "
+                 "integer; using %zu slots\n",
+                 spec, ihs::dlt::kDefaultRingCapacity);
+    return ihs::dlt::kDefaultRingCapacity;
+  }
+
+  std::size_t want =
+      v > static_cast<unsigned long long>(ihs::dlt::kMaxRingCapacity)
+          ? ihs::dlt::kMaxRingCapacity
+          : static_cast<std::size_t>(v);
+  want = std::max(want, ihs::dlt::kMinRingCapacity);
+  const std::size_t capacity = round_up_pow2(want);
+
+  // Say so when the value in force is not the value asked for. A ring silently
+  // one power of two off from the request is exactly the kind of thing that
+  // gets read back out of a log as evidence.
+  if (static_cast<unsigned long long>(capacity) != v) {
+    std::fprintf(stderr,
+                 "[ihs_log] IHS_LOG_RING_CAPACITY=%s adjusted to %zu slots "
+                 "(power of two within [%zu, %zu])\n",
+                 spec, capacity, ihs::dlt::kMinRingCapacity,
+                 ihs::dlt::kMaxRingCapacity);
+  }
+  return capacity;
+}
+
 }  // namespace
 
 namespace ihs::dlt {
+
+std::size_t ring_capacity() noexcept {
+  // Function-local static: resolved on first use, which is the first ring
+  // construction, and thread-safe without a lock of our own.
+  static const std::size_t capacity = resolve_ring_capacity();
+  return capacity;
+}
+
+ThreadRing::ThreadRing()
+    : capacity_(static_cast<std::uint32_t>(ring_capacity())),
+      mask_(capacity_ - 1),
+      slots_(std::make_unique<RingSlot[]>(capacity_)) {}
 
 bool ThreadRing::push(std::uint32_t ctx_index,
                       std::uint8_t level,
@@ -29,12 +96,12 @@ bool ThreadRing::push(std::uint32_t ctx_index,
   const std::uint32_t head = head_.load(std::memory_order_relaxed);
   const std::uint32_t tail = tail_.load(std::memory_order_acquire);
 
-  if (head - tail >= kRingCapacity) {
+  if (head - tail >= capacity_) {
     dropped_.fetch_add(1, std::memory_order_relaxed);
     return false;
   }
 
-  RingSlot& slot = slots_[head & kMask];
+  RingSlot& slot = slots_[head & mask_];
   slot.ctx_index = ctx_index;
   slot.level = level;
   slot.flags = flags;
@@ -83,7 +150,7 @@ const RingSlot* ThreadRing::peek() const noexcept {
   if (head == tail) {
     return nullptr;
   }
-  return &slots_[tail & kMask];
+  return &slots_[tail & mask_];
 }
 
 void ThreadRing::pop() noexcept {

--- a/shared/src/logging/thread_ring.hpp
+++ b/shared/src/logging/thread_ring.hpp
@@ -6,21 +6,48 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
 
 namespace ihs::dlt {
 
-inline constexpr std::size_t kRingCapacity = 256;  // power of two
-static_assert((kRingCapacity & (kRingCapacity - 1)) == 0,
-              "kRingCapacity must be a power of two");
+// Ring depth, in slots. A RingSlot is cache-line padded around a 240-byte
+// text buffer, so the default costs ~80 KiB per logging thread.
+//
+// The default is a footprint/loss compromise tuned for steady-state logging,
+// and a diagnostic run is not steady-state: a burst that outruns the drain
+// worker -- scene load, asset streaming, anything that logs per item at debug
+// or verbose level -- sheds records, and what survives reads like a complete
+// log rather than one with holes in it. Depth is therefore configurable, so
+// such a run can pay memory the shipped configuration does not have to.
+inline constexpr std::size_t kDefaultRingCapacity = 256;
+inline constexpr std::size_t kMinRingCapacity = 16;
+// 64 Ki slots is ~20 MiB per logging thread -- already generous for a
+// diagnostic run, and having a ceiling keeps a fat-fingered value from turning
+// the first log call into an allocation failure.
+inline constexpr std::size_t kMaxRingCapacity = 64 * 1024;
+
+// Ring depth for this process: IHS_LOG_RING_CAPACITY when set, otherwise
+// kDefaultRingCapacity. Always a power of two -- a requested value is clamped
+// to [kMinRingCapacity, kMaxRingCapacity] and then rounded up -- so the index
+// mask stays valid.
+//
+// Resolved once, on first use, and constant for the life of the process.
+// Rings are pooled and reused across threads, so a depth that could change
+// under a running process would leave rings of assorted depths behind and make
+// "how much can this thread buffer" unanswerable.
+[[nodiscard]] std::size_t ring_capacity() noexcept;
 
 // Single-producer (owning thread), single-consumer (worker) ring.
 // Producer writes are lock-free and wait-free; the consumer drains by peeking
 // and advancing the tail. Overflows are counted, not blocked.
 class ThreadRing {
  public:
-  ThreadRing() noexcept = default;
+  // Allocates its slot array, so unlike the old inline-array ring this can
+  // throw. Rings are only ever created through RingRegistry::acquire_ring(),
+  // which already reaches the caller through a throwing `new ThreadRing()`.
+  ThreadRing();
 
   ThreadRing(const ThreadRing&) = delete;
   ThreadRing& operator=(const ThreadRing&) = delete;
@@ -41,7 +68,7 @@ class ThreadRing {
     const std::uint32_t head = head_.load(std::memory_order_relaxed);
     const std::uint32_t tail = tail_.load(std::memory_order_acquire);
     const std::uint32_t used = head - tail;
-    return used >= kRingCapacity ? 0 : kRingCapacity - used;
+    return used >= capacity_ ? 0 : capacity_ - used;
   }
 
   // Consumer side — called only from the worker thread.
@@ -129,13 +156,24 @@ class ThreadRing {
 
  public:
  private:
-  static constexpr std::uint32_t kMask = kRingCapacity - 1;
+  // Depth and index mask for this ring, fixed at construction from
+  // ring_capacity(). Members rather than constants because the depth is now a
+  // process setting resolved at runtime. Both are read-only afterwards, so
+  // sharing a cache line with in_use_ costs nothing: in_use_ is written only
+  // when a thread claims or releases the ring.
+  const std::uint32_t capacity_;
+  const std::uint32_t mask_;
 
   std::atomic<bool> in_use_{true};  // born claimed by its creating thread
   alignas(64) std::atomic<std::uint32_t> head_{0};  // producer writes
   alignas(64) std::atomic<std::uint32_t> tail_{0};  // consumer reads
   alignas(64) std::atomic<std::uint64_t> dropped_{0};
-  alignas(64) RingSlot slots_[kRingCapacity]{};
+  // Heap-allocated rather than an inline array so the depth can be chosen at
+  // runtime. RingSlot is alignas(64), so array new returns cache-line aligned
+  // storage and the inline array's false-sharing property is preserved. In
+  // practice never freed -- rings outlive their owning thread by design (see
+  // RingRegistry) -- but owned here so the type stays honest.
+  std::unique_ptr<RingSlot[]> slots_;
 };
 
 }  // namespace ihs::dlt

--- a/shell/logging/README.md
+++ b/shell/logging/README.md
@@ -119,7 +119,11 @@ Log calls are safe from any thread. The producer side (this directory) does the
 fmt formatting on the calling thread, then hands off to a **wait-free enqueue**
 into a **per-thread single-producer/single-consumer ring** inside `ihs_shared`.
 When a ring is full the record is dropped and a per-ring counter is bumped —
-`ihs_log` never blocks the caller. Formatting-to-I/O happens on a separate drain
+`ihs_log` never blocks the caller. The ring is 256 slots deep by default
+(~80 KiB per logging thread); `IHS_LOG_RING_CAPACITY` raises that for a run
+whose bursts are shedding records. Note what dropping means for a reader:
+absence of a record is not evidence that the event did not happen, so a log
+being mined for what is *missing* wants a depth the burst fits inside. Formatting-to-I/O happens on a separate drain
 worker thread. `ihs_log_flush()` (via `IHS_LOGGING_FLUSH()` or the error-level
 auto-flush) is synchronous.
 
@@ -157,8 +161,10 @@ from the environment at `ihs_log_start` time.
 ### Env vars
 
 These are read by the `ihs_shared` sink set (see
-[`shared/src/logging/sink_set.cpp`](../../shared/src/logging/sink_set.cpp)); the
-shell logging surface honors them transparently.
+[`shared/src/logging/sink_set.cpp`](../../shared/src/logging/sink_set.cpp)) —
+except `IHS_LOG_RING_CAPACITY`, which the ring itself resolves (see
+[`shared/src/logging/thread_ring.cpp`](../../shared/src/logging/thread_ring.cpp)).
+The shell logging surface honors them transparently.
 
 | Env | Default | Effect |
 |------|---------|--------|
@@ -167,6 +173,7 @@ shell logging surface honors them transparently.
 | `IHS_LOG_FILE` | — | Output path when `IHS_LOG_SINK=file`. Unset with `file` warns and uses console. |
 | `IHS_LOG_FILE_MAX_BYTES` | — | Rotation size threshold for the file sink. |
 | `IHS_LOG_FILE_MAX_FILES` | — | Number of rotated files to keep. |
+| `IHS_LOG_RING_CAPACITY` | `256` | Per-thread SPSC ring depth, in slots. Rounded up to a power of two and clamped to `[16, 65536]`; anything adjusted or unparseable is reported on stderr. Each slot is a cache-line padded 240-byte record, so the default is ~80 KiB per logging thread and the ceiling ~20 MiB. Resolved once, at first use. Raise it when a burst is dropping records. |
 | `IHS_DLT_LIBRARY` | `libdlt.so.2` | Soname/path override for the DLT library the bridge `dlopen`s (also used by the load test to point at the stub). |
 
 ### DLT sink

--- a/shell/logging/tests/compat-matrix/CMakeLists.txt
+++ b/shell/logging/tests/compat-matrix/CMakeLists.txt
@@ -76,3 +76,10 @@ target_compile_options(compat_smoke PRIVATE -Wall -Wextra -Werror)
 
 enable_testing()
 add_test(NAME compat_smoke COMMAND compat_smoke)
+
+# Same binary, ring depth configured. Has to be a separate process: the depth
+# is resolved once per process, on first use, so it cannot be exercised from
+# within the default-depth run.
+add_test(NAME compat_smoke_ring_capacity COMMAND compat_smoke)
+set_tests_properties(compat_smoke_ring_capacity PROPERTIES
+    ENVIRONMENT "IHS_LOG_RING_CAPACITY=1024")

--- a/shell/logging/tests/compat-matrix/compat_smoke.cc
+++ b/shell/logging/tests/compat-matrix/compat_smoke.cc
@@ -9,6 +9,9 @@
 //      macros that switch the backend inside ihs::format_to.
 //   3. The direct DltBridge::log() path (pre-formatted strings).
 //   4. The per-thread SPSC ring: push N messages, flush, confirm zero drops.
+//   5. Ring depth: within bounds, a power of two, and equal to
+//      IHS_LOG_RING_CAPACITY when that asks for a legal depth. The CMake side
+//      registers this binary twice, once with that variable set.
 //
 // The logging surface (ihs_log_* + the console/file sinks) is always compiled
 // in; ENABLE_DLT only adds the DLT sink. So the same body runs in both
@@ -25,6 +28,7 @@
 #include "thread_ring.hpp"
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -71,12 +75,14 @@ int main() {
       std::string_view{"pre-formatted message"});
   check(pushed, "direct log push");
 
-  // 4. Ring push stress: stay well under kRingCapacity so the worker drains
-  // between bursts without any drops.
+  // 4. Ring push stress: stay well under the ring depth so the worker drains
+  // between bursts without any drops. Derived from ring_capacity() rather than
+  // hardcoded, so the burst stays proportional when the depth is configured.
   auto& ring = ihs::dlt::RingRegistry::thread_local_ring();
   const std::uint64_t dropped_before = ring.dropped();
+  const int burst = static_cast<int>(ihs::dlt::ring_capacity() / 2);
 
-  for (int i = 0; i < 128; ++i) {
+  for (int i = 0; i < burst; ++i) {
     IHS_LOG_INFO(kCtx,
 #if defined(IHS_HAS_FORMAT_TO_N)
                  "burst {}",
@@ -90,6 +96,28 @@ int main() {
 
   check(ring.dropped() == dropped_before,
         "ring should not drop within capacity");
+
+  // 5. Ring depth. The invariants the index mask depends on, plus the one that
+  // makes the knob worth having: a depth that is read but not applied would
+  // leave a diagnostic run shedding records while the operator believes it
+  // raised the ceiling.
+  const std::size_t capacity = ihs::dlt::ring_capacity();
+  check(capacity >= ihs::dlt::kMinRingCapacity &&
+            capacity <= ihs::dlt::kMaxRingCapacity,
+        "ring capacity within bounds");
+  check((capacity & (capacity - 1)) == 0, "ring capacity is a power of two");
+
+  if (const char* asked = std::getenv("IHS_LOG_RING_CAPACITY");
+      asked != nullptr && *asked != '\0') {
+    const unsigned long long want = std::strtoull(asked, nullptr, 10);
+    // Only a legal request must be honored exactly; anything else is clamped
+    // or rounded on purpose, and the bounds checks above already cover it.
+    if (want != 0 && (want & (want - 1)) == 0 &&
+        want >= ihs::dlt::kMinRingCapacity &&
+        want <= ihs::dlt::kMaxRingCapacity) {
+      check(capacity == want, "configured ring capacity is honored");
+    }
+  }
 
   IHS_LOGGING_FLUSH();
   IHS_LOGGING_STOP();


### PR DESCRIPTION
## What

The per-thread SPSC ring is 256 slots, fixed at compile time. Depth now comes from `IHS_LOG_RING_CAPACITY`, defaulting to that same 256 — a shipped configuration is byte-for-byte unchanged unless the variable is set.

## Why

256 slots is a reasonable steady-state figure and a bad one for a burst. A producer that outruns the drain worker sheds records, and what survives reads like a complete log rather than one with holes in it.

Measured on a bounded 30k-record burst from one thread — the shape a scene load or asset-streaming pass has:

| capacity | emitted | dropped | |
|---|---|---|---|
| 256 (default) | 30000 | 29744 | 99.1% lost |
| 1024 | 30000 | 28976 | 96.6% lost |
| 8192 | 30000 | 21808 | 72.7% lost |
| 32768 | 30000 | 0 | |
| 65536 | 30000 | 0 | |

The cost is not the missing lines, it is that absence stops meaning anything. Comparing an asset manifest against the load records in a verbose run of a Flutter application said **19 of 114 textures never loaded**, one of them next to the visual defect being chased. Every one of them had loaded. Two runs of the same binary disagreed about *which* were missing, and that disagreement was the only thing that gave it away.

The same run with the depth raised keeps all **1,065,438** records, drops none, and accounts for all 106 textures.

## How

- `IHS_LOG_RING_CAPACITY` is clamped to `[16, 65536]` and rounded up to a power of two. The ceiling is ~20 MiB per logging thread — enough for a diagnostic run, low enough that a fat-fingered value is not an allocation failure. Anything adjusted or unparseable is reported on stderr, since a ring silently one power of two off from the request is exactly what later gets read back out of a log as evidence.
- Slots move from an inline array to a heap allocation, so `kRingCapacity`/`kMask` become per-ring members. `RingSlot` is `alignas(64)`, so array `new` still returns cache-line aligned storage and the inline array's false-sharing property holds.
- `push()` trades two compile-time constants for two `const` members on the same read-only cache line, against a `clock_gettime` and a 240-byte `memcpy` it already pays.
- Resolved once per process, on first use. Rings are pooled and reused across threads, so a depth that could change would leave rings of assorted depths behind.
- Construction can now throw. Rings are only created through `RingRegistry::acquire_ring()`, which already reaches the caller through a throwing `new ThreadRing()`.

## Tests

`compat_smoke` derives its burst from the depth instead of hardcoding 128, and asserts the bounds, the power-of-two invariant, and that a legal request is honored exactly — a knob that is read but not applied would leave an operator believing they had raised a ceiling that was still 256. The compat matrix registers a second run with the variable set; that needs a separate process, because the depth resolves once.

Built and passing locally at C++17/20/23 × `ENABLE_DLT=ON`/`OFF` (8 legs, `-Wall -Wextra -Werror`), plus adversarial values: `1000` → 1024, `3` → 16, `999999999` → 65536, `131072` → 65536, and `-1`/`abc`/`0` → default, each with the stderr notice and a clean exit.

## Follow-up, not in this PR

Nothing reports drops on the reading side — `ihs_shared` counts them per ring but never emits the count, so a reader has no signal that what they are holding is incomplete. A one-line report piggy-backed on the next successful enqueue is cheap and would have made the investigation above unnecessary. Happy to send it separately.