### PR TITLE
build: put shared libraries beside the shell and find them via $ORIGIN/lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,39 @@ project(ivi-homescreen
 include(git)
 include(options)
 
+#
+# Runtime layout: the shell binary sits beside a lib/ holding the shared
+# libraries it links, and finds them through an $ORIGIN-relative RPATH. That
+# is the layout a deployed bundle already has, so a build tree and an install
+# resolve identically and neither needs LD_LIBRARY_PATH.
+#
+# Worth stating because CMake's automatic build-tree RPATH -- absolute paths
+# into each target's build directory -- hides a layout mismatch rather than
+# fixing it: everything resolves in the build tree and only breaks once the
+# binary moves. A build driven with an explicit RPATH gets no such help. emb
+# passes $ORIGIN/lib:$ORIGIN, and against the default layout, which leaves
+# libihs_shared.so in shared/, the shell then cannot start at all:
+#
+#     homescreen: error while loading shared libraries: libihs_shared.so.1:
+#         cannot open shared object file: No such file or directory
+#
+# The executable's own location is load-bearing (workflows, scripts and docs
+# all name build/shell/homescreen), so lib/ is placed relative to it rather
+# than the other way round.
+#
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/shell/lib")
+
+# Guarded so an integrator keeps the last word: emb passes a wider
+# $ORIGIN/lib:$ORIGIN, and a distro build that wants no RPATH at all passes an
+# empty one. Both are explicit choices, and both already satisfy the layout
+# above -- overriding them here would only narrow a decision made outside.
+if(NOT DEFINED CMAKE_BUILD_RPATH)
+    set(CMAKE_BUILD_RPATH "\$ORIGIN/lib")
+endif()
+if(NOT DEFINED CMAKE_INSTALL_RPATH)
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN/lib")
+endif()
+
 # Backend selection is no longer mutually exclusive: every BUILD_BACKEND_* may
 # be ON together and all selected backends link into one binary. The active
 # backend is resolved at runtime via backend::ShellRegistry (see


### PR DESCRIPTION
## The failure

`crash-handler` has been red since 2026-08-27, on every PR, exiting 127 where 139 was expected:

```
homescreen: error while loading shared libraries: libihs_shared.so.1:
    cannot open shared object file: No such file or directory
```

It never reaches the crash it exists to verify.

## Why

The tree sets no RPATH and no output directories. `libihs_shared.so` lands in `shared/`, the shell binary lands in `shell/`, and the only thing holding them together is CMake's *automatic* build-tree RPATH — absolute paths into each target's build directory. Comparing the last passing run against a failing one shows exactly that:

| | RPATH on the shell binary |
|---|---|
| 08-26, passing | `<build>:<build>/shared` |
| 08-27 onward, failing | `$ORIGIN/lib:$ORIGIN` |

The build goes through emb, which passes `$ORIGIN/lib:$ORIGIN`. That is the correct RPATH for a deployed bundle — the problem is entirely on our side: an explicit RPATH displaces the automatic one, and this tree's layout puts nothing at either location. The automatic RPATH was never a fix, only a build-tree-shaped disguise for a layout that could not survive being relocated.

## The change

Shared libraries build into `shell/lib`, and the RPATH is `$ORIGIN/lib` — the layout a deployed bundle already has, so a build tree and an install resolve identically and neither needs `LD_LIBRARY_PATH`. The executable's own location is load-bearing (workflows, scripts and docs all name `build/shell/homescreen`), so `lib/` is placed relative to it rather than the other way round.

Both RPATH variables are set only when the caller has not, so an integrator keeps the last word — emb's wider `$ORIGIN/lib:$ORIGIN` survives, as does the empty value a distro build passes when it wants no RPATH at all.

## Verification

A full build needs the submodules and the engine, so I checked the mechanism on a reduction of the same shape — executable in `shell/`, versioned `.so` with `SOVERSION 1` in a sibling directory:

| scenario | RUNPATH | runs from an unrelated cwd |
|---|---|---|
| our default | `$ORIGIN/lib` | yes |
| `BUILD_WITH_INSTALL_RPATH=ON` (emb-style) | `$ORIGIN/lib` | yes |
| override `$ORIGIN/lib:$ORIGIN` | `$ORIGIN/lib:$ORIGIN` | yes |
| override empty (distro) | none | no — the caller's explicit choice |

In every case the library lands in `shell/lib` and the binary keeps its path. CI is the real check.

Unblocks the `crash-handler` check on #498, which is otherwise unrelated.