### PR TITLE
docs: state the CMake flag defaults the build actually resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,13 @@ See the [configuration docs](shell/configuration/README.md) for the complete opt
 
 `ENABLE_XDG_CLIENT` - Enable XDG Client. Defaults to ON
 
-`ENABLE_AGL_SHELL_CLIENT` - Enable AGL Client. Defaults to OFF
+`ENABLE_AGL_SHELL_CLIENT` - Enable AGL Client. Defaults to ON
 
 `ENABLE_IVI_SHELL_CLIENT` - Enable ivi-shell Client. Defaults to OFF
 
-`ENABLE_DRM_LEASE_CLIENT` - Enable drm lease Client. Defaults to OFF
+`ENABLE_SIMPLE_SHELL_CLIENT` - Enable RDK/Westeros simple_shell Client. Defaults to OFF
+
+`BUILD_BACKEND_WAYLAND_LEASED_DRM` - Build the Wayland leased-DRM backend (drm-lease-v1). Must be paired with a renderer tier - see [Backend Support](#backend-support). Defaults to OFF
 
 `ENABLE_LTO` - Enable Link Time Optimization. Defaults to OFF
 
@@ -164,9 +166,9 @@ See the [configuration docs](shell/configuration/README.md) for the complete opt
 
 `BUILD_EGL_ENABLE_3D` - Build with EGL Stencil, Depth, and Stencil config Enabled. Defaults to ON
 
-`BUILD_EGL_ENABLE_MULTISAMPLE` - Build with EGL Sample set to 4. Defaults to ON
+`BUILD_EGL_ENABLE_MULTISAMPLE` - Build with EGL Sample set to 4. Defaults to OFF
 
-`BUILD_BACKEND_WAYLAND_VULKAN` - Build Backed for Vulkan. Defaults to OFF
+`BUILD_BACKEND_WAYLAND_VULKAN` - Build Backend for Vulkan. Declared only when `BUILD_BACKEND_WAYLAND_EGL=OFF`, and defaults to ON in that case; with the default `BUILD_BACKEND_WAYLAND_EGL=ON` it is not declared
 
 `BUILD_COMPOSITOR` - Enable the `FlutterCompositor` backing-store API so platform-view layers can be interleaved with Flutter UI. See [Platform View Plugins](#platform-view-plugins). Defaults to OFF.
 

--- a/docs/specs/ARCHITECTURE.md
+++ b/docs/specs/ARCHITECTURE.md
@@ -426,7 +426,7 @@ codegen, packaging, options, docs). Key structural points:
   tests, and each individual plugin are all CMake toggles. See the README for the
   full option list.
 - **Compositor-protocol shells** are gated separately (`ENABLE_XDG_CLIENT`,
-  `ENABLE_AGL_SHELL_CLIENT`, `ENABLE_IVI_SHELL_CLIENT`, `ENABLE_DRM_LEASE_CLIENT`).
+  `ENABLE_AGL_SHELL_CLIENT`, `ENABLE_IVI_SHELL_CLIENT`, `ENABLE_SIMPLE_SHELL_CLIENT`).
 - **Plugins** are out-of-tree (§7.1), referenced by cloning into the repo root
   or via `-DPLUGIN_DIR`.
 - **`shared/`** builds independently as `ihs_shared` (§7.2).


### PR DESCRIPTION
Four rows in the CMake Build flags table on v3.0 disagree with what a configure actually resolves, and one flag the table documents is declared nowhere.

Two commands check the whole change:

```
$ cmake -B build -G Ninja
$ grep -E '^(ENABLE_AGL_SHELL_CLIENT|BUILD_EGL_ENABLE_MULTISAMPLE|ENABLE_SIMPLE_SHELL_CLIENT):' build/CMakeCache.txt

$ git log --all -S ENABLE_DRM_LEASE_CLIENT -- '*.cmake' CMakeLists.txt
```

The table says AGL defaults OFF, but the cache resolves it ON. It says multisample defaults ON, but the cache resolves OFF. Simple-shell is in the cache with no row at all.

The second command returns nothing. `ENABLE_DRM_LEASE_CLIENT` has never been an option in any revision — it entered as a README line in `9ceb43fa` and stayed one. The capability is real under `BUILD_BACKEND_WAYLAND_LEASED_DRM`, which this README already documents in the Backend Support table, so the row now points there rather than restating the spec.

Defaults are read from `CMakeCache.txt` rather than from the `option()` call, because `option()` alone is not sound in this tree: `cmake/options.cmake:106` declares `BUILD_HUD` ON and `:107-110` forces it OFF whenever `BUILD_COMPOSITOR` is OFF, which is the default.

Bounds: I verified the 22 rows declared in this repository. The 15 `BUILD_PLUGIN_*` rows are declared outside it and I did not check them.

Documentation only — no build file is touched and no default changes.
