### PR TITLE
[docs] Per-backend READMEs, updated to v3.0

### DIFF
--- a/shell/backend/README.md
+++ b/shell/backend/README.md
@@ -1,0 +1,301 @@
+# Backend abstraction
+
+The display-target layer of the embedder. A `Backend` owns everything that is
+specific to *how* one Flutter view reaches the screen — surface lifecycle, the
+`FlutterRendererConfig` / `FlutterCompositor` handed to the engine, and the
+per-target vsync source — behind a single abstract interface
+([`backend.h`](backend.h)). One process can compile in several concrete
+backends; a process-wide [`BackendRegistry`](backend_registry.h) holds
+the compiled-in set, and the `Backend::Create` factory builds the right
+concrete instance per view at runtime from the resolved config. This folder is
+the parent of the per-backend implementation directories, each of which has its
+own README.
+
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| Abstract `Backend` interface (surface, renderer/compositor config, vsync) | Built-in | Always |
+| Runtime backend registry (`BackendRegistry` singleton) | Built-in | Always |
+| Per-view factory (`Backend::Create`) | Built-in | Always |
+| Compiled-in backend registration (`RegisterCompiledBackends`) | Per backend | `BUILD_BACKEND_*` |
+| Env-aware backend resolution (`ResolveKeyForConfig`) | Built-in | Always |
+| Multiple backends in one binary, resolved per view | Built-in | Depends on enabled `BUILD_BACKEND_*` |
+| EGL share-context export to plugins (`GetEglContext`) | Opt-in per backend | EGL backends only |
+| Vulkan handle export to plugins (`GetVulkanContext`) | Opt-in per backend | Vulkan backends only |
+| Reusable backing-store pool (`BackingStorePool`) | Built-in header | Used by EGL / Vulkan backends |
+| GL/EGL symbol resolver (`GlProcessResolver`) | Built-in | EGL-based backends |
+| Motion-to-photon profiler hook (`GetMotionToPhoton`) | Opt-in per backend | DRM/KMS backends, `IVI_M2P_PROFILE` |
+| Compositor-surface registration (platform views) | Opt-in per backend | `BUILD_COMPOSITOR` |
+| Debug HUD config plumbing (`SetHudConfig`) | Opt-in per backend | `BUILD_HUD` |
+| `--drm-list-modes` hook per backend | Per backend | DRM + software (DRM sink) backends |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph startup["Startup (main / App)"]
+        RCB["RegisterCompiledBackends()"]
+        EAB["EnsureActiveBackend()"]
+        RCB -->|"one descriptor per\nBUILD_BACKEND_* gate"| REG[("BackendRegistry\n(Meyers singleton)")]
+        EAB -->|"ResolveKeyForConfig(configs[0])"| REG
+        EAB -->|"SetActive()"| REG
+    end
+
+    subgraph perview["Per view"]
+        FV["FlutterView"] --> CREATE["Backend::Create(config, display)"]
+        CREATE -->|"ResolveKeyForConfig(config)"| REG
+        REG -->|"BackendDescriptor"| DESC["descriptor.make_backend(config, display)"]
+        DESC --> B["concrete Backend*"]
+    end
+
+    subgraph display["Per device-context (App::BuildDisplays)"]
+        MD["descriptor.make_display(configs)"] --> IDISP["IDisplay*"]
+    end
+
+    B -->|"GetRenderConfig()\nGetCompositorConfig()\nGetVsyncCallback()"| ENGINE["Flutter engine"]
+    IDISP -.->|"passed to make_backend"| DESC
+```
+
+A `Backend` is the unified display-target interface. Each concrete
+implementation lives in its own subfolder and is compiled behind its own
+`BUILD_BACKEND_*` guard, so a build pulls in only the backends it enables.
+Because every instance is isolated, heterogeneous backends can run concurrently
+(one process, several views, each on the device-context display `App` placed it
+on).
+
+- **`backend.h` — the abstract `Backend`.** Declares the virtual surface
+  lifecycle (`Resize`, `CreateSurface`, `TextureMakeCurrent`/`ClearCurrent`),
+  the engine-facing config accessors (`GetRenderConfig`, `GetCompositorConfig`),
+  the optional per-backend `GetVsyncCallback` (returning `nullptr` leaves
+  Flutter on its internal wall-clock scheduler), and lifecycle hooks
+  (`SetEngineHandle`, `SetPlatformTaskRunner`, `StopVsyncMonitor`,
+  `ReleaseRenderSurfaces`). It also declares the static `Backend::Create`
+  factory. Two plugin-interop escape hatches are declared here and default to
+  "not supported": `GetEglContext` (fills a `BackendEglContext` so a plugin can
+  create a share-context) and `GetVulkanContext` (fills a `BackendVulkanContext`
+  so a plugin renders a platform view into a `VkImage` on the same device the
+  engine uses). Under `BUILD_COMPOSITOR` it adds the compositor-surface
+  registration hooks for platform views, and under `BUILD_HUD` the `SetHudConfig`
+  plumbing. It owns a `profiling::MotionToPhoton` that only the DRM/KMS backends
+  opt into via `InitMotionToPhoton()` (gated on `IVI_M2P_PROFILE`).
+- **`backend_registry.h` / `.cc` — the registry.** `BackendDescriptor` is one
+  compiled-in backend's runtime identity: a string `key`, a `make_display`
+  callable, a `make_backend` callable (which expects the `IDisplay` its own
+  `make_display` produced), and an optional `list_modes` hook.
+  `BackendRegistry` is a Meyers singleton holding the descriptor table; it is populated once at startup, one active descriptor is
+  resolved before `App` is constructed, and it is read-only thereafter, so no
+  locking is required.
+- **`register_backends.h` / `.cc` — registration + resolution.** This single
+  translation unit gates each backend's `make_display`/`make_backend` body
+  behind its own `BUILD_BACKEND_*` guard (the bodies that used to live inline in
+  `App::MakeDisplay` and the `Backend::Create` `#if/#elif` chains).
+  - `RegisterCompiledBackends()` registers one descriptor per enabled backend,
+    including the three leased-DRM tiers (which reuse the direct DRM/software
+    factories, changing only where the DRM fd comes from).
+  - `EnsureActiveBackend()` makes `App` self-contained: it registers the
+    compiled-in backends (if not already), resolves the active key from the
+    configs, and calls `SetActive`. Returns `false` when nothing resolves.
+  - `ResolveKeyForConfig()` is the per-view selector. An exact registry key
+    (from `[view.backend]` / `--backend`) wins; otherwise the sole compiled
+    backend; otherwise an environment heuristic — a live Wayland session picks a
+    `wayland-*` backend, else KMS-direct (`drm-kms-*` / `software`) — honoring
+    the legacy `egl`/`vulkan` renderer hint within the chosen family. The leased
+    family is resolved **before** any fallback and never degrades to an unleased
+    backend (leasing drives a connector the compositor handed over; falling back
+    to an unleased backend would grab a whole card outright — the opposite of
+    what was asked).
+- **`Backend::Create` — the per-view factory.** Defined in
+  [`../view/flutter_view.cc`](../view/flutter_view.cc); it resolves the view's
+  key, looks up the descriptor, calls `descriptor->make_backend(config,
+  display)`, wires the HUD config under `BUILD_HUD`, and returns the instance
+  (`nullptr` on a resolution failure; concrete backends `exit()` on a hard
+  init failure).
+- **`backing_store_pool.h` — reusable backing-store pool.** A header-only,
+  backend-agnostic free-list keyed by `(width, height)` that mirrors the
+  engine's backing-store reuse. Any type providing `Width()`/`Height()` works;
+  the Wayland-EGL and Wayland-Vulkan backends instantiate it for their FBO /
+  texture / Vulkan stores. Thread-safe (`Acquire`/`Release`/`Flush` from any
+  thread).
+- **`gl_process_resolver.h` / `.cc` — GL/EGL symbol loader.** A process-lifetime
+  singleton (`GlProcessResolver::GetInstance()`) wrapping `EglProcessResolver`,
+  which `dlopen`s `libGLESv2.so.2` + `libEGL.so.1` and resolves GL entry points
+  (falling back to `eglGetProcAddress`). Used by the EGL-based backends
+  (`wayland_egl`, `drm_kms_egl`) to feed the engine's GL proc-resolver. Handles
+  are intentionally never `dlclose`d.
+
+Distinct from the Wayland *compositor-protocol* shells in
+[`../wayland/shell/`](../wayland/shell/) (the `--shell` option): a backend is a
+presentation target, a shell is a compositor role.
+
+### File map
+
+```
+shell/backend/
+├── backend.h              # Abstract Backend interface + BackendEglContext / BackendVulkanContext
+├── backend_registry.h     # BackendDescriptor + BackendRegistry (singleton) declarations
+├── backend_registry.cc    # Registry storage, Register/Resolve/Keys/SetActive/Active
+├── register_backends.h    # RegisterCompiledBackends / EnsureActiveBackend / ResolveKeyForConfig
+├── register_backends.cc   # Per-backend make_display / make_backend bodies + registration + resolver
+├── backing_store_pool.h   # Header-only reusable backing-store free-list
+├── gl_process_resolver.h  # EGL/GLES symbol resolver (singleton) declarations
+├── gl_process_resolver.cc # dlopen of libGLESv2 / libEGL, dlsym + eglGetProcAddress fallback
+├── drm_kms_egl/           # DRM/KMS + EGL backend            (see drm_kms_egl/README.md)
+├── drm_kms_vulkan/        # DRM/KMS + Vulkan backend         (see drm_kms_vulkan/README.md)
+├── software/              # CPU (software) backend + sinks   (see software/README.md)
+├── wayland_egl/           # Wayland client + EGL backend     (see wayland_egl/README.md)
+├── wayland_vulkan/        # Wayland client + Vulkan backend  (see wayland_vulkan/README.md)
+├── wayland_leased_drm/    # drm-lease-v1 client (leased tiers) (see wayland_leased_drm/README.md)
+└── hud/                   # Compositor debug HUD overlay      (Dear ImGui)
+```
+
+Related, outside this folder:
+
+```
+shell/view/flutter_view.cc          # Definition of Backend::Create (the per-view factory)
+shell/app.cc                        # BuildDisplays(): EnsureActiveBackend + one display per device-context
+shell/main.cc                       # --drm-list-modes dispatch via the active descriptor
+shell/display/idisplay.h            # IDisplay seam a backend's make_display produces
+shell/configuration/configuration.cc # [view.backend] / --backend parsing (see configuration/README.md)
+cmake/options.cmake                 # BUILD_BACKEND_* / BUILD_SOFTWARE_* / BUILD_HUD options
+```
+
+### Threading model
+
+The registry is populated and made active during single-threaded startup and is
+read-only afterward, so `Resolve`/`Active`/`Keys` need no locking. Concrete
+backends drive their own threading (rasterizer, page-flip/event-loop threads);
+the `Backend` hooks encode the ordering contract the shell must honor —
+`ReleaseRenderSurfaces()` runs *after* the engine threads are joined but *before*
+the display members are destroyed, and `StopVsyncMonitor()` runs before the
+engine destructs so async work cannot outlive the engine handle. Any backend
+wiring `FlutterEngineOnVsync` must marshal it onto the platform task runner
+handed to it via `SetPlatformTaskRunner()`. `BackingStorePool` is safe to call
+from any thread.
+
+---
+
+## Build steps
+
+Backends are **additive**: each is compiled in behind its own `BUILD_BACKEND_*`
+CMake option, and at least one must be enabled for a usable binary. A
+single-backend build registers exactly one descriptor;
+[`register_backends.cc`](register_backends.cc) and
+[`backend_registry.cc`](backend_registry.cc) are always compiled (they are
+backend-agnostic).
+
+### Configure + build
+
+```sh
+cmake -B build -G Ninja \
+  -DBUILD_BACKEND_WAYLAND_EGL=ON \
+  -DBUILD_BACKEND_DRM_KMS_EGL=OFF
+cmake --build build
+```
+
+Options are declared in [`cmake/options.cmake`](../../cmake/options.cmake):
+
+- `BUILD_BACKEND_WAYLAND_EGL` (default **ON**) — Wayland client + EGL/GLES.
+- `BUILD_BACKEND_WAYLAND_VULKAN` (default ON only when `BUILD_BACKEND_WAYLAND_EGL` is OFF) — Wayland client + Vulkan.
+- `BUILD_BACKEND_DRM_KMS_EGL` (default OFF) — direct KMS scanout + EGL/GLES.
+- `BUILD_BACKEND_DRM_KMS_VULKAN` (default OFF) — direct KMS scanout + Vulkan (zero-copy dma-buf).
+- `BUILD_BACKEND_SOFTWARE` (default OFF) — CPU rendering; `BUILD_SOFTWARE_SINK_DRM` / `BUILD_SOFTWARE_SINK_FBDEV` / `BUILD_SOFTWARE_INPUT_LIBINPUT` select its scanout sinks and input.
+- `BUILD_BACKEND_WAYLAND_LEASED_DRM` (default OFF) — the `drm-lease-v1` client; combine with one or more renderer stacks to enable the leased tiers.
+- `BUILD_COMPOSITOR` (default OFF) — enables the `FlutterCompositor` backing-store API (required for platform-view layers and `BUILD_HUD`).
+- `BUILD_HUD` (default ON, forced OFF without `BUILD_COMPOSITOR`) — the Dear ImGui debug overlay.
+
+### Build matrix
+
+| Config | CMake flags | Backend keys registered |
+|--------|-------------|-------------------------|
+| Wayland EGL (default) | `-DBUILD_BACKEND_WAYLAND_EGL=ON` | `wayland-egl` |
+| Wayland Vulkan | `-DBUILD_BACKEND_WAYLAND_EGL=OFF -DBUILD_BACKEND_WAYLAND_VULKAN=ON` | `wayland-vulkan` |
+| DRM/KMS EGL | `-DBUILD_BACKEND_DRM_KMS_EGL=ON` | `drm-kms-egl` |
+| DRM/KMS Vulkan | `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON` | `drm-kms-vulkan` |
+| Software | `-DBUILD_BACKEND_SOFTWARE=ON` | `software` |
+| Leased DRM (EGL renderer) | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_DRM_KMS_EGL=ON` | `drm-kms-egl`, `wayland-leased-drm-egl` |
+| Leased DRM (Vulkan renderer) | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_DRM_KMS_VULKAN=ON` | `drm-kms-vulkan`, `wayland-leased-drm-vulkan` |
+| Leased DRM (software) | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_SOFTWARE=ON -DBUILD_SOFTWARE_SINK_DRM=ON` | `software`, `wayland-leased-drm-software` |
+
+Multiple backends may be enabled together; each adds its key, and
+`ResolveKeyForConfig` picks between them per view.
+
+---
+
+## Running
+
+The backend is selected at runtime, not at build time (when more than one is
+compiled in). Selection precedence, per view:
+
+1. An exact registry key from `[view.backend]` `type` (TOML) or `--backend`
+   (CLI) — the primary path.
+2. If only one backend is compiled in, that backend (with a warning if a
+   different one was explicitly requested).
+3. The **leased** family (`wayland-leased-drm[-egl|-vulkan|-software]`) —
+   resolved before any fallback; the bare name `wayland-leased-drm` picks the
+   first available tier (vulkan → egl → software) and never falls back to an
+   unleased backend.
+4. Otherwise an environment heuristic: a live Wayland session
+   (`WAYLAND_DISPLAY` set **and** the socket exists) selects a `wayland-*`
+   backend; otherwise KMS-direct (`drm-kms-*`) then `software`. The legacy
+   `egl`/`vulkan` hint chooses the renderer within the selected family.
+
+When the resolved key differs from what was configured (a bare family name, a
+legacy hint, or an unset field), the resolution is logged at `info`:
+`[backend] resolved '<configured>' -> '<key>'`. A build with no usable backend
+aborts at startup.
+
+### CLI Flags
+
+| Flag | What it does |
+|------|-------------|
+| `--backend <key>` | Select the active backend. The `<key>` is the registry key of a compiled-in backend (see the build matrix above). A bare family name (e.g. `wayland-leased-drm`) picks the first available tier (vulkan → egl → software) and never falls back to an unleased backend. If no backend resolves, the process aborts at startup. |
+
+The `[view.backend]` TOML table mirrors `--backend` (`type = "..."`) and carries
+the DRM- and lease-only sub-tables. See
+[`../configuration/README.md`](../configuration/README.md) for the full
+configuration surface and layering order.
+
+---
+
+## Diagnostics/Debug
+
+- **Confirm the resolved backend.** Startup logs `[backend] resolved
+  '<configured>' -> '<key>'` whenever the effective key differs from the
+  configured string, and the resolved config (including `Backend:`) is printed
+  by the configuration layer. Raise verbosity with `IHS_LOG_LEVEL=debug`.
+- **A leased request that "isn't available"** logs an explicit `[backend]`
+  error listing the `BUILD_BACKEND_*` flags to rebuild with, rather than
+  silently falling back — by design.
+- **`--drm-list-modes`** enumerates the active backend's connector modes; a
+  backend without a `list_modes` hook (e.g. Wayland) logs
+  `the '<key>' backend does not support --drm-list-modes`.
+- **Hard init failures fail fast.** A concrete backend that cannot initialize
+  logs `[FlutterView] <backend> init failed; aborting` (or the equivalent) and
+  `exit()`s rather than letting the engine dereference a null backend.
+- **Per-backend debugging** (validation layers, DRM knobs, GL caps, sink
+  selection) is covered in each backend subdirectory's README.
+
+---
+
+## References
+
+- [`backend.h`](backend.h) — the abstract `Backend` interface.
+- [`backend_registry.h`](backend_registry.h) / [`backend_registry.cc`](backend_registry.cc) — the registry and descriptor.
+- [`register_backends.h`](register_backends.h) / [`register_backends.cc`](register_backends.cc) — registration and resolution.
+- [`backing_store_pool.h`](backing_store_pool.h) — reusable backing-store pool.
+- [`gl_process_resolver.h`](gl_process_resolver.h) / [`gl_process_resolver.cc`](gl_process_resolver.cc) — GL/EGL symbol resolver.
+- Per-backend implementations:
+  - [`wayland_egl/README.md`](wayland_egl/README.md)
+  - [`wayland_vulkan/README.md`](wayland_vulkan/README.md)
+  - [`wayland_leased_drm/README.md`](wayland_leased_drm/README.md)
+  - [`drm_kms_egl/README.md`](drm_kms_egl/README.md)
+  - [`drm_kms_vulkan/README.md`](drm_kms_vulkan/README.md)
+  - [`software/README.md`](software/README.md)
+  - [`hud/`](hud/) — compositor debug HUD (Dear ImGui overlay).
+- [`../configuration/README.md`](../configuration/README.md) — `[view.backend]` / `--backend` parsing and layering.
+- [`../view/flutter_view.cc`](../view/flutter_view.cc) — `Backend::Create` definition.
+- [`../app.cc`](../app.cc) — `EnsureActiveBackend` + per-device-context display creation.
+- [`../../cmake/options.cmake`](../../cmake/options.cmake) — `BUILD_BACKEND_*` options.

--- a/shell/backend/README.md
+++ b/shell/backend/README.md
@@ -25,7 +25,7 @@ own README.
 | Vulkan handle export to plugins (`GetVulkanContext`) | Opt-in per backend | Vulkan backends only |
 | Reusable backing-store pool (`BackingStorePool`) | Built-in header | Used by EGL / Vulkan backends |
 | GL/EGL symbol resolver (`GlProcessResolver`) | Built-in | EGL-based backends |
-| Motion-to-photon profiler hook (`GetMotionToPhoton`) | Opt-in per backend | DRM/KMS backends, `IVI_M2P_PROFILE` |
+| Motion-to-photon profiler hook (`GetMotionToPhoton`) | Opt-in per backend | DRM/KMS, software, and Wayland backends; `IVI_M2P_PROFILE` |
 | Compositor-surface registration (platform views) | Opt-in per backend | `BUILD_COMPOSITOR` |
 | Debug HUD config plumbing (`SetHudConfig`) | Opt-in per backend | `BUILD_HUD` |
 | `--drm-list-modes` hook per backend | Per backend | DRM + software (DRM sink) backends |
@@ -79,8 +79,9 @@ on).
   so a plugin renders a platform view into a `VkImage` on the same device the
   engine uses). Under `BUILD_COMPOSITOR` it adds the compositor-surface
   registration hooks for platform views, and under `BUILD_HUD` the `SetHudConfig`
-  plumbing. It owns a `profiling::MotionToPhoton` that only the DRM/KMS backends
-  opt into via `InitMotionToPhoton()` (gated on `IVI_M2P_PROFILE`).
+  plumbing. DRM/KMS and software backends own a `profiling::MotionToPhoton`
+  instance on `Backend`; Wayland owns its instance on `Display`. All are gated by
+  `IVI_M2P_PROFILE`.
 - **`backend_registry.h` / `.cc` — the registry.** `BackendDescriptor` is one
   compiled-in backend's runtime identity: a string `key`, a `make_display`
   callable, a `make_backend` callable (which expects the `IDisplay` its own
@@ -145,6 +146,8 @@ shell/backend/
 ├── drm_kms_egl/           # DRM/KMS + EGL backend            (see drm_kms_egl/README.md)
 ├── drm_kms_vulkan/        # DRM/KMS + Vulkan backend         (see drm_kms_vulkan/README.md)
 ├── software/              # CPU (software) backend + sinks   (see software/README.md)
+├── headless_egl/          # Headless EGL encoder             (see headless_egl/README.md)
+├── headless_vulkan/       # Headless Vulkan encoder + export consumer (see headless_vulkan/README.md)
 ├── wayland_egl/           # Wayland client + EGL backend     (see wayland_egl/README.md)
 ├── wayland_vulkan/        # Wayland client + Vulkan backend  (see wayland_vulkan/README.md)
 ├── wayland_leased_drm/    # drm-lease-v1 client (leased tiers) (see wayland_leased_drm/README.md)
@@ -202,6 +205,8 @@ Options are declared in [`cmake/options.cmake`](../../cmake/options.cmake):
 - `BUILD_BACKEND_DRM_KMS_EGL` (default OFF) — direct KMS scanout + EGL/GLES.
 - `BUILD_BACKEND_DRM_KMS_VULKAN` (default OFF) — direct KMS scanout + Vulkan (zero-copy dma-buf).
 - `BUILD_BACKEND_SOFTWARE` (default OFF) — CPU rendering; `BUILD_SOFTWARE_SINK_DRM` / `BUILD_SOFTWARE_SINK_FBDEV` / `BUILD_SOFTWARE_INPUT_LIBINPUT` select its scanout sinks and input.
+- `BUILD_BACKEND_HEADLESS_EGL` (default OFF) — GPU-EGL encoder (GPU render → NV12 → HW encode; needs EGL/GLES/gbm + `v4l2-webrtc-codec`).
+- `BUILD_BACKEND_HEADLESS_VULKAN` (default OFF) — headless Vulkan encoder (no display / scanout).
 - `BUILD_BACKEND_WAYLAND_LEASED_DRM` (default OFF) — the `drm-lease-v1` client; combine with one or more renderer stacks to enable the leased tiers.
 - `BUILD_COMPOSITOR` (default OFF) — enables the `FlutterCompositor` backing-store API (required for platform-view layers and `BUILD_HUD`).
 - `BUILD_HUD` (default ON, forced OFF without `BUILD_COMPOSITOR`) — the Dear ImGui debug overlay.
@@ -215,6 +220,8 @@ Options are declared in [`cmake/options.cmake`](../../cmake/options.cmake):
 | DRM/KMS EGL | `-DBUILD_BACKEND_DRM_KMS_EGL=ON` | `drm-kms-egl` |
 | DRM/KMS Vulkan | `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON` | `drm-kms-vulkan` |
 | Software | `-DBUILD_BACKEND_SOFTWARE=ON` | `software` |
+| Headless EGL encoder | `-DBUILD_BACKEND_HEADLESS_EGL=ON` | `headless-egl` |
+| Headless Vulkan encoder | `-DBUILD_BACKEND_HEADLESS_VULKAN=ON` | `headless-vulkan` |
 | Leased DRM (EGL renderer) | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_DRM_KMS_EGL=ON` | `drm-kms-egl`, `wayland-leased-drm-egl` |
 | Leased DRM (Vulkan renderer) | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_DRM_KMS_VULKAN=ON` | `drm-kms-vulkan`, `wayland-leased-drm-vulkan` |
 | Leased DRM (software) | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_SOFTWARE=ON -DBUILD_SOFTWARE_SINK_DRM=ON` | `software`, `wayland-leased-drm-software` |
@@ -293,6 +300,8 @@ configuration surface and layering order.
   - [`wayland_leased_drm/README.md`](wayland_leased_drm/README.md)
   - [`drm_kms_egl/README.md`](drm_kms_egl/README.md)
   - [`drm_kms_vulkan/README.md`](drm_kms_vulkan/README.md)
+  - [`headless_egl/README.md`](headless_egl/README.md)
+  - [`headless_vulkan/README.md`](headless_vulkan/README.md)
   - [`software/README.md`](software/README.md)
   - [`hud/`](hud/) — compositor debug HUD (Dear ImGui overlay).
 - [`../configuration/README.md`](../configuration/README.md) — `[view.backend]` / `--backend` parsing and layering.

--- a/shell/backend/drm_kms_egl/README.md
+++ b/shell/backend/drm_kms_egl/README.md
@@ -51,7 +51,16 @@ This document is the architecture + operations guide for the backend.
   Opens `/dev/dri/cardN` and `/dev/input/event*` through the seat
   provider so the fds are master-capable and revocable on VT switch.
   Owns the dispatch thread that pumps `Seat::dispatch()` and the udev
-  `HotplugMonitor`. Open() returns nullptr when no seat backend exists
+  `HotplugMonitor`. The dispatch loop blocks indefinitely on a
+  `WakeEventFd` (reusing `shell/input/wake_event_fd.h`) rather than
+  polling every 200 ms — both watched fds (libseat fd, hotplug fd) are
+  readable only when there is something to dispatch, so the old timeout
+  existed solely to re-evaluate the `stop_` flag, which changes exactly
+  once at teardown. The eventfd is written once in the destructor after
+  `stop_` is set, closing the lost-wake window across the check/block
+  boundary. When the eventfd is unavailable (`fd() == -1`) the loop
+  degrades to a 200 ms cap as fallback.
+  Open() returns nullptr when no seat backend exists
   (no logind/seatd/builtin); callers fall back to a direct-open path
   with foreground-VT and `drmSetMaster` guards.
 

--- a/shell/backend/drm_kms_vulkan/README.md
+++ b/shell/backend/drm_kms_vulkan/README.md
@@ -3,14 +3,75 @@
 Drives the Flutter **Vulkan** renderer and presents the result on hardware
 KMS planes via **zero-copy dma-buf import**, using the drm-cxx scene
 abstraction. The session / modeset / seat / input stack is shared with the
-`drm_kms_egl` backend (those translation units sit below the pixel layer and
-are GL-free); only the renderer and the present path differ.
+[drm_kms_egl](../drm_kms_egl/README.md) backend (those translation units sit
+below the pixel layer and are GL-free); only the renderer and the present path
+differ.
 
 Enable with `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON`. **`-DBUILD_COMPOSITOR=ON` is
 required** — the engine only reaches the present path through the Flutter
 compositor's `CreateBackingStore` / `PresentLayers` callbacks.
 
-## How it works
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| Vulkan render + zero-copy dma-buf KMS scanout | ✓ | `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON` + `-DBUILD_COMPOSITOR=ON` |
+| Zero-copy gate (Vulkan 1.1 + dma-buf extension set + openable DRM node) | ✓ | Refuses cleanly at init with a diagnostic if unmet |
+| Render-node-aware physical-device selection (vendor/name fallback) | ✓ | Picks the real GPU over a software ICD (llvmpipe) |
+| Explicit DRM-format-modifier backing stores, exported as dma-buf | ✓ | `NegotiateModifiers` intersects GPU export ↔ plane `IN_FORMATS` |
+| Triple-buffered, vsync-paced present (ring of scanout buffers) | ✓ | `avoid_backing_store_cache` + non-blocking page flips |
+| Page-flip-locked Flutter vsync | ✓ | `IVI_DRMVK_VSYNC=0` for wall-clock fallback |
+| Scanout rotation (0/90/180/270) | ✓ | `--drm-rotation`; 90/270 use a tiled non-DCC modifier |
+| Rotation-aware touch + HW cursor; per-device pointer transform | ✓ | `--input-transform` (shared DRM seat) |
+| KMS HW cursor (drm-cxx / xcursor) | ✓ | Requires libxcursor (`HAVE_DRM_CURSOR`); `--disable-cursor` |
+| libseat session, with direct-master fallback | ✓ | `LIBSEAT_BACKEND=seatd` forces the fallback |
+| wayland-leased-drm: drive an externally-owned DRM fd | ✓ | Second `Create()` overload, lease fd + connector + revocation gate |
+| Standalone zero-copy capability probe (`drm_kms_vulkan_probe`) | ✓ | `-DBUILD_DRM_KMS_VULKAN_PROBE=ON` (implied by the backend) |
+| Debug HUD (imgui Vulkan) | ✓ | `-DBUILD_HUD=ON`; `IVI_HUD` / `[hud].enable`; explicit-sync path |
+| DCC / tiled scanout consumption in the unrotated path | deferred | Advertised in the negotiated set, not yet driving allocation |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    FE[FlutterEngine]
+
+    FE -->|Vulkan renderer config| RC["GetNextImage / PresentImage<br/>(stubs — never called on compositor path)"]
+    FE -->|compositor callbacks| VDB
+
+    subgraph VDB[VulkanDrmBackend]
+        DEV["VkInstance 1.1 + VkDevice<br/>DeviceCaps (zero-copy gate)"]
+        BS["VulkanBackingStore ×N<br/>exported modifier VkImage → dma-buf"]
+        SCENE["drm-cxx LayerScene<br/>single persistent layer"]
+        CUR["DrmCursor (HW cursor)"]
+        VS["IVsyncProvider + async flip reader"]
+        DEV --> BS
+        BS --> SCENE
+    end
+
+    subgraph SHARED["shared with drm_kms_egl (GL-free)"]
+        SESS["DrmSession (libseat)"]
+        SEAT["DrmSeat (libinput + xkb)"]
+        SESS --> SEAT
+    end
+
+    BS -->|drmModeAddFB2WithModifiers| CARD["/dev/dri/cardN<br/>primary plane scanout"]
+    SCENE --> CARD
+    SESS --> CARD
+    VS -->|page-flip event| SCENE
+```
+
+The backend brings up a Vulkan 1.1 instance and selects a physical device that
+can do zero-copy dma-buf scanout, then opens the DRM device, takes master,
+discovers the scanout target, and builds the `LayerScene` the present path
+commits onto. Each Flutter backing store is an exported modifier `VkImage`
+scanned out zero-copy on the primary plane. Session / modeset / seat / input
+are reused verbatim from the EGL backend; only the renderer and present path
+differ.
+
+**How it works, step by step:**
 
 1. **Device bring-up.** Creates a Vulkan 1.1 instance and selects a physical
    device that can do zero-copy dma-buf scanout: render-node-aware when the
@@ -55,6 +116,196 @@ compositor's `CreateBackingStore` / `PresentLayers` callbacks.
    callbacks. They are never invoked on the compositor path, but the embedder
    rejects a Vulkan renderer config that leaves them null, so they are stubs.
 
+### Module responsibilities
+
+- **`VulkanDrmBackend`** ([vulkan_drm_backend.cc](vulkan_drm_backend.cc),
+  [vulkan_drm_backend.h](vulkan_drm_backend.h)) — the `Backend` implementation.
+  `Create()` runs the Vulkan bring-up (instance → physical device → logical
+  device + queues), then `SetupCompositor()` opens the DRM device, takes master,
+  discovers the scanout target, and builds the `LayerScene`. Implements the
+  Flutter compositor callbacks (`CreateBackingStore` / `CollectBackingStore` /
+  `PresentLayers`) and the scanout hand-off barrier. Returns nullptr on failure;
+  the caller treats null as a hard init failure and aborts, exactly as
+  `drm_kms_egl` does. A second `Create()` overload drives an externally-owned
+  DRM fd for wayland-leased-drm (lease fd + connector id + revocation gate),
+  leaving the Vulkan side untouched.
+
+- **`drm_kms_vulkan::VulkanBackingStore`**
+  ([vulkan_backing_store.cc](vulkan_backing_store.cc),
+  [vulkan_backing_store.h](vulkan_backing_store.h)) — a device-local `VkImage`
+  allocated with an explicit DRM format modifier and exported as a dma-buf,
+  ready for zero-copy KMS scanout. Owns the image, memory, view, and dma-buf fd;
+  reads back the chosen modifier and per-plane layout for the framebuffer
+  import. Exposes an address-stable `FlutterVulkanImage`.
+
+- **`drm_kms_vulkan::ScanoutTarget`**
+  ([drm_scanout_target.cc](drm_scanout_target.cc),
+  [drm_scanout_target.h](drm_scanout_target.h)) — discovers the KMS scanout
+  target (connected connector + CRTC + mode + primary plane + that plane's
+  `IN_FORMATS` modifiers) read-only, without taking DRM master. A second
+  overload probes an already-open lease fd, pinned to the leased connector.
+
+- **`drm_kms_vulkan::NegotiateModifiers`**
+  ([modifier_format.cc](modifier_format.cc),
+  [modifier_format.h](modifier_format.h)) — intersects the modifiers the ICD can
+  export for the color format with the plane's `IN_FORMATS`, ordered tiled-first
+  with `LINEAR` last. `DescribeModifier` decodes a modifier to a readable label
+  (e.g. `AMD(GFX10_RBPLUS 64K_R_X dcc=1 retile)`).
+
+- **`drm_kms_vulkan::DeviceCaps` / `ProbeDeviceCaps`**
+  ([device_caps.cc](device_caps.cc), [device_caps.h](device_caps.h)) —
+  capability summary filled at bring-up and logged. `ProbeDeviceCaps` is the
+  lightweight read-only zero-copy gate used by the probe tool (throwaway
+  instance, no logical device). `DrmNodeNumber` resolves a DRM node path's
+  (major, minor) to match a physical device's DRM node against the scanout
+  device.
+
+- **`drm_kms_vulkan_probe`** ([probe_main.cc](probe_main.cc)) — standalone
+  exerciser for the zero-copy gate. Runs the same `ProbeDeviceCaps()` in
+  isolation (no libseat / DRM master) and dumps every plane's advertised
+  `IN_FORMATS` modifiers, decoded. Exit code mirrors the backend's contract:
+  0 = gate passed, 1 = refused.
+
+### File map
+
+- [vulkan_drm_backend.cc](vulkan_drm_backend.cc), [vulkan_drm_backend.h](vulkan_drm_backend.h) — the `VulkanDrmBackend` backend: bring-up, compositor callbacks, present, vsync, HW cursor.
+- [vulkan_backing_store.cc](vulkan_backing_store.cc), [vulkan_backing_store.h](vulkan_backing_store.h) — exported modifier `VkImage` → dma-buf backing store.
+- [drm_scanout_target.cc](drm_scanout_target.cc), [drm_scanout_target.h](drm_scanout_target.h) — read-only KMS scanout-target discovery (path + lease fd).
+- [modifier_format.cc](modifier_format.cc), [modifier_format.h](modifier_format.h) — modifier negotiation + human-readable modifier decode.
+- [device_caps.cc](device_caps.cc), [device_caps.h](device_caps.h) — capability struct + zero-copy probe + DRM-node number resolution.
+- [probe_main.cc](probe_main.cc) — `drm_kms_vulkan_probe` standalone gate/modifier dump tool.
+
+Shared verbatim from [drm_kms_egl](../drm_kms_egl/README.md) (GL-free, below the
+pixel layer): `scene_layer_source_vk.cc`, `drm_session.cc`, `driver_probe.cc`,
+`drm_cursor.cc`, plus [shell/display](../../display/README.md)'s
+`drm_display.cc` / `drm_output_provider.cc` / `drm_device_resolver.cc` /
+`drm_mode_list.cc` and [shell/input](../../input/README.md)'s `drm_seat.cc`.
+
+### Threading model
+
+- **Main thread**: argv parse, backend `Create()`, engine bring-up.
+- **Flutter rasterizer thread**: the compositor callbacks
+  (`CreateBackingStoreImpl` / `PresentLayersImpl`) and every KMS commit. Slot
+  state stays raster-thread-local.
+- **Async flip-reader thread**: arms `drmHandleEvent` for the next page-flip
+  event and, on completion (`OnFlipEvent`), returns the vsync baton with the
+  kernel scanout time; touches no slot state.
+- **DrmSession / DrmSeat dispatch threads**: reused from `drm_kms_egl` — libseat
+  session events + udev hotplug, and libinput + xkb input.
+
+The HW cursor is created against the compositor's DRM device and destroyed
+before it, so it never outlives that device.
+
+---
+
+## Build steps
+
+### Dependencies
+
+Same DRM / GBM / seat / input stack as `drm_kms_egl`; on Ubuntu 24.04 /
+Debian 13 / Fedora 41+:
+
+```bash
+sudo apt-get install -y \
+  ninja-build cmake pkg-config \
+  libdrm-dev libgbm-dev libinput-dev libudev-dev \
+  libxkbcommon-dev libxcursor-dev libseat-dev
+```
+
+There is **no build-time Vulkan SDK / `libvulkan` dependency**: only the
+vendored `third_party/Vulkan-Headers` are needed at build time. The Vulkan
+loader and an ICD are resolved at runtime via the dynamic loader (see Running).
+
+### Configure + build
+
+```bash
+cmake -GNinja -B cmake-build-debug-clang \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DBUILD_BACKEND_DRM_KMS_VULKAN=ON \
+  -DBUILD_COMPOSITOR=ON
+
+ninja -C cmake-build-debug-clang
+```
+
+`BUILD_BACKEND_DRM_KMS_VULKAN` is mutually exclusive with the EGL and Wayland
+backends. `BUILD_COMPOSITOR=ON` is **required** — the present path is only
+reachable through the Flutter compositor callbacks.
+
+### Build matrix
+
+| Config | CMake flags | Present path compiled in |
+|--------|-------------|--------------------------|
+| Backend | `-DBUILD_BACKEND_DRM_KMS_VULKAN=ON -DBUILD_COMPOSITOR=ON` | Full Vulkan zero-copy scanout backend (+ `drm_kms_vulkan_probe`) |
+| Probe only | `-DBUILD_DRM_KMS_VULKAN_PROBE=ON` | Just the standalone `drm_kms_vulkan_probe`, cross-buildable alongside any backend |
+
+- **`BUILD_BACKEND_DRM_KMS_VULKAN`** — build the backend; implies the probe tool.
+- **`BUILD_DRM_KMS_VULKAN_PROBE`** — build only the probe (device_caps + modifier_format have no shell/EGL/Wayland/DRM-master deps).
+- **`BUILD_VULKAN_VALIDATION`** — vendor the Khronos validation layer so `-d` guarantees validation even on images with no system layer registry (off by default).
+- **`BUILD_COMPOSITOR_DMABUF_EXPORT`** — export backing-store memory as a dma-buf fd for zero-copy plugins (requires `VK_KHR_external_memory_fd`; falls back silently).
+- **`BUILD_HUD`** — compile the imgui Vulkan debug HUD (requires `BUILD_COMPOSITOR`).
+
+### Optional features detected at configure time
+
+- **libxcursor** missing → `HAVE_DRM_CURSOR` undefined, `drm_cursor.cc` not
+  compiled, no HW cursor at runtime (logged at `message(STATUS …)`, build
+  continues).
+
+---
+
+## Running
+
+The backend needs **DRM master** on the scanout device.
+
+- `--drm-device <node>` — the KMS device with the connectors (the display
+  controller, e.g. `card1` for vc4 on a Pi, not the render-only `v3d` node).
+- `--drm-mode <W>x<H>[@<R>]` — select the scanout mode (`R` = integer refresh
+  Hz; omitted = any). Unset uses the connector's preferred mode.
+
+Session / DRM master:
+
+- With a libseat seat (logind) the backend uses it automatically
+  (`[DrmDisplay] libseat session active`).
+- Without a usable seat (e.g. a plain SSH login or a console login with no
+  logind seat), libseat's in-process builtin backend cannot grab the VT. Force
+  the legacy direct-master path by setting **`LIBSEAT_BACKEND=seatd`** with no
+  seatd daemon running: libseat fails to open the seat, `DrmSession::Open()`
+  returns null, and the backend falls back to a direct `/dev/dri` open +
+  `drmSetMaster`. Run from an active VT or as root.
+
+Example (Pi, forcing the fallback and a specific mode):
+
+```sh
+LIBSEAT_BACKEND=seatd LD_LIBRARY_PATH=<bundle>/lib \
+    homescreen --drm-device /dev/dri/card1 --drm-mode 1920x1080@60 -b <bundle>
+```
+
+The Vulkan loader and an ICD must be present at runtime (`libvulkan1` +
+`mesa-vulkan-drivers` for V3DV on the Pi; the headers are vendored, so the
+loader is dlopen'd, never linked).
+
+### CLI Flags
+
+| Flag | What it does |
+|------|-------------|
+| `--drm-device <node>` | KMS device with the connectors (display controller node) |
+| `--drm-mode <W>x<H>[@<R>]` | Select the scanout mode (`R` = integer refresh Hz); unset = connector preferred |
+| `--drm-rotation <0\|90\|180\|270>` | Rotate the scanout (see Rotation) |
+| `--drm-list-modes` | Report each connector's modes and which planes can rotate, then exit |
+| `--input-transform "<name-substring>=<0\|90\|180\|270>[,flip-x][,flip-y]"` | Per-device pointer transform, matched on the libinput device-name substring (repeatable; first match wins) |
+| `--disable-cursor` | Disable the KMS HW cursor |
+
+### Env vars
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `IVI_DRMVK_VSYNC` | (on) | `0` disables page-flip-locked vsync (falls back to the engine's wall-clock scheduler) |
+| `IVI_DRMVK_PROFILE` | (off) | Enables per-frame cadence profiling (also enabled by the `IVI_PROFILE` umbrella) |
+| `IVI_DRMVK_NO_EXPLICIT_SYNC` | (off) | Set to force the CPU-fence fallback instead of the explicit-sync (`IN_FENCE_FD`) scanout hand-off |
+| `IVI_HUD` | (off) | Enable the debug HUD (also honored via `[hud].enable`); `BUILD_HUD` builds only |
+| `LIBSEAT_BACKEND` | — | `seatd` (with no seatd daemon running) forces the direct-master fallback path |
+
+---
+
 ## Hardware support
 
 Zero-copy scanout requires a buffer that **both** the render GPU and the
@@ -69,7 +320,7 @@ a live run. The negotiated set is logged decoded (e.g. `AMD(GFX10_RBPLUS
 64K_R_X dcc=1 retile)`) — but note this lists what the plane *can* scan out, not
 what is used: the backing stores are allocated **LINEAR** by default (a tiled,
 non-DCC modifier only for a 90/270 rotation, which amdgpu requires; see
-"Rotation" below). So DCC is advertised but not yet consumed — making it real is
+"Rotation" above). So DCC is advertised but not yet consumed — making it real is
 a follow-on once the negotiated modifier drives allocation in the unrotated path.
 
 | Platform | Render → display | Result |
@@ -197,37 +448,6 @@ into the keyboard/scroll path, not a second pointer), so it is not separately
 addressable through libinput; per-pad control would need the Steam Input /
 hidraw protocol instead.
 
-## Running
-
-The backend needs **DRM master** on the scanout device.
-
-- `--drm-device <node>` — the KMS device with the connectors (the display
-  controller, e.g. `card1` for vc4 on a Pi, not the render-only `v3d` node).
-- `--drm-mode <W>x<H>[@<R>]` — select the scanout mode (`R` = integer refresh
-  Hz; omitted = any). Unset uses the connector's preferred mode.
-
-Session / DRM master:
-
-- With a libseat seat (logind) the backend uses it automatically
-  (`[DrmDisplay] libseat session active`).
-- Without a usable seat (e.g. a plain SSH login or a console login with no
-  logind seat), libseat's in-process builtin backend cannot grab the VT. Force
-  the legacy direct-master path by setting **`LIBSEAT_BACKEND=seatd`** with no
-  seatd daemon running: libseat fails to open the seat, `DrmSession::Open()`
-  returns null, and the backend falls back to a direct `/dev/dri` open +
-  `drmSetMaster`. Run from an active VT or as root.
-
-Example (Pi, forcing the fallback and a specific mode):
-
-```sh
-LIBSEAT_BACKEND=seatd LD_LIBRARY_PATH=<bundle>/lib \
-    homescreen --drm-device /dev/dri/card1 --drm-mode 1920x1080@60 -b <bundle>
-```
-
-The Vulkan loader and an ICD must be present at runtime (`libvulkan1` +
-`mesa-vulkan-drivers` for V3DV on the Pi; the headers are vendored, so the
-loader is dlopen'd, never linked).
-
 ## Cross-compiling for the Raspberry Pi
 
 emb cross-compiles the backend for aarch64 from the project's `.emb/`
@@ -242,3 +462,54 @@ Vulkan entry points are dlopen'd, so no link-time `libvulkan`). A JIT (debug)
 bundle works for testing: `flutter build bundle --debug` produces an
 architecture-independent `kernel_blob.bin` that runs on the target's matching
 debug engine.
+
+---
+
+## Diagnostics/Debug
+
+- **Zero-copy gate.** The backend runs `ProbeDeviceCaps()` at `Create()`; on
+  refusal it logs the cause and returns nullptr (FlutterView then exits with
+  `EXIT_FAILURE`). To observe the gate without bringing up libseat / DRM master,
+  run the standalone probe:
+
+  ```sh
+  drm_kms_vulkan_probe [/dev/dri/cardN]     # default /dev/dri/card0
+  ```
+
+  Exit code 0 = gate passed, 1 = refused. The probe also dumps every plane's
+  advertised `IN_FORMATS` modifiers, decoded and labeled by plane type (PRIMARY
+  / OVERLAY / CURSOR), so you can see whether the display can scan out a
+  tiled/compressed layout (AMD DCC, ARM AFBC, Broadcom UIF) and on which plane.
+  It is read-only (no DRM master), so it is safe to run alongside a live
+  compositor. Force a refuse for testing with a software ICD:
+  `VK_ICD_FILENAMES=<lavapipe icd.json> drm_kms_vulkan_probe`, or point it at a
+  non-existent node.
+
+- **Negotiated modifiers.** The backend logs the negotiated modifier set decoded
+  by `DescribeModifier` (e.g. `AMD(GFX10_RBPLUS 64K_R_X dcc=1 retile)`).
+
+- **`--drm-list-modes`.** Reports every connector's modes and which planes can
+  rotate, then exits — no engine bring-up, no TTY required.
+
+- **Cadence profiling.** `IVI_DRMVK_PROFILE` (or the `IVI_PROFILE` umbrella)
+  enables per-frame cadence profiling, written from the rasterizer thread.
+
+- **Validation layers.** Build with `-DBUILD_VULKAN_VALIDATION=ON` and run with
+  `-d` to guarantee the Khronos validation layer even on images with no system
+  layer registry.
+
+- **Debug HUD.** With `-DBUILD_HUD=ON`, set `IVI_HUD` (or `[hud].enable`) to draw
+  the imgui Vulkan HUD; it is recorded into the scanout-barrier command buffer
+  (explicit-sync path only) so the scanout fence covers it.
+
+---
+
+## References
+
+- [drm_kms_egl backend](../drm_kms_egl/README.md) — the shared session / modeset / seat / input stack and the GL present path.
+- [shell/backend overview](../README.md) — the backend registry and `Backend` interface.
+- [shell/display](../../display/README.md) — `DrmDisplay` and DRM mode-list support.
+- [shell/input](../../input/README.md) — the shared `DrmSeat` (libinput + xkb, input transforms).
+- [shell/backend/hud](../hud/README.md) — the debug HUD.
+- [Vulkan `VK_EXT_image_drm_format_modifier`](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_image_drm_format_modifier.html) — the explicit-modifier image extension the zero-copy gate requires.
+- [Linux DRM format modifiers](https://www.kernel.org/doc/html/latest/gpu/drm-kms.html) — KMS plane `IN_FORMATS` and framebuffer modifier import.

--- a/shell/backend/drm_kms_vulkan/README.md
+++ b/shell/backend/drm_kms_vulkan/README.md
@@ -227,9 +227,9 @@ cmake -GNinja -B cmake-build-debug-clang \
 ninja -C cmake-build-debug-clang
 ```
 
-`BUILD_BACKEND_DRM_KMS_VULKAN` is mutually exclusive with the EGL and Wayland
-backends. `BUILD_COMPOSITOR=ON` is **required** — the present path is only
-reachable through the Flutter compositor callbacks.
+`BUILD_BACKEND_DRM_KMS_VULKAN` can be enabled alongside other backends and
+selected per view through the backend registry. `BUILD_COMPOSITOR=ON` is
+**required** because presentation is reachable only through compositor callbacks.
 
 ### Build matrix
 

--- a/shell/backend/headless_egl/README.md
+++ b/shell/backend/headless_egl/README.md
@@ -130,6 +130,7 @@ Three threads are involved:
 
 - GBM (`libgbm`) — provided by the system Mesa
 - EGL / GLES 3 — provided by the system Mesa
+- `v4l2-webrtc-codec` checkout — supplies the V4L2 encoder sources; set `-DV4L2WC_DIR=<path>` if it is not a sibling of this repository
 - `Nv12GlPacker` and `INv12Consumer` — compiled from `backend/software/`
 
 ### Configure + build

--- a/shell/backend/headless_egl/README.md
+++ b/shell/backend/headless_egl/README.md
@@ -1,0 +1,232 @@
+# headless_egl backend
+
+An EGL-only rendering backend that runs with **no display, no Wayland, and no
+scanout**. The Flutter engine renders on the GPU (OpenGL ES 3) into a real EGL
+window surface backed by a `gbm_surface`; on `eglSwapBuffers` the presented
+buffer is imported as a GL texture and packed RGBA→NV12 on the GPU, then handed
+to an `INv12Consumer` (file encoder or WebRTC) via dma-buf. It is the
+zero-copy counterpart of the software backend's CPU `EncoderSink`: the GPU
+both rasterizes and colour-converts, and no CPU touches the pixels.
+
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| OpenGL ES 3 render target (gbm_surface + EGL window surface) | Built-in | Always |
+| GPU RGBA→NV12 color conversion (Nv12GlPacker) | Built-in | Always |
+| Zero-copy dma-buf export to encoder/bridge | Built-in | Always |
+| Synthetic vsync pacing (free-run, no display) | Built-in | `IVI_ENC_MAX_FPS` (default 30 fps; `≤0` disables) |
+| Consumer-paced vsync with ring backpressure | Opt-in | `IVI_HEADLESS_PACED=1` |
+| Free-run (ceiling-only) vsync mode | Opt-in | `IVI_HEADLESS_FREERUN=1` |
+| Per-frame vsync baton delivery | Built-in | Always |
+| Pointer injection through engine input path | Built-in | Always |
+| EGL context export to plugins (`GetEglContext`) | Built-in | Always once device is created |
+| No display surface; `CreateSurface` / `Resize` are stubs | Built-in | Always |
+
+---
+
+## Architecture
+
+`HeadlessEglBackend` derives from the abstract [`Backend`](../backend.h)
+interface. It opens a DRM render node, creates a GBM device, initializes an
+EGL display with OpenGL ES 3, and allocates a double-buffered `gbm_surface`
+for the engine to render into. On each present the just-presented buffer is
+imported as a GL texture and passed to the `Nv12GlPacker`, which GPU-converts
+it to NV12 and submits the result to the `INv12Consumer`.
+
+```mermaid
+flowchart TD
+    subgraph init["Init (constructor)"]
+        HE["HeadlessEglBackend(w, h, consumer)"]
+        HE --> IE["InitEgl(render_node)"]
+        IE --> ODR["open(render_node)"]
+        ODR --> GC["gbm_create_device(fd)"]
+        GC --> ED["eglGetDisplay / eglInitialize"]
+        ED --> EC["eglChooseConfig + eglCreateContext"]
+        EC --> GS["gbm_surface_create_with_modifiers"]
+        GS --> EWS["eglCreateWindowSurface"]
+    end
+
+    subgraph render["Per frame (raster thread)"]
+        MC["MakeCurrent()"]
+        MC --> R["Flutter renders into gbm_surface FBO 0"]
+        P["Present(info) → eglSwapBuffers"]
+        P --> LFB["gbm_surface_lock_front_buffer"]
+        LFB --> IMP["Import gbm_bo as GL_TEXTURE_2D via EGLImage"]
+        IMP --> PK["packer_.PackAndSubmit(import_tex)"]
+        PK --> REL["gbm_surface_release_buffer(locked_bo_)"]
+        REL --> N["locked_bo_ = bo; ++frame_index_"]
+    end
+
+    subgraph vsync["Vsync (free-run or consumer-paced)"]
+        VSTART["StartVsyncIfReady()"]
+        VSTART --> VTIMER["steady_timer @ IVI_ENC_MAX_FPS"]
+        VSTART --> VPACER["ConsumerPacedVsyncSource (paced)"]
+        VTIMER --> ARM["ArmVsyncTimer()"]
+        ARM --> DEL["vsync_.DeliverParkedBaton()"]
+        DEL --> ARM2["ArmVsyncTimer()"]
+        VPACER --> SUB["SubmitBaton(baton)"]
+    end
+
+    subgraph consumer["NV12 Consumer"]
+        PK --> CONS["INv12Consumer\n(file:out.h264 | webrtc:host:port)"]
+    end
+```
+
+### Module responsibilities
+
+- **EGL device bring-up.** `InitEgl` → opens the DRM render node, creates a GBM
+  device, resolves `eglGetPlatformDisplayEXT` for `EGL_PLATFORM_GBM_KHR`,
+  initializes EGL, selects an OPAQUE XRGB8888 config (no alpha), creates a
+  GL ES 3 context and a shared resource context, allocates a double-buffered
+  `gbm_surface` with a `DRM_FORMAT_MOD_LINEAR` modifier (untiled so it
+  imports as a plain `GL_TEXTURE_2D`), and wraps it in an EGL window surface.
+- **Render target ring.** The `gbm_surface` is the engine's swap chain — two
+  buffers the driver manages on `eglSwapBuffers`. The just-presented buffer
+  is locked and imported each frame; the previously locked buffer is released.
+- **NV12 packing.** `InitRenderTarget` sets up a single reusable import texture
+  and initializes the `Nv12GlPacker`. `Present` imports the linear `gbm_bo` as
+  an `EGLImage` via `EGL_EXT_image_dma_buf_import`, binds it to the import
+  texture, and calls `packer_.PackAndSubmit` which GPU-converts RGBA→NV12 and
+  hands the result to the consumer.
+- **Vsync.** `StartVsyncIfReady` creates a free-running `steady_timer` paced
+  at `IVI_ENC_MAX_FPS` (default 30 fps). `IVI_HEADLESS_PACED=1` replaces the
+  timer with a `ConsumerPacedVsyncSource` whose credit budget is the packer's
+  ring depth, so the engine renders at the consumer's real rate and stalls
+  cleanly when the encoder backs up. `IVI_HEADLESS_FREERUN=1` starts the paced
+  source in ceiling-only (detached) mode. `IVI_HEADLESS_VSYNC=0` (or a
+  non-positive fps) disables synthetic vsync entirely and leaves Flutter on
+  its internal wall-clock scheduler.
+- **Consumer.** The `INv12Consumer` is supplied at construction. The sink is
+  selected by `IVI_ENC_SINK` (default `file:out.h264`); `file:<path>` writes
+  an H.264 file, `webrtc:<host>:<port>` streams via WebRTC.
+
+### File map
+
+| Path | Responsibility |
+|------|----------------|
+| [headless_egl.h](headless_egl.h) / [headless_egl.cc](headless_egl.cc) | `HeadlessEglBackend` — EGL/GBM bring-up, swap-chain present, NV12 pack integration, synthetic vsync, consumer wiring |
+
+### Threading model
+
+Three threads are involved:
+
+- **Raster thread** — drives `MakeCurrent` / `Present` (the Flutter renderer's
+  present callbacks). All GL/EGL operations (buffer import, NV12 packing,
+  consumer submission) run here.
+- **Platform task runner** — the vsync `Trampoline` and timer handlers run on
+  it via `asio::post` onto its strand; `InjectPointer` marshals input events
+  onto it before calling `FlutterEngineSendPointerEvent`.
+- **Consumer thread** — `INv12Consumer` owns its own encoding/streaming thread;
+  it receives NV12 frames from the packer without blocking the raster thread.
+
+`std::atomic` flags (`vsync_running_`) coordinate state between threads.
+
+---
+
+## Build steps
+
+### Dependencies
+
+- GBM (`libgbm`) — provided by the system Mesa
+- EGL / GLES 3 — provided by the system Mesa
+- `Nv12GlPacker` and `INv12Consumer` — compiled from `backend/software/`
+
+### Configure + build
+
+```sh
+cmake -B build -G Ninja -DBUILD_BACKEND_HEADLESS_EGL=ON
+ninja -C build
+```
+
+### Build matrix
+
+| Config | CMake flags | Output |
+|--------|-------------|--------|
+| Headless EGL | `-DBUILD_BACKEND_HEADLESS_EGL=ON` | `headless_egl.cc` |
+
+### Optional features detected at configure time
+
+None — this backend has no configure-time feature detection. GBM/EGL/GL
+extensions are probed at runtime in `InitEgl` and `Present`; any shortfall
+results in a log warning and a failed present (not a hard abort).
+
+---
+
+## Running
+
+There is no display. The backend boots and paces at `IVI_ENC_MAX_FPS` frames
+per second; `IVI_HEADLESS_VSYNC=0` disables synthetic vsync and leaves Flutter
+on its wall-clock scheduler.
+
+### CLI Flags
+
+| Flag | What it does |
+|------|-------------|
+
+### Env vars
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `IVI_HEADLESS_VSYNC` | (not set) | Any non-zero value enables synthetic vsync pacing. `0` or unset with `IVI_ENC_MAX_FPS≤0` disables pacing and leaves Flutter on wall-clock. |
+| `IVI_ENC_MAX_FPS` | `30` | Encode rate in fps; used as the synthetic vsync rate and as the packer's rate ceiling. `≤0` disables pacing. |
+| `IVI_HEADLESS_PACED` | `0` | Any non-zero value enables consumer-paced vsync: the packer's ring depth is the credit budget and `IVI_ENC_MAX_FPS` is the rate ceiling. The engine renders at the consumer's real rate and stalls when the encoder backs up. |
+| `IVI_HEADLESS_FREERUN` | `0` | Any non-zero value starts the paced vsync source in ceiling-only (detached) mode. |
+| `IVI_ENC_RENDER_NODE` | `/dev/dri/renderD128` | DRM render node to open for GBM. |
+| `IVI_ENC_SINK` | `file:out.h264` | Consumer spec: `file:<path>` (H.264 file) or `webrtc:<host>:<port>` (WebRTC stream). |
+
+---
+
+## Diagnostics/Debug
+
+- **Logs go to stderr.** Look for `[HeadlessEgl]` prefixes.
+- **Confirm EGL bring-up.** Startup logs `[HeadlessEgl] EGL {major}.{minor} ready
+  on {render_node} (XRGB8888)`.
+- **Confirm render target.** First `MakeCurrent` logs
+  `[HeadlessEgl] render target ready {W}x{H}`.
+- **Confirm vsync mode.** `StartVsyncIfReady` logs either
+  `[HeadlessEgl] synthetic vsync at {N} fps` (timer mode) or nothing (paced
+  or disabled).
+- **Confirm present.** Each `Present` that reaches `eglSwapBuffers` and the
+  packer logs nothing on success; failures log `[HeadlessEgl] eglSwapBuffers
+  failed` or `[HeadlessEgl] import eglCreateImageKHR failed`.
+- **`--drm-list-modes`** is not supported; the backend logs
+  `the 'headless_egl' backend does not support --drm-list-modes`.
+
+---
+
+## Known limitations / follow-ups
+
+1. **Geometry changes are ignored** — `Resize()` logs a warning and keeps the
+   initial extent. A mid-run resize would require tearing down and recreating
+   the swap chain, EGL contexts, import texture, and packer.
+2. **No platform-view composition** — `GetCompositorConfig` returns a
+   single-surface compositor; platform-view layers are not supported in a
+   headless context.
+3. **Fixed encode resolution** — the backend is constructed with an initial
+   width and height and ignores Flutter view resize requests. The consumer
+   sees a fixed-resolution stream.
+4. **H.264 file output only for file sink** — the `file:` consumer writes raw
+   H.264 frames (NAL units) to disk; playback requires a container (e.g.
+   MP4) or a player that accepts raw H.264.
+5. **No WebRTC validation in-tree** — the `webrtc:` consumer is implemented
+   but not exercised by any integration test; the socket framing and
+   signalling are a follow-up.
+6. **GBM linear modifier requirement** — the swap chain forces
+   `DRM_FORMAT_MOD_LINEAR` so the presented buffers import cleanly as
+   `GL_TEXTURE_2D`. A driver that rejects the forced modifier falls back to
+   a plain `gbm_surface_create` which may hand back tiled buffers; these
+   may mis-import as dashed or blocky garbage.
+
+---
+
+## References
+
+- [Backend interface](../backend.h) — display-target abstraction
+- [Backend overview README](../README.md)
+- [headless_vulkan backend README](../headless_vulkan/README.md) — the Vulkan sibling with the same no-display architecture
+- [Nv12GlPacker](../../backend/software/nv12_gl_packer.h) — GPU RGBA→NV12 packer
+- [INv12Consumer](../../backend/software/nv12_consumer.h) — encoder/bridge consumer interface
+- [drm_kms_egl backend README](../drm_kms_egl/README.md) — EGL/KMS sibling with real scanout
+- `EGL_EXT_image_dma_buf_import` — dma-buf import extension
+- GBM (`libgbm`) — Generic Buffer Management for DRM render nodes

--- a/shell/backend/headless_vulkan/README.md
+++ b/shell/backend/headless_vulkan/README.md
@@ -248,11 +248,10 @@ Consumer                           Bridge (HeadlessVulkanBackend)
 
 ## Known limitations / follow-ups
 
-1. **No scanout path yet** — the render-target ring is opaque. Frames are
-   composited and discarded. The dma-buf / opaque-fd export machinery is in
-   place but no socket consumer exists in-tree; the bridge plugin (e.g.
-   CARLA/Unreal) is responsible for connecting to the Unix SEQPACKET socket
-   and consuming the exported images.
+1. **No in-tree socket bridge yet** — frames are discarded unless export is
+   enabled and a bridge consumes the C ABI. The export machinery and standalone
+   socket consumer are in-tree, but a downstream bridge plugin must expose the
+   backend's C ABI over the Unix SEQPACKET socket.
 2. **Geometry changes are ignored** — `Resize()` logs a warning and keeps the
    initial pool extent. The pool can only be rebuilt at a new size via
    `RebuildExportPool` (consumer-driven), not by a Flutter view resize.
@@ -280,7 +279,7 @@ Consumer                           Bridge (HeadlessVulkanBackend)
 - [headless_egl backend README](../headless_egl/README.md) — the EGL sibling with the same no-display architecture
 - [wayland_vulkan backend README](../wayland_vulkan/README.md) — Vulkan/WSI comparison baseline
 - [drm_kms_vulkan backend README](../drm_kms_vulkan/README.md) — Vulkan zero-copy KMS sibling
-- [ihs/vk_export.h](../../../shared/abi/ihs/vk_export.h) — exported C ABI header
+- [ihs/vk_export.h](../../../shared/include/ihs/vk_export.h) — exported C ABI header
 - `VK_KHR_external_memory`, `VK_KHR_external_memory_fd` — opaque-fd export extensions
 - `VK_EXT_external_memory_dma_buf`, `VK_EXT_image_drm_format_modifier` — dma-buf export extensions
 - `VK_KHR_external_semaphore`, `VK_KHR_external_semaphore_fd` — semaphore export extensions

--- a/shell/backend/headless_vulkan/README.md
+++ b/shell/backend/headless_vulkan/README.md
@@ -1,0 +1,287 @@
+# headless_vulkan backend
+
+A Vulkan-only rendering backend that runs with **no display, no Wayland, and no
+scanout**. It boots the Flutter Vulkan renderer against a minimal Vulkan device
+(instance + one graphics queue) and feeds it a 3-slot ring of `VkImage` render
+targets; frames are composited and then go nowhere. It is the foundation for a
+future dma-buf-export + external-semaphore-synchronized socket path that a
+downstream bridge plugin (e.g. CARLA/Unreal) will consume.
+
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| Vulkan render target ring (3 × `VK_FORMAT_R8G8B8A8_UNORM`) | Built-in | Always |
+| Synthetic vsync pacing (free-run, no display) | Built-in | `IVI_HEADLESS_FPS` (default 30 fps; `≤0` disables) |
+| External-memory export: opaque-fd pool | Opt-in | `IVI_VK_EXPORT_MODE=opaque` |
+| External-memory export: dma-buf pool with DRM modifiers | Opt-in | `IVI_VK_EXPORT_MODE=dmabuf` |
+| Per-frame cross-process GPU sync (render_done / consumer_done as OPAQUE_FD semaphores) | Opt-in | Auto when export is active; `IVI_VK_EXPORT_LOOPBACK=1` enables in-process self-consumer |
+| Loopback stand-in consumer for same-process validation | Opt-in | `IVI_VK_EXPORT_LOOPBACK=1` |
+| In-process C ABI (`ihs_vk_export_get_api`) for bridge plugins | Built-in | Always |
+| Pointer injection through engine input path | Built-in | Always |
+| Vulkan device UUID pinning | Opt-in | `IVI_VK_DEVICE_UUID` (hex, no separators) |
+| Vulkan context export to plugins (`GetVulkanContext`) | Built-in | Always once device is created |
+| Consumer-driven pool resize (rebuild + generation bump) | Built-in | Always (triggers on `RebuildExportPool` call) |
+| No display surface; `CreateSurface` / `Resize` are stubs | Built-in | Always |
+
+---
+
+## Architecture
+
+`HeadlessVulkanBackend` derives from the abstract [`Backend`](../backend.h)
+interface. It creates a Vulkan instance, selects the first non-CPU physical
+device that supports Vulkan 1.1, opens one graphics queue, and allocates a
+ring of 3 `VkImage` + dedicated `VkDeviceMemory` render targets. The engine
+composites into these images via the Vulkan render config callbacks; the images
+are never presented anywhere.
+
+```mermaid
+flowchart TD
+    subgraph init["Init (constructor)"]
+        HV["HeadlessVulkanBackend(w, h)"]
+        HV --> IV["InitVulkan()"]
+        IV --> CI["CreateInstance()"]
+        CI --> SPD["SelectPhysicalDevice()"]
+        SPD --> CLD["CreateLogicalDevice()"]
+        CLD --> CRT["CreateRenderTargets()"]
+        CRT --> REG["ihs::RegisterVkExportBackend(this)"]
+    end
+
+    subgraph render["Per frame (raster thread)"]
+        GNI["GetNextImageCallback\n→ returns image_[current_]"]
+        GNI --> P["Flutter renders into image_[k]"]
+        P --> PC["PresentCallback"]
+        PC --> ADV["current_image_ = (k+1) % 3"]
+    end
+
+    subgraph export["Export path (future socket consumer)"]
+        CAPS["FillExportCaps()"]
+        TABLE["FillImageTable() → dup'd fds"]
+        CAPS --> TABLE
+        TABLE --> FR["FramePresent via socket"]
+        FR --> FREL["FrameRelease → OnConsumerReleaseFrame"]
+        FREL --> RB{"rebaseline\nsemaphores?"}
+        RB -->|yes| RES["RebaselineSemaphores()"]
+    end
+
+    subgraph vsync["Vsync (free-run)"]
+        VSYNC["ConsumerPacedVsyncSource\nfree-run @ IVI_HEADLESS_FPS"]
+        VSYNC --> SUB["SubmitBaton(baton)"]
+        SUB --> GNI
+    end
+```
+
+### Module responsibilities
+
+- **Vulkan device bring-up.** `InitVulkan` → `CreateInstance` → `SelectPhysicalDevice`
+  → `CreateLogicalDevice`. `SelectPhysicalDevice` skips CPU/software renderers
+  (`llvmpipe`, `lavapipe`, `SwiftShader`) and optionally pins to a specific
+  GPU via `IVI_VK_DEVICE_UUID`. The device UUID is retained for the future
+  export handshake.
+- **Render target ring.** `CreateRenderTargets` allocates 3 `VkImage` +
+  dedicated `VkDeviceMemory` slots (`VK_IMAGE_TILING_OPTIMAL`,
+  `VK_FORMAT_R8G8B8A8_UNORM`). This is the **plain pool**. When
+  `IVI_VK_EXPORT_MODE` is set, a **exportable pool** is attempted first
+  (`CreateExportablePool`): opaque-fd or dma-buf allocation with DRM modifier
+  tiling, using `VK_KHR_external_memory[_fd]` / `VK_EXT_external_memory_dma_buf`
+  / `VK_EXT_image_drm_format_modifier` extensions. On any failure the plain
+  pool is used as fallback, so the backend always boots and paces.
+- **Per-frame sync.** When the exportable pool is active, a pair of
+  OPAQUE_FD-exportable binary semaphores per image (`render_done_[i]` /
+  `consumer_done_[i]`) is created, their fds exported, and each
+  `consumer_done_[i]` pre-signaled so the first `GetNextImage` wait passes.
+  `RebaselineSemaphores` recreates the semaphores from scratch between consumer
+  sessions (binary semaphores cannot be reset in place). `IVI_VK_EXPORT_LOOPBACK=1`
+  enables an in-process self-consumer that stands in for the future socket
+  consumer.
+- **Vsync.** `StartVsyncIfReady` creates a `ConsumerPacedVsyncSource` run in
+  **free-run mode** (ceiling-only pacing; no consumer). `IVI_HEADLESS_FPS=0`
+  disables synthetic vsync entirely and leaves Flutter on its internal
+  wall-clock scheduler.
+- **Export ABI.** `vk_export_api.cc` exposes `ihs_vk_export_get_api` (the
+  `IhsVkExportApiV1` table) so a bridge plugin can query the pool caps, receive
+  per-present frame notifications, inject pointer input, and drive pool resizes.
+  The test consumer in `export_consumer/` validates the full wire protocol
+  (hello → caps → image table → frame present/release loop → resize) over a
+  Unix SEQPACKET socket.
+
+### File map
+
+| Path | Responsibility |
+|------|----------------|
+| [headless_vulkan.h](headless_vulkan.h) / [headless_vulkan.cc](headless_vulkan.cc) | `HeadlessVulkanBackend` — Vulkan device bring-up, render-target ring, export pool, per-frame sync semaphores, synthetic vsync, export ABI stubs |
+| [vk_export_api.h](vk_export_api.h) / [vk_export_api.cc](vk_export_api.cc) | Exported `ihs_vk_export_get_api` C ABI (delegates to the active backend instance) |
+| [export_consumer/export_consumer_main.cc](export_consumer/export_consumer_main.cc) | Standalone same-device test consumer — connects to the bridge socket, imports the pool, validates zero-copy content correctness, drives vsync pacing |
+| [export_consumer/vk_consumer.h](export_consumer/vk_consumer.h) / [vk_consumer.cc](export_consumer/vk_consumer.cc) | Vulkan import of the exported pool + per-frame render_done wait / consumer_done signal |
+| [export_consumer/wire_client.h](export_consumer/wire_client.h) / [wire_client.cc](export_consumer/wire_client.cc) | Unix SEQPACKET framing send/receive for the wire protocol |
+| [export_consumer/wire_protocol.h](export_consumer/wire_protocol.h) | Wire protocol v1: `Hello`, `Caps`, `ImageTable`, `FramePresent`, `FrameRelease`, `InputPointer`, `Resize`, `Bye` messages + SCM_RIGHTS fd ordering |
+
+### Threading model
+
+Three threads are involved:
+
+- **Raster thread** — drives `GetNextImageCallback` and `PresentCallback` (the Flutter renderer's present callbacks). All Vulkan queue operations (semaphore signal/wait, image layout queries, pool rebuild via `PerformResize`) run here. Frame-present listener callbacks also fire here.
+- **Bridge IO thread** — calls the exported C ABI functions (`FillImageTable`, `FillExportCaps`, `SetExportFrameListener`, `SetExportPaceSource`, `RebuildExportPool`, `InjectPointer`). Mutexes guard shared state:
+  - `export_fd_mutex_` — serializes `FillImageTable`'s fd reads against `RebaselineSemaphores`' rewrites
+  - `resize_mutex_` / `resize_cv_` — `RebuildExportPool` blocks on the raster thread's `PerformResize`
+  - `frame_listener_mutex_` — `SetExportFrameListener` vs. `PresentCallback` on different threads
+- **Platform task runner** — the `VsyncTrampoline` runs on it; `InjectPointer` marshals input events onto it before calling `FlutterEngineSendPointerEvent`.
+
+`std::atomic` flags (`resize_pending_`, `sync_rebaseline_pending_`, `vsync_running_`, `export_consumer_active_`) coordinate state between threads without holding the mutexes for long.
+
+---
+
+## Build steps
+
+### Dependencies
+
+No external Vulkan loader library is linked — `vulkan.hpp` dlopens `libvulkan`
+at runtime and uses its own dynamic dispatch loader. The only build-time
+requirement is the vendored Vulkan headers in `third_party/Vulkan-Headers/`.
+
+### Configure + build
+
+```sh
+cmake -B build -G Ninja -DBUILD_BACKEND_HEADLESS_VULKAN=ON
+ninja -C build
+```
+
+### Build matrix
+
+| Config | CMake flags | Output |
+|--------|-------------|--------|
+| Headless Vulkan (base) | `-DBUILD_BACKEND_HEADLESS_VULKAN=ON` | `headless_vulkan.cc`, `vk_export_api.cc` |
+| + test consumer | always compiled in | adds `export_consumer_main.cc`, `vk_consumer.cc`, `wire_client.cc` |
+
+### Optional features detected at configure time
+
+None — this backend has no configure-time feature detection. The Vulkan device
+extensions and export capabilities are probed at runtime in `CreateRenderTargets`
+and `CreateExportSemaphores`; any shortfall falls back to the non-exportable
+plain pool without affecting bring-up.
+
+---
+
+## Running
+
+There is no display. The backend always boots and paces at `IVI_HEADLESS_FPS`
+frames per second; `IVI_HEADLESS_FPS=0` disables synthetic vsync.
+
+
+### CLI Flags
+
+| Flag | What it does |
+|------|-------------|
+
+### Env vars
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `IVI_HEADLESS_FPS` | `30` | Synthetic vsync rate in fps. `≤0` disables the pacer and leaves Flutter on its wall-clock scheduler. |
+| `IVI_VK_DEVICE_UUID` | (none) | 16 hex bytes ( separators optional) — pins the physical device by its `deviceUUID` rather than taking the first non-CPU Vulkan 1.1 device. |
+| `IVI_VK_EXPORT_MODE` | (none) | `opaque` — allocate the pool with `VK_KHR_external_memory` + export OPAQUE_FD handles. `dmabuf` — allocate with DRM modifier tiling and export dma-buf handles. Unset means no export; the plain (non-exportable) pool is used. |
+| `IVI_VK_EXPORT_LOOPBACK` | `0` | Any non-zero value enables the in-process self-consumer: after each present, the backend waits `render_done[i]` and signals `consumer_done[i]` on the same queue, validating the semaphore round-trip without a real socket. |
+
+---
+
+## Diagnostics/Debug
+
+- **Logs go to stderr.** Look for `[HeadlessVulkan]` prefixes.
+- **Confirm device selection.** Startup logs `[HeadlessVulkan] selected device
+  '<name>'`. Use `IVI_VK_DEVICE_UUID` to pin to a specific GPU.
+- **Confirm export mode.** When `IVI_VK_EXPORT_MODE` is set, logs show
+  `[HeadlessVulkan] export pool active: mode={dmabuf|opaque} images=3 WxH`.
+  If the device lacks the required extensions or export capability, it logs a
+  warning and falls back to the non-exportable pool — it never hard-fails
+  bring-up.
+- **Confirm semaphore state.** When loopback or a consumer is attached,
+  `[HeadlessVulkan] image N sync semaphores: render_done_fd=N consumer_done_fd=N`
+  is logged per slot.
+- **Per-frame frame-present notification.** `SetExportFrameListener` fires the
+  registered callback on the raster thread after each present, with the slot
+  index and frame sequence.
+- **Pool rebuild.** `RebuildExportPool(w, h)` (called from the bridge IO thread)
+  triggers a raster-thread pool rebuild at the next `GetNextImage` boundary,
+  bumps `generation_`, and logs `[HeadlessVulkan] pool rebuilt WxH -> WxH
+  (generation N)`. A timeout (2 s) is applied so a stalled raster does not
+  hang the bridge.
+- **`--drm-list-modes`** is not supported; the backend logs
+  `the 'headless_vulkan' backend does not support --drm-list-modes`.
+
+---
+
+## Wire protocol (export consumer)
+
+The `export_consumer/` directory contains a standalone test consumer that
+exercises the full wire protocol v1 over a Unix SEQPACKET socket (default:
+`$XDG_RUNTIME_DIR/ihs-vk-export.sock`, else `/tmp/ihs-vk-export.sock`).
+
+### Message flow
+
+```
+Consumer                           Bridge (HeadlessVulkanBackend)
+    |                                        |
+    | -------- Hello (deviceUUID) ---------> |
+    | <------- Caps ------------------------ |
+    | <------- ImageTable (+ fds) -----------|
+    |                                        |
+    | (per frame)                           |
+    | <------- FramePresent (slot, seq) ----|
+    | -------- FrameRelease (slot) -------->|
+    |                                        |
+    | (optional resize)                      |
+    | -------- Resize (WxH) --------------> |
+    | <------- ImageTable (+ fds) -----------|
+    |                                        |
+    | -------- Bye ------------------------>|
+```
+
+### Env vars (consumer)
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `IHS_VK_CONSUMER_SOCKET` | `$XDG_RUNTIME_DIR/ihs-vk-export.sock` | Unix SEQPACKET socket path |
+| `IHS_VK_CONSUMER_FRAMES` | `120` | Stop after this many frames |
+| `IHS_VK_CONSUMER_RESIZE` | (none) | Send one `Resize` after a few frames (e.g. `800x600`) to exercise pool rebuild |
+
+---
+
+## Known limitations / follow-ups
+
+1. **No scanout path yet** — the render-target ring is opaque. Frames are
+   composited and discarded. The dma-buf / opaque-fd export machinery is in
+   place but no socket consumer exists in-tree; the bridge plugin (e.g.
+   CARLA/Unreal) is responsible for connecting to the Unix SEQPACKET socket
+   and consuming the exported images.
+2. **Geometry changes are ignored** — `Resize()` logs a warning and keeps the
+   initial pool extent. The pool can only be rebuilt at a new size via
+   `RebuildExportPool` (consumer-driven), not by a Flutter view resize.
+3. **Single GPU only** — `SelectPhysicalDevice` picks one non-CPU Vulkan 1.1
+   device; multi-GPU systems require `IVI_VK_DEVICE_UUID` to pin to the
+   correct GPU. There is no GPU-failover logic.
+4. **Binary semaphores only** — the per-frame sync semaphores are binary
+   (not timeline). If a consumer stalls, the backend will wait indefinitely
+   on `vkQueueWaitIdle` during `RebaselineSemaphores`. Timeline semaphores
+   are a future improvement.
+5. **No platform-view composition** — `BUILD_COMPOSITOR` has no effect on this
+   backend; there is no `FlutterCompositor` backing-store API integration.
+   Platform-view layers are not supported in a headless context.
+6. **Loopback consumer is single-threaded** — the in-process self-consumer
+   (`IVI_VK_EXPORT_LOOPBACK=1`) performs no actual content validation; it
+   only exercises the semaphore round-trip. Full zero-copy correctness
+   validation requires the real socket consumer.
+
+---
+
+## References
+
+- [Backend interface](../backend.h) — display-target abstraction
+- [Backend overview README](../README.md)
+- [headless_egl backend README](../headless_egl/README.md) — the EGL sibling with the same no-display architecture
+- [wayland_vulkan backend README](../wayland_vulkan/README.md) — Vulkan/WSI comparison baseline
+- [drm_kms_vulkan backend README](../drm_kms_vulkan/README.md) — Vulkan zero-copy KMS sibling
+- [ihs/vk_export.h](../../../shared/abi/ihs/vk_export.h) — exported C ABI header
+- `VK_KHR_external_memory`, `VK_KHR_external_memory_fd` — opaque-fd export extensions
+- `VK_EXT_external_memory_dma_buf`, `VK_EXT_image_drm_format_modifier` — dma-buf export extensions
+- `VK_KHR_external_semaphore`, `VK_KHR_external_semaphore_fd` — semaphore export extensions
+- `vulkan.hpp` dynamic dispatch — runtime Vulkan loader (dlopen libvulkan)

--- a/shell/backend/headless_vulkan/export_consumer/README.md
+++ b/shell/backend/headless_vulkan/export_consumer/README.md
@@ -1,0 +1,187 @@
+# export_consumer
+
+A standalone same-device test consumer for the `ihs-vk-export` path. It connects
+to the bridge's Unix SEQPACKET socket, imports the headless-vulkan backend's
+exported Vulkan image pool (dma-buf or opaque-fd memory plus binary
+render_done/consumer_done semaphores), and for each presented frame waits
+render_done, copies the image out to a host buffer and checksums it (proving
+zero-copy content correctness), then signals consumer_done and sends a
+FrameRelease pacing edge back to the backend. It is the consumer half of the
+export path described in [vk_export_api.h](../vk_export_api.h).
+
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| Same-device OPAQUE_FD import | Built-in | When bridge offers `kHandleOpaqueFd` |
+| Same-device dma-buf import (with DRM modifier) | Built-in | When bridge offers `kHandleDmaBuf` |
+| Import-symmetric to `HeadlessVulkanBackend` export | Built-in | Always |
+| Per-frame GPU-wait render_done, copy-out, checksum (FNV-1a), signal consumer_done | Built-in | Always |
+| CPU-side pacing via FrameRelease (drives consumer-paced vsync) | Built-in | Always |
+| Optional resize exercise (`IHS_VK_CONSUMER_RESIZE`) | Opt-in | `IHS_VK_CONSUMER_RESIZE="WxH"` |
+| Frame budget limiter (`IHS_VK_CONSUMER_FRAMES`) | Opt-in | Default 120 frames |
+| Clean teardown on SIGINT or bridge Bye | Built-in | Always |
+
+---
+
+## Architecture
+
+The consumer is a self-contained binary that talks to the bridge over the wire
+protocol defined in [wire_protocol.h](wire_protocol.h). It follows the same
+device as the backend (physical device 0), sends a `Hello` with its own
+`deviceUUID`, receives `Caps` and an `ImageTable`, imports every pool image and
+both semaphores per slot, and then enters a `poll` loop waiting for `FramePresent`
+messages from the bridge.
+
+```mermaid
+flowchart TD
+    subgraph init["Init"]
+        direction TB
+        E["main()"] --> C["ConnectSeqpacket(socket_path)"]
+        C --> I["VkConsumer::InitVulkan()"]
+        I --> VI["CreateInstance"]
+        VI --> SP["SelectPhysicalDevice  (device 0)"]
+        SP --> CL["CreateLogicalDevice + queues"]
+        CL --> H["Send Hello (protocol_ver, deviceUUID, name)"]
+        H --> RC["Recv Caps"]
+        RC --> CT["Consume Caps (handle_type, extent, slot_count)"]
+        CT --> RT["Recv ImageTable"]
+        RT --> IM["VkConsumer::ImportImageTable(descs, fds)"]
+        IM --> IS["ImportSlotImage (per slot)"]
+        IS --> ISS["ImportSlotSemaphore (render_done, consumer_done)"]
+    end
+
+    subgraph loop["Per-frame loop"]
+        direction TB
+        P["poll(sock, POLLIN)"] --> RF["RecvFramePresent (slot, seq)"]
+        RF --> CP["VkConsumer::ConsumePresent(slot, seq)"]
+        CP --> WR["Wait render_done (binary semaphore)"]
+        WR --> AI["Acquire image from foreign producer queue"]
+        AI --> CO["Copy image to readback buffer"]
+        CO --> RI["Release image back to producer"]
+        RI --> SC["Signal consumer_done (binary)"]
+        SC --> CF["CPU-wait per-slot fence"]
+        CF --> CS["Checksum (FNV-1a) -> FrameStats"]
+        CS --> SR["Send FrameRelease (pacing edge)"]
+        SR --> P
+    end
+
+    subgraph teardown["Shutdown"]
+        direction TB
+        BYE["Recv Bye / SIGINT"] --> T["VkConsumer::Teardown()"]
+        T --> CB["Close consumer socket"]
+        CB --> EXIT["Exit 0"]
+    end
+```
+
+### Module responsibilities
+
+- **`wire_protocol.h`** — the shared wire protocol contract: message types,
+  payload structs, handle-type bits, and capability flags. Every struct is
+  padding-free and guarded with a `static_assert` on size.
+- **`wire_client.h` / `wire_client.cc`** — minimal SEQPACKET framing: connect,
+  send framed messages (with optional SCM_RIGHTS fds), and receive one
+  datagram. The consumer only needs Hello, FrameRelease, Bye, and
+  Resize as outgoing, and Caps, ImageTable, FramePresent, Bye as incoming.
+- **`vk_consumer.h` / `vk_consumer.cc`** — the Vulkan import engine: creates a
+  dynamic-dispatch instance on physical device 0, imports the image table
+  (opaque-fd or dma-buf), and per frame submits a copy-out command buffer that
+  waits render_done, copies the image to host memory, checksums it with FNV-1a,
+  and signals consumer_done.
+- **`export_consumer_main.cc`** — the entry point: resolves socket path and
+  frame budget from env, performs the handshake (Hello → Caps → ImageTable),
+  enters the per-frame poll loop, and exercises an optional resize request.
+
+### File map
+
+| Path | Responsibility |
+|------|----------------|
+| [wire_protocol.h](wire_protocol.h) | Shared wire protocol: message types, payload structs, handle-type bits, capability flags |
+| [wire_client.h](wire_client.h) / [wire_client.cc](wire_client.cc) | SEQPACKET framing: connect, send, receive, SCM_RIGHTS fd handling |
+| [vk_consumer.h](vk_consumer.h) / [vk_consumer.cc](vk_consumer.cc) | Vulkan import engine: instance/device creation, image table import, per-frame copy-out and checksum |
+| [export_consumer_main.cc](export_consumer_main.cc) | Entry point: handshake, poll loop, env-driven configuration, teardown |
+
+### Threading model
+
+The consumer is **single-threaded**. All Vulkan operations (import, present
+consume, copy-out, fence wait) run on the main thread. The `poll` loop blocks
+on the socket until the bridge sends a `FramePresent`.
+
+---
+
+## Build steps
+
+### Dependencies
+
+- Vulkan 1.1 runtime (dynamic loader + driver; no link-time libvulkan)
+- vendored `vulkan.hpp` (from the shell's third_party) — used for dynamic
+  dispatch via `VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1`
+
+### Configure + build
+
+```sh
+cmake -B build -G Ninja
+ninja -C build ihs-vk-export-consumer
+```
+
+### Build matrix
+
+| Config | CMake flags | Output |
+|--------|-------------|--------|
+| Export consumer (default) | (none) | `ihs-vk-export-consumer` binary |
+
+### Optional features detected at configure time
+
+None — this binary has no configure-time feature detection. Vulkan extensions
+are probed at runtime during `VkConsumer::InitVulkan`.
+
+---
+
+## Running
+
+The consumer must be run **after** the compositor (bridge) is already listening
+on the SEQPACKET socket. It connects, imports, consumes frames, then exits
+cleanly when the frame budget is reached or on SIGINT.
+
+```sh
+./build/shell/backend/headless_vulkan/export_consumer/ihs-vk-export-consumer
+```
+
+### CLI Flags
+
+None — configuration is entirely environment-driven.
+
+### Env vars
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `IHS_VK_CONSUMER_SOCKET` | `$XDG_RUNTIME_DIR/ihs-vk-export.sock` (fallback `/tmp/ihs-vk-export.sock`) | Unix SEQPACKET socket path to connect to the bridge. |
+| `IHS_VK_CONSUMER_FRAMES` | `120` | Stop after consuming this many frames. |
+| `IHS_VK_CONSUMER_RESIZE` | (unset) | `"WxH"` — after a few frames, send one `Resize` message to exercise the backend's pool rebuild. |
+
+---
+
+## Diagnostics/Debug
+
+- **Logs go to stderr.** Look for `[ihs-vk-consumer]` prefixes.
+- **Handshake success.** `Hello -> Caps -> ImageTable` logs the bridge's
+  `deviceUUID` match and the imported handle type (dma-buf or opaque-fd).
+- **Per-frame stats.** Every consumed frame logs the slot index, frame
+  sequence, FNV-1a CRC, and two sampled pixels (`px_first` and `px_center`) so
+  you can confirm content changes frame to frame.
+- **Exit code.** `0` on a clean run (frame budget or SIGINT); non-zero on any
+  protocol, import, or Vulkan error.
+
+---
+
+## Known limitations / follow-ups
+
+1. **Physical device 0 only** — the consumer always selects `physical_device[0]`.
+   A multi-GPU system must ensure the backend and consumer land on the same GPU
+   (the `deviceUUID` handshake catches a mismatch, but the consumer does not
+   search).
+2. **Binary semaphores only** — the consumer uses binary semaphore waits and
+   signals. The bridge can offer timeline semaphores (`kCapsTimelineSemaphores`),
+   but the consumer does not exploit them yet.
+3. **No pointer/key injection** — `kInputPointer` and `kInputKey` messages are
+   defined in the wire protocol but not yet implemented in the consumer.

--- a/shell/backend/headless_vulkan/export_consumer/README.md
+++ b/shell/backend/headless_vulkan/export_consumer/README.md
@@ -120,15 +120,15 @@ on the socket until the bridge sends a `FramePresent`.
 ### Configure + build
 
 ```sh
-cmake -B build -G Ninja
-ninja -C build ihs-vk-export-consumer
+cmake -B build -G Ninja -DBUILD_BACKEND_HEADLESS_VULKAN=ON
+ninja -C build ihs_vk_export_consumer
 ```
 
 ### Build matrix
 
 | Config | CMake flags | Output |
 |--------|-------------|--------|
-| Export consumer (default) | (none) | `ihs-vk-export-consumer` binary |
+| Export consumer (default) | (none) | `ihs_vk_export_consumer` binary |
 
 ### Optional features detected at configure time
 
@@ -144,7 +144,7 @@ on the SEQPACKET socket. It connects, imports, consumes frames, then exits
 cleanly when the frame budget is reached or on SIGINT.
 
 ```sh
-./build/shell/backend/headless_vulkan/export_consumer/ihs-vk-export-consumer
+./build/shell/backend/headless_vulkan/export_consumer/ihs_vk_export_consumer
 ```
 
 ### CLI Flags

--- a/shell/backend/hud/README.md
+++ b/shell/backend/hud/README.md
@@ -1,0 +1,259 @@
+# Debug HUD overlay
+
+An optional, non-interactive [Dear ImGui](https://github.com/ocornut/imgui)
+overlay that a compositor backend draws over the composited frame to surface
+live present statistics — FPS against the display refresh, average/worst frame
+interval, stall count, dma-buf/explicit-sync state — and a per-platform-view
+table (size, present count, and whether each view took the zero-copy dma-buf
+path). It exists purely as a compositor debugging aid: it steals no input, has
+no title bar or hot key, and is enabled from the view's `[hud]` config table or
+the `IVI_HUD` environment variable. Rendering is split into a shared,
+backend-neutral UI core (`HudBase`) and two thin render backends (`GlHud` for
+the OpenGL-ES/EGL paths, `VulkanHud` for the Vulkan paths), so a given binary
+only pulls in the imgui render backend for the renderers it was built with.
+
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| Frame stats (FPS / avg / worst / stalls) | Built-in | With HUD active |
+| FPS histogram with green/red refresh threshold | Built-in | With HUD active |
+| Per-view table (id, size, presents, idle frames, path) | Built-in | With HUD active |
+| View appear/dispose flash + age-out | Built-in | With HUD active |
+| dma-buf present / explicit-sync indicators | Built-in | Reported per backend |
+| OpenGL-ES render backend (`GlHud`) | Built-in | `BUILD_BACKEND_WAYLAND_EGL` / `BUILD_BACKEND_DRM_KMS_EGL` |
+| Vulkan render backend (`VulkanHud`) | Built-in | `BUILD_BACKEND_WAYLAND_VULKAN` / `BUILD_BACKEND_DRM_KMS_VULKAN` |
+| Offscreen texture render (DRM plane compositor) | Built-in | `GlHud::RenderOffscreen`, drm-kms-egl |
+| Corner / margin / font / colors / opacity | Built-in | `[hud]` config table |
+| Enable from config or env | Built-in | `[hud] enable` / `IVI_HUD` |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TD
+    cfg["view [hud] table\n(configuration)"] --> fv["FlutterView::Backend::Create\nBuildHudConfig() -> SetHudConfig()"]
+    env["IVI_HUD env var"] --> be
+    fv -->|"hud_config_ +\nhud_config_enable_"| be["concrete Backend\n(present path)"]
+    be -->|"lazily on first present"| create["GlHud::Create /\nVulkanHud::Create"]
+    create --> base["HudBase (shared UI core)"]
+    subgraph base_core["HudBase"]
+      ctx["imgui context + dark style"]
+      win["BuildWindow(): stats text +\nFPS histogram + per-view table"]
+      rows["UpdateViewRows(): track/age views"]
+    end
+    base --> base_core
+    be -->|"HudStats + HudViewSample[]\nper frame"| rf["HudBase::RenderFrame()"]
+    rf -->|"template method"| impl["ImplNewFrame()\nImplRenderDrawData()"]
+    impl --> gl["GlHud\n(imgui_impl_opengl3, GLES2)"]
+    impl --> vk["VulkanHud\n(imgui_impl_vulkan, loader-based)"]
+```
+
+The HUD is a small class hierarchy rooted at the backend-neutral interface
+[`IHud`](ihud.h) (just `IsOpen()` / `SetOpen()`). [`HudBase`](hud_base.h) owns
+everything renderer-independent: the imgui context and style, the frame-time
+history ring, the green/red FPS histogram, the per-view row tracking, and the
+overlay window layout. Concrete backends supply only two hooks — an imgui
+new-frame call and a draw-data submission — through `HudBase::RenderFrame`,
+which is a template method: it sets the display size and delta time, updates the
+view rows, calls `ImplNewFrame()`, builds the window, then calls
+`ImplRenderDrawData()` with the recorded draw list (skipping submission entirely
+when the draw data is empty).
+
+- **`IHud`** — the tiny virtual surface a backend holds a HUD through, plus the
+  plain-old-data structs it feeds each frame: `HudStats` (FPS, avg/worst frame
+  interval, target refresh, stalls, dma-buf/explicit-sync flags), `HudViewSample`
+  (one composited platform view: id, size, dma-buf path), and `HudConfig`
+  (corner, margin, font scale, background alpha, RGBA text color).
+- **`HudBase`** — shared implementation. `InitContext()` creates the imgui
+  context with `IniFilename`/`LogFilename` disabled (a compositor must not write
+  `imgui.ini`). `BuildWindow()` positions a decoration-free, input-less window in
+  the configured corner and draws the stats, histogram, and view table.
+  `UpdateViewRows()` keeps a `ViewRow` per Flutter platform-view id, flashing
+  green just after a view appears and red while it is dying, and dropping rows a
+  short grace period after a view stops being composited.
+- **`GlHud`** — OpenGL-ES render backend over `imgui_impl_opengl3` (GLSL ES
+  `#version 100`). `Render()` draws over the default framebuffer (FBO 0) just
+  before the backend's buffer swap; `RenderOffscreen()` renders into an owned,
+  reused transparent RGBA texture and returns its GL name, for the DRM plane
+  compositor that composites the HUD onto a KMS-inverted scanout buffer with the
+  same y-flip it applies to app layers.
+- **`VulkanHud`** — Vulkan render backend over `imgui_impl_vulkan`. It is built
+  `IMGUI_IMPL_VULKAN_NO_PROTOTYPES`, so it resolves every Vulkan entry point
+  through the shell's interposed `vkGetInstanceProcAddr` — the same
+  queue-serialising loader the rest of the compositor uses — rather than linking
+  libvulkan. Its render pass loads (preserves) the composited image in `GENERAL`
+  layout and records the overlay into the caller's command buffer and target
+  image view; framebuffers are cached per image view and dropped on swapchain
+  resize (`DropFramebuffers()`).
+
+Each backend creates its HUD lazily on the first present once it has determined
+the HUD is enabled, feeds it a rolling window of present intervals as `HudStats`,
+and builds the `HudViewSample` list from that frame's `FlutterLayer`
+platform-view layers.
+
+### File map
+
+| Path | Purpose |
+|------|---------|
+| [ihud.h](ihud.h) | `IHud` interface + `HudStats` / `HudViewSample` / `HudConfig` structs |
+| [hud_base.h](hud_base.h) | `HudBase` shared UI core (declaration) |
+| [hud_base.cc](hud_base.cc) | imgui context, window layout, FPS histogram, per-view tracking |
+| [gl_hud.h](gl_hud.h) | `GlHud` OpenGL-ES render backend (declaration) |
+| [gl_hud.cc](gl_hud.cc) | `imgui_impl_opengl3` init, default-FBO + offscreen render |
+| [vulkan_hud.h](vulkan_hud.h) | `VulkanHud` Vulkan render backend (declaration) |
+| [vulkan_hud.cc](vulkan_hud.cc) | render pass / descriptor pool, loader wiring, command recording |
+
+### Threading model
+
+Input-facing HUD methods (`SetOpen`, config) are set once on the platform thread
+before the first present; `RenderFrame` and all GPU work run on the
+raster/present thread with the backend's GL context current (`GlHud`) or inside
+the caller's command buffer under the shared Vulkan queue lock (`VulkanHud`).
+The concrete backend is responsible for not racing the two; in practice the HUD
+is configured before presenting begins and thereafter only touched from the
+present path. Teardown must run while the device / GL context is still valid: a
+backend resets its HUD (with the context current) so `imgui_impl_*_Shutdown`
+lands on a live device, and only then does `~HudBase` destroy the imgui context.
+
+---
+
+## Build steps
+
+### Dependencies
+
+- **Dear ImGui** — vendored at [`third_party/imgui`](../../../third_party/imgui)
+  (1.92.8); no system package required. The core (`imgui.cpp`, `imgui_draw.cpp`,
+  `imgui_tables.cpp`, `imgui_widgets.cpp`) is always built when the HUD is on;
+  the `imgui_impl_vulkan` and/or `imgui_impl_opengl3` render backends are
+  compiled only for the enabled renderers.
+- No extra runtime libraries: the Vulkan backend resolves through the shell's
+  interposed loader, and the GL backend uses imgui's bundled GL loader.
+
+### Configure + build
+
+The HUD is gated by the `BUILD_HUD` CMake option (default `ON`), defined in
+[cmake/options.cmake](../../../cmake/options.cmake) and emitted as
+`BUILD_HUD` in the generated config header. It additionally **requires
+`BUILD_COMPOSITOR`**: if `BUILD_HUD` is on but the compositor is off, configure
+disables the HUD and prints a status line. The HUD sources are only added to the
+shell target when a compatible backend is also enabled (see
+[shell/CMakeLists.txt](../../CMakeLists.txt)).
+
+```sh
+cmake -B build -G Ninja \
+    -DBUILD_COMPOSITOR=ON \
+    -DBUILD_HUD=ON \
+    -DBUILD_BACKEND_WAYLAND_EGL=ON
+cmake --build build
+```
+
+To drop the vendored imgui and HUD code entirely (size-constrained builds):
+
+```sh
+cmake -B build -G Ninja -DBUILD_HUD=OFF
+```
+
+### Build matrix
+
+| Config | CMake flags | Present path compiled in |
+|--------|-------------|--------------------------|
+| GL HUD | `BUILD_HUD=ON BUILD_COMPOSITOR=ON` + `BUILD_BACKEND_WAYLAND_EGL` or `BUILD_BACKEND_DRM_KMS_EGL` | `hud_base.cc` + `gl_hud.cc` |
+| Vulkan HUD | `BUILD_HUD=ON BUILD_COMPOSITOR=ON` + `BUILD_BACKEND_WAYLAND_VULKAN` or `BUILD_BACKEND_DRM_KMS_VULKAN` | `hud_base.cc` + `vulkan_hud.cc` |
+| Both | any GL **and** any Vulkan backend enabled | `hud_base.cc` + `gl_hud.cc` + `vulkan_hud.cc` |
+| Off | `BUILD_HUD=OFF`, or `BUILD_COMPOSITOR=OFF`, or no compatible backend | none (imgui not linked) |
+
+- `BUILD_HUD` — master switch for the overlay + vendored imgui.
+- `BUILD_COMPOSITOR` — hard prerequisite; the HUD draws in the compositor
+  present path, so it is force-disabled without it.
+- `BUILD_BACKEND_*` — select which render backend translation units compile,
+  matching the imgui impl sources added in
+  [third_party/imgui/CMakeLists.txt](../../../third_party/imgui/CMakeLists.txt).
+
+---
+
+## Running
+
+The HUD is off by default. It is summoned open when the resolved view config
+sets `[hud] enable = true` **or** the `IVI_HUD` environment variable is present;
+either source turns it on (they are OR-ed in the backend). It is a
+non-interactive overlay — no hot key, no pointer capture, no title bar — so once
+enabled it simply appears in the configured corner and updates every present.
+The window is created lazily on the first present after enablement; if the imgui
+render backend fails to initialise, the backend logs a warning
+(`HUD unavailable (...)`) and never retries.
+
+Enable via config:
+
+```toml
+[hud]
+enable = true
+corner = "top-right"
+```
+
+Enable via environment (any backend):
+
+```sh
+IVI_HUD=1 ./homescreen -b /path/to/bundle
+```
+
+On startup a backend logs `debug HUD enabled` once the overlay is created.
+
+### Env vars
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `IVI_HUD` | unset | If set (any value), enables the HUD regardless of the `[hud] enable` config value. |
+
+### `[hud]` config table
+
+Appearance and layout only (enablement aside); parsed by the
+[configuration](../../configuration/README.md) layer into `Config::hud` and
+translated to `HudConfig` in `FlutterView` (`BuildHudConfig`). Ignored unless
+the build has `BUILD_HUD` and the compositor is on.
+
+| Key | Type | Default | Values | Effect |
+|-----|------|---------|--------|--------|
+| `enable` | bool | `false` | `true` \| `false` | Enable the HUD (`IVI_HUD` also enables it). |
+| `corner` | string | `top-left` | `top-left` \| `top-right` \| `bottom-left` \| `bottom-right` | Screen corner the overlay hugs. |
+| `margin` | float | `12` | float (px) | Gap from the chosen corner. |
+| `font_scale` | float | `1.0` | float | Multiplies the base HUD font size. |
+| `bg_alpha` | float | `0.75` | float `[0,1]` | Window background opacity. |
+| `text_color` | string | `#FFFFFF` | `#RRGGBB` or `#RRGGBBAA` | HUD text color (malformed values keep opaque white). |
+
+See the generated [config reference](../../../docs/config-examples/reference.toml)
+(`[view.hud]`) for the authoritative list.
+
+---
+
+## Diagnostics/Debug
+
+- **HUD does not appear** — confirm the binary was built with `BUILD_HUD=ON`,
+  `BUILD_COMPOSITOR=ON`, and a compatible backend; check the startup log for
+  `debug HUD enabled` (created) versus `HUD unavailable (...)` (imgui init
+  failed). If neither line appears, the enable source was not seen — verify
+  `IVI_HUD` is exported or `[hud] enable = true` is in the resolved config.
+- **Reading the overlay** — the FPS line shows measured versus target (display
+  refresh); histogram bars are green at or above 90% of refresh and red below.
+  `stalls` counts presents that blocked on a buffer/flip. The
+  `dma-buf present` / `explicit sync` lines reflect the backend's present path.
+  The per-view table lists each composited platform view: `id`, `size`,
+  cumulative `presents`, idle-frame count (`Δf`), and `path` (`dma-buf`, `WSI`,
+  or `disposed`); rows flash green on appearance and red while aging out.
+- **`imgui.ini` / logs** — the HUD disables imgui's ini and log files, so it
+  never writes state to disk.
+
+---
+
+## References
+
+- [Dear ImGui](https://github.com/ocornut/imgui) — vendored at
+  [`third_party/imgui`](../../../third_party/imgui)
+- [`shell/configuration/README.md`](../../configuration/README.md) — how the
+  `[hud]` table is parsed and layered
+- [`docs/config-examples/reference.toml`](../../../docs/config-examples/reference.toml) —
+  generated `[view.hud]` config reference
+- [`cmake/options.cmake`](../../../cmake/options.cmake) — `BUILD_HUD` /
+  `BUILD_COMPOSITOR` options
+- [`shell/CMakeLists.txt`](../../CMakeLists.txt) — HUD source gating

--- a/shell/backend/software/README.md
+++ b/shell/backend/software/README.md
@@ -25,6 +25,7 @@ Two intended use cases:
 | `FileSink` — write each frame as a NetPBM PAM (P7) golden | ✓ | `IVI_SW_SINK=file:<pattern>`; always compiled in |
 | `FbDevSink` — mmap `/dev/fb*`, auto-detect 32-bpp BGRA/BGRX or 16-bpp RGB565 | ✓ | `IVI_SW_SINK=fbdev[:<dev>]`; `BUILD_SOFTWARE_SINK_FBDEV` (ON) |
 | `DrmDumbSink` — DRM dumb buffer, page-flip, kernel-timestamped vsync | ✓ | `IVI_SW_SINK=drm-dumb[:<dev>]`; `BUILD_SOFTWARE_SINK_DRM` (auto/libdrm) |
+| `EncoderSink` — CPU BGRA→NV12 into a dma-buf ring, V4L2 hardware H.264 encode | ✓ | `IVI_SW_SINK=encoder:file:<path>`; `BUILD_SOFTWARE_SINK_ENCODER` (OFF) |
 | Page-flip-locked Flutter vsync (drm-dumb only) | ✓ | `IVI_SW_VSYNC=0` for wall-clock fallback |
 | RGB565 scanout format for drm-dumb | ✓ | `IVI_SW_DRM_FORMAT=rgb565` |
 | Bayer 4×4 ordered dithering on RGB565 pack path | ✓ | `IVI_SW_DRM_DITHER=1` (drm-dumb + fbdev) |
@@ -49,9 +50,13 @@ flowchart LR
     SINK --> FILE["FileSink<br/>(write PAM)"]
     SINK --> FB["FbDevSink<br/>(mmap + swizzle)"]
     SINK --> DRM["DrmDumbSink<br/>(page-flip + vsync)"]
+    SINK --> ENC["EncoderSink<br/>(BGRA→NV12 → dma-buf ring)"]
 
     DRM -->|PAGE_FLIP_EVENT| VS["vsync_callback<br/>(kernel scanout timestamp)"]
     VS -.->|FlutterEngineOnVsync| FE
+    ENC -->|"dma-buf fd"| CONS["INv12Consumer"]
+    CONS --> FEH["V4L2 HW H.264 encoder"]
+    FEH --> OUT["file:<path>"]
 ```
 
 `SoftwareBackend` is the Flutter-facing surface — it implements
@@ -85,13 +90,22 @@ how `DrmDisplay` owns `DrmSeat`).
   `FileSink` ([file_sink.cc](file_sink.cc), [file_sink.h](file_sink.h)),
   `FbDevSink` ([fbdev_sink.cc](fbdev_sink.cc), [fbdev_sink.h](fbdev_sink.h)),
   `DrmDumbSink` ([drm_dumb_sink.cc](drm_dumb_sink.cc),
-  [drm_dumb_sink.h](drm_dumb_sink.h)). See the Sinks table below.
+  [drm_dumb_sink.h](drm_dumb_sink.h)),
+  `EncoderSink` ([encoder_sink.cc](encoder_sink.cc),
+  [encoder_sink.h](encoder_sink.h)). See the Sinks table below.
 - **`SinkFactory`** ([sink_factory.cc](sink_factory.cc),
   [sink_factory.h](sink_factory.h)) — parses the `IVI_SW_SINK` spec and
   builds the active sink; unrecognized specs warn and fall back to `NoneSink`.
 - **`pixel_swizzle.h`** ([pixel_swizzle.h](pixel_swizzle.h)) — the pack
   helpers: `FlutterToBGRX8888` (XRGB, single-pass memcpy + alpha-force),
   `FlutterToRGB565` / `FlutterToRGB565_BayerDither`.
+- **`INv12Consumer`** ([nv12_consumer.h](nv12_consumer.h),
+  [nv12_consumer.cc](nv12_consumer.cc)) — the NV12 consumer seam shared by
+  the `EncoderSink` and the `headless_egl` backend: `MakeNv12Consumer(spec)`
+  builds a `FileEncoderConsumer` (V4L2 M2M H.264) from `file:<path>`, and a
+  `WebRtcConsumer` from `webrtc:<host>:<port>` when
+  `BUILD_SOFTWARE_SINK_ENCODER_WEBRTC` is on. The consumer owns its encode /
+  send thread.
 - **`SoftwareSeat`** ([input/software_seat.cc](input/software_seat.cc),
   [input/software_seat.h](input/software_seat.h),
   [input/libinput_log_bridge.h](input/libinput_log_bridge.h)) — libinput
@@ -109,6 +123,7 @@ how `DrmDisplay` owns `DrmSeat`).
 | **FileSink** | `file:<path-pattern>` | Writes each frame as a NetPBM PAM (P7) file. Pattern with `%d` / `%05d` interpolates the frame index. Pattern without `%` writes the first frame only. Parent directories auto-created. | — |
 | **FbDevSink** | `fbdev[:<device>]` | Opens `/dev/fb0` (or operator path), mmaps, packs each Present. Auto-detects 32-bpp BGRA/BGRX or 16-bpp RGB565 from the driver's `FBIOGET_VSCREENINFO` offsets; refuses palettized / `nonstd != 0` / other layouts with a clear error. | — |
 | **DrmDumbSink** | `drm-dumb[:<device>]` | Opens `/dev/dri/card0`, picks first connected connector + its CRTC + preferred mode, allocates 2 dumb buffers (XRGB8888 by default, RGB565 via `IVI_SW_DRM_FORMAT=rgb565` when the plane advertises it), modesets onto buffer 0. Per-frame: pack into the back buffer, `drmModePageFlip`. PAGE_FLIP_EVENT drives Flutter's `vsync_callback` with the kernel-provided scanout timestamp. | ✓ |
+| **EncoderSink** | `encoder:file:<path>` | Packs each Flutter present from BGRA into a 4-slot dma-buf ring as NV12; hands each slot's dma-buf fd to the `INv12Consumer` (today, the V4L2 hardware H.264 encoder). When the ring is full the present is dropped — latency over a growing queue. The encoder thread owns the encode; the consumer's release callback returns the slot. | — |
 
 `drm-dumb` is the only sink that advertises `SupportsVsync()`;
 `SoftwareBackend::GetVsyncCallback()` returns a trampoline iff the
@@ -124,6 +139,9 @@ scheduler.
 - [file_sink.cc](file_sink.cc), [file_sink.h](file_sink.h) — `FileSink` (PAM goldens).
 - [fbdev_sink.cc](fbdev_sink.cc), [fbdev_sink.h](fbdev_sink.h) — `FbDevSink` (fbdev mmap + swizzle).
 - [drm_dumb_sink.cc](drm_dumb_sink.cc), [drm_dumb_sink.h](drm_dumb_sink.h) — `DrmDumbSink` (dumb buffer page-flip + vsync).
+- [encoder_sink.cc](encoder_sink.cc), [encoder_sink.h](encoder_sink.h) — `EncoderSink` (CPU BGRA→NV12 pack into a dma-buf ring; hands slots to an `INv12Consumer`).
+- [nv12_consumer.cc](nv12_consumer.cc), [nv12_consumer.h](nv12_consumer.h) — `INv12Consumer` seam + `FileEncoderConsumer` (V4L2 M2M H.264) + WebRTC consumer.
+- [webrtc_consumer.cc](webrtc_consumer.cc) — WebRTC send consumer (only TU that links libwebrtc; gated by `BUILD_SOFTWARE_SINK_ENCODER_WEBRTC`).
 - [sink_factory.cc](sink_factory.cc), [sink_factory.h](sink_factory.h) — `IVI_SW_SINK` spec parse → sink build.
 - [pixel_swizzle.h](pixel_swizzle.h) — BGRA→XRGB / RGB565 pack helpers (+ Bayer dither).
 - [software_cursor.cc](software_cursor.cc), [software_cursor.h](software_cursor.h) — shared cursor bitmap composited by the dumb sink.
@@ -138,6 +156,11 @@ scheduler.
   rasterizer (via `FlutterEngineDeinitialize` + `Shutdown`) before dropping
   the sink. `FlutterView`'s dtor enforces this by calling `StopVsyncMonitor`
   before `m_flutter_engine` destructs.
+- **`EncoderSink` consumer thread**: the `INv12Consumer` owns its encode /
+  send thread. The rasterizer thread only does the BGRA→NV12 pack and hands
+  the dma-buf fd to the consumer; the consumer's release callback (invoked
+  from its own thread) returns the ring slot. The ring is mutex-guarded for
+  the `in_flight` bit so the two threads don't collide on a slot.
 - **Platform task runner**: `DrmDumbSink`'s PAGE_FLIP_EVENT arrives on the
   platform task runner via asio `async_wait` on the drm fd (mirrors
   `drm_kms_egl`'s pattern); the handler exchanges the parked vsync baton and
@@ -160,6 +183,13 @@ scheduler.
 - `linux/fb.h` — ships with every libc (fbdev sink needs no library dep).
 - `libinput` + `libudev` + `xkbcommon` (pkg-config) — optional, only for the
   `SoftwareSeat`.
+- `v4l2-webrtc-codec` checkout — required for the `EncoderSink`. CMake
+  validates that `${V4L2WC_DIR}/src/v4l2_m2m_encoder.cc` and `log.cc` exist
+  at configure time; the default is a sibling of this repo. Pass
+  `-DV4L2WC_DIR=<path>` to point elsewhere.
+- `libwebrtc` (flat C ABI headers + prebuilt `.so`) — optional, only for the
+  WebRTC send consumer behind `BUILD_SOFTWARE_SINK_ENCODER_WEBRTC`. CMake
+  validates `${LIBWEBRTC_DIR}/include/c/lw_c_api.h` and `LIBWEBRTC_SO`.
 
 ### Configure + build
 
@@ -184,6 +214,8 @@ CMakeLists.
 | + fbdev panel | `-DBUILD_SOFTWARE_SINK_FBDEV=ON` (default) | `FbDevSink` (`/dev/fb*` mmap) |
 | + DRM dumb buffer | `-DBUILD_SOFTWARE_SINK_DRM=ON` (auto if libdrm) | `DrmDumbSink` (page-flip + vsync) |
 | + libinput input | `-DBUILD_SOFTWARE_INPUT_LIBINPUT=ON` (auto if deps) | `SoftwareSeat` |
+| + V4L2 encoder | `-DBUILD_SOFTWARE_SINK_ENCODER=ON` | `EncoderSink` (`encoder:file:<path>`) |
+| + WebRTC send | `-DBUILD_SOFTWARE_SINK_ENCODER=ON -DBUILD_SOFTWARE_SINK_ENCODER_WEBRTC=ON` | adds the WebRTC consumer |
 
 Sink / input sub-options:
 
@@ -192,6 +224,8 @@ Sink / input sub-options:
 | `BUILD_SOFTWARE_SINK_DRM` | auto-on if pkg-config finds `libdrm`, else off | Pulls in `libdrm` for the drm-dumb sink. Force-on without libdrm is a fatal configure error. |
 | `BUILD_SOFTWARE_SINK_FBDEV` | ON | No library dep — `linux/fb.h` ships with every libc. |
 | `BUILD_SOFTWARE_INPUT_LIBINPUT` | auto-on if pkg-config finds `libinput` + `libudev` + `xkbcommon`, else off | Pulls in the libinput stack for the `SoftwareSeat`. Force-on without deps is a fatal configure error. |
+| `BUILD_SOFTWARE_SINK_ENCODER` | OFF | Compiles `encoder_sink.cc` + `nv12_consumer.cc` + the V4L2 M2M encoder from `v4l2-webrtc-codec`. Requires the V4L2 checkout at `V4L2WC_DIR`. |
+| `BUILD_SOFTWARE_SINK_ENCODER_WEBRTC` | OFF | Adds the WebRTC send consumer. Implies `BUILD_SOFTWARE_SINK_ENCODER`. Requires `LIBWEBRTC_DIR` (headers) and `LIBWEBRTC_SO` (prebuilt libwebrtc.so). |
 
 `NoneSink`, `MemorySink`, and `FileSink` are always compiled in.
 
@@ -201,6 +235,11 @@ Sink / input sub-options:
   compiled in; absent → sink omitted (`drm-dumb` specs fall back to `NoneSink`).
 - **libinput + libudev + xkbcommon** present → `BUILD_SOFTWARE_INPUT_LIBINPUT`
   auto-on, `SoftwareSeat` compiled in; absent → no CPU-backend input.
+- **v4l2-webrtc-codec checkout** — `BUILD_SOFTWARE_SINK_ENCODER` is
+  user-opted-in; when ON, CMake fatally errors at configure time if
+  `V4L2WC_DIR` does not contain the expected sources. There is no
+  pkg-config auto-detection for this feature — it is a target-only
+  feature that needs a V4L2 M2M encoder node at runtime.
 
 ### Toolchain compatibility
 
@@ -327,6 +366,35 @@ A `SetVsyncBaton` idle-kick drains the baton inline when no flip is
 in flight so Flutter never sits forever on the first frame or
 post-resume.
 
+### Encoder sink (V4L2 hardware H.264)
+
+```sh
+IVI_SW_SINK=encoder:file:out.h264 \
+IVI_SW_STOP_AFTER_FRAMES=300 \
+  ./homescreen -b bundle
+```
+
+The `EncoderSink` requires a target with a V4L2 M2M encoder node (e.g.
+`/dev/video11` on a Jetson, or any VPU exposing a V4L2 M2M encoder). The
+default node is `/dev/video11`; override with `IVI_ENC_DEVICE`. The sink:
+
+* opens the V4L2 M2M encoder from the `v4l2-webrtc-codec` checkout;
+* allocates a 4-slot dma-buf ring sized for the configured resolution;
+* per present: packs Flutter's BGRA into the back slot as NV12 on the CPU,
+  calls `DMA_BUF_IOCTL_SYNC` to flush caches, and hands the dma-buf fd to the
+  consumer; when the ring is full the present is dropped (latency over a
+  growing queue);
+* the consumer's encode thread calls back with a release when it has
+  consumed the frame, returning the slot to the ring.
+
+The encoder produces H.264 Annex-B access units appended to the output
+file. The first frame after each configure is forced to be a keyframe (IDR)
+so the stream is always decodable from the start.
+
+The `webrtc:` consumer variant (behind
+`BUILD_SOFTWARE_SINK_ENCODER_WEBRTC`) sends each dma-buf frame to a remote
+peer via libwebrtc's V4L2 encoder factory instead of writing to a file.
+
 ### Env vars
 
 | Env | Default | Effect |
@@ -339,6 +407,9 @@ post-resume.
 | `IVI_SW_INPUT` | `auto` | Wires the libinput-backed `SoftwareSeat` for device targets. Set to `none` to skip — useful for CI runs that lack `/dev/input/event*` or want pure engine-only smoke. |
 | `IVI_SW_DRM_FORMAT` | `xrgb8888` | Pick the `DrmDumbSink` buffer format. `rgb565` halves framebuffer footprint and CRTC scanout bandwidth (the real bottleneck on legacy SoCs like TI AM335x / STM32MP1). If the picked CRTC's planes don't advertise RGB565, the sink warns and falls back to XRGB. Unrecognized values warn and fall back. Has no effect on `fbdev:` (auto-detected from the panel) or the other sinks. |
 | `IVI_SW_DRM_DITHER` | `0` (off) | `1` enables Bayer 4×4 ordered dithering on the RGB565 pack path in both `drm-dumb` and `fbdev` sinks. Hides the banding that pure truncation produces on smooth gradients at the cost of bit-exact goldens. No-op when the active sink's format is BGRX8888 — there's no precision loss to hide. |
+| `IVI_ENC_DEVICE` | `/dev/video11` | V4L2 M2M encoder node for `EncoderSink`. Override for targets where the encoder sits on a different node. |
+| `IVI_ENC_BITRATE` | `4000000` | Target bitrate in bits/s for the V4L2 encoder. |
+| `IVI_ENC_FPS` | `30` | Encoder framerate; also sets the rate ceiling for the consumer-paced vsync. |
 
 ---
 
@@ -542,6 +613,19 @@ push the histogram toward wayland_egl's profile.
   `[X,R,G,B]` on BE rather than `[B,G,R,X]` — `FbDevSink` would
   need a dedicated helper. Not implemented since all shipping
   targets are LE; flagged for the day a BE target appears.
+- **`EncoderSink` is target-only.** The V4L2 M2M encoder path assumes
+  a kernel driver exposing a V4L2 M2M encoder node (typically on Jetson
+  or other VPU-equipped boards). On a desktop without a VPU the
+  configure-time dependency check still passes (the checkout is
+  present), but the sink will fail at runtime when it tries to open
+  the default node — there is no in-tree encoder fallback. Use the
+  `file:` sink for desktop / CI golden capture.
+- **`EncoderSink` ring is fixed at 4 slots.** The `kRingSize = 4`
+  constant in `encoder_sink.h` is sized for the consumer's encode
+  budget, not user-tunable. A faster consumer (WebRTC at high
+  resolution) could overflow the ring more often; a slower consumer
+  wastes dma-buf memory. The ring size is a target-only tuning
+  knob, not exposed through `IVI_SW_SINK`.
 - **Headers rely on transitive includes for some std:: types.** As of
   v3.0 the tree-wide sweep in commit `24e01fe3` added `#include <array>`
   to `drm_dumb_sink.h` (the backend's headers are now self-sufficient
@@ -559,7 +643,9 @@ push the histogram toward wayland_egl's profile.
 - [shell/backend/README.md](../README.md) — backend selection overview.
 - [drm_kms_egl](../drm_kms_egl/README.md) — the drm fd / asio page-flip pattern `DrmDumbSink` mirrors.
 - [wayland_vulkan](../wayland_vulkan/README.md) — the FIFO / strict-vblank-gating finding cross-referenced in Benchmarks.
+- [headless_egl](../headless_egl/README.md) — the GPU-side sibling that reuses the same `INv12Consumer` / `FileEncoderConsumer` stack from `encoder_sink.cc`.
 - [shell/vsync](../../vsync/README.md) — the shared `IVsyncProvider` baton lifecycle.
 - [shell/profiling](../../profiling/README.md) — `FrameProfile` and the `IVI_*_PROFILE` cadence histograms.
 - [shell/input](../../input/README.md) — the sibling `DrmSeat` libinput/xkb stack `SoftwareSeat` parallels.
 - Linux `linux/fb.h` (fbdev), `libdrm` / `drm_fourcc.h` (dumb buffers), `libinput` + `xkbcommon` (input), `vkms` / `vfb` kernel modules (test harness).
+- `v4l2-webrtc-codec` checkout — V4L2 M2M encoder sources (`src/v4l2_m2m_encoder.cc`, `src/log.cc`) and the flat-C `INv12Consumer` contract shared with the headless-EGL backend.

--- a/shell/backend/software/README.md
+++ b/shell/backend/software/README.md
@@ -15,34 +15,92 @@ Two intended use cases:
    without a render-capable GPU). The CPU does both Flutter's raster
    work and the present-side memcpy / swizzle.
 
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| CPU `kSoftware` renderer → pluggable `ISurfaceSink` | ✓ | `-DBUILD_BACKEND_SOFTWARE=ON` |
+| `NoneSink` — discards every frame (CI engine-only smoke) | ✓ | `IVI_SW_SINK=none` (default); always compiled in |
+| `MemorySink` — mutex-guarded latest-frame snapshot for in-process fixtures | ✓ | `IVI_SW_SINK=memory`; always compiled in |
+| `FileSink` — write each frame as a NetPBM PAM (P7) golden | ✓ | `IVI_SW_SINK=file:<pattern>`; always compiled in |
+| `FbDevSink` — mmap `/dev/fb*`, auto-detect 32-bpp BGRA/BGRX or 16-bpp RGB565 | ✓ | `IVI_SW_SINK=fbdev[:<dev>]`; `BUILD_SOFTWARE_SINK_FBDEV` (ON) |
+| `DrmDumbSink` — DRM dumb buffer, page-flip, kernel-timestamped vsync | ✓ | `IVI_SW_SINK=drm-dumb[:<dev>]`; `BUILD_SOFTWARE_SINK_DRM` (auto/libdrm) |
+| Page-flip-locked Flutter vsync (drm-dumb only) | ✓ | `IVI_SW_VSYNC=0` for wall-clock fallback |
+| RGB565 scanout format for drm-dumb | ✓ | `IVI_SW_DRM_FORMAT=rgb565` |
+| Bayer 4×4 ordered dithering on RGB565 pack path | ✓ | `IVI_SW_DRM_DITHER=1` (drm-dumb + fbdev) |
+| libinput `SoftwareSeat` — pointer / keyboard / key-repeat / multi-touch | ✓ | `IVI_SW_INPUT` (auto); `BUILD_SOFTWARE_INPUT_LIBINPUT` (auto) |
+| Frame-count-bounded runtime for CI | ✓ | `IVI_SW_STOP_AFTER_FRAMES=<N>` |
+| Present-call + vsync cadence profiling | ✓ | `IVI_SW_PROFILE` / `IVI_VSYNC_PROFILE` |
+| Platform-view software compositor | ✗ deferred | `GetCompositorConfig()` returns all-null callbacks |
+| fbdev vsync (`FBIO_WAITFORVSYNC`) | ✗ | Broadly broken/non-standard across drivers; use drm-dumb |
+
+---
+
 ## Architecture
 
+```mermaid
+flowchart LR
+    FE["Flutter Engine<br/>software.surface_present_callback(buf, rb, h)"]
+    FE -->|kSoftware present| PT["SoftwareBackend::PresentTrampoline()"]
+    PT -->|Present(buf, row_bytes, height)| SINK{{ISurfaceSink}}
+
+    SINK --> NONE["NoneSink<br/>(drop)"]
+    SINK --> MEM["MemorySink<br/>(memcpy → vector)"]
+    SINK --> FILE["FileSink<br/>(write PAM)"]
+    SINK --> FB["FbDevSink<br/>(mmap + swizzle)"]
+    SINK --> DRM["DrmDumbSink<br/>(page-flip + vsync)"]
+
+    DRM -->|PAGE_FLIP_EVENT| VS["vsync_callback<br/>(kernel scanout timestamp)"]
+    VS -.->|FlutterEngineOnVsync| FE
 ```
-Flutter Engine                SoftwareBackend                 ISurfaceSink
-──────────────                ───────────────                 ────────────
-software.surface_present_     PresentTrampoline() ───▶        Present(buf, rb, h)
-  callback(buf, rb, h)                                          ├─ NoneSink     (drop)
-                                                                ├─ MemorySink   (memcpy → vector)
-                                                                ├─ FileSink     (write PAM)
-                                                                ├─ FbDevSink    (mmap + swizzle)
-                                                                └─ DrmDumbSink  (page-flip + vsync)
-```
 
-* `SoftwareBackend` is the Flutter-facing surface — implements
-  `GetRenderConfig` with `type=kSoftware` plus a static present
-  trampoline. Owns the sink.
-* `ISurfaceSink` is the abstraction: one `Present(const void*,
-  size_t row_bytes, size_t height)` plus optional vsync hooks. Sinks
-  are picked at startup from the `IVI_SW_SINK` env var.
-* Sinks are single-file and small: no threading, no buffer pooling.
-  The callback runs on Flutter's rasterizer thread; the sink either
-  copies / writes / mmaps synchronously and returns.
+`SoftwareBackend` is the Flutter-facing surface — it implements
+`GetRenderConfig` with `type=kSoftware` plus a static present trampoline,
+and owns the sink. `ISurfaceSink` is the abstraction: one
+`Present(const void*, size_t row_bytes, size_t height)` plus optional
+vsync hooks. Sinks are picked at startup from the `IVI_SW_SINK` env var.
+Sinks are single-file and small: no threading, no buffer pooling. The
+callback runs on Flutter's rasterizer thread; the sink either copies /
+writes / mmaps synchronously and returns.
 
-`SoftwareDisplay` is a no-op `IDisplay` so `App::Loop`'s sleep math
-has a refresh-rate denominator. Defaults to 60 Hz; nothing else
-interesting lives there.
+`SoftwareDisplay` is a no-op `IDisplay` so `App::Loop`'s sleep math has a
+refresh-rate denominator. It defaults to 60 Hz; nothing else interesting
+lives there. It also owns the libinput-backed `SoftwareSeat` (parallel to
+how `DrmDisplay` owns `DrmSeat`).
 
-## Sinks
+### Module responsibilities
+
+- **`SoftwareBackend`** ([software_backend.cc](software_backend.cc),
+  [software_backend.h](software_backend.h)) — the Flutter-facing `Backend`.
+  Implements `GetRenderConfig` (`type=kSoftware`) plus the static
+  `PresentTrampoline`, owns the active sink, resolves the framebuffer extent
+  from the sink's `NativeSize()`, gates `GetVsyncCallback()` on the sink
+  advertising a real vblank source, and emits the `IVI_SW_PROFILE` session
+  summary on clean dtor.
+- **`ISurfaceSink`** ([surface_sink.h](surface_sink.h)) — the present
+  abstraction: `Present(buf, row_bytes, height)` plus optional vsync /
+  cursor / task-runner hooks.
+- **Sinks** — one translation unit each: `NoneSink`
+  ([none_sink.h](none_sink.h)), `MemorySink` ([memory_sink.h](memory_sink.h)),
+  `FileSink` ([file_sink.cc](file_sink.cc), [file_sink.h](file_sink.h)),
+  `FbDevSink` ([fbdev_sink.cc](fbdev_sink.cc), [fbdev_sink.h](fbdev_sink.h)),
+  `DrmDumbSink` ([drm_dumb_sink.cc](drm_dumb_sink.cc),
+  [drm_dumb_sink.h](drm_dumb_sink.h)). See the Sinks table below.
+- **`SinkFactory`** ([sink_factory.cc](sink_factory.cc),
+  [sink_factory.h](sink_factory.h)) — parses the `IVI_SW_SINK` spec and
+  builds the active sink; unrecognized specs warn and fall back to `NoneSink`.
+- **`pixel_swizzle.h`** ([pixel_swizzle.h](pixel_swizzle.h)) — the pack
+  helpers: `FlutterToBGRX8888` (XRGB, single-pass memcpy + alpha-force),
+  `FlutterToRGB565` / `FlutterToRGB565_BayerDither`.
+- **`SoftwareSeat`** ([input/software_seat.cc](input/software_seat.cc),
+  [input/software_seat.h](input/software_seat.h),
+  [input/libinput_log_bridge.h](input/libinput_log_bridge.h)) — libinput
+  `ISeat` driving pointer / keyboard / key-repeat / multi-touch into Flutter.
+- **`SoftwareCursor`** ([software_cursor.cc](software_cursor.cc),
+  [software_cursor.h](software_cursor.h)) — shared cursor bitmap composited
+  by the dumb sink.
+
+### Sinks
 
 | Sink | Spec syntax | What it does | Vsync |
 |---|---|---|---|
@@ -57,20 +115,53 @@ interesting lives there.
 active sink advertises it. Everyone else runs on Flutter's wall-clock
 scheduler.
 
-## Env vars
+### File map
 
-| Env | Default | Effect |
-|---|---|---|
-| `IVI_SW_SINK` | `none` | Pick the active sink at startup. Syntax above. Unrecognized specs log a warn and fall back to `NoneSink` so a CI typo never refuses to start. |
-| `IVI_SW_STOP_AFTER_FRAMES` | (off) | Raise `SIGTERM` after N successful presents. Lets CI bound runtime by frame count instead of wall-clock. Bare integer ≥ 1; leading `-`/`+` is rejected and logged. First crosser latches via `compare_exchange` so the signal fires exactly once. |
-| `IVI_SW_VSYNC` | `1` (on) | `0` forces Flutter onto its wall-clock scheduler regardless of whether the active sink advertises `SupportsVsync()`. Useful for A/B benchmarking the vsync_callback contribution (see benchmarks section). |
-| `IVI_SW_PROFILE` | (off) | Enable `SoftwareBackend` **present-call** cadence profiling (when Flutter hands the backend a rendered frame). Every 60 frames logs `[SoftwareBackend] profile (n=60): fps=X mean_interval=Yus max_interval=Zus discarded=N buckets[60Hz/30Hz/20Hz/slow/idle]=…`. Session summary on clean dtor. Same shape as `IVI_VK_PROFILE` / `IVI_WL_PROFILE` for cross-backend comparison. |
-| `IVI_VSYNC_PROFILE` | (off) | Enable **vsync/scanout** cadence profiling for the shared `IVsyncProvider` (drm-dumb sink: from the kernel page-flip timestamp). Logs under the `[SoftwareVsync]` label, same window/bucket shape. Display-side companion to `IVI_SW_PROFILE`'s rasterizer-side numbers; the same var also gates `[WaylandVsync]` / `[DrmVsync]` on those backends. |
-| `IVI_SW_INPUT` | `auto` | Wires the libinput-backed `SoftwareSeat` for device targets. Set to `none` to skip — useful for CI runs that lack `/dev/input/event*` or want pure engine-only smoke. |
-| `IVI_SW_DRM_FORMAT` | `xrgb8888` | Pick the `DrmDumbSink` buffer format. `rgb565` halves framebuffer footprint and CRTC scanout bandwidth (the real bottleneck on legacy SoCs like TI AM335x / STM32MP1). If the picked CRTC's planes don't advertise RGB565, the sink warns and falls back to XRGB. Unrecognized values warn and fall back. Has no effect on `fbdev:` (auto-detected from the panel) or the other sinks. |
-| `IVI_SW_DRM_DITHER` | `0` (off) | `1` enables Bayer 4×4 ordered dithering on the RGB565 pack path in both `drm-dumb` and `fbdev` sinks. Hides the banding that pure truncation produces on smooth gradients at the cost of bit-exact goldens. No-op when the active sink's format is BGRX8888 — there's no precision loss to hide. |
+- [software_backend.cc](software_backend.cc), [software_backend.h](software_backend.h) — the `SoftwareBackend` `Backend`: kSoftware render config, present trampoline, sink ownership, extent resolution, vsync gate, profile summary.
+- [surface_sink.h](surface_sink.h) — the `ISurfaceSink` present abstraction.
+- [none_sink.h](none_sink.h) — `NoneSink` (drop).
+- [memory_sink.h](memory_sink.h) — `MemorySink` (latest-frame snapshot).
+- [file_sink.cc](file_sink.cc), [file_sink.h](file_sink.h) — `FileSink` (PAM goldens).
+- [fbdev_sink.cc](fbdev_sink.cc), [fbdev_sink.h](fbdev_sink.h) — `FbDevSink` (fbdev mmap + swizzle).
+- [drm_dumb_sink.cc](drm_dumb_sink.cc), [drm_dumb_sink.h](drm_dumb_sink.h) — `DrmDumbSink` (dumb buffer page-flip + vsync).
+- [sink_factory.cc](sink_factory.cc), [sink_factory.h](sink_factory.h) — `IVI_SW_SINK` spec parse → sink build.
+- [pixel_swizzle.h](pixel_swizzle.h) — BGRA→XRGB / RGB565 pack helpers (+ Bayer dither).
+- [software_cursor.cc](software_cursor.cc), [software_cursor.h](software_cursor.h) — shared cursor bitmap composited by the dumb sink.
+- [input/software_seat.cc](input/software_seat.cc), [input/software_seat.h](input/software_seat.h) — libinput `SoftwareSeat`.
+- [input/libinput_log_bridge.h](input/libinput_log_bridge.h) — libinput → project log bridge.
 
-## Build
+### Threading model
+
+- **Single rasterizer thread**: every sink's `Present()` is called from
+  Flutter's rasterizer. `FbDevSink` and `DrmDumbSink` rely on that for
+  lock-free hot paths; the dtor contract is that the embedder must join the
+  rasterizer (via `FlutterEngineDeinitialize` + `Shutdown`) before dropping
+  the sink. `FlutterView`'s dtor enforces this by calling `StopVsyncMonitor`
+  before `m_flutter_engine` destructs.
+- **Platform task runner**: `DrmDumbSink`'s PAGE_FLIP_EVENT arrives on the
+  platform task runner via asio `async_wait` on the drm fd (mirrors
+  `drm_kms_egl`'s pattern); the handler exchanges the parked vsync baton and
+  posts `FlutterEngineOnVsync` onto the engine's strand with the
+  kernel-provided scanout timestamp. A `SetVsyncBaton` idle-kick drains the
+  baton inline when no flip is in flight so Flutter never sits forever on the
+  first frame or post-resume.
+- **`SoftwareSeat`**: libinput fd + key-repeat timerfd polled on the
+  `SoftwareDisplay` input path, started/stopped via
+  `IDisplay::StartEvents()` / `StopEvents()`.
+
+---
+
+## Build steps
+
+### Dependencies
+
+- CMake + Ninja + a C++ toolchain (no GPU, no Wayland, no Mesa runtime).
+- `libdrm` (pkg-config) — optional, only for the `drm-dumb` sink.
+- `linux/fb.h` — ships with every libc (fbdev sink needs no library dep).
+- `libinput` + `libudev` + `xkbcommon` (pkg-config) — optional, only for the
+  `SoftwareSeat`.
+
+### Configure + build
 
 ```sh
 cmake -B build -G Ninja \
@@ -85,7 +176,16 @@ Backend selection is mutually exclusive — `BUILD_BACKEND_SOFTWARE`
 must be on with everything else off, enforced by the top-level
 CMakeLists.
 
-### Sink sub-options
+### Build matrix
+
+| Config | CMake flags | Present path compiled in |
+|--------|-------------|--------------------------|
+| Headless / CI (always) | `-DBUILD_BACKEND_SOFTWARE=ON` | `NoneSink`, `MemorySink`, `FileSink` — always compiled in |
+| + fbdev panel | `-DBUILD_SOFTWARE_SINK_FBDEV=ON` (default) | `FbDevSink` (`/dev/fb*` mmap) |
+| + DRM dumb buffer | `-DBUILD_SOFTWARE_SINK_DRM=ON` (auto if libdrm) | `DrmDumbSink` (page-flip + vsync) |
+| + libinput input | `-DBUILD_SOFTWARE_INPUT_LIBINPUT=ON` (auto if deps) | `SoftwareSeat` |
+
+Sink / input sub-options:
 
 | CMake flag | Default | Notes |
 |---|---|---|
@@ -95,32 +195,26 @@ CMakeLists.
 
 `NoneSink`, `MemorySink`, and `FileSink` are always compiled in.
 
-## Input
+### Optional features detected at configure time
 
-`SoftwareSeat` is a libinput-backed `homescreen::ISeat` that drives
-keyboard, pointer, and multi-touch events into Flutter from
-`/dev/input/event*`. Owned by `SoftwareDisplay` (parallel to how
-`DrmDisplay` owns `DrmSeat`) and started/stopped via the existing
-`IDisplay::StartEvents()` / `StopEvents()` lifecycle.
+- **libdrm** present → `BUILD_SOFTWARE_SINK_DRM` auto-on, `DrmDumbSink`
+  compiled in; absent → sink omitted (`drm-dumb` specs fall back to `NoneSink`).
+- **libinput + libudev + xkbcommon** present → `BUILD_SOFTWARE_INPUT_LIBINPUT`
+  auto-on, `SoftwareSeat` compiled in; absent → no CPU-backend input.
 
-Devices are opened under the calling process's credentials via raw
-`::open` — no libseat dependency. The operator must be in the
-`input` group (universal on systemd distros) or running as root.
-
-Coverage:
-
-| Source | What it does |
-|---|---|
-| Pointer | Relative + absolute motion clamped to the viewport, BTN_LEFT / RIGHT / MIDDLE / SIDE / EXTRA buttons, horizontal + vertical scroll axes. |
-| Keyboard | evdev keycode + 8 → xkb scancode via `xkb_state_key_get_one_sym`; system-default RMLVO (`XKB_DEFAULT_*` env vars honoured). Delivered through the project-wide `KeyCallback`. |
-| Key repeat | timerfd polled alongside libinput's fd; armed on press of an `xkb_keymap_key_repeats`-positive key at 500 ms / 33 ms (~30 Hz) cadence, disarmed on release of the currently-repeating key. Most-recently-pressed wins when a second repeating key arrives. |
-| Touch | libinput slots → Flutter per-finger `device` ids. Per slot: `kAdd + kDown` on touch-down, `kMove` on motion, `kUp + kRemove` on release, `kCancel + kRemove` on libinput cancellation. Bounded to 16 slots. |
-
-Not yet implemented: gesture events (`LIBINPUT_EVENT_GESTURE_*`),
-switch events (`LIBINPUT_EVENT_SWITCH_*`), tablet/pen, hot keymap
-reload, libseat session integration.
+---
 
 ## Running
+
+The backend needs no display server and no GPU. Sinks that touch device
+nodes need group membership:
+
+- `fbdev` → the `video` group (or whatever owns `/dev/fb*` on the target).
+- `drm-dumb` → the `video` (or distro-specific) group; needs DRM master on
+  the card.
+- `SoftwareSeat` input → the `input` group (universal on systemd distros) or
+  root; devices are opened directly under the calling process's credentials
+  via raw `::open`, no libseat dependency.
 
 ### CI / engine-only smoke
 
@@ -225,7 +319,57 @@ A `SetVsyncBaton` idle-kick drains the baton inline when no flip is
 in flight so Flutter never sits forever on the first frame or
 post-resume.
 
-## Lifecycle + safety
+### Env vars
+
+| Env | Default | Effect |
+|---|---|---|
+| `IVI_SW_SINK` | `none` | Pick the active sink at startup. Syntax above. Unrecognized specs log a warn and fall back to `NoneSink` so a CI typo never refuses to start. |
+| `IVI_SW_STOP_AFTER_FRAMES` | (off) | Raise `SIGTERM` after N successful presents. Lets CI bound runtime by frame count instead of wall-clock. Bare integer ≥ 1; leading `-`/`+` is rejected and logged. First crosser latches via `compare_exchange` so the signal fires exactly once. |
+| `IVI_SW_VSYNC` | `1` (on) | `0` forces Flutter onto its wall-clock scheduler regardless of whether the active sink advertises `SupportsVsync()`. Useful for A/B benchmarking the vsync_callback contribution (see benchmarks section). |
+| `IVI_SW_PROFILE` | (off) | Enable `SoftwareBackend` **present-call** cadence profiling (when Flutter hands the backend a rendered frame). Every 60 frames logs `[SoftwareBackend] profile (n=60): fps=X mean_interval=Yus max_interval=Zus discarded=N buckets[60Hz/30Hz/20Hz/slow/idle]=…`. Session summary on clean dtor. Same shape as `IVI_VK_PROFILE` / `IVI_WL_PROFILE` for cross-backend comparison. |
+| `IVI_VSYNC_PROFILE` | (off) | Enable **vsync/scanout** cadence profiling for the shared `IVsyncProvider` (drm-dumb sink: from the kernel page-flip timestamp). Logs under the `[SoftwareVsync]` label, same window/bucket shape. Display-side companion to `IVI_SW_PROFILE`'s rasterizer-side numbers; the same var also gates `[WaylandVsync]` / `[DrmVsync]` on those backends. |
+| `IVI_SW_INPUT` | `auto` | Wires the libinput-backed `SoftwareSeat` for device targets. Set to `none` to skip — useful for CI runs that lack `/dev/input/event*` or want pure engine-only smoke. |
+| `IVI_SW_DRM_FORMAT` | `xrgb8888` | Pick the `DrmDumbSink` buffer format. `rgb565` halves framebuffer footprint and CRTC scanout bandwidth (the real bottleneck on legacy SoCs like TI AM335x / STM32MP1). If the picked CRTC's planes don't advertise RGB565, the sink warns and falls back to XRGB. Unrecognized values warn and fall back. Has no effect on `fbdev:` (auto-detected from the panel) or the other sinks. |
+| `IVI_SW_DRM_DITHER` | `0` (off) | `1` enables Bayer 4×4 ordered dithering on the RGB565 pack path in both `drm-dumb` and `fbdev` sinks. Hides the banding that pure truncation produces on smooth gradients at the cost of bit-exact goldens. No-op when the active sink's format is BGRX8888 — there's no precision loss to hide. |
+
+---
+
+## Input
+
+`SoftwareSeat` is a libinput-backed `homescreen::ISeat` that drives
+keyboard, pointer, and multi-touch events into Flutter from
+`/dev/input/event*`. Owned by `SoftwareDisplay` (parallel to how
+`DrmDisplay` owns `DrmSeat`) and started/stopped via the existing
+`IDisplay::StartEvents()` / `StopEvents()` lifecycle.
+
+Devices are opened under the calling process's credentials via raw
+`::open` — no libseat dependency. The operator must be in the
+`input` group (universal on systemd distros) or running as root.
+
+Coverage:
+
+| Source | What it does |
+|---|---|
+| Pointer | Relative + absolute motion clamped to the viewport, BTN_LEFT / RIGHT / MIDDLE / SIDE / EXTRA buttons, horizontal + vertical scroll axes. |
+| Keyboard | evdev keycode + 8 → xkb scancode via `xkb_state_key_get_one_sym`; system-default RMLVO (`XKB_DEFAULT_*` env vars honoured). Delivered through the project-wide `KeyCallback`. |
+| Key repeat | timerfd polled alongside libinput's fd; armed on press of an `xkb_keymap_key_repeats`-positive key at 500 ms / 33 ms (~30 Hz) cadence, disarmed on release of the currently-repeating key. Most-recently-pressed wins when a second repeating key arrives. |
+| Touch | libinput slots → Flutter per-finger `device` ids. Per slot: `kAdd + kDown` on touch-down, `kMove` on motion, `kUp + kRemove` on release, `kCancel + kRemove` on libinput cancellation. Bounded to 16 slots. |
+
+Not yet implemented: gesture events (`LIBINPUT_EVENT_GESTURE_*`),
+switch events (`LIBINPUT_EVENT_SWITCH_*`), tablet/pen, hot keymap
+reload, libseat session integration.
+
+---
+
+## Diagnostics/Debug
+
+Present-side and scanout-side cadence are observable via the profilers:
+`IVI_SW_PROFILE=1` logs the rasterizer-side present cadence under
+`[SoftwareBackend]`, and `IVI_VSYNC_PROFILE=1` logs the drm-dumb kernel
+page-flip cadence under `[SoftwareVsync]` (see Env vars for the line shape
+and bucket thresholds).
+
+### Lifecycle + safety
 
 * **Single rasterizer thread**: every sink's `Present()` is called
   from Flutter's rasterizer. `FbDevSink` and `DrmDumbSink` rely on
@@ -248,6 +392,8 @@ post-resume.
   The existing `main.cc` handler flips a `sig_atomic_t` flag, the
   trampoline unwinds, `App::Loop` observes the flag and returns
   normally — no hard exit, no torn destructor state.
+
+---
 
 ## Benchmarks (DrmDumbSink, vkms @ 60 Hz)
 
@@ -272,8 +418,9 @@ configuration. Steady-state windows reported (windows dominated by
 content-load stalls — see "vkms quirk" below — are excluded for the
 typical-case table).
 
-### Steady-state, vsync ON
+### Results summary
 
+**Steady-state, vsync ON** —
 `IVI_SW_SINK=drm-dumb IVI_SW_PROFILE=1 IVI_SW_STOP_AFTER_FRAMES=240`:
 
 | Run | fps | mean interval | 60Hz (≤17 ms) | 30Hz (18-33 ms) | 20Hz | slow | idle |
@@ -282,10 +429,9 @@ typical-case table).
 | r2 w1 | 57.15 | 17.50 ms | 39 | 20 | 0 | 0 | 0 |
 | r3 w1 | 55.96 | 17.87 ms | 37 | 22 | 0 | 0 | 0 |
 
-### Steady-state, vsync OFF
-
-Same workload, `IVI_SW_VSYNC=0` forcing Flutter to wall-clock
-scheduling regardless of the sink's `SupportsVsync()`:
+**Steady-state, vsync OFF** — same workload, `IVI_SW_VSYNC=0` forcing
+Flutter to wall-clock scheduling regardless of the sink's
+`SupportsVsync()`:
 
 | Run | fps | mean interval | 60Hz (≤17 ms) | 30Hz (18-33 ms) | 20Hz | slow | idle |
 |---|---:|---:|---:|---:|---:|---:|---:|
@@ -294,16 +440,14 @@ scheduling regardless of the sink's `SupportsVsync()`:
 | r3 w1 | 54.26 | 18.43 ms | 30 | 27 | 2 | 0 | 0 |
 | r3 w4 | 58.34 | 17.14 ms | 50 | 10 | 0 | 0 | 0 |
 
-### Reading
-
-The two configurations are **statistically indistinguishable** at
-the histogram layer — ~50-83 % on-vblank, ~17-50 % one-vblank-late,
-mean interval within ~0.3 ms of the 16.67 ms vblank period in both
-cases. The DrmDumbSink's spin-wait on `flip_pending_` paces the
-rasterizer thread to the kernel's PAGE_FLIP_EVENT cadence
-*regardless* of whether Flutter's `vsync_callback` is also wired —
-the sink's natural backpressure dominates the present-interval
-metric.
+**Reading.** The two configurations are **statistically
+indistinguishable** at the histogram layer — ~50-83 % on-vblank,
+~17-50 % one-vblank-late, mean interval within ~0.3 ms of the 16.67 ms
+vblank period in both cases. The DrmDumbSink's spin-wait on
+`flip_pending_` paces the rasterizer thread to the kernel's
+PAGE_FLIP_EVENT cadence *regardless* of whether Flutter's
+`vsync_callback` is also wired — the sink's natural backpressure
+dominates the present-interval metric.
 
 This matches the wayland_vulkan FIFO finding documented in
 `shell/backend/wayland_vulkan/README.md`: when the sink (or WSI)
@@ -315,12 +459,10 @@ or from a wall-clock estimate. Animation-timing precision and
 input-to-photon latency may differ in ways this profiler doesn't
 measure; the present-interval rate doesn't.
 
-### vkms quirk worth knowing
-
-Longer runs occasionally show a window with `fps≈3` and a
-`max_interval` north of 10 seconds (vsync-off r3 w2 in the matrix
-above hit ~18 s). This is the kernel's vkms module pausing the
-writeback queue when no consumer is reading from the
+**vkms quirk worth knowing.** Longer runs occasionally show a window
+with `fps≈3` and a `max_interval` north of 10 seconds (vsync-off r3 w2
+in the matrix above hit ~18 s). This is the kernel's vkms module
+pausing the writeback queue when no consumer is reading from the
 `card0-Writeback-2` connector — PAGE_FLIP_EVENT stops arriving,
 the rasterizer parks on `flip_pending_`, and the spin-wait
 eventually trips its 5×-refresh deadline and force-clears the flag.
@@ -330,9 +472,8 @@ see the same artefact. Not a regression — same behaviour with
 vsync wiring off. On a real panel with a connected scanout
 consumer this doesn't occur.
 
-### Cross-backend comparison
-
-Per-vblank hit rate on the wonderous bundle at 60 Hz:
+**Cross-backend comparison.** Per-vblank hit rate on the wonderous
+bundle at 60 Hz:
 
 | Backend | 60Hz on-vblank | Mean interval | Notes |
 |---|---:|---:|---|
@@ -353,41 +494,56 @@ or 32-byte AVX2), so 1024×768 BGRA→XRGB is well under 1 ms on a
 modern host. A panel with a faster CPU or smaller dimensions would
 push the histogram toward wayland_egl's profile.
 
+---
+
 ## Known limitations
 
-1. **No platform-view compositor.** `GetCompositorConfig()` returns
-   a struct with all callbacks null, so the engine uses the
-   non-compositor `surface_present_callback` path for the entire
-   scene. Layer interleaving with platform views would need a
-   software compositor (one CPU-allocated buffer per layer + blend
-   on the rasterizer). Doable, not done.
-2. **fbdev / DRM pixel formats** are limited to 32-bpp BGRA/BGRX
-   and 16-bpp RGB565. RGB555, packed-YUV, 10-bpc (XRGB2101010), and
-   palettized layouts would each need a dedicated pack helper in
-   `pixel_swizzle.h`. RGB555 is the closest existing case
-   (`FlutterToRGB565` is the template; mask widths shift by one bit
-   on R/B and G drops from 6 to 5).
-3. **`DrmDumbSink` picks the first connected connector** and its
-   currently-bound CRTC. Multi-output panels, choosing by name
-   (`HDMI-A-1`), or explicit mode selection aren't yet exposed.
-   The sink-spec syntax has room — `drm-dumb:/dev/dri/card0,connector=HDMI-A-1,mode=1920x1080@60`
-   would parse cleanly when the use case shows up.
-4. **Input coverage is partial.** `SoftwareSeat` (see *Input* above)
-   handles pointer, keyboard, key-repeat, and multi-touch via
-   libinput. Not yet wired: gesture events (`LIBINPUT_EVENT_GESTURE_*`),
-   switch events, tablet/pen, hot keymap reload, libseat session
-   integration (devices are opened directly under the calling
-   process's credentials).
-5. **fbdev has no vsync**. `FBIO_WAITFORVSYNC` is broadly broken
-   across drivers and not standardized; the sink doesn't expose it.
-   For real vsync on a CPU-only SoC, use `drm-dumb` instead.
-6. **`DrmDumbSink` refresh from `vrefresh`** is integer Hz; modes
-   that report 59.94 round to 60 and Flutter's deadline drifts
-   ~one frame per 17 minutes. If drift matters, switch to
-   `mode.clock * 1000 / (htotal * vtotal)`.
-7. **BE host (big-endian)** isn't tested. `pixel_swizzle.h` keeps a
-   correct branch for DRM XRGB (byte order is endian-invariant per
-   drm_fourcc.h), but fbdev with `red.offset=16` lands at memory
-   `[X,R,G,B]` on BE rather than `[B,G,R,X]` — `FbDevSink` would
-   need a dedicated helper. Not implemented since all shipping
-   targets are LE; flagged for the day a BE target appears.
+- **No platform-view compositor.** `GetCompositorConfig()` returns
+  a struct with all callbacks null, so the engine uses the
+  non-compositor `surface_present_callback` path for the entire
+  scene. Layer interleaving with platform views would need a
+  software compositor (one CPU-allocated buffer per layer + blend
+  on the rasterizer). Doable, not done.
+- **fbdev / DRM pixel formats** are limited to 32-bpp BGRA/BGRX
+  and 16-bpp RGB565. RGB555, packed-YUV, 10-bpc (XRGB2101010), and
+  palettized layouts would each need a dedicated pack helper in
+  `pixel_swizzle.h`. RGB555 is the closest existing case
+  (`FlutterToRGB565` is the template; mask widths shift by one bit
+  on R/B and G drops from 6 to 5).
+- **`DrmDumbSink` picks the first connected connector** and its
+  currently-bound CRTC. Multi-output panels, choosing by name
+  (`HDMI-A-1`), or explicit mode selection aren't yet exposed.
+  The sink-spec syntax has room — `drm-dumb:/dev/dri/card0,connector=HDMI-A-1,mode=1920x1080@60`
+  would parse cleanly when the use case shows up.
+- **Input coverage is partial.** `SoftwareSeat` (see *Input* above)
+  handles pointer, keyboard, key-repeat, and multi-touch via
+  libinput. Not yet wired: gesture events (`LIBINPUT_EVENT_GESTURE_*`),
+  switch events, tablet/pen, hot keymap reload, libseat session
+  integration (devices are opened directly under the calling
+  process's credentials).
+- **fbdev has no vsync**. `FBIO_WAITFORVSYNC` is broadly broken
+  across drivers and not standardized; the sink doesn't expose it.
+  For real vsync on a CPU-only SoC, use `drm-dumb` instead.
+- **`DrmDumbSink` refresh from `vrefresh`** is integer Hz; modes
+  that report 59.94 round to 60 and Flutter's deadline drifts
+  ~one frame per 17 minutes. If drift matters, switch to
+  `mode.clock * 1000 / (htotal * vtotal)`.
+- **BE host (big-endian)** isn't tested. `pixel_swizzle.h` keeps a
+  correct branch for DRM XRGB (byte order is endian-invariant per
+  drm_fourcc.h), but fbdev with `red.offset=16` lands at memory
+  `[X,R,G,B]` on BE rather than `[B,G,R,X]` — `FbDevSink` would
+  need a dedicated helper. Not implemented since all shipping
+  targets are LE; flagged for the day a BE target appears.
+
+---
+
+## References
+
+- [backend/backend.h](../backend.h) — the `Backend` interface `SoftwareBackend` implements.
+- [shell/backend/README.md](../README.md) — backend selection overview.
+- [drm_kms_egl](../drm_kms_egl/README.md) — the drm fd / asio page-flip pattern `DrmDumbSink` mirrors.
+- [wayland_vulkan](../wayland_vulkan/README.md) — the FIFO / strict-vblank-gating finding cross-referenced in Benchmarks.
+- [shell/vsync](../../vsync/README.md) — the shared `IVsyncProvider` baton lifecycle.
+- [shell/profiling](../../profiling/README.md) — `FrameProfile` and the `IVI_*_PROFILE` cadence histograms.
+- [shell/input](../../input/README.md) — the sibling `DrmSeat` libinput/xkb stack `SoftwareSeat` parallels.
+- Linux `linux/fb.h` (fbdev), `libdrm` / `drm_fourcc.h` (dumb buffers), `libinput` + `xkbcommon` (input), `vkms` / `vfb` kernel modules (test harness).

--- a/shell/backend/software/README.md
+++ b/shell/backend/software/README.md
@@ -202,6 +202,14 @@ Sink / input sub-options:
 - **libinput + libudev + xkbcommon** present → `BUILD_SOFTWARE_INPUT_LIBINPUT`
   auto-on, `SoftwareSeat` compiled in; absent → no CPU-backend input.
 
+### Toolchain compatibility
+
+`drm_dumb_sink.h` explicitly includes `<array>` rather than relying on a
+transitive include. This is required on Yocto dunfell (riscv64 / armv7),
+where older toolchains do not expose `std::array` transitively through
+`<atomic>` or `<functional>` and the build otherwise stops with
+`implicit instantiation of undefined template 'std::array<…>'`.
+
 ---
 
 ## Running
@@ -534,6 +542,14 @@ push the histogram toward wayland_egl's profile.
   `[X,R,G,B]` on BE rather than `[B,G,R,X]` — `FbDevSink` would
   need a dedicated helper. Not implemented since all shipping
   targets are LE; flagged for the day a BE target appears.
+- **Headers rely on transitive includes for some std:: types.** As of
+  v3.0 the tree-wide sweep in commit `24e01fe3` added `#include <array>`
+  to `drm_dumb_sink.h` (the backend's headers are now self-sufficient
+  for `std::vector`, `std::string`, `std::map`, `std::array`, and
+  `std::function`). This is the sort of latent dependency that breaks
+  Yocto dunfell toolchains on riscv64/armv7 — the new toolchain
+  includes enough for it to compile, but the explicit include is the
+  durable fix.
 
 ---
 

--- a/shell/backend/wayland_egl/README.md
+++ b/shell/backend/wayland_egl/README.md
@@ -150,6 +150,14 @@ ninja -C build
 | + platform-view compositor | `BUILD_BACKEND_WAYLAND_EGL=ON BUILD_COMPOSITOR=ON` | adds `egl_backing_store.cc`, `gl_caps.cc`, `gl_compositor.cc` |
 | + debug HUD | `... BUILD_COMPOSITOR=ON BUILD_HUD=ON` | adds the imgui GL HUD (`GlHud`) |
 
+### Toolchain compatibility
+
+`egl.h` explicitly includes `<array>` rather than relying on a transitive
+include. This is required on Yocto dunfell (riscv64 / armv7), where older
+toolchains do not expose `std::array` transitively through `<vector>` or
+`<EGL/egl.h>` and the build otherwise stops with
+`implicit instantiation of undefined template 'std::array<…>'`.
+
 ---
 
 ## Running
@@ -403,6 +411,12 @@ the bundle stayed stable for much longer.
    drop the mutex on `feedback_in_flight_`, but it's a fleet-wide
    change to all Wayland event handling and is deferred to a separate
    change.
+4. **Headers rely on transitive includes for some std:: types.** As of
+   v3.0 the tree-wide sweep in commit `24e01fe3` added `#include <array>`
+   to `egl.h`. The backend's headers are now self-sufficient for
+   `std::vector`, `std::string`, `std::map`, `std::array`, and
+   `std::function` — the explicit include is the durable fix for toolchains
+   that don't pull `<array>` in transitively (e.g. Yocto dunfell).
 ---
 
 ## References

--- a/shell/backend/wayland_egl/README.md
+++ b/shell/backend/wayland_egl/README.md
@@ -5,27 +5,52 @@ buffer pool) with the optional homescreen GL compositor for platform views.
 This README covers the parts that aren't obvious from the source — the
 compositor-mediated vsync path in particular.
 
-## Vsync via `wp_presentation_feedback`
+## Features
 
-The compositor — not the application — owns the scanout schedule on
-Wayland. There is no equivalent of `drmModePageFlip` to wait on. The
-right hook is the `wp_presentation_time` extension: every commit you
-care about, you mint a `wp_presentation_feedback` object before
-`wl_surface.commit` and the compositor sends you back a `presented`
-event with the realized scanout timestamp.
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| EGL + GL ES presenter on `wl_egl_window` | Built-in | `BUILD_BACKEND_WAYLAND_EGL` |
+| Compositor-mediated vsync via `wp_presentation_feedback` | Built-in | `IVI_WL_VSYNC` (default on); needs `wp_presentation` + `CLOCK_MONOTONIC` |
+| Wall-clock scheduler fallback | Built-in | Auto when vsync unusable / `IVI_WL_VSYNC=0` |
+| Partial repaint (buffer-age + `eglSetDamageRegionKHR` + `eglSwapBuffersWithDamageKHR`) | Built-in (Skia GL only) | Auto-disabled under Impeller (`--enable-impeller`) |
+| GL compositor for platform views | Opt-in | `BUILD_COMPOSITOR` |
+| Debug HUD (imgui GL) | Opt-in | `BUILD_HUD` + `BUILD_COMPOSITOR`; `IVI_HUD` / F12 |
+| Per-frame cadence profiling | Opt-in | `IVI_WL_PROFILE` |
+| Motion-to-photon profiling | Opt-in | `IVI_M2P_PROFILE` / `IVI_PROFILE` |
+| EGL share-context export to plugins (`GetEglContext`) | Built-in | Always |
 
-```
-Flutter raster thread                Display event_thread_
-─────────────────────                ────────────────────
-PresentLayers
-  RequestPresentationFeedback()      ───┐
-  eglSwapBuffers (commits surface)      │  compositor scans out
-  …                                     │
-                                        ▼
-                                     on_feedback_presented(tv_ns, refresh)
-                                        ├─ update last_refresh_ns_
-                                        ├─ exchange vsync_baton_
-                                        └─ asio::post(strand, [&]{ OnVsync() })
+---
+
+## Architecture
+
+The `WaylandEglBackend` derives from both [Egl](egl.h) (EGL context/surface
+lifecycle, damage-extension probing) and the abstract
+[Backend](../backend.h) interface (renderer/compositor config + vsync). It
+owns a `wl_egl_window` bound to the view's `wl_surface`, and — when
+`BUILD_COMPOSITOR` is set — a GL compositor plus backing-store pools for
+platform-view layers.
+
+The compositor — not the application — owns the scanout schedule on Wayland.
+There is no equivalent of `drmModePageFlip` to wait on. The right hook is the
+`wp_presentation_time` extension: every commit you care about, you mint a
+`wp_presentation_feedback` object before `wl_surface.commit` and the compositor
+sends you back a `presented` event with the realized scanout timestamp. The
+`wp_presentation` machinery lives in a Display-owned
+[WaylandVsyncProvider](../../vsync/wayland_vsync_provider.h); the backend
+forwards to it (gate, baton submit, feedback request, stop).
+
+```mermaid
+sequenceDiagram
+    participant R as Flutter raster thread
+    participant E as Display event_thread_
+    R->>R: PresentLayers
+    R->>E: RequestPresentationFeedback()
+    R->>R: eglSwapBuffers (commits surface)
+    Note over E: compositor scans out
+    E->>E: on_feedback_presented(tv_ns, refresh)
+    E->>E: update last_refresh_ns_
+    E->>E: exchange vsync_baton_
+    E->>R: asio::post(strand, [&]{ OnVsync() })
 ```
 
 The baton-return path uses the platform task runner's strand so
@@ -37,7 +62,7 @@ The baton-return path uses the platform task runner's strand so
 inline via `PostOnVsync` so Flutter doesn't sit forever waiting for an
 `OnVsync` that would never come from a commit that hasn't happened yet.
 
-## When `vsync_callback` is wired
+### When `vsync_callback` is wired
 
 `WaylandEglBackend::GetVsyncCallback()` returns `&VsyncTrampoline` iff
 all three of:
@@ -53,7 +78,92 @@ Otherwise it returns `nullptr` and the engine falls back to its
 internal wall-clock scheduler. The decision is logged once at startup
 (`info`-level — "wp_presentation not advertised" / "clock_id != CLOCK_MONOTONIC").
 
-## Env vars
+### Module responsibilities
+
+- **Presentation.** `WaylandEglBackend` builds the `FlutterRendererConfig`
+  (OpenGL), maps the `wl_egl_window` to an EGL surface, and drives
+  `eglSwapBuffers` / the damage swap path from the rasterizer thread.
+- **Vsync.** The backend forwards to the Display-owned `WaylandVsyncProvider`:
+  `GetVsyncCallback` gates on `vsync_->Usable()`; `VsyncTrampoline` →
+  `SetVsyncBaton` → `vsync_->SubmitBaton`; `RequestPresentationFeedback` →
+  `vsync_->RequestFeedback`; `StopVsyncMonitor` → `vsync_->Stop`.
+- **Partial repaint.** Buffer-age existing-damage tracking
+  (`m_existing_damage_map`, `m_damage_history`) feeds
+  `eglSetDamageRegionKHR` / `eglSwapBuffersWithDamageKHR` — Skia GL only (see
+  [partial_repaint_gate.h](partial_repaint_gate.h)).
+- **Compositor (`BUILD_COMPOSITOR`).** `GlCompositor` blits/quad-composites
+  backing stores onto the window framebuffer for platform-view layers;
+  `GlCaps` probes the runtime GL feature set; `EglFboBackingStore` /
+  `EglTextureBackingStore` (pooled via `BackingStorePool`) hold the engine's
+  render targets.
+
+### File map
+
+| Path | Responsibility |
+|------|----------------|
+| [wayland_egl.h](wayland_egl.h) / [wayland_egl.cc](wayland_egl.cc) | `WaylandEglBackend` — surface lifecycle, renderer/compositor config, vsync forwarding, partial repaint, swap profiling |
+| [egl.h](egl.h) / [egl.cc](egl.cc) | `Egl` base — EGL display/context/surface, make-current, swap, damage-extension probing (`EGL_KHR_partial_update`, buffer age) |
+| [partial_repaint_gate.h](partial_repaint_gate.h) | `EngineSwitchesEnableImpeller()` — pure parse of `--enable-impeller` to gate the partial-repaint path |
+| [gl_caps.h](gl_caps.h) / [gl_caps.cc](gl_caps.cc) | `GlCaps` — runtime GL capability probe (`BUILD_COMPOSITOR`) |
+| [gl_compositor.h](gl_compositor.h) / [gl_compositor.cc](gl_compositor.cc) | `GlCompositor` — blit / quad-shader layer composition (`BUILD_COMPOSITOR`) |
+| [egl_backing_store.h](egl_backing_store.h) / [egl_backing_store.cc](egl_backing_store.cc) | `EglFboBackingStore` / `EglTextureBackingStore` — engine render targets (`BUILD_COMPOSITOR`) |
+
+### Threading model
+
+The `on_feedback_presented` / `discarded` listeners fire on
+[Display](../../wayland/display.h)'s `event_thread_`, which is a separate thread
+from the platform task runner. That's why the feedback-in-flight state is
+guarded by a mutex and `OnVsync` is always posted via the runner's strand
+(never inline). `RequestPresentationFeedback` runs on the rasterizer thread
+(the `m_wl_surface` handle is `std::atomic` because `CreateSurface` on the
+platform thread can otherwise race it during a resize). The `eglSwapBuffers`
+self-time profile (`swap_profile_`) is accumulated and flushed entirely on the
+rasterizer thread, kept separate from the event-thread cadence profile to avoid
+a cross-thread data race.
+
+A future refactor could move `wl_display_dispatch` onto the platform task runner
+via an asio `async_wait` on the display fd — at which point the listener would
+fire on the runner thread, the mutex could be dropped, and `OnVsync` could be
+called inline. That change is out of scope here because it touches all Wayland
+event dispatch (input, configure, output).
+
+---
+
+## Build steps
+
+### Configure + build
+
+The backend compiles when `BUILD_BACKEND_WAYLAND_EGL` is enabled. Platform-view
+composition (the `GlCompositor` / backing-store sources) additionally requires
+`BUILD_COMPOSITOR`.
+
+```sh
+cmake -B build -G Ninja -DBUILD_BACKEND_WAYLAND_EGL=ON
+ninja -C build
+```
+
+### Build matrix
+
+| Config | CMake flags | Present path compiled in |
+|--------|-------------|--------------------------|
+| Base EGL presenter | `BUILD_BACKEND_WAYLAND_EGL=ON` | `wayland_egl.cc`, `egl.cc`, `gl_process_resolver.cc` |
+| + platform-view compositor | `BUILD_BACKEND_WAYLAND_EGL=ON BUILD_COMPOSITOR=ON` | adds `egl_backing_store.cc`, `gl_caps.cc`, `gl_compositor.cc` |
+| + debug HUD | `... BUILD_COMPOSITOR=ON BUILD_HUD=ON` | adds the imgui GL HUD (`GlHud`) |
+
+---
+
+## Running
+
+Runtime requires a Wayland compositor. For the compositor-mediated vsync path,
+the compositor must advertise the `wp_presentation` global with a
+`CLOCK_MONOTONIC` clock (KWin, Mutter, weston, sway). When it does not, the
+backend logs the reason once and falls back to Flutter's internal wall-clock
+scheduler.
+
+Read logs on stderr; the vsync-wiring decision and profiling summaries are
+emitted at `info` level.
+
+### Env vars
 
 | Env | Default | Effect |
 |------|---------|--------|
@@ -62,17 +172,6 @@ internal wall-clock scheduler. The decision is logged once at startup
 | `IVI_M2P_PROFILE` | (off) | Anything non-empty enables the **motion-to-photon** (input-to-scanout) profiler. Joins kernel input time from `zwp_input_timestamps_v1` (pointer/touch) with compositor scanout time from `wp_presentation` feedback. Reports two latencies per window: **frame-accurate** — each input is attributed to the frame whose build cutoff (the baton's `frame_start_time`) is at or after it, i.e. the frame that actually rendered it, giving true `present − input`; and **floor** — `present − input` for the first scanout at or after the input, which under-counts by the engine pipeline depth. Every 120 presents logs `[wayland] motion->photon: frame-accurate p50=Xms p99=Yms max=Zms \| floor p50=xms p99=yms \| n=N dropped=D`, plus a session summary (both metrics) at teardown; their difference is the pipeline depth (typically one to two frames). `IVI_PROFILE` enables it too. |
 
 ## Architectural notes
-
-**Single-threaded vs platform-runner dispatch.** The `on_feedback_presented` /
-`discarded` listeners fire on `Display::event_thread_`, which is a
-separate thread from the platform task runner. That's why
-`feedback_in_flight_` is guarded by a mutex and `OnVsync` is always
-posted via the runner's strand (never inline). A future refactor could
-move `wl_display_dispatch` onto the platform task runner via an asio
-`async_wait` on the display fd — at which point the listener would fire
-on the runner thread, the mutex could be dropped, and `OnVsync` could
-be called inline. That change is out of scope here because it touches
-all Wayland event dispatch (input, configure, output).
 
 **Per-commit object, not a long-lived stream.** Unlike DRM's
 `PAGE_FLIP_EVENT` (one fd you read forever), `wp_presentation_feedback`
@@ -112,6 +211,62 @@ active renderer is inferred from the `--enable-impeller` engine switch
 `partial_repaint_gate.h`. Finishing Impeller's own present-damage wiring
 in the engine is what would let this path light up under Impeller.
 
+### What the compositor is responsible for
+
+Unlike DRM where the application owns the scanout schedule, on Wayland the
+compositor decides:
+
+- When the frame actually presents (it may delay, e.g. to align with another
+  surface's commit on a transactional compositor like KWin).
+- The realized refresh rate (compositor reports it per-frame in
+  `wp_presentation_feedback.refresh`; can change mid-session for
+  variable-refresh-rate panels).
+- Whether the commit is direct-scanned-out or composited (reported via the
+  `flags` arg: `WP_PRESENTATION_FEEDBACK_KIND_ZERO_COPY` indicates direct
+  scanout).
+
+The client's job is to feed the compositor at the cadence the compositor asks
+for, then trust its `presented` events for pacing. That's what this backend
+does.
+
+---
+
+## Diagnostics/Debug
+
+- **`IVI_WL_PROFILE=1`** adds a log line every 60 presented frames with
+  mean/max interval, discarded count, the compositor-reported refresh, and a
+  5-bucket histogram of per-frame intervals against a 60Hz baseline (≤17ms =
+  on-vblank, 18-33ms = 1 vblank missed, 34-50ms = 2 vblanks missed, 51-100ms =
+  slow, >100ms = idle/pause). On clean shutdown, `StopVsyncMonitor` emits a
+  one-line session summary + histogram covering the entire run.
+- **`WAYLAND_DEBUG=client`** gives the raw protocol trace — useful to verify
+  that exactly one `wp_presentation_feedback` request is minted per commit and
+  exactly one `presented` or `discarded` returns per request.
+- **Validation:** compare `mean_interval` to compositor-reported `refresh` — if
+  they match, the client is keeping cadence; if `mean_interval > refresh`, the
+  client is missing vblanks. The histogram makes the *miss distribution* legible
+  (occasional double-miss vs. constant single-miss have different root causes).
+
+### Known limitations / follow-ups
+
+1. **SIGTERM shutdown is racy** — `WaylandEglBackend::GetRenderConfig` lambdas
+   dereference `state->view_controller->engine` after teardown, producing a
+   SIGSEGV ~1.9s after SIGTERM. Reproduces identically with `IVI_WL_VSYNC=0`, so
+   the race is pre-existing and unrelated to the wp_presentation vsync work. DRM
+   fixed the analogous race in commit `17ade4ef [shutdown] race-free
+   engine/view/embedder teardown on SIGTERM`; wayland_egl needs the same
+   treatment.
+2. **Cross-clock translation not implemented** — when the compositor advertises
+   a `clock_id` other than `CLOCK_MONOTONIC`, this backend falls back to the
+   wall-clock scheduler. Could be lifted by sampling both clocks once at startup
+   and adding the delta to each `presented` timestamp before passing it to
+   `OnVsync`. No mainline compositor needs this today.
+3. **`wl_display_dispatch` still on its own thread** — see the Threading model
+   section above. Moving dispatch to the platform task runner via asio would
+   simplify the synchronization model and drop the mutex on the feedback state,
+   but it's a fleet-wide change to all Wayland event handling and is deferred to
+   a separate change.
+
 ---
 
 ## Benchmarks
@@ -141,11 +296,11 @@ refresh`, the client is missing vblanks. The histogram makes the *miss
 distribution* legible (occasional double-miss vs. constant single-miss
 have different root causes).
 
-### Headline result — KWin Wayland @ 60Hz
+### Results summary
 
-Aggregate across 23 profile windows (~23 seconds, 1380 presented
-frames) on the flutter-wonderous-app bundle, `IVI_WL_VSYNC=1
-IVI_WL_PROFILE=1`:
+Headline result — KWin Wayland @ 60Hz. Aggregate across 23 profile windows
+(~23 seconds, 1380 presented frames) on the flutter-wonderous-app bundle,
+`IVI_WL_VSYNC=1 IVI_WL_PROFILE=1`:
 
 | Metric | Value |
 |---|---:|
@@ -173,11 +328,11 @@ double-skip into the 20Hz bucket or worse. That's KWin's transactional
 commit model: once the deadline is missed, the next entire vblank is
 forfeit, not just half of it.
 
-### Comparison to `drm_kms_egl`
+#### Comparison to `drm_kms_egl`
 
-DRM benchmark (from `shell/backend/drm_kms_egl/README.md`):
-amdgpu RDNA/Polaris @ 240Hz, same wonderous bundle, `IVI_DRM_RT=1
-IVI_DRM_VSYNC=1`, 64,769-frame sample.
+DRM benchmark (from [drm_kms_egl](../drm_kms_egl/README.md)): amdgpu
+RDNA/Polaris @ 240Hz, same wonderous bundle, `IVI_DRM_RT=1 IVI_DRM_VSYNC=1`,
+64,769-frame sample.
 
 | Metric | DRM @ 240Hz | wayland_egl @ 60Hz |
 |---|---:|---:|
@@ -213,7 +368,7 @@ hash-table crash within ~30s, capping the runtime per smoke. The
 240Hz DRM measurement was on different hardware (Jetson Orin) where
 the bundle stayed stable for much longer.
 
-### Differences from `drm_kms_egl` (architecture)
+#### Differences from `drm_kms_egl` (architecture)
 
 | Aspect | drm_kms_egl | wayland_egl |
 |---|---|---|
@@ -224,22 +379,6 @@ the bundle stayed stable for much longer.
 | Discards | n/a (kernel never drops a flip silently) | Possible (compositor may supersede or occlude); counted as a frame for baton purposes |
 | Direct scanout | REFLECT_Y probe enables it on capable hardware | Compositor decides; client cannot opt in |
 
-### What the compositor is responsible for
-
-Unlike DRM where the application owns the scanout schedule, on Wayland
-the compositor decides:
-- When the frame actually presents (it may delay, e.g. to align with
-  another surface's commit on a transactional compositor like KWin).
-- The realized refresh rate (compositor reports it per-frame in
-  `wp_presentation_feedback.refresh`; can change mid-session for
-  variable-refresh-rate panels).
-- Whether the commit is direct-scanned-out or composited (reported via
-  the `flags` arg: `WP_PRESENTATION_FEEDBACK_KIND_ZERO_COPY` indicates
-  direct scanout).
-
-The client's job is to feed the compositor at the cadence the compositor
-asks for, then trust its `presented` events for pacing. That's what
-this backend does.
 
 ---
 
@@ -264,3 +403,15 @@ this backend does.
    drop the mutex on `feedback_in_flight_`, but it's a fleet-wide
    change to all Wayland event handling and is deferred to a separate
    change.
+---
+
+## References
+
+- [EGL base class](egl.h) — EGL context/surface lifecycle, damage extensions
+- [Backend interface](../backend.h) — display-target abstraction
+- [Backend overview README](../README.md)
+- [WaylandVsyncProvider](../../vsync/wayland_vsync_provider.h) — `wp_presentation` vsync source
+- [drm_kms_egl backend README](../drm_kms_egl/README.md) — DRM comparison baseline
+- [Display](../../wayland/display.h) — owns `event_thread_` and the vsync provider
+- `wp_presentation_time` Wayland protocol extension
+- `EGL_KHR_partial_update`, `EGL_EXT_buffer_age`, `EGL_KHR_swap_buffers_with_damage`

--- a/shell/backend/wayland_egl/README.md
+++ b/shell/backend/wayland_egl/README.md
@@ -14,7 +14,7 @@ compositor-mediated vsync path in particular.
 | Wall-clock scheduler fallback | Built-in | Auto when vsync unusable / `IVI_WL_VSYNC=0` |
 | Partial repaint (buffer-age + `eglSetDamageRegionKHR` + `eglSwapBuffersWithDamageKHR`) | Built-in (Skia GL only) | Auto-disabled under Impeller (`--enable-impeller`) |
 | GL compositor for platform views | Opt-in | `BUILD_COMPOSITOR` |
-| Debug HUD (imgui GL) | Opt-in | `BUILD_HUD` + `BUILD_COMPOSITOR`; `IVI_HUD` / F12 |
+| Debug HUD (imgui GL) | Opt-in | `BUILD_HUD` + `BUILD_COMPOSITOR`; `IVI_HUD` / `[hud].enable` |
 | Per-frame cadence profiling | Opt-in | `IVI_WL_PROFILE` |
 | Motion-to-photon profiling | Opt-in | `IVI_M2P_PROFILE` / `IVI_PROFILE` |
 | EGL share-context export to plugins (`GetEglContext`) | Built-in | Always |

--- a/shell/backend/wayland_leased_drm/README.md
+++ b/shell/backend/wayland_leased_drm/README.md
@@ -15,6 +15,144 @@ Target use cases: an instrument cluster or HUD panel leased from a primary IVI
 compositor, and any deployment where one process must own a connector while a
 compositor owns the rest of the card.
 
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| DRM connector lease via `wp_drm_lease_device_v1` (drm-lease-v1, staging) | Built-in | `BUILD_BACKEND_WAYLAND_LEASED_DRM` |
+| EGL/GBM scanout on the leased fd | Opt-in | `wayland-leased-drm-egl` key; `BUILD_BACKEND_DRM_KMS_EGL` |
+| Vulkan scanout on the leased fd | Opt-in | `wayland-leased-drm-vulkan` key; `BUILD_BACKEND_DRM_KMS_VULKAN` |
+| CPU + dumb-buffer scanout on the leased fd | Opt-in | `wayland-leased-drm-software` key; `BUILD_BACKEND_SOFTWARE` + `BUILD_SOFTWARE_SINK_DRM` |
+| Read-only connector probe (`--lease-list-connectors`) | Built-in | Always; scriptable exit codes |
+| Revocation watch (`finished` / connection loss) on a monitor thread | Built-in | Always; latches `LeaseHold::revoked()` |
+| Bounded negotiation deadline | Built-in | `--lease-timeout-ms` (default 5000) |
+| Reacquire-and-rebuild after revocation | Not implemented | Deferred — revoke stops updates until process restart |
+
+---
+
+## Architecture
+
+Two axes, deliberately orthogonal:
+
+- **Acquisition** — how the DRM fd is obtained: direct open (`drm-kms-*`) vs
+  leased (here).
+- **Renderer** — how frames are produced: EGL/GBM, Vulkan, or CPU + dumb buffers.
+
+The lease only changes acquisition. That is why the egl tier's `make_backend` is
+`MakeDrmEglBackend` **unchanged**: the adopted-fd path is a construction tag on
+`DrmDisplay`, not a subclass, so the backend factory cannot tell the difference.
+
+```mermaid
+flowchart TD
+    main[main] --> reg["BackendRegistry\nwayland-leased-drm-{egl|vulkan|software}"]
+
+    subgraph md["make_display"]
+        acquire["LeaseClient::Acquire(cfg)"]
+        hold["LeaseHold\nlease_fd, connector_id, name,\ncard path, wl_display + monitor thread,\nrevoked flag"]
+        acquire --> hold
+        hold -->|egl / vulkan| drmdisp["DrmDisplay(AdoptFd, ..., fd, hold)"]
+        hold -->|software| swdisp["SoftwareDisplay + LeasedScanout\n{fd, connector_id, revoked, owner}"]
+    end
+
+    subgraph mb["make_backend"]
+        egl["MakeDrmEglBackend(cfg, display)\n[egl — reused verbatim]"]
+        vk["MakeDrmVulkanBackend(cfg, display)\n[vulkan — branches on display->adopted_fd()]"]
+        sw["DrmDumbSink::Create(fd, owner, conn, revoked)\n[software]"]
+    end
+
+    reg --> md
+    reg --> mb
+    drmdisp -.-> egl
+    drmdisp -.-> vk
+    swdisp -.-> sw
+```
+
+### Why compound registry keys
+
+The renderer determines the display type (`DrmDisplay` vs `SoftwareDisplay`), and
+`BackendDescriptor` requires `make_backend` to receive the concrete `IDisplay`
+its own `make_display` produced. A single key with an internal renderer switch
+would have to resolve the renderer *before* `make_display` runs — re-implementing
+key resolution inside a descriptor. Three keys keep the invariant.
+
+### What the adopted-fd path does differently
+
+The compositor, not this process, is the lessor:
+
+- **No `drmSetMaster`, no foreground-VT guard.** The lease fd is already master
+  over its leased object set; the compositor owns the VT.
+- **No `drmDropMaster` at teardown.** The lease is returned by destroying the
+  `wp_drm_lease_v1` object, which lets the compositor revoke and re-advertise.
+- **No libseat session.** The compositor already holds the session controller for
+  the seat; taking it would fight. Input falls back to direct evdev.
+- **Input can be duplicated, and defaults to off under a host session.** A leased
+  client has no `wl_surface`, so the compositor delivers it no input — its only
+  source is libinput on `/dev/input/event*`, and those reads are *ungrabbed*. On
+  a host with a live Wayland session that means every keystroke and pointer event
+  reaches **both** this process and the session compositor (input is duplicated,
+  not stolen). `lease_input` controls it: `auto` (default) reads evdev on an
+  embedded target — no `WAYLAND_DISPLAY` — but disables it when a host session is
+  detected, warning why; `on` forces evdev even under a session (an embedded box
+  running its own compositor, with input devices partitioned between them); `off`
+  never reads evdev. `--drm-no-seat` does **not** affect this — it bypasses
+  libseat, not input.
+- **Outputs are enumerated through the lease fd**, whose resource view the kernel
+  filters to the leased objects. Re-opening the card by path would both show
+  connectors we do not hold *and* require permissions a leased client may not
+  have — the whole point of leasing is not needing them.
+
+The fd is **borrowed**: `drm::Device::from_fd` does not close it, and neither does
+the sink. The `LeaseHold` owns it, and must outlive everything built on it. That
+is why the display holds the hold.
+
+### Revocation
+
+Revocation is normal, not exceptional: **every VT switch away from the compositor
+is a revoke**, because the compositor loses DRM master. Hot-unplug and compositor
+exit do it too. It arrives as `wp_drm_lease_v1.finished` on the monitor thread,
+which latches `LeaseHold::revoked()`.
+
+What the kernel does, verified against a real lease on vkms (see
+`test/unit_test/leased_drm_vkms-test`):
+
+- The KMS objects vanish from the fd's view — every commit naming them fails.
+- **The fd stays open and remains a functional render fd**: GEM allocation and
+  prime export still succeed. Leases partition mode objects only.
+
+Renderers gate on `revoked()`. The software tier drops the frame and *parks the
+vsync source* rather than discarding: parking makes the engine stall (the
+documented steady state), whereas handing the baton back would spin the UI and
+raster threads at 100% CPU with nothing reaching a panel.
+
+Note `wp_drm_lease_connector_v1.withdrawn` **post-grant does not revoke** — the
+spec is explicit that the lease is unaffected; just destroy the offer object.
+
+Reacquire-and-rebuild is not implemented yet; today a revoked lease means
+the panel stops updating until the process is restarted.
+
+### File map
+
+| Path | Responsibility |
+|------|----------------|
+| [lease_client.h](lease_client.h) | `LeaseClient` / `LeaseHold` / `LeaseConfig` / `LeaseOffer` API; `RevokeCause`, `LeaseError` enums; `MaybeListLeaseConnectors` entry point |
+| [lease_client.cc](lease_client.cc) | drm-lease-v1 negotiation state machine, monitor thread, revocation latch, read-only `Probe`, connector/device selection |
+
+### Threading model
+
+Negotiation is synchronous with a deadline on the caller's thread. Once granted,
+the `wl_display` moves to a **monitor thread** that lives for the process
+lifetime, so `finished` and `withdrawn` are always observed. The monitor thread
+latches `LeaseHold::revoked()` and runs `LeaseConfig::on_revoked` exactly once —
+either on the monitor thread, or inline on the caller's thread from `Acquire()`
+itself if `finished` arrived in the same dispatch batch as `lease_fd`. The
+handler must be cheap and must not block: the monitor thread is what teardown
+joins. `LatchRevoked` is idempotent and safe from either thread. Renderers read
+`revoked()` with acquire ordering; once true it never clears (reacquire builds a
+new `LeaseHold`). The monitor thread must outlive every backend built on the
+lease fd, so the display in every family owns the `LeaseHold`.
+
+---
+
 ## Read this first: can you actually get a lease?
 
 Two things must both be true, and the second one is what usually bites.
@@ -60,98 +198,7 @@ outside:
 | 1 | reached a lease device, but it offers **nothing** — the non-desktop gate above |
 | 2 | no Wayland session, or the compositor has no drm-lease-v1 |
 
-## Architecture
-
-```
-main → BackendRegistry["wayland-leased-drm-{egl|vulkan|software}"]
-  make_display:
-    LeaseClient::Acquire(cfg) ─▶ LeaseHold { lease_fd, connector_id, name,
-        │                                    card path, wl_display + monitor
-        │                                    thread, revoked flag }
-        ├── egl/vulkan ▶ DrmDisplay(AdoptFd, …, fd, hold)
-        └── software ─▶ SoftwareDisplay + LeasedScanout{fd, connector_id,
-                                                        revoked, owner}
-  make_backend:
-        ├── MakeDrmEglBackend(cfg, display)          [egl — reused verbatim]
-        ├── MakeDrmVulkanBackend(cfg, display)       [vulkan — branches on
-        │                                             display->adopted_fd()]
-        └── DrmDumbSink::Create(fd, owner, conn, revoked)   [software]
-```
-
-Two axes, deliberately orthogonal:
-
-- **Acquisition** — how the DRM fd is obtained: direct open (`drm-kms-*`) vs
-  leased (here).
-- **Renderer** — how frames are produced: EGL/GBM, Vulkan, or CPU + dumb buffers.
-
-The lease only changes acquisition. That is why the egl tier's `make_backend` is
-`MakeDrmEglBackend` **unchanged**: the adopted-fd path is a construction tag on
-`DrmDisplay`, not a subclass, so the backend factory cannot tell the difference.
-
-### Why compound registry keys
-
-The renderer determines the display type (`DrmDisplay` vs `SoftwareDisplay`), and
-`BackendDescriptor` requires `make_backend` to receive the concrete `IDisplay`
-its own `make_display` produced. A single key with an internal renderer switch
-would have to resolve the renderer *before* `make_display` runs — re-implementing
-key resolution inside a descriptor. Three keys keep the invariant.
-
-### What the adopted-fd path does differently
-
-The compositor, not this process, is the lessor:
-
-- **No `drmSetMaster`, no foreground-VT guard.** The lease fd is already master
-  over its leased object set; the compositor owns the VT.
-- **No `drmDropMaster` at teardown.** The lease is returned by destroying the
-  `wp_drm_lease_v1` object, which lets the compositor revoke and re-advertise.
-- **No libseat session.** The compositor already holds the session controller for
-  the seat; taking it would fight. Input falls back to direct evdev.
-- **Input can be duplicated, and defaults to off under a host session.** A leased
-  client has no `wl_surface`, so the compositor delivers it no input — its only
-  source is libinput on `/dev/input/event*`, and those reads are *ungrabbed*. On
-  a host with a live Wayland session that means every keystroke and pointer event
-  reaches **both** this process and the session compositor (input is duplicated,
-  not stolen). `lease_input` controls it: `auto` (default) reads evdev on an
-  embedded target — no `WAYLAND_DISPLAY` — but disables it when a host session is
-  detected, warning why; `on` forces evdev even under a session (an embedded box
-  running its own compositor, with input devices partitioned between them); `off`
-  never reads evdev. `--drm-no-seat` does **not** affect this — it bypasses
-  libseat, not input.
-- **Outputs are enumerated through the lease fd**, whose resource view the kernel
-  filters to the leased objects. Re-opening the card by path would both show
-  connectors we do not hold *and* require permissions a leased client may not
-  have — the whole point of leasing is not needing them.
-
-The fd is **borrowed**: `drm::Device::from_fd` does not close it, and neither does
-the sink. The `LeaseHold` owns it, and must outlive everything built on it. That
-is why the display holds the hold.
-
-## Revocation
-
-Revocation is normal, not exceptional: **every VT switch away from the compositor
-is a revoke**, because the compositor loses DRM master. Hot-unplug and compositor
-exit do it too. It arrives as `wp_drm_lease_v1.finished` on the monitor thread,
-which latches `LeaseHold::revoked()`.
-
-What the kernel does, verified against a real lease on vkms (see
-`test/unit_test/leased_drm_vkms-test`):
-
-- The KMS objects vanish from the fd's view — every commit naming them fails.
-- **The fd stays open and remains a functional render fd**: GEM allocation and
-  prime export still succeed. Leases partition mode objects only.
-
-Renderers gate on `revoked()`. The software tier drops the frame and *parks the
-vsync source* rather than discarding: parking makes the engine stall (the
-documented steady state), whereas handing the baton back would spin the UI and
-raster threads at 100% CPU with nothing reaching a panel.
-
-Note `wp_drm_lease_connector_v1.withdrawn` **post-grant does not revoke** — the
-spec is explicit that the lease is unaffected; just destroy the offer object.
-
-Reacquire-and-rebuild is not implemented yet; today a revoked lease means
-the panel stops updating until the process is restarted.
-
-## Status
+### Status
 
 | Tier | Registry key | Requires | State |
 |---|---|---|---|
@@ -167,7 +214,11 @@ what was configured, on hardware you may not own.
 Scope today: one connector per lease, one lease per process. Multi-connector
 leases and lease-per-view are deferred; the protocol supports both.
 
-## Build
+---
+
+## Build steps
+
+### Configure + build
 
 ```bash
 cmake -B build -G Ninja \
@@ -175,36 +226,43 @@ cmake -B build -G Ninja \
   -DBUILD_BACKEND_DRM_KMS_EGL=ON        # or: -DBUILD_BACKEND_SOFTWARE=ON
 ```
 
-The configure output says which tiers are registered. A lease-only build (no
-surface backends) links `wayland-client` alone — `wayland-cursor`, `xkbcommon`
-and `wayland-protocols` are surface-backend dependencies this client does not
-have. `drm-lease-v1.xml` is vendored under `shell/wayland/protocols/` because the
+The configure output says which tiers are registered.
+
+### Dependencies
+
+A lease-only build (no surface backends) links `wayland-client` alone —
+`wayland-cursor`, `xkbcommon` and `wayland-protocols` are surface-backend
+dependencies this client does not have. The lease client also links `libdrm`
+(`PkgConfig::DRM`): `drmGetDeviceNameFromFd2()` resolves the lease/enumeration fd
+to a node path. On a cross sysroot `xf86drm.h` lives under `<libdrm/>`, so the
+include dir must come from pkg-config rather than the default search path.
+
+`drm-lease-v1.xml` is vendored under `shell/wayland/protocols/` because the
 staging XML only ships with wayland-protocols >= 1.22 and the project floor is
 1.20.
 
+### Build matrix
+
+| Config | CMake flags | Present path compiled in |
+|--------|-------------|--------------------------|
+| EGL lease | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_DRM_KMS_EGL=ON` | `wayland-leased-drm-egl` → `MakeDrmEglBackend` (EGL/GBM) |
+| Vulkan lease | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_DRM_KMS_VULKAN=ON` | `wayland-leased-drm-vulkan` → `MakeDrmVulkanBackend` |
+| Software lease | `-DBUILD_BACKEND_WAYLAND_LEASED_DRM=ON -DBUILD_BACKEND_SOFTWARE=ON -DBUILD_SOFTWARE_SINK_DRM=ON` | `wayland-leased-drm-software` → `DrmDumbSink` (CPU + dumb buffers) |
+
+A tier whose renderer stack is not built is refused, not substituted (see
+[Status](#status)).
+
+---
+
 ## Running
+
+The compositor must implement drm-lease-v1 **and** be willing to offer the
+connector — see [Read this first](#read-this-first-can-you-actually-get-a-lease).
+Confirm with `homescreen --lease-list-connectors` before launching a bundle.
 
 ```bash
 homescreen --backend=wayland-leased-drm-egl --lease-connector=HDMI-A-1 -b <bundle>
 ```
-
-| Flag | Env | TOML | Meaning |
-|---|---|---|---|
-| `--backend` | — | `[view.backend] type` | `wayland-leased-drm[-vulkan\|-egl\|-software]`; the bare family name resolves vulkan → egl → software among the tiers this build registered. Name a tier explicitly to pin it |
-| `--lease-connector` | `HOMESCREEN_LEASE_CONNECTOR` | `[view.backend.lease] connector` | Connector to request by name. Unset + one offer takes it; unset + several is fatal and lists them |
-| `--lease-device` | `HOMESCREEN_LEASE_DEVICE` | `[view.backend.lease] device` | Which `wp_drm_lease_device_v1` when several are advertised (one per DRM node): index or node path |
-| `--lease-timeout-ms` | `HOMESCREEN_LEASE_TIMEOUT_MS` | `[view.backend.lease] timeout_ms` | Bound on the whole negotiation (default 5000) |
-| `--lease-input` | `HOMESCREEN_LEASE_INPUT` | `[view.backend.lease] input` | Read input from raw evdev: `auto` (default; on for embedded, off under a host Wayland session), `on` (force), `off` (never). See the input-duplication note above |
-
-The timeout is load-bearing, not cosmetic: the spec lets a compositor defer the
-DRM fd until it regains DRM master, so without a bound a VT-switched-away
-compositor would hang startup indefinitely. Every wait in the negotiation is
-bounded by it, including the roundtrips.
-
-The `drm_*` tuning knobs pass through unchanged for the egl tier, and
-`IVI_SW_DRM_MODE` / format / dither for the software tier — those describe how to
-drive a connector, which a lease does not change. `IVI_SW_SINK` is **not**
-consulted on the leased software path: the backend key already chose the sink.
 
 Failures are fatal by design. A leased backend that cannot get its lease has
 nothing to fall back to:
@@ -213,7 +271,59 @@ nothing to fall back to:
 [E] [leased-drm] could not acquire a lease: no connectors offered for leasing
 ```
 
-## Tests
+### CLI Flags
+
+| Flag | What it does |
+|------|-------------|
+| `--backend` | `wayland-leased-drm[-vulkan\|-egl\|-software]`; the bare family name resolves vulkan → egl → software among the tiers this build registered. Name a tier explicitly to pin it. TOML: `[view.backend] type` |
+| `--lease-connector` | Connector to request by name. Unset + one offer takes it; unset + several is fatal and lists them. TOML: `[view.backend.lease] connector` |
+| `--lease-device` | Which `wp_drm_lease_device_v1` when several are advertised (one per DRM node): index or node path. TOML: `[view.backend.lease] device` |
+| `--lease-timeout-ms` | Bound on the whole negotiation (default 5000). TOML: `[view.backend.lease] timeout_ms` |
+| `--lease-list-connectors` | Read-only probe of what the compositor will lease; prints offers and exits with a scriptable code. No bundle required |
+
+The timeout is load-bearing, not cosmetic: the spec lets a compositor defer the
+DRM fd until it regains DRM master, so without a bound a VT-switched-away
+compositor would hang startup indefinitely. Every wait in the negotiation is
+bounded by it, including the roundtrips.
+
+### Env vars
+
+| Env | Default | Effect |
+|------|---------|--------|
+| `HOMESCREEN_LEASE_CONNECTOR` | unset | Same as `--lease-connector` |
+| `HOMESCREEN_LEASE_DEVICE` | unset | Same as `--lease-device` |
+| `HOMESCREEN_LEASE_TIMEOUT_MS` | `5000` | Same as `--lease-timeout-ms` |
+
+The `drm_*` tuning knobs pass through unchanged for the egl tier, and
+`IVI_SW_DRM_MODE` / format / dither for the software tier — those describe how to
+drive a connector, which a lease does not change. `IVI_SW_SINK` is **not**
+consulted on the leased software path: the backend key already chose the sink.
+
+---
+
+## Diagnostics/Debug
+
+Reach for `homescreen --lease-list-connectors` first when a leased backend will
+not start. It runs before config parsing (raw `argv`, no bundle required), probes
+read-only, and distinguishes the two failures that look identical from the
+outside via scriptable exit codes: `0` offers listed, `1` reached a lease device
+but zero connectors offered (the non-desktop gate), `2` no Wayland session or no
+drm-lease-v1. It reads `--lease-device` and `--lease-timeout-ms` off `argv` for
+the same reason.
+
+Revocation causes are logged distinctly because they demand different operator
+actions (`RevokeCause`): `kFinished` (`wp_drm_lease_v1.finished` — VT switch away
+or hot-unplug, routine and self-healing on VT return), `kConnectionLost` (the
+compositor exited or crashed), and `kMonitorFailure` (poll error on the monitor
+thread; the lease's true state is unknown, treated as lost).
+
+Negotiation failures surface as `LeaseError` values, each a distinct operator
+signal: `kNoWaylandSession`, `kConnectFailed`, `kNoLeaseDevice`,
+`kDeviceAmbiguous`, `kDeviceNotFound`, `kNoOffers`, `kConnectorAmbiguous`,
+`kConnectorNotFound`, `kDenied` (compositor sent `finished` instead of
+`lease_fd`), `kTimeout`, `kProtocolError`.
+
+### Tests
 
 | Tier | Target | Needs |
 |---|---|---|
@@ -245,3 +355,15 @@ sudo modprobe vkms
 
 Alternatively pin the compositor away from vkms (`WLR_DRM_DEVICES`) or create a
 private device via `/sys/kernel/config/vkms`.
+
+---
+
+## References
+
+- [drm-lease-v1 (staging) protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/drm-lease/drm-lease-v1.xml) — `wp_drm_lease_device_v1`
+- [wayland.app drm-lease-v1 support matrix](https://wayland.app/protocols/drm-lease-v1)
+- [drm_kms_egl backend](../drm_kms_egl/README.md) — direct-open EGL/GBM present path reused here
+- [drm_kms_vulkan backend](../drm_kms_vulkan/README.md) — direct-open Vulkan present path reused here
+- [software backend](../software/README.md) — CPU + dumb-buffer sink reused here
+- [wayland_egl backend](../wayland_egl/README.md) — sibling surface backend
+- `libdrm` (`PkgConfig::DRM`) — `drmGetDeviceNameFromFd2`, `drmModeCreateLease`

--- a/shell/backend/wayland_leased_drm/README.md
+++ b/shell/backend/wayland_leased_drm/README.md
@@ -280,6 +280,7 @@ nothing to fall back to:
 | `--lease-device` | Which `wp_drm_lease_device_v1` when several are advertised (one per DRM node): index or node path. TOML: `[view.backend.lease] device` |
 | `--lease-timeout-ms` | Bound on the whole negotiation (default 5000). TOML: `[view.backend.lease] timeout_ms` |
 | `--lease-list-connectors` | Read-only probe of what the compositor will lease; prints offers and exits with a scriptable code. No bundle required |
+| `--lease-input` | Raw-evdev input policy: `auto` (enabled only without a host Wayland session), `on`, or `off`. TOML: `[view.backend.lease] input` |
 
 The timeout is load-bearing, not cosmetic: the spec lets a compositor defer the
 DRM fd until it regains DRM master, so without a bound a VT-switched-away
@@ -293,6 +294,7 @@ bounded by it, including the roundtrips.
 | `HOMESCREEN_LEASE_CONNECTOR` | unset | Same as `--lease-connector` |
 | `HOMESCREEN_LEASE_DEVICE` | unset | Same as `--lease-device` |
 | `HOMESCREEN_LEASE_TIMEOUT_MS` | `5000` | Same as `--lease-timeout-ms` |
+| `HOMESCREEN_LEASE_INPUT` | `auto` | Same as `--lease-input` |
 
 The `drm_*` tuning knobs pass through unchanged for the egl tier, and
 `IVI_SW_DRM_MODE` / format / dither for the software tier — those describe how to
@@ -313,9 +315,9 @@ the same reason.
 
 Revocation causes are logged distinctly because they demand different operator
 actions (`RevokeCause`): `kFinished` (`wp_drm_lease_v1.finished` — VT switch away
-or hot-unplug, routine and self-healing on VT return), `kConnectionLost` (the
-compositor exited or crashed), and `kMonitorFailure` (poll error on the monitor
-thread; the lease's true state is unknown, treated as lost).
+or hot-unplug; commits remain gated until process restart), `kConnectionLost`
+(the compositor exited or crashed), and `kMonitorFailure` (poll error on the
+monitor thread; the lease's true state is unknown, treated as lost).
 
 Negotiation failures surface as `LeaseError` values, each a distinct operator
 signal: `kNoWaylandSession`, `kConnectFailed`, `kNoLeaseDevice`,

--- a/shell/backend/wayland_vulkan/README.md
+++ b/shell/backend/wayland_vulkan/README.md
@@ -175,6 +175,14 @@ ninja -C build
 | + platform-view compositor | `BUILD_BACKEND_WAYLAND_VULKAN=ON BUILD_COMPOSITOR=ON` | adds `vulkan_backing_store.cc`, `wl_layer_compositor.cc`, `wl_dmabuf_present.cc`, `wl_explicit_sync.cc` (enables `IVI_VK_DMABUF`) |
 | + debug HUD | `... BUILD_COMPOSITOR=ON BUILD_HUD=ON` | adds the imgui Vulkan HUD (`VulkanHud`) |
 
+### Toolchain compatibility
+
+`wayland_vulkan.h` explicitly includes `<functional>` rather than relying on a
+transitive include. This is required on Yocto dunfell (riscv64 / armv7), where
+older toolchains do not expose `std::function` transitively through
+`<condition_variable>`, `<mutex>`, or `<vector>` and the build otherwise stops
+with `implicit instantiation of undefined template 'std::function<…>'`.
+
 ---
 
 ## Running

--- a/shell/backend/wayland_vulkan/README.md
+++ b/shell/backend/wayland_vulkan/README.md
@@ -6,7 +6,58 @@ README covers the parts that aren't obvious from the source — the
 compositor-mediated vsync path, the present-mode lever, and the
 profiler used to characterize them.
 
-## Vsync via `wp_presentation_feedback`
+## Features
+
+| Capability | Status | Toggle / scope |
+|---|---|---|
+| Vulkan presenter on `VK_KHR_wayland_surface` WSI swapchain | Built-in | `BUILD_BACKEND_WAYLAND_VULKAN` (default on) |
+| Compositor-mediated vsync via `wp_presentation_feedback` | Built-in | `IVI_VK_VSYNC` (default on); needs `wp_presentation` + `CLOCK_MONOTONIC` |
+| Wall-clock scheduler fallback | Built-in | Auto when vsync unusable / `IVI_VK_VSYNC=0` |
+| Selectable swapchain present mode (`fifo`/`fifo_relaxed`/`mailbox`/`immediate`) | Built-in | `IVI_VK_PRESENT_MODE` (default `fifo`); falls back to FIFO if unadvertised |
+| Vulkan compositor for platform-view layers | Opt-in | `BUILD_COMPOSITOR` |
+| Zero-copy dma-buf present path (bypasses WSI swapchain) | Experimental | `IVI_VK_DMABUF`; needs `zwp_linux_dmabuf_v1` v4 + renderable modifier |
+| Explicit sync on the dma-buf path via `wp_linux_drm_syncobj` | Experimental | Auto when advertised + timeline semaphores; `IVI_VK_NO_EXPLICIT_SYNC` forces CPU fence |
+| VkQueue host-access serialization (queue interposer) | Built-in | Always (embedder proc-address swap) |
+| Vulkan share-context export to plugins (`GetVulkanContext`) | Built-in | Always once device is created |
+| Per-frame cadence profiling (incl. `pipeline_*` beginFrame-to-present) | Opt-in | `IVI_VK_PROFILE` |
+| Motion-to-photon profiling | Opt-in | `IVI_M2P_PROFILE` / `IVI_PROFILE` |
+
+---
+
+## Architecture
+
+The `WaylandVulkanBackend` derives from the abstract [Backend](../backend.h)
+interface. It brings up a Vulkan instance + device with the
+`VK_KHR_wayland_surface` WSI, creates a swapchain against the view's
+`wl_surface`, and drives `vkQueuePresentKHR` from the rasterizer thread. When
+`BUILD_COMPOSITOR` is set it additionally owns a Vulkan `LayerCompositor` plus
+backing-store pools for platform-view layers, and can optionally present via a
+zero-copy dma-buf path that bypasses the WSI swapchain entirely.
+
+The compositor — not the application — owns the scanout schedule on Wayland.
+The vsync hook is the `wp_presentation_time` extension: a
+`wp_presentation_feedback` object is minted before every commit and the
+compositor returns the realized scanout timestamp. The `wp_presentation`
+machinery lives in a Display-owned
+[WaylandVsyncProvider](../../vsync/wayland_vsync_provider.h); the backend
+forwards to it (gate, baton submit, feedback request, stop).
+
+```mermaid
+sequenceDiagram
+    participant R as Flutter raster thread
+    participant E as Display event_thread_
+    R->>R: PresentCallback / PresentLayersImpl
+    R->>E: RequestPresentationFeedback()
+    R->>R: vkQueuePresentKHR (commits)
+    Note over E: compositor scans out
+    E->>E: on_feedback_presented(tv_ns, refresh)
+    E->>E: update last_refresh_ns_
+    E->>E: exchange vsync_baton_
+    E->>E: store last_begin_frame_ns_
+    E->>R: asio::post(strand, [&]{ OnVsync() })
+```
+
+### Vsync via `wp_presentation_feedback`
 
 Architecturally identical to `wayland_egl`'s wiring — same baton dance,
 same Display event-thread dispatch — but with two practical differences
@@ -28,27 +79,14 @@ that turn out to matter:
    that wasn't already in play. What our wiring *does* add is delivering
    the timestamps to the Flutter Engine — Mesa keeps them to itself.
 
-```
-Flutter raster thread                Display event_thread_
-─────────────────────                ────────────────────
-PresentCallback / PresentLayersImpl
-  RequestPresentationFeedback()      ───┐
-  vkQueuePresentKHR (commits)           │  compositor scans out
-  …                                     │
-                                        ▼
-                                     on_feedback_presented(tv_ns, refresh)
-                                        ├─ update last_refresh_ns_
-                                        ├─ exchange vsync_baton_
-                                        ├─ store last_begin_frame_ns_
-                                        └─ asio::post(strand, [&]{ OnVsync() })
-```
+The baton flow is shown in the Mermaid sequence diagram above.
 
 `SetVsyncBaton` includes the same idle-wake kick as the EGL backend —
 if no feedback is in flight (first frame, post-idle wake from input)
 it drains the baton inline so Flutter doesn't sit forever waiting on
 a commit that hasn't been scheduled.
 
-## When `vsync_callback` is wired
+### When `vsync_callback` is wired
 
 `WaylandVulkanBackend::GetVsyncCallback()` returns `&VsyncTrampoline`
 iff all three of:
@@ -60,7 +98,98 @@ iff all three of:
 Otherwise it returns `nullptr` and the engine falls back to its
 internal wall-clock scheduler. The decision is logged once at startup.
 
-## Env vars
+### Module responsibilities
+
+- **Presentation.** `WaylandVulkanBackend` builds the `FlutterRendererConfig`
+  (Vulkan), creates the `VK_KHR_wayland_surface` WSI swapchain against the
+  view's `wl_surface`, and drives `vkQueuePresentKHR` from the rasterizer
+  thread (`PresentCallback` for non-compositor builds, `PresentLayersImpl`
+  under `BUILD_COMPOSITOR`).
+- **Vsync.** The backend forwards to the Display-owned `WaylandVsyncProvider`:
+  `GetVsyncCallback` gates on the three conditions above; `VsyncTrampoline` →
+  `SetVsyncBaton`; `RequestPresentationFeedback` mints a per-commit feedback
+  object; `StopVsyncMonitor` cancels outstanding objects before engine
+  teardown.
+- **Queue serialization.** `wayland_vulkan::VulkanQueueInterposer` serializes
+  host access to the single `VkQueue` shared between the Flutter raster thread
+  and the platform thread, via the embedder's
+  `get_instance_proc_address_callback` proc-swap contract.
+- **Compositor (`BUILD_COMPOSITOR`).** `wl_vulkan::LayerCompositor`
+  src-over-blends the Flutter layer stack into a slot image so platform-view
+  layers under transparent Flutter overlays compose correctly;
+  `VulkanBackingStore` (pooled via `BackingStorePool`) holds the engine's
+  `VkImage` render targets and tracks their layout.
+- **dma-buf present (`IVI_VK_DMABUF`).** `wl_vulkan::DmabufImage` /
+  `WlDmabufBuffer` (`wl_dmabuf_present`) allocate modifier-tiled,
+  dma-buf-exported `VkImage` slots wrapped as `wl_buffer`s;
+  `NegotiateModifiers` intersects GPU-exportable modifiers with the
+  compositor's advertised set; `wl_vulkan::ExplicitSync` (`wl_explicit_sync`)
+  provides `wp_linux_drm_syncobj` producer/consumer sync.
+
+### File map
+
+| Path | Responsibility |
+|------|----------------|
+| [wayland_vulkan.h](wayland_vulkan.h) / [wayland_vulkan.cc](wayland_vulkan.cc) | `WaylandVulkanBackend` — Vulkan/WSI bring-up, swapchain present, vsync forwarding, present-mode selection, profiling, compositor + dma-buf present paths |
+| [vulkan_queue_interposer.h](vulkan_queue_interposer.h) / [vulkan_queue_interposer.cc](vulkan_queue_interposer.cc) | `VulkanQueueInterposer` — externally-synchronized host access to the shared `VkQueue` via the embedder proc-address swap |
+| [vulkan_backing_store.h](vulkan_backing_store.h) / [vulkan_backing_store.cc](vulkan_backing_store.cc) | `VulkanBackingStore` — device-local `VkImage` render target (optionally dma-buf-exported), layout tracking (`BUILD_COMPOSITOR`) |
+| [wl_layer_compositor.h](wl_layer_compositor.h) / [wl_layer_compositor.cc](wl_layer_compositor.cc) | `LayerCompositor` — premultiplied src-over layer composition into a slot image (`BUILD_COMPOSITOR`) |
+| [wl_dmabuf_present.h](wl_dmabuf_present.h) / [wl_dmabuf_present.cc](wl_dmabuf_present.cc) | `DmabufImage` / `WlDmabufBuffer` + `NegotiateModifiers` — modifier-tiled dma-buf slots and modifier negotiation (`IVI_VK_DMABUF`) |
+| [wl_explicit_sync.h](wl_explicit_sync.h) / [wl_explicit_sync.cc](wl_explicit_sync.cc) | `ExplicitSync` — `wp_linux_drm_syncobj` producer/consumer timeline sync for the dma-buf path |
+| [shaders/](shaders/) | GLSL/SPIR-V shaders for the `LayerCompositor` blend pipeline |
+
+### Threading model
+
+Same as `wayland_egl`: the `on_feedback_presented` / `on_feedback_discarded`
+listeners fire on [Display](../../wayland/display.h)'s `event_thread_`, so
+`feedback_in_flight_` is guarded by a mutex and `OnVsync` is always posted via
+the platform runner's strand (never inline). `RequestPresentationFeedback` runs
+on the rasterizer thread. The `pipeline_*` profile is accumulated on the
+rasterizer thread, kept separate from the event-thread cadence profile to avoid
+a cross-thread race. The future refactor of moving Wayland dispatch onto the
+platform task runner via asio applies here too. See the
+[Architectural notes](#architectural-notes) for the per-commit feedback-object
+lifecycle and the Mesa-internal-feedback duplication detail.
+
+---
+
+## Build steps
+
+### Configure + build
+
+The backend compiles when `BUILD_BACKEND_WAYLAND_VULKAN` is enabled (default
+on). Platform-view composition (the `LayerCompositor` / backing-store sources)
+and the experimental dma-buf present path additionally require
+`BUILD_COMPOSITOR`.
+
+```sh
+cmake -B build -G Ninja -DBUILD_BACKEND_WAYLAND_VULKAN=ON
+ninja -C build
+```
+
+### Build matrix
+
+| Config | CMake flags | Present path compiled in |
+|--------|-------------|--------------------------|
+| Base Vulkan presenter | `BUILD_BACKEND_WAYLAND_VULKAN=ON` | `wayland_vulkan.cc`, `vulkan_queue_interposer.cc` (WSI swapchain present) |
+| + platform-view compositor | `BUILD_BACKEND_WAYLAND_VULKAN=ON BUILD_COMPOSITOR=ON` | adds `vulkan_backing_store.cc`, `wl_layer_compositor.cc`, `wl_dmabuf_present.cc`, `wl_explicit_sync.cc` (enables `IVI_VK_DMABUF`) |
+| + debug HUD | `... BUILD_COMPOSITOR=ON BUILD_HUD=ON` | adds the imgui Vulkan HUD (`VulkanHud`) |
+
+---
+
+## Running
+
+Runtime requires a Wayland compositor. For the compositor-mediated vsync path,
+the compositor must advertise the `wp_presentation` global with a
+`CLOCK_MONOTONIC` clock. When it does not, the backend logs the reason once and
+falls back to Flutter's internal wall-clock scheduler. Mesa's Vulkan WSI
+additionally requires `zwp_linux_dmabuf_v1` or `wl_drm` to allocate swapchain
+images at all (see Known limitations).
+
+Read logs on stderr; the vsync-wiring decision and profiling summaries are
+emitted at `info` level.
+
+### Env vars
 
 | Env | Default | Effect |
 |------|---------|--------|
@@ -70,6 +199,8 @@ internal wall-clock scheduler. The decision is logged once at startup.
 | `IVI_VK_PRESENT_MODE` | `fifo` | One of `fifo`, `fifo_relaxed`, `mailbox`, `immediate`. Selects the swapchain present mode if the compositor advertises it; otherwise falls back to FIFO with a warn. See "Present-mode interaction" below — `mailbox` is the only setting where `vsync_callback`'s contribution becomes large. |
 | `IVI_VK_DMABUF` | (off) | **Experimental** zero-copy dma-buf present path (see below). When set, and the compositor advertises a DRM format modifier this GPU can render into, the compositor path bypasses the WSI swapchain entirely: it blits the engine's frame into a modifier-tiled, dma-buf-exported `VkImage` and commits it as a `wl_buffer` (via `zwp_linux_dmabuf_v1`) directly on the `wl_surface`, so the compositor can promote the surface to a hardware plane. Off by default; falls back to the swapchain when unset or when no renderable modifier is shared. |
 | `IVI_VK_NO_EXPLICIT_SYNC` | (off) | On the dma-buf path, force the CPU-fence producer sync instead of `wp_linux_drm_syncobj` explicit sync (see below). For bisecting / A-B'ing the timeline path; no effect on the swapchain path. |
+
+---
 
 ## Experimental: zero-copy dma-buf present (`IVI_VK_DMABUF`)
 
@@ -226,6 +357,29 @@ configurations, not for precise per-frame attribution.
 
 ---
 
+## Diagnostics/Debug
+
+- **`IVI_VK_PROFILE=1`** adds a log line every 60 presented frames with
+  fps, mean/max interval, present failures, compositor discards, the
+  compositor-reported refresh, a flag OR (`VSYNC|HW_CLOCK|HW_COMPLETION`),
+  the `pipeline_*` beginFrame-to-present latency, and the 5-bucket histogram
+  (matches the `wayland_egl` bucket thresholds). On clean shutdown the
+  backend's dtor emits a one-line session summary covering the whole run.
+- **`IVI_M2P_PROFILE=1`** (or `IVI_PROFILE=1`) enables the motion-to-photon
+  profiler described in the Env vars table — frame-accurate and floor
+  input-to-scanout latencies every 120 presents plus a teardown summary.
+- **`WAYLAND_DEBUG=client`** gives the raw protocol trace. Expect **two**
+  `wp_presentation_feedback` objects per commit (one from the embedder, one
+  from Mesa's WSI) — see Architectural notes.
+- **Vulkan synchronization validation layer** — the explicit-sync dma-buf
+  path (`IVI_VK_DMABUF`) has been validated hazard-free under it on
+  mutter/RADV.
+- **Startup decision** — the `vsync_callback` wiring decision (`wp_presentation`
+  advertised, `clock_id`, `IVI_VK_VSYNC`) and the dmabuf pre-flight warning are
+  logged once at `info`/`warn` level.
+
+---
+
 ## Benchmarks
 
 Measured on KWin Wayland (Fedora 43, kernel 6.19, AMD RADV
@@ -341,3 +495,18 @@ gives up backpressure for input latency — different operating point.
    `CollectBackingStore` predate this work. The lint CI doesn't
    catch them because the lint workflow's build dir uses the EGL
    backend; left for a separate cleanup PR.
+
+---
+
+## References
+
+- [Backend interface](../backend.h) — display-target abstraction
+- [Backend overview README](../README.md)
+- [WaylandVsyncProvider](../../vsync/wayland_vsync_provider.h) — `wp_presentation` vsync source
+- [wayland_egl backend README](../wayland_egl/README.md) — EGL comparison baseline / shared vsync wiring
+- [drm_kms_egl backend README](../drm_kms_egl/README.md) — DRM comparison baseline
+- [drm_kms_vulkan backend README](../drm_kms_vulkan/README.md) — Vulkan zero-copy KMS sibling
+- [Display](../../wayland/display.h) — owns `event_thread_` and the vsync provider
+- `VK_KHR_wayland_surface`, `VK_KHR_swapchain` — Vulkan WSI
+- `wp_presentation_time`, `zwp_linux_dmabuf_v1`, `wp_linux_drm_syncobj`, `zwp_input_timestamps_v1` — Wayland protocol extensions
+- wayland-cxx-scanner `skia-vulkan-dmabuf` example — dma-buf present path reference


### PR DESCRIPTION
## Summary

Introduces comprehensive architecture and operations documentation for every backend in `backend`. Each README covers the backend's purpose, architecture diagram, module responsibilities, feature matrix, build instructions, and runtime configuration.

Additionally, the backends are documented to match the current state of `v3.0`, which is ahead of this branch. The upstream changes are noted so the doc and code converge when the branches are reconciled.

## Backends documented

| Backend | README | v3.0 sync notes |
|---|---|---|
| `drm_kms_egl` | `README.md` | Dispatch loop redesign — `WakeEventFd`-based indefinite blocking poll |
| `drm_kms_vulkan` | `README.md` | — |
| `headless_egl` | `README.md` | — |
| `headless_vulkan` | `README.md` | — |
| `hud` | `README.md` | — |
| `software` | `README.md` | `drm_dumb_sink.h` now explicitly includes `<array>` |
| `wayland_egl` | `README.md` | `egl.h` now explicitly includes `<array>` |
| `wayland_leased_drm` | `README.md` | — |
| `wayland_vulkan` | `README.md` | `wayland_vulkan.h` now explicitly includes `<functional>` |

## Upstream changes documented

Two upstream commits on `v3.0` are not yet on this branch. Both are reflected in the relevant READMEs so that when the code is reconciled, the docs are already accurate.

### `drm_kms_egl` — `5f684f3a` *"fix: stop DrmSession waking 5x/s on an idle system"*

The `DrmSession` dispatch loop no longer polls every 200 ms. It now:

- Blocks indefinitely on a `WakeEventFd` (reuses `wake_event_fd.h`).
- Writes the eventfd once in the destructor after setting `stop_`, closing the lost-wake window across the check/block boundary.
- Falls back to the 200 ms cap only when the eventfd is unavailable (`fd() == -1`).

### `software` / `wayland_egl` / `wayland_vulkan` — `24e01fe3` *"fix: include the standard headers these declarations need"*

Three headers now include the standard headers they actually use, rather than relying on transitive includes:

| Header | New include |
|---|---|
| `drm_dumb_sink.h` | `<array>` |
| `egl.h` | `<array>` |
| `wayland_vulkan.h` | `<functional>` |

On Yocto dunfell (riscv64 / armv7), older toolchains don't re-export `std::array` or `std::function` from `<atomic>`, `<vector>`, `<EGL/egl.h>`, or `<mutex>`, so the build fails with `implicit instantiation of undefined template '…'`. Each affected README carries a short **Toolchain compatibility** note recording the root cause so the explicit includes aren't simplified away in future cleanups.