### PR TITLE
[docs] `display`, `vsync`, and `input` subsystems

### DIFF
--- a/shell/display/README.md
+++ b/shell/display/README.md
@@ -1,0 +1,246 @@
+# display/
+
+The display abstraction layer for the Flutter embedder. A `IDisplay` is the
+event / output source a view runs against — either a Wayland compositor
+connection or a DRM card — and is the seam that makes "one master domain, N
+named outputs" uniform across backends, which is what lets a single process
+drive multiple physical displays from one configuration.
+
+It also hosts the backend-agnostic output binding machinery (`OutputMatch`,
+`OutputManager`) and the per-card DRM plumbing (master acquisition, libseat
+session, hotplug monitoring, page-flip event routing, EDID/identity helpers,
+scale math).
+
+---
+
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| `IDisplay` abstraction (event pump + output provider) | ✓ | Always compiled |
+| `SoftwareDisplay` — no-op display for the software backend | ✓ | `-DBUILD_BACKEND_SOFTWARE=ON` |
+| `DrmDisplay` — DRM master + libseat session + hotplug monitor | ✓ | `-DBUILD_BACKEND_DRM_KMS_EGL=ON` or `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON` |
+| `DrmDisplay` adopted-fd constructor (wayland-leased-drm) | ✓ | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON` |
+| `DrmOutputProvider` — enumerates card connectors as outputs | ✓ | DRM backends |
+| `OutputManager` — resolves `[view.output]` to a connector / `wl_output` | ✓ | Always compiled |
+| `OutputMatch` priority tiers (output_id, EDID serial, name, index) | ✓ | Always compiled |
+| EDID read (`ProbeConnectorInfo`) | ✓ | DRM backends |
+| `IHS_OUTPUT_NAME` udev role names (`ReadOutputIds`) | ✓ | DRM backends |
+| `ResolveDrmDevice` — picks the right `/dev/dri/cardN` | ✓ | DRM backends |
+| `PrintDrmModes` for `--drm-list-modes` | ✓ | DRM backends |
+| Per-card `PAGE_FLIP_EVENT` reader + dispatch routing | ✓ | DRM backends |
+| `ScalePolicy` — fractional / HiDPI buffer scaling | ✓ | Always compiled (header-only) |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    App["App<br/>(owns displays)"] --> ID["IDisplay (abstract)"]
+
+    ID --> Wl["Wayland Display<br/>(shell/wayland)"]
+    ID --> SD["SoftwareDisplay<br/>no-op"]
+    ID --> DD["DrmDisplay"]
+
+    DD --> DS["DrmSession<br/>(libseat)"]
+    DD --> HPM["udev HotplugMonitor"]
+    DD --> FPR["PAGE_FLIP reader thread<br/>(per card)"]
+
+    ID -.->|GetOutputProvider()| OP["IOutputProvider"]
+    OP --> DOP["DrmOutputProvider"]
+    OP --> WOP["Wayland registry<br/>(shell/wayland)"]
+
+    OP -->|EnumerateOutputs()| OM["OutputManager<br/>ResolveForView()"]
+    OM -->|name| BE["Backend<br/>(scans out)"]
+```
+
+`IDisplay` is the single interface `App` talks to. A Wayland connection, a DRM
+card, and the no-op software display are all the same shape to `App::Run` — it
+just calls `StartEvents` / `PollEvents` / `GetRefreshRate` /
+`GetOutputProvider`. The backends then reach into the concrete display to
+drive their scanout.
+
+The output-binding path is independent of any concrete display:
+`OutputManager::ResolveForView()` asks the display's `IOutputProvider` for the
+currently-connected outputs, runs the view's `[view.output]` constraint through
+`ResolveOutput()`, and hands the connector / `wl_output` name to the backend.
+
+### Module responsibilities
+
+- **`IDisplay`** ([idisplay.h](idisplay.h)) — the abstract base. Event pump
+  (`StartEvents` / `StopEvents` / `PollEvents`), refresh-rate and mode queries,
+  `SetViewControllerState` so the seat can deliver input, and
+  `GetOutputProvider` for the output-binding path.
+- **`SoftwareDisplay`** ([software_display.{h,cc}](software_display.h)) —
+  no-op `IDisplay` for the software backend. Refresh rate is the only field
+  `App::Loop` consumes; it also owns the libinput-backed `SoftwareSeat` and,
+  for the leased-DRM path, the `LeasedScanout` descriptor.
+- **`DrmDisplay`** ([drm_display.{h,cc}](drm_display.h)) — the DRM card's
+  master domain. Owns the libseat session (or the legacy direct-open +
+  `drmSetMaster` fallback with the foreground-VT guard), the udev hotplug
+  monitor, the per-card `PAGE_FLIP_EVENT` reader thread, and the plane
+  coordinator. The adopted-fd constructor wires it up for wayland-leased-drm
+  (no `drmSetMaster`, no libseat session, enumeration through the lease fd).
+- **`IOutputProvider`** ([output_provider.h](output_provider.h)) — the
+  "source of physical outputs" seam. `EnumerateOutputs()` returns the
+  connected ones plus (on DRM) enumerated-but-disconnected ports;
+  `SetOutputListener` installs a listener for hotplug callbacks.
+- **`DrmOutputProvider`** ([drm_output_provider.{h,cc}](drm_output_provider.h))
+  — enumerates the card's connectors as `OutputInfo`. Uses libdrm only (no DRM
+  master, no GL/GBM), so it is safe to call before, and independently of, the
+  backend. `SetEnumerationFd` switches enumeration through a lease fd.
+- **`OutputInfo` / `OutputMatch` / `ResolveOutput`**
+  ([output.{h,cc}](output.h)) — the data + match logic. Match tiers, most
+  specific first: `output_id` (udev role), EDID `serial`, connector / `wl_name`,
+  `index` (deprecated). `ResolveOutputDetailed` distinguishes
+  `kUnconstrained` (no `[view.output]`) from `kUnresolved` (a constraint that
+  was set and nothing satisfied it).
+- **`OutputManager`** ([output_manager.{h,cc}](output_manager.h)) — the
+  backend-agnostic entry point. Reads the display's provider, runs the
+  resolver, logs the decision.
+- **`DiffOutputs` / `ClassifyOutputTransition`**
+  ([output.{h,cc}](output.h)) — pure functions that turn two enumerations into
+  a list of changes, and a change + view state into an `OutputTransition`
+  (`kNone` / `kMoved` / `kAppeared` / `kLost` / `kReconfigured`).
+- **`ProbeConnectorInfo`** ([connector_edid.{h,cc}](connector_edid.h)) —
+  reads and parses a connector's EDID. Returns nullopt when the connector has
+  no EDID (ordinary on embedded DSI panels).
+- **`ReadOutputIds`** ([output_identity.{h,cc}](output_identity.h)) — reads
+  the `IHS_OUTPUT_NAME` udev property of each connector on a card. This is the
+  only output-binding key that survives a change of board.
+- **`ResolveDrmDevice`** ([drm_device_resolver.{h,cc}](drm_device_resolver.h))
+  — picks which `/dev/dri/cardN` to use. Explicit → single card → first card
+  with a connected non-virtual connector → refuse to guess.
+- **`PrintDrmModes`** ([drm_mode_list.{h,cc}](drm_mode_list.h)) — supports
+  `--drm-list-modes`; read-only, prints every connector's modes + plane
+  rotation capabilities.
+- **`ScalePolicy`** ([scale_policy.h](scale_policy.h)) — the normative
+  fractional-scale rounding. Carries scale as `scale_120` (unity = 120),
+  rounds in the integer domain, and is bit-identical to the
+  wayland-cxx-scanner reference via shared conformance vectors.
+- **Cursor sinks** ([icursor_shape_sink.h](icursor_shape_sink.h),
+  [../input/cursor_position_sink.h](../input/cursor_position_sink.h)) — small
+  interfaces so the seat can retarget a live cursor regardless of which
+  concrete cursor (HW plane, GL-composited, software) the backend is using.
+
+---
+
+## Build steps
+
+### Configure + build
+
+These sources build only when the corresponding backend is enabled:
+
+| Source | Gate |
+|--------|------|
+| `display/output.{h,cc}`, `display/output_manager.{h,cc}` | Always |
+| `display/software_display.{h,cc}` | `BUILD_BACKEND_SOFTWARE` |
+| `display/drm_display.{h,cc}`, `display/connector_edid.{h,cc}`, `display/drm_device_resolver.{h,cc}`, `display/drm_mode_list.{h,cc}`, `display/output_identity.{h,cc}`, `display/drm_output_provider.{h,cc}` | `BUILD_BACKEND_DRM_KMS_EGL` or `BUILD_BACKEND_DRM_KMS_VULKAN` |
+
+Example:
+
+```bash
+cmake -GNinja -B build -DBUILD_BACKEND_DRM_KMS_EGL=ON
+ninja -C build
+```
+
+### Dependencies
+
+- **libdrm** — connector enumeration, EDID read, mode listing.
+- **drm-cxx** — `drm::Device`, `drm::session::Seat`, `HotplugMonitor`, cursor
+  loading.
+- **libseat** (optional) — DRM master + input fd revocation. Without it the
+  display falls back to direct `/dev/dri` open + the legacy VT / master
+  guards.
+- **libudev** — hotplug monitoring and `IHS_OUTPUT_NAME` role names.
+
+---
+
+## Running
+
+### DRM card selection
+
+When `[view.backend.drm.device]` is not set, `ResolveDrmDevice` applies this
+precedence:
+
+1. An explicit `--drm-device` / `HOMESCREEN_DRM_DEVICE` is used verbatim.
+2. Exactly one `/dev/dri/cardN` present → that card, whatever its number.
+3. Several cards → the first with a connected, non-virtual connector.
+4. Otherwise → **refuse to guess**; the caller fail-fasts.
+
+### Output binding
+
+A view pins itself to an output via the `[view.output]` table. The most
+specific set field wins:
+
+| Tier | Key | Scope | Notes |
+|------|-----|-------|-------|
+| 1 | `output_id` | DRM only | udev role name (`IHS_OUTPUT_NAME`). Portable across boards. |
+| 2 | `serial` | DRM only | EDID serial. Only if it identifies exactly one connected output. |
+| 3 | `drm_connector` / `wl_name` | Per backend | Connector / `wl_output` name. |
+| 4 | `index` | All | Deprecated, unstable. |
+
+A `output_id` that matches more than one output **parks the view** rather than
+falling through — naming a role is a deliberate statement about which display
+a view belongs on.
+
+### Multi-display layout
+
+Multiple views can share one input seat (e.g. several displays on one DRM
+card). Each view declares its position in the combined pointer space via
+`[view.output] x` / `y`, and binds its touch panel via `touch_device` (a
+libinput device-name substring).
+
+### Reading logs
+
+Key prefixes:
+
+- `[OutputManager]` — binding decisions.
+- `[OutputResolver]` — resolver-tier messages (ambiguous / no-match).
+- `[DrmDisplay]` — session open, VT guard, master acquisition.
+- `[DrmOutputProvider]` — enumeration diagnostics.
+
+---
+
+## Diagnostics/Debug
+
+- **`--drm-list-modes`** — prints every connector's modes + plane rotation
+  capabilities for the resolved card. Read-only; returns before booting the
+  engine.
+- **`HOMESCREEN_DRM_NO_SEAT=1`** — bypass libseat; the display opens
+  `/dev/dri` directly and self-acquires DRM master. Useful when debugging the
+  master-acquisition path without a logind / seatd running.
+- **`IHS_OUTPUT_NAME` udev rule** — to debug role-name binding, check that the
+  property is set on the connector's sysfs node:
+  `cat /sys/class/drm/<card>-<connector>/IHS_OUTPUT_NAME`.
+
+---
+
+## Known limitations
+
+- `IHS_OUTPUT_NAME` is DRM-only today. The Wayland path cannot read a
+  connector identity, so a compositor advertising `HDMI-1` for a kernel
+  `HDMI-A-1` will not resolve by name without a normalization step.
+- `OutputMatch::index` is deprecated. Enumeration order can shift across
+  probes and reboots; the resolver logs a warning when it is used.
+- A `DrmDisplay` built through the adopted-fd path has no
+  `no_seat` knob — the compositor owns the VT, so the answer is always "no
+  seat".
+
+---
+
+## References
+
+- [`shell/display/idisplay.h`](idisplay.h) — `IDisplay` interface
+- [`shell/display/drm_display.h`](drm_display.h) — `DrmDisplay` + adopted-fd
+  constructor
+- [`shell/display/output.h`](output.h) — `OutputInfo`, `OutputMatch`,
+  `ResolveOutput`, `DiffOutputs`
+- [`shell/display/output_manager.h`](output_manager.h) — `OutputManager`
+- [`shell/configuration/README.md`](../configuration/README.md) — `[view.output]`
+  config reference
+- [`shell/backend/drm_kms_egl/README.md`](../backend/drm_kms_egl/README.md) —
+  the DRM/KMS-EGL backend that consumes `DrmDisplay`
+- [`shell/backend/software/README.md`](../backend/software/README.md) — the
+  software backend that consumes `SoftwareDisplay`

--- a/shell/display/README.md
+++ b/shell/display/README.md
@@ -1,6 +1,6 @@
 # display/
 
-The display abstraction layer for the Flutter embedder. A `IDisplay` is the
+The display abstraction layer for the Flutter embedder. An `IDisplay` is the
 event / output source a view runs against — either a Wayland compositor
 connection or a DRM card — and is the seam that makes "one master domain, N
 named outputs" uniform across backends, which is what lets a single process
@@ -18,7 +18,7 @@ scale math).
 | Capability | Status | Toggle / scope |
 |---|---|---|
 | `IDisplay` abstraction (event pump + output provider) | ✓ | Always compiled |
-| `SoftwareDisplay` — no-op display for the software backend | ✓ | `-DBUILD_BACKEND_SOFTWARE=ON` |
+| `SoftwareDisplay` — no-op display for the software backend | ✓ | `-DBUILD_BACKEND_SOFTWARE=ON`, `-DBUILD_BACKEND_HEADLESS_EGL=ON`, or `-DBUILD_BACKEND_HEADLESS_VULKAN=ON` |
 | `DrmDisplay` — DRM master + libseat session + hotplug monitor | ✓ | `-DBUILD_BACKEND_DRM_KMS_EGL=ON` or `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON` |
 | `DrmDisplay` adopted-fd constructor (wayland-leased-drm) | ✓ | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON` |
 | `DrmOutputProvider` — enumerates card connectors as outputs | ✓ | DRM backends |
@@ -135,7 +135,7 @@ These sources build only when the corresponding backend is enabled:
 | Source | Gate |
 |--------|------|
 | `display/output.{h,cc}`, `display/output_manager.{h,cc}` | Always |
-| `display/software_display.{h,cc}` | `BUILD_BACKEND_SOFTWARE` |
+| `display/software_display.{h,cc}` | `BUILD_BACKEND_SOFTWARE`, `BUILD_BACKEND_HEADLESS_EGL`, or `BUILD_BACKEND_HEADLESS_VULKAN` |
 | `display/drm_display.{h,cc}`, `display/connector_edid.{h,cc}`, `display/drm_device_resolver.{h,cc}`, `display/drm_mode_list.{h,cc}`, `display/output_identity.{h,cc}`, `display/drm_output_provider.{h,cc}` | `BUILD_BACKEND_DRM_KMS_EGL` or `BUILD_BACKEND_DRM_KMS_VULKAN` |
 
 Example:
@@ -181,7 +181,7 @@ specific set field wins:
 | 3 | `drm_connector` / `wl_name` | Per backend | Connector / `wl_output` name. |
 | 4 | `index` | All | Deprecated, unstable. |
 
-A `output_id` that matches more than one output **parks the view** rather than
+An `output_id` that matches more than one output **parks the view** rather than
 falling through — naming a role is a deliberate statement about which display
 a view belongs on.
 
@@ -211,9 +211,10 @@ Key prefixes:
 - **`HOMESCREEN_DRM_NO_SEAT=1`** — bypass libseat; the display opens
   `/dev/dri` directly and self-acquires DRM master. Useful when debugging the
   master-acquisition path without a logind / seatd running.
-- **`IHS_OUTPUT_NAME` udev rule** — to debug role-name binding, check that the
-  property is set on the connector's sysfs node:
-  `cat /sys/class/drm/<card>-<connector>/IHS_OUTPUT_NAME`.
+- **`IHS_OUTPUT_NAME` udev rule** — to debug role-name binding, verify that the
+  udev environment property is set on the connector:
+  `udevadm info --query=property --path=/sys/class/drm/<card>-<connector>`.
+  Note: this is a udev *environment property*, not a sysfs attribute.
 
 ---
 

--- a/shell/input/README.md
+++ b/shell/input/README.md
@@ -1,14 +1,17 @@
 # input/
 
 The input subsystem: the single place raw device input is turned into Flutter
-input. It consumes host input (`libinput` on DRM, Wayland seats otherwise),
-does the keyboard translation (xkb) and auto-repeat, and forwards events to
-the running Flutter engine as `FlutterKeyEvent` / `FlutterPointerEvent`.
+input. It consumes host input (e.g. `libinput` on DRM), does the keyboard
+translation (xkb) and auto-repeat, and forwards events to the running Flutter
+engine as `FlutterKeyEvent` / `FlutterPointerEvent`.
 
-The `ISeat` interface is the seam: each backend pairs with a concrete seat
-(`DrmSeat` for DRM-KMS, `SoftwareSeat` for the software backend, a
-Wayland seat for Wayland). The backend-shared keyboard core (xkb translation
-+ key-repeat) lives here so every libinput-backed seat behaves identically.
+`ISeat` is an abstract interface to be implemented by backends that need a
+libinput-driven seat. The DRM-KMS backends use the in-tree `DrmSeat`; the
+software backend has its own `SoftwareSeat` (under `shell/backend/software/input/`);
+a future `WaylandSeat` could plug in here when a Wayland-client + DRM-rendering
+combination wants a `wl_seat`-backed input source. The backend-shared keyboard
+core (xkb translation + key-repeat) lives here so every libinput-backed seat
+behaves identically.
 
 ---
 
@@ -40,7 +43,6 @@ flowchart TD
 
     IS --> DS["DrmSeat<br/>libinput + drm::input::Seat"]
     IS --> SS["SoftwareSeat<br/>(backend/software)"]
-    IS --> WS["Wayland seat<br/>(shell/wayland)"]
 
     DS --> KB["XkbKeyboard<br/>(xkbcommon)"]
     DS --> KR["KeyRepeater<br/>(timerfd)"]
@@ -143,10 +145,10 @@ substring); touches from that panel route to that view instead of the primary.
 
 ### VT switch
 
-`Ctrl+Alt+F<n>` is intercepted from libinput's stream before it reaches the
-kernel's keymap-layer handler. `DrmSeat::SetVtSwitchHandler` installs the
-handler; returning `true` consumes the event so it does not also reach
-Flutter.
+On the direct-open path, `K_OFF` disables the kernel console keymap handler, so
+`DrmSeat` detects `Ctrl+Alt+F<n>` in libinput's stream. A handler installed with
+`DrmSeat::SetVtSwitchHandler` performs the switch; returning `true` consumes the
+event so it does not also reach Flutter.
 
 ### Keyboard LEDs
 
@@ -160,12 +162,9 @@ pushes this to the physical LEDs at startup and on every device-add.
 - **`IVI_M2P_PROFILE=1`** (or `IVI_PROFILE=1`) — enables the motion-to-photon
   profiler. Input batches are fed from `DrmSeat::HandleEvent` and
   `SoftwareSeat` via the shared `MotionToPhoton::RecordInput`.
-- **`HOMESCREEN_DRM_NO_SEAT=1`** — bypass libseat. `DrmSeat` then opens
-  `/dev/input/event*` directly and applies the legacy `K_OFF` TTY keyboard-mode
-  hack.
-- **`--drm-no-seat` / `HOMESCREEN_DRM_NO_SEAT`** — skip the libseat session
-  entirely. The seat's `InputDeviceOpener` is empty, and the seat falls back
-  to direct evdev.
+- **`--drm-no-seat` / `HOMESCREEN_DRM_NO_SEAT=1`** — bypass the libseat
+  session. `DrmSeat` opens `/dev/input/event*` directly and applies the legacy
+  `K_OFF` TTY keyboard-mode handling.
 - **Degraded poll mode** — when `eventfd()` fails at construction, the seat
   degrades to a 100 ms `poll` timeout. A warning is logged once.
 

--- a/shell/input/README.md
+++ b/shell/input/README.md
@@ -1,0 +1,201 @@
+# input/
+
+The input subsystem: the single place raw device input is turned into Flutter
+input. It consumes host input (`libinput` on DRM, Wayland seats otherwise),
+does the keyboard translation (xkb) and auto-repeat, and forwards events to
+the running Flutter engine as `FlutterKeyEvent` / `FlutterPointerEvent`.
+
+The `ISeat` interface is the seam: each backend pairs with a concrete seat
+(`DrmSeat` for DRM-KMS, `SoftwareSeat` for the software backend, a
+Wayland seat for Wayland). The backend-shared keyboard core (xkb translation
++ key-repeat) lives here so every libinput-backed seat behaves identically.
+
+---
+
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| `ISeat` abstraction | ✓ | Always compiled |
+| `DrmSeat` — libinput-backed seat for DRM-KMS | ✓ | `-DBUILD_BACKEND_DRM_KMS_EGL=ON` or `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON` |
+| `XkbKeyboard` — xkbcommon translation, shared | ✓ | libinput seats |
+| `KeyRepeater` — timerfd-driven auto-repeat, shared | ✓ | libinput seats |
+| `WakeEventFd` — eventfd waker, shared | ✓ | libinput seats |
+| Cursor shape / position sinks (HW plane + composited) | ✓ | DRM-KMS backends |
+| Multi-display pointer routing (`ViewRegion` layout) | ✓ | DRM-KMS backends |
+| Touch bonding (`touch_device` libinput name match) | ✓ | DRM-KMS backends |
+| VT-switch (`Ctrl+Alt+F<n>`) handler | ✓ | `DrmSeat` |
+| Session pause / resume (libseat VT round-trip) | ✓ | `DrmSeat` + libseat |
+| Hot-swap xkb keymap (dormant — future settings channel) | ✓ | `DrmSeat` |
+| Motion-to-photon input endpoint | ✓ | `IVI_M2P_PROFILE` (or `IVI_PROFILE`) |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    FE["FlutterEngine<br/>(via FlutterDesktopViewControllerState)"]
+    FE --> IS["ISeat (abstract)"]
+
+    IS --> DS["DrmSeat<br/>libinput + drm::input::Seat"]
+    IS --> SS["SoftwareSeat<br/>(backend/software)"]
+    IS --> WS["Wayland seat<br/>(shell/wayland)"]
+
+    DS --> KB["XkbKeyboard<br/>(xkbcommon)"]
+    DS --> KR["KeyRepeater<br/>(timerfd)"]
+    DS --> WE["WakeEventFd"]
+
+    DS -->|FlutterKeyEvent / FlutterPointerEvent| FE
+    DS -.->|SetShape| CUR["DrmCursor / GlCursor"]
+```
+
+`DrmSeat` runs a dedicated dispatch thread that pumps `drm::input::Seat`
+events. Events received before the Flutter engine is up are dropped. When a
+libseat session is live, the seat opens `/dev/input/event*` through the
+session's `InputDeviceOpener`, giving input fds the same revocable lifetime as
+the DRM fd.
+
+### Module responsibilities
+
+- **`ISeat`** ([iseat.h](iseat.h)) — the lifecycle contract. `Start` / `Stop`
+  / `SetViewControllerState`. `SetViewControllerState` is safe to call at any
+  time, including before the engine is running; `nullptr` pauses delivery.
+- **`DrmSeat`** ([drm_seat.{h,cc}](drm_seat.h)) — the libinput-backed seat.
+  Owns the dispatch thread, the `ViewRegion` map for multi-display pointer
+  routing, the HW / composited cursor, and the VT-switch / session-pause
+  handlers. `SetViewport`, `SetRegionLayout`, `SetCursor`, `SetGlCursor`,
+  `SetInputTransforms`, `SetCursorRotation` are all wired before `Start`.
+- **`XkbKeyboard`** ([xkb_keyboard.{h,cc}](xkb_keyboard.h)) — owns the
+  xkbcommon context, keymap, and state. `ProcessKey` resolves a keycode and
+  advances modifier state; `ResolveSym` does so without mutating. Shared by
+  every libinput-backed seat.
+- **`KeyRepeater`** ([key_repeater.{h,cc}](key_repeater.h)) — timerfd-driven
+  key auto-repeat. Defaults match X11/Wayland convention (600 ms delay, 25 Hz).
+  Synthesized repeats re-resolve the held key against the keyboard's current
+  state each tick, so a Shift/AltGr level change mid-hold takes effect on the
+  next repeat.
+- **`WakeEventFd`** ([wake_event_fd.{h,cc}](wake_event_fd.h)) — RAII eventfd
+  that breaks a seat's dispatch `poll()` out of an infinite block when a
+  cross-thread flag changes (stop, session pause/resume, keymap reload).
+- **`KeymapConfig`** / **`KeymapOptions`** — owned-string variants of the
+  RMLVO options, safe to pass across threads.
+- **`ICursorPositionSink`** ([cursor_position_sink.h](cursor_position_sink.h))
+  — the composited-cursor sink. Pushes pointer positions (in
+  render/viewport pixels) to a cursor that has no hardware plane — e.g. the
+  EGL backend's `GlCursor` on display controllers (i.MX LCDIF, etc.) that
+  expose only a primary plane.
+- **`ICursorShapeSink`** ([../display/icursor_shape_sink.h](../display/icursor_shape_sink.h))
+  — the cursor-shape retarget seam. `IDisplay::ActivateSystemCursor` calls
+  `SetShape` to swap the live sprite regardless of which concrete cursor the
+  backend is using.
+
+### Threading model
+
+- **Seat dispatch thread** — runs `DispatchLoop`, pumps libinput / drm-cxx
+  events, calls `KeyCallback` into the embedder. All calls into
+  `XkbKeyboard` / `KeyRepeater` come from here.
+- **`WakeEventFd`** — the dispatch `poll()` watches the libinput fd, the
+  repeater timer fd, and the wake fd. A write to the wake fd breaks the poll
+  so the next iteration can pick up a stop / pause / reload.
+- **Session libseat dispatch thread** — `DrmSeat::OnSessionPaused` /
+  `OnSessionResumed` are called from the libseat dispatch thread, NOT the seat
+  dispatch thread. They flip a pending flag; `DispatchLoop` picks it up on
+  the next iteration and calls the matching libinput suspend/resume on the
+  right thread.
+
+---
+
+## Build steps
+
+### Configure + build
+
+| Source | Gate |
+|--------|------|
+| `input/iseat.h` | Always (header) |
+| `input/xkb_keyboard.cc`, `input/key_repeater.cc`, `input/wake_event_fd.cc` | `BUILD_SOFTWARE_INPUT_LIBINPUT` or `BUILD_BACKEND_DRM_KMS_EGL` or `BUILD_BACKEND_DRM_KMS_VULKAN` |
+| `input/drm_seat.cc` | `BUILD_BACKEND_DRM_KMS_EGL` or `BUILD_BACKEND_DRM_KMS_VULKAN` |
+
+### Dependencies
+
+- **libinput** — evdev + multi-touch.
+- **xkbcommon** — keymap + modifier state.
+- **libseat** (optional) — `/dev/input/event*` opener for the DRM-KMS path.
+
+---
+
+## Running
+
+### Pointer routing across displays
+
+Multiple views can share one seat (several displays on one DRM card). Each
+view declares its rectangle in the combined pointer space via
+`DrmSeat::SetRegionLayout` + `SetViewport`. The pointer accumulates in
+combined space; the region under it receives events in its own local (render)
+coordinates and owns the sprite that tracks it.
+
+### Touch bonding
+
+A touch panel reports absolute coordinates in its own space with no cursor,
+so unlike a mouse it cannot be routed by pointer position. Each view can name
+a touch panel via `DrmSeat::SetRegionTouchDevice` (a libinput device-name
+substring); touches from that panel route to that view instead of the primary.
+
+### VT switch
+
+`Ctrl+Alt+F<n>` is intercepted from libinput's stream before it reaches the
+kernel's keymap-layer handler. `DrmSeat::SetVtSwitchHandler` installs the
+handler; returning `true` consumes the event so it does not also reach
+Flutter.
+
+### Keyboard LEDs
+
+`XkbKeyboard::Leds()` returns the Caps/Num/Scroll lock latch. `DrmSeat`
+pushes this to the physical LEDs at startup and on every device-add.
+
+---
+
+## Diagnostics/Debug
+
+- **`IVI_M2P_PROFILE=1`** (or `IVI_PROFILE=1`) — enables the motion-to-photon
+  profiler. Input batches are fed from `DrmSeat::HandleEvent` and
+  `SoftwareSeat` via the shared `MotionToPhoton::RecordInput`.
+- **`HOMESCREEN_DRM_NO_SEAT=1`** — bypass libseat. `DrmSeat` then opens
+  `/dev/input/event*` directly and applies the legacy `K_OFF` TTY keyboard-mode
+  hack.
+- **`--drm-no-seat` / `HOMESCREEN_DRM_NO_SEAT`** — skip the libseat session
+  entirely. The seat's `InputDeviceOpener` is empty, and the seat falls back
+  to direct evdev.
+- **Degraded poll mode** — when `eventfd()` fails at construction, the seat
+  degrades to a 100 ms `poll` timeout. A warning is logged once.
+
+---
+
+## Known limitations
+
+- **Hot-swap keymap is dormant.** `DrmSeat::ReloadKeymap` is implemented but
+  has no caller today; it is intended for a future settings/locale channel.
+- **Events before the engine is up are dropped.** The state pointer resolves
+  to a null engine handle in that window.
+- **Multi-seat is not supported.** There is one `ISeat` per display; a
+  multi-seat configuration (e.g. a touchscreen + a mouse + a keyboard on
+  different seats) requires the backends to coordinate.
+- **`DrmSeat::SetInputTransforms`** rotates/reflects relative-pointer deltas
+  for devices bolted to a rotated chassis (e.g. the Steam Deck's right
+  trackpad). Unmatched devices (an external mouse) are left alone.
+
+---
+
+## References
+
+- [`shell/input/iseat.h`](iseat.h) — `ISeat` interface
+- [`shell/input/drm_seat.h`](drm_seat.h) — `DrmSeat`
+- [`shell/input/xkb_keyboard.h`](xkb_keyboard.h) — `XkbKeyboard`
+- [`shell/input/key_repeater.h`](key_repeater.h) — `KeyRepeater`
+- [`shell/input/wake_event_fd.h`](wake_event_fd.h) — `WakeEventFd`
+- [`shell/display/README.md`](../display/README.md) — the cursor sinks that
+  `DrmSeat` pushes to
+- [`shell/backend/software/README.md`](../backend/software/README.md) — the
+  `SoftwareSeat` that reuses `XkbKeyboard` + `KeyRepeater`
+- [`shell/profiling/README.md`](../profiling/README.md) — the
+  motion-to-photon profiler fed from `DrmSeat`

--- a/shell/vsync/README.md
+++ b/shell/vsync/README.md
@@ -68,8 +68,10 @@ other thread.
 - **`WaylandVsyncProvider`**
   ([wayland_vsync_provider.{h,cc}](wayland_vsync_provider.h)) — owns
   `wp_presentation`, turns its per-commit `wp_presentation_feedback.presented`
-  events into `OnVsync` calls. One `WpFeedbackHandler` per commit; in-flight
-  feedback objects are destroyed race-safely with `Stop()`.
+  events into `OnVsync` calls. Presentation feedback corresponds to the
+  `wl_surface.commit` made by either the EGL (`eglSwapBuffers`) or Vulkan
+  rendering path. One `WpFeedbackHandler` per commit; in-flight feedback
+  objects are destroyed race-safely with `Stop()`.
 - **`ConsumerPacedVsyncSource`**
   ([consumer_paced_vsync.{h,cc}](consumer_paced_vsync.h)) — drives vsync from
   downstream consumer completion instead of a wall clock. A **credit** is one
@@ -86,7 +88,10 @@ other thread.
 - **Platform task-runner thread** — the only place `FlutterEngineOnVsync` is
   invoked. `PostOnVsync` posts there via the runner's strand.
 - **Any thread** — `SubmitBaton`, `AddCredit`, `SetFreeRun`, `SetParked`.
-  All state hops to the strand.
+  State is lock-free atomics; `SubmitBaton` and `SetParked` update atomics on
+  the caller's thread, and only the callback delivery (`PostOnVsync`) is
+  posted. `ConsumerPacedVsyncSource` additionally posts its mutable
+  scheduling state (credits, ceiling timer) to the strand.
 
 ---
 
@@ -112,14 +117,14 @@ Wayland provider is gated:
 
 ## Running
 
-### Vsync sources and when they fire
+### Vsync sources and completion signals
 
-| Source | Fires `OnPresented` when… |
-|--------|--------------------------|
-| `WaylandVsyncProvider` | the compositor's `wp_presentation_feedback.presented` event arrives (after `eglSwapBuffers`). |
-| DRM page-flip | the kernel delivers `PAGE_FLIP_EVENT` on the card fd. |
-| Software page-flip | the sink's page-flip completes. |
-| `ConsumerPacedVsyncSource` | the consumer releases a frame slot (`AddCredit`). |
+| Source | Completion / pacing signal |
+|--------|----------------------------|
+| `WaylandVsyncProvider` | `OnPresented` fires when the compositor's `wp_presentation_feedback.presented` event arrives. |
+| DRM page-flip | `DeliverVsync` is called when the kernel delivers `PAGE_FLIP_EVENT` on the card fd. |
+| Software page-flip | `DeliverVsync` is called when the sink's page-flip completes. |
+| `ConsumerPacedVsyncSource` | A parked baton becomes deliverable when the consumer releases a frame slot (`AddCredit`); no present is recorded. |
 
 ### Vsync profiling
 
@@ -157,18 +162,15 @@ should do. `SetParked(false)` unparks and delivers any parked baton.
   no source event will fire to return the baton (a VT resume, a post-modeset
   drain). Unlike `DeliverDiscard` it records no profile discard.
 - **Consumer-paced free-run** — `SetFreeRun(true)` paces on the ceiling alone,
-  ignoring credits, for when no consumer is attached (a detached export pool,
-  or a consumer that hitched — a watchdog flips this on until frame release
-  edges resume).
+  ignoring credits, for when no consumer is attached. Headless EGL enables it
+  from the `IVI_HEADLESS_FREERUN` env var; headless Vulkan flips it on and off
+  as export consumers attach and detach. Turning it back off resets the credit
+  count to the full pipeline depth.
 
 ---
 
 ## Known limitations
 
-- `IVsyncProvider` tracks a single engine. OSGi forward-compat requires a
-  register/unregister set for the VsyncCoordinator (one source → many bundle
-  engines). The source and baton fan-out are deliberately separable here so
-  that extension is additive.
 - `ConsumerPacedVsyncSource::SetFreeRun` resets the credit count to the full
   pipeline depth. A consumer that hitched and re-established the pool must
   start with that invariant.

--- a/shell/vsync/README.md
+++ b/shell/vsync/README.md
@@ -1,0 +1,191 @@
+# vsync/
+
+The backend-spanning vsync baton machinery. Flutter hands the embedder an
+opaque `baton` via its `vsync_callback` and expects exactly one
+`FlutterEngineOnVsync(baton)` back, marshaled onto the platform task runner.
+The park/drain/marshal dance is identical across backends; only the *source*
+of the vblank signal differs (a Wayland `wp_presentation.presented` event, a
+DRM `PAGE_FLIP_EVENT`, or a software page-flip). This directory holds the
+shared baton class and the per-source providers.
+
+---
+
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| `IVsyncProvider` — baton park/drain/marshal machinery | ✓ | Always compiled |
+| Cold-start safety (parked baton survives before runner is wired) | ✓ | Always |
+| Frame parking (suspend production, keep engine warm) | ✓ | Always |
+| Discard + parked-baton delivery (wall-clock fallback) | ✓ | Always |
+| Per-present cadence profiling (window + session summary) | ✓ | `IVI_VSYNC_PROFILE` |
+| `WaylandVsyncProvider` — `wp_presentation` → `OnVsync` | ✓ | `-DBUILD_BACKEND_WAYLAND_EGL=ON` or `-DBUILD_BACKEND_WAYLAND_VULKAN=ON` |
+| `ConsumerPacedVsyncSource` — backpressure / credit-based pacing | ✓ | Always compiled (used by `headless-egl`) |
+| Motion-to-photon hookup on `OnPresented` | ✓ | `IVI_M2P_PROFILE` (or `IVI_PROFILE`) |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    FE["FlutterEngine<br/>vsync_callback(engine, baton)"] -->|SubmitBaton| IV["IVsyncProvider<br/>park / drain / marshal"]
+
+    IV -->|IsSourcePending?| SRC["source state"]
+
+    SRC --> WLP["WaylandVsyncProvider<br/>wp_presentation_feedback"]
+    SRC --> CPT["ConsumerPacedVsyncSource<br/>(credit + ceiling)"]
+    SRC --> DRM["DRM backend<br/>PAGE_FLIP_EVENT"]
+
+    WLP -->|OnPresented / OnDiscarded| IV
+    DRM -->|DeliverVsync / DeliverDiscard| IV
+    CPT -->|AddCredit / SetFreeRun| IV
+
+    IV -->|PostOnVsync| TR["TaskRunner strand"]
+    TR -->|FlutterEngineOnVsync| FE
+```
+
+The Flutter engine's vsync callback is a trampoline — it parks the baton in
+the provider and returns. The provider then decides when to hand it back:
+
+- **`IsSourcePending()` true** (a present is already in flight) → wait for the
+  source's completion event.
+- **`IsSourcePending()` false** (idle pipeline) → drain inline, on the wall
+  clock, so Flutter is never stalled.
+
+`DeliverVsync(frame_start_ns)` / `DeliverDiscard()` are called by the source
+when a frame is actually presented or dropped. `PostOnVsync` posts
+`FlutterEngineOnVsync` onto the platform runner — Flutter rejects it from any
+other thread.
+
+### Module responsibilities
+
+- **`IVsyncProvider`** ([ivsync_provider.{h,cc}](ivsync_provider.h)) — the
+  baton machinery. State is lock-free atomics; the platform-runner strand is
+  the only place `FlutterEngineOnVsync` is called. Sources can either subclass
+  (override `IsSourcePending` / `PeriodNs`) or drive the composition path
+  (`SetSourcePending` / `SetPeriodNs`).
+- **`WaylandVsyncProvider`**
+  ([wayland_vsync_provider.{h,cc}](wayland_vsync_provider.h)) — owns
+  `wp_presentation`, turns its per-commit `wp_presentation_feedback.presented`
+  events into `OnVsync` calls. One `WpFeedbackHandler` per commit; in-flight
+  feedback objects are destroyed race-safely with `Stop()`.
+- **`ConsumerPacedVsyncSource`**
+  ([consumer_paced_vsync.{h,cc}](consumer_paced_vsync.h)) — drives vsync from
+  downstream consumer completion instead of a wall clock. A **credit** is one
+  free slot in the producer's pipeline; delivering a baton commits a slot,
+  `AddCredit` returns one. An optional `min_period_ns` caps the rate so a fast
+  consumer cannot free-run the engine. Used today by the headless-EGL GLES
+  encoder; a Vulkan encoder can drive it unchanged.
+
+### Threading model
+
+- **Source thread** (Wayland event thread, DRM page-flip reader thread,
+  encoder consumer thread) — calls `DeliverVsync` / `DeliverDiscard` /
+  `AddCredit`.
+- **Platform task-runner thread** — the only place `FlutterEngineOnVsync` is
+  invoked. `PostOnVsync` posts there via the runner's strand.
+- **Any thread** — `SubmitBaton`, `AddCredit`, `SetFreeRun`, `SetParked`.
+  All state hops to the strand.
+
+---
+
+## Build steps
+
+### Configure + build
+
+`IVsyncProvider` and `ConsumerPacedVsyncSource` are always compiled. The
+Wayland provider is gated:
+
+| Source | Gate |
+|--------|------|
+| `vsync/ivsync_provider.cc`, `vsync/consumer_paced_vsync.cc` | Always |
+| `vsync/wayland_vsync_provider.cc` | `BUILD_BACKEND_WAYLAND_EGL` or `BUILD_BACKEND_WAYLAND_VULKAN` |
+
+### Dependencies
+
+- **wayland-cxx-scanner** — generated `presentation_time::client` bindings.
+- **Asio** — `steady_timer` for the ceiling timer in
+  `ConsumerPacedVsyncSource`.
+
+---
+
+## Running
+
+### Vsync sources and when they fire
+
+| Source | Fires `OnPresented` when… |
+|--------|--------------------------|
+| `WaylandVsyncProvider` | the compositor's `wp_presentation_feedback.presented` event arrives (after `eglSwapBuffers`). |
+| DRM page-flip | the kernel delivers `PAGE_FLIP_EVENT` on the card fd. |
+| Software page-flip | the sink's page-flip completes. |
+| `ConsumerPacedVsyncSource` | the consumer releases a frame slot (`AddCredit`). |
+
+### Vsync profiling
+
+`IVI_VSYNC_PROFILE=1` enables per-present cadence diagnostics. A window
+summary is logged every 60 presents and a session summary on `Stop()`. The
+label tags the log lines (e.g. `[DrmVsync]`, `[WaylandVsync]`,
+`[SoftwareVsync]`).
+
+### Motion-to-photon
+
+When `IVI_M2P_PROFILE=1` (or `IVI_PROFILE=1`), `OnPresented` feeds the
+motion-to-photon profiler with the real present timestamp. The cutoff
+(`frame_start_time`) is stamped at baton delivery and read back by the
+profiler to attribute inputs to the frame that consumed them.
+
+### Parking
+
+`SetParked(true)` stops frame production without tearing down the engine.
+The baton is simply not handed back — Flutter asked for a vsync and gets no
+answer, so it builds no frame and the whole pipeline (UI thread, rasterizer,
+GPU, scanout) goes quiet. This is what a view whose display was unplugged
+should do. `SetParked(false)` unparks and delivers any parked baton.
+
+---
+
+## Diagnostics/Debug
+
+- **Cold-start leak** — a baton parked before the platform runner is wired is
+  *left parked* (not exchanged out and dropped); `SetEngine` drains it via a
+  kick latch once the runner arrives. This is the documented fix for #210.
+- **Discarded frames** — `DeliverDiscard()` counts a discard and hands the
+  baton back on the wall clock so Flutter keeps scheduling. Discards are
+  profiled when `IVI_VSYNC_PROFILE` is set.
+- **Parked-baton kick** — `DeliverParkedBaton()` is for control-flow kicks where
+  no source event will fire to return the baton (a VT resume, a post-modeset
+  drain). Unlike `DeliverDiscard` it records no profile discard.
+- **Consumer-paced free-run** — `SetFreeRun(true)` paces on the ceiling alone,
+  ignoring credits, for when no consumer is attached (a detached export pool,
+  or a consumer that hitched — a watchdog flips this on until frame release
+  edges resume).
+
+---
+
+## Known limitations
+
+- `IVsyncProvider` tracks a single engine. OSGi forward-compat requires a
+  register/unregister set for the VsyncCoordinator (one source → many bundle
+  engines). The source and baton fan-out are deliberately separable here so
+  that extension is additive.
+- `ConsumerPacedVsyncSource::SetFreeRun` resets the credit count to the full
+  pipeline depth. A consumer that hitched and re-established the pool must
+  start with that invariant.
+- `WaylandVsyncProvider` leaves vsync unset when `wp_presentation` is not
+  usable (unbound, or its announced clock is not `CLOCK_MONOTONIC`); Flutter
+  then falls back to its wall-clock scheduler.
+
+---
+
+## References
+
+- [`shell/vsync/ivsync_provider.h`](ivsync_provider.h) — `IVsyncProvider`
+- [`shell/vsync/wayland_vsync_provider.h`](wayland_vsync_provider.h) —
+  `WaylandVsyncProvider`
+- [`shell/vsync/consumer_paced_vsync.h`](consumer_paced_vsync.h) —
+  `ConsumerPacedVsyncSource`
+- [`shell/profiling/README.md`](../profiling/README.md) —
+  `FrameProfile` + `MotionToPhoton`
+- [`shell/task_runner.h`](../task_runner.h) — the platform runner that
+  `FlutterEngineOnVsync` is marshaled onto


### PR DESCRIPTION
## Summary

Adds three new README files that document the display, vsync, and input subsystems of the Flutter embedder. The [Architecture doc](https://github.com/toyota-connected/ivi-homescreen/blob/main/docs/specs/ARCHITECTURE.md) references these as "details" links but the files did not yet exist.

## What changed

| File | Covers |
|------|--------|
| `README.md` | `IDisplay` abstraction, `DrmDisplay` / `SoftwareDisplay`, `OutputManager` + `OutputMatch` binding tiers, EDID / udev identity helpers, card resolution, scale policy |
| `README.md` | `IVsyncProvider` baton machinery, `WaylandVsyncProvider`, `ConsumerPacedVsyncSource` backpressure pacing, parking, discards, `IVI_VSYNC_PROFILE` / `IVI_M2P_PROFILE` gates |
| `README.md` | `ISeat` abstraction, `DrmSeat`, the shared `XkbKeyboard` + `KeyRepeater` core, multi-display pointer routing, touch bonding, VT-switch, session pause/resume, cursor sinks |

Each README follows the structure of `template.README.md`: features table, Mermaid architecture diagram, module responsibilities, build matrix, runtime notes, diagnostics, known limitations, and cross-references to related subsystems.