### PR TITLE
Give the Wayland EGL backend a render-node allocator

### DIFF
--- a/cmake/config_common.h.in
+++ b/cmake/config_common.h.in
@@ -27,6 +27,12 @@
 #ifndef BUILD_BACKEND_WAYLAND_VULKAN
 #cmakedefine01 BUILD_BACKEND_WAYLAND_VULKAN
 #endif
+// Set when libgbm was found alongside the Wayland EGL backend. Gates the
+// render-node allocator the backend hands to platform-view producers; without
+// it they fall back to exporting a GL texture, which not every driver allows.
+#ifndef BUILD_BACKEND_WAYLAND_EGL_GBM
+#cmakedefine01 BUILD_BACKEND_WAYLAND_EGL_GBM
+#endif
 // Spelled to match the option in cmake/options.cmake. It previously read
 // BUILD_BACKEND_WAYLAND_DRM_LEASED, which matched no CMake variable, so
 // #cmakedefine01 always emitted 0 — every gate on it would have been silently

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -72,6 +72,18 @@ endif ()
 #
 option(BUILD_BACKEND_WAYLAND_EGL "Build Backend for EGL" ON)
 if (BUILD_BACKEND_WAYLAND_EGL)
+    # Platform-view producers need an allocator whose buffers the compositor
+    # can import. gbm on the EGL display's own render node is that allocator;
+    # without it a producer can only export a GL texture, which not every
+    # driver permits. Probed here rather than in shell/ because the config
+    # header is generated before that directory is added.
+    find_package(PkgConfig)
+    pkg_check_modules(GBM QUIET IMPORTED_TARGET GLOBAL gbm)
+    if (TARGET PkgConfig::GBM)
+        set(BUILD_BACKEND_WAYLAND_EGL_GBM ON)
+    else ()
+        message(STATUS "wayland-egl: no libgbm; platform views fall back to GL texture export")
+    endif ()
     option(BUILD_EGL_TRANSPARENCY "Build with EGL Transparency Enabled" ON)
     option(BUILD_EGL_ENABLE_3D "Build with EGL Stencil, Depth, and Stencil config Enabled" ON)
     option(BUILD_EGL_ENABLE_MULTISAMPLE "Build with EGL Sample set to 4" OFF)

--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -134,6 +134,9 @@ if (BUILD_BACKEND_WAYLAND_EGL)
             backend/wayland_egl/egl.cc
             backend/gl_process_resolver.cc
     )
+    if (TARGET PkgConfig::GBM)
+        target_link_libraries(${PROJECT_NAME} PRIVATE PkgConfig::GBM)
+    endif ()
     if (BUILD_COMPOSITOR)
         target_sources(${PROJECT_NAME} PRIVATE
                 backend/wayland_egl/egl_backing_store.cc

--- a/shell/backend/wayland_egl/wayland_egl.cc
+++ b/shell/backend/wayland_egl/wayland_egl.cc
@@ -42,6 +42,22 @@
 #include <GLES2/gl2.h>
 #endif
 
+#if BUILD_BACKEND_WAYLAND_EGL_GBM
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <gbm.h>
+
+#include <string>
+
+// eglext.h may predate EGL_EXT_device_query; the value is fixed by the
+// extension registry.
+#ifndef EGL_DEVICE_EXT
+#define EGL_DEVICE_EXT 0x322C
+#endif
+#endif
+
 #if BUILD_HUD
 #include "backend/hud/gl_hud.h"
 #endif
@@ -79,16 +95,131 @@ WaylandEglBackend::WaylandEglBackend(Display* shell_display,
   }
 }
 
-#if BUILD_HUD
 WaylandEglBackend::~WaylandEglBackend() {
+#if BUILD_HUD
   // Tear the HUD down with the GL context current so imgui's glDelete* land on
   // a live context (the Egl base — destroyed after this — still owns it).
   if (hud_) {
     MakeCurrent();
     hud_.reset();
   }
+#endif
+#if BUILD_BACKEND_WAYLAND_EGL_GBM
+  if (m_gbm_device != nullptr) {
+    gbm_device_destroy(m_gbm_device);
+    m_gbm_device = nullptr;
+  }
+  if (m_gbm_fd >= 0) {
+    close(m_gbm_fd);
+    m_gbm_fd = -1;
+  }
+#endif
 }
 
+#if BUILD_BACKEND_WAYLAND_EGL_GBM
+namespace {
+
+// EGL_EXT_device_query / EGL_EXT_device_drm{,_render_node}. Spelled out here so
+// the backend builds against an egl.h that predates them; the entry points are
+// resolved at runtime and absence just means the scan below runs instead.
+constexpr EGLint kDrmDeviceFileExt = 0x3233;
+constexpr EGLint kDrmRenderNodeFileExt = 0x3377;
+using QueryDisplayAttribFn = EGLBoolean (*)(EGLDisplay, EGLint, intptr_t*);
+using QueryDeviceStringFn = const char* (*)(void*, EGLint);
+
+// The node the EGL display renders on, or an empty string. Asking EGL rather
+// than guessing keeps the allocator and the GL context on one device; a buffer
+// from the wrong node imports as garbage or not at all.
+std::string EglRenderNode(EGLDisplay display) {
+  const auto query_attrib = reinterpret_cast<QueryDisplayAttribFn>(
+      eglGetProcAddress("eglQueryDisplayAttribEXT"));
+  const auto query_string = reinterpret_cast<QueryDeviceStringFn>(
+      eglGetProcAddress("eglQueryDeviceStringEXT"));
+  if (query_attrib == nullptr || query_string == nullptr) {
+    return {};
+  }
+  intptr_t device = 0;
+  if (query_attrib(display, EGL_DEVICE_EXT, &device) == EGL_FALSE ||
+      device == 0) {
+    return {};
+  }
+  auto* dev = reinterpret_cast<void*>(device);
+  // Prefer the render node: the primary node needs DRM master or an
+  // authenticated fd, neither of which a Wayland client has.
+  for (const EGLint name : {kDrmRenderNodeFileExt, kDrmDeviceFileExt}) {
+    const char* path = query_string(dev, name);
+    if (path != nullptr && path[0] != '\0') {
+      return path;
+    }
+  }
+  return {};
+}
+
+// Last resort when EGL will not name its device: the lowest-numbered render
+// node. Right on a single-GPU board, a coin flip on anything else — hence the
+// warning.
+std::string FirstRenderNode() {
+  DIR* dir = opendir("/dev/dri");
+  if (dir == nullptr) {
+    return {};
+  }
+  std::string best;
+  while (const dirent* ent = readdir(dir)) {
+    const std::string_view name(ent->d_name);
+    if (name.rfind("renderD", 0) != 0) {
+      continue;
+    }
+    if (best.empty() || name < std::string_view(best)) {
+      best.assign(name);
+    }
+  }
+  closedir(dir);
+  return best.empty() ? std::string() : "/dev/dri/" + best;
+}
+
+}  // namespace
+
+void WaylandEglBackend::EnsureGbmDevice() const {
+  if (m_gbm_probed) {
+    return;
+  }
+  m_gbm_probed = true;
+
+  std::string node = EglRenderNode(GetDisplay());
+  if (node.empty()) {
+    node = FirstRenderNode();
+    if (!node.empty()) {
+      ihs::log::warn(
+          "[WaylandEglBackend] EGL would not name its DRM device; guessing {} "
+          "for platform-view allocation",
+          node);
+    }
+  }
+  if (node.empty()) {
+    ihs::log::info(
+        "[WaylandEglBackend] no DRM render node — platform views fall back to "
+        "GL texture export");
+    return;
+  }
+
+  m_gbm_fd = open(node.c_str(), O_RDWR | O_CLOEXEC);
+  if (m_gbm_fd < 0) {
+    ihs::log::warn("[WaylandEglBackend] open({}) failed: {}", node,
+                   strerror(errno));
+    return;
+  }
+  m_gbm_device = gbm_create_device(m_gbm_fd);
+  if (m_gbm_device == nullptr) {
+    ihs::log::warn("[WaylandEglBackend] gbm_create_device({}) failed", node);
+    close(m_gbm_fd);
+    m_gbm_fd = -1;
+    return;
+  }
+  ihs::log::info("[WaylandEglBackend] platform-view allocator on {}", node);
+}
+#endif  // BUILD_BACKEND_WAYLAND_EGL_GBM
+
+#if BUILD_HUD
 void WaylandEglBackend::MaybeRenderHud(const FlutterLayer** layers,
                                        size_t count) {
   if (!hud_checked_) {
@@ -630,9 +761,16 @@ bool WaylandEglBackend::GetEglContext(BackendEglContext* out) const {
   // share_context transitively shares GL objects with Flutter's raster
   // context.
   out->share_context = GetTextureContext();
-  // No gbm on a Wayland EGL backend — platform views present via wl_surface /
-  // GL texture, not a KMS plane, so there is no scanout buffer to export.
+  // Not a scanout allocator — there is no KMS plane here — but producers need
+  // some way to mint dma-bufs the compositor can import, and exporting a GL
+  // texture is not portable (panfrost rejects it). A gbm device on the render
+  // node EGL is already using gives them one.
+#if BUILD_BACKEND_WAYLAND_EGL_GBM
+  EnsureGbmDevice();
+  out->gbm_device = m_gbm_device;
+#else
   out->gbm_device = nullptr;
+#endif
   return out->display != EGL_NO_DISPLAY && out->share_context != EGL_NO_CONTEXT;
 }
 

--- a/shell/backend/wayland_egl/wayland_egl.h
+++ b/shell/backend/wayland_egl/wayland_egl.h
@@ -34,6 +34,7 @@
 #include "egl.h"
 
 struct wl_output;
+struct gbm_device;
 class Display;
 class TaskRunner;
 
@@ -81,11 +82,10 @@ class WaylandEglBackend : public Egl, public Backend {
                     bool enable_impeller,
                     int buffer_size = kEglBufferSize);
 
-#if BUILD_HUD
   // Out-of-line so the GlHud unique_ptr (incomplete here) is destroyed where
-  // GlHud is complete; also tears the HUD down with the GL context current.
+  // GlHud is complete; also tears the HUD down with the GL context current,
+  // and closes the render node opened for platform-view allocation.
   ~WaylandEglBackend() override;
-#endif
 
   /**
    * @brief Resize Flutter engine Window size
@@ -221,6 +221,27 @@ class WaylandEglBackend : public Egl, public Backend {
 #endif
 
  private:
+#if BUILD_BACKEND_WAYLAND_EGL_GBM
+  // Allocator handed to platform-view producers so they can hand the
+  // compositor a dma-buf. Producers can otherwise only render into a GL
+  // texture and export its storage, which panfrost refuses
+  // (drmPrimeHandleToFD EINVAL) even though it imports gbm buffers happily.
+  // Opened on first use from GetEglContext, which is const.
+  mutable int m_gbm_fd{-1};
+  mutable struct gbm_device* m_gbm_device{nullptr};
+  mutable bool m_gbm_probed{false};
+
+  /**
+   * @brief Open the DRM render node behind the EGL display and wrap it in a
+   * gbm_device. Idempotent; leaves m_gbm_device null when unavailable, which
+   * puts producers back on the GL-texture path.
+   * @return void
+   * @relation
+   * wayland, egl
+   */
+  void EnsureGbmDevice() const;
+#endif
+
   struct wl_egl_window* m_egl_window{};
   // wl_surface backing m_egl_window. We stash it from CreateSurface so
   // wp_presentation_feedback() can mint a feedback object per commit.


### PR DESCRIPTION
`GetEglContext` returned `gbm_device = nullptr`, reasoning that no KMS plane means no buffer to export. That conflates the scanout path with allocation: platform-view producers do not want a plane to scan out on, they want a device to allocate importable dma-bufs from.

Without one, a GL producer falls back to rendering into a GL texture and exporting its storage. Desktop Mesa allows that. panfrost does not:

```
MESA: error: drmPrimeHandleToFD() failed (err=22)
[E] eglExportDMABUFImageMESA failed (egl 0x3000)
[E] GL producer: ring slot 0 alloc failed
[E] view 0 producer init failed for kind 1
```

The app then loads its whole scene, reports a live camera, and draws nothing.  No message points at buffer allocation.

## Change

Open the render node EGL itself is using — `EGL_EXT_device_query` plus `EGL_EXT_device_drm_render_node` — so the allocator and the GL context land on one device; a buffer from the wrong node imports as garbage or not at all.  Falls back to the lowest-numbered `/dev/dri/renderD*` with a warning, and to
the existing GL-texture path when there is no node or no libgbm, so a host without gbm behaves exactly as before.

Probed in `cmake/options.cmake` rather than `shell/CMakeLists.txt`, because `config/common.h` is generated before that directory is added.

## Tested

- **RK3588 / Mali-G610 / panfrost / weston:** from nothing on screen to a full scene with two animated character rigs, held 330 s. `platform-view allocator on /dev/dri/renderD128`, zero producer errors.
- **Desktop / radeonsi / Mesa 26.1.8:** three arms on one bundle — this branch on EGL, the pre-change shell on EGL, and Vulkan. The two EGL frames are identical apart from the HUD's own fps text (6366 vs 6364 unique colors), so the change is neutral where the old path already worked. Vulkan is unaffected.

That desktop bundle renders incorrectly under GLES (6.4k colors against Vulkan's 158k) both with and without this change — a pre-existing fault in the ES path on that driver, unrelated to platform views.