### PR TITLE
Tidy generate_module_docs.py

### DIFF
--- a/docs/source/generate_module_docs.py
+++ b/docs/source/generate_module_docs.py
@@ -1,5 +1,4 @@
 import xml.etree.ElementTree as ET
-import subprocess
 import os
 import sys
 
@@ -24,25 +23,21 @@ for file in os.listdir(doxygen_path):
 					file_class_dict[file_name] = []
 				file_class_dict[file_name].append([object_name, root[0].attrib['kind']])
 				
-rst_file = open("modules.rst", "w")
-rst_file.write("Modules\n")
-rst_file.write("=======\n")
-rst_file.write("\n")
+with open("modules.rst", "w") as rst_file:
+	rst_file.write("Modules\n")
+	rst_file.write("=======\n")
+	rst_file.write("\n")
 
-for key in file_class_dict.keys():
-	rst_file.write(key + "\n")
-	for x in range(len(key)):
-		rst_file.write("-")
-	rst_file.write("\n\n")
-	for item_name, item_type in file_class_dict[key]:
-		if "class" in item_type:
-			rst_file.write(".. doxygenclass:: " + item_name + "\n")
-		else:
-			rst_file.write(".. doxygenstruct:: " + item_name + "\n")
-		rst_file.write("   :project: ivi-homescreen\n")
-		rst_file.write("   :members:\n")
-		rst_file.write("   :private-members:\n")
-		rst_file.write("   :undoc-members:\n\n")
-
-
-
+	for key in file_class_dict.keys():
+		rst_file.write(key + "\n")
+		rst_file.write("-" * len(key))
+		rst_file.write("\n\n")
+		for item_name, item_type in file_class_dict[key]:
+			if "class" in item_type:
+				rst_file.write(".. doxygenclass:: " + item_name + "\n")
+			else:
+				rst_file.write(".. doxygenstruct:: " + item_name + "\n")
+			rst_file.write("   :project: ivi-homescreen\n")
+			rst_file.write("   :members:\n")
+			rst_file.write("   :private-members:\n")
+			rst_file.write("   :undoc-members:\n\n")


### PR DESCRIPTION
Three code-quality findings the bot raised on #503, in a file that PR does not
touch:

- `modules.rst` is written through a context manager, so it closes if a write
  throws
- the dash underline is one `"-" * len(key)` write instead of a loop with an
  unused variable
- `subprocess` was imported and never used

Output verified identical to the previous version on the same input.