### PR TITLE
Include <cstdlib> before fmt/format.h

### DIFF
--- a/shell/logging/logging.h
+++ b/shell/logging/logging.h
@@ -30,6 +30,19 @@
 #ifndef FMT_HEADER_ONLY
 #define FMT_HEADER_ONLY
 #endif
+// fmt/format.h defines detail::allocator, which calls malloc and free
+// without declaring them. It relied on some other header providing
+// <cstdlib> transitively; libc++ 23 no longer does, and the calls are
+// then neither visible at the point of definition nor reachable by ADL:
+//
+//   fmt/format.h:747:28: error: use of undeclared identifier 'malloc'
+//   fmt/format.h:752:35: error: call to function 'free' that is neither
+//     visible in the template definition nor found by argument-dependent lookup
+//
+// Include it before fmt so the declarations are in scope there. Upstream
+// fmt has since dropped that allocator, but no released version has.
+#include <cstdlib>
+
 #include <fmt/format.h>
 
 #include "ihs/logging.h"


### PR DESCRIPTION
fmt defines `detail::allocator`, which calls `malloc` and `free` without
declaring them:

```cpp
T* p = static_cast<T*>(malloc(n * sizeof(T)));
void deallocate(T* p, size_t) { free(p); }
```

It relied on some other header providing `<cstdlib>` transitively. libc++ 23 no
longer does, so the calls are neither visible at the point of definition nor
reachable by ADL:

```
fmt/format.h:747:28: error: use of undeclared identifier 'malloc'
fmt/format.h:752:35: error: call to function 'free' that is neither visible in
  the template definition nor found by argument-dependent lookup
```

`shell/logging/logging.h` includes `fmt/format.h` ahead of any C header, so every
translation unit that reaches fmt through it fails -- that is all of
`plugins/common`, which is why meta-flutter's build of ivi-homescreen breaks on
all four architectures now that OpenEmbedded has moved to clang/llvm 23.1.0.
Tracked in meta-flutter/meta-flutter#902.

Including `<cstdlib>` first puts the declarations in scope where fmt defines
those templates.

## Why not bump the fmt submodule instead

Upstream fmt has dropped that allocator on master, but **no released version
has**:

| fmt | `malloc`/`free` uses in format.h |
|---|---|
| 11.2.0 (pinned here) | 2 |
| 12.0.0 | 2 |
| 12.1.0 | 2 |
| 12.2.0 (latest) | 1 |
| master | 0 |

So a version bump would not fix it, and would be a major-version move on top.
`shell/logging/tests/bench/logging_bench.cc` is the only other file including
fmt directly and it already includes `<cstdlib>`.

Not built here beyond confirming the include order and clang-format; CI is the
real check.
