### PR TITLE
drm-kms-egl: guard optional cursor calls

### DIFF
--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -1193,11 +1193,16 @@ bool DrmCompositor::PresentViaGlFallback(const FlutterLayer** layers,
 // ─── Cursor staging + shared commit settle ──────────────────────────────
 
 bool DrmCompositor::StageCursorInto(drm::AtomicRequest& req) {
+#if HAVE_DRM_CURSOR
   bool needs_modeset = false;
   if (cursor_ != nullptr) {
     (void)cursor_->Stage(req, &needs_modeset);
   }
   return needs_modeset;
+#else
+  (void)req;
+  return false;
+#endif
 }
 
 void DrmCompositor::SettleAtomicCommit(const bool blocking) {
@@ -3065,9 +3070,11 @@ bool DrmCompositor::PresentLayersViaScene(const FlutterLayer** layers,
   // cursor plane in its own commit would avoid this separate commit (which
   // reintroduces the flip contention on nvidia-drm in fullscreen scene
   // mode). No-op when no cursor is staged.
+#if HAVE_DRM_CURSOR
   if (cursor_ != nullptr) {
     cursor_->CommitPending();
   }
+#endif
 
   // Rotate every BS pool that participated. Same slot-pipeline
   // bookkeeping as the legacy path — the scene path does not touch


### PR DESCRIPTION
## Summary

Guard `DrmCursor::Stage()` and `DrmCursor::CommitPending()` calls with
`HAVE_DRM_CURSOR`.

The cursor implementation is omitted when libxcursor is unavailable, but these
two calls remained unconditional and produced unresolved symbols during
linking.

## Testing

Built `ivi-homescreen` through Yocto with the DRM/KMS EGL backend and without
libxcursor.

CMake reported:

    No package 'xcursor' found
    libxcursor not found; DRM HW cursor disabled

Before this change, linking failed with undefined references to:

- `homescreen::DrmCursor::Stage(drm::AtomicRequest&, bool*)`
- `homescreen::DrmCursor::CommitPending()`

The same configuration links successfully after this change.