### PR TITLE
cmake: make AGL shell client opt-in; sync flag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ Below are some of the flags available for configuring the CMake build. Please no
 
 `ENABLE_IVI_SHELL_CLIENT` - Enable ivi-shell Client. Defaults to OFF
 
-`ENABLE_DRM_LEASE_CLIENT` - Enable drm lease Client. Defaults to OFF
+`ENABLE_SIMPLE_SHELL_CLIENT` - Enable RDK/Westeros simple_shell Client. Defaults to OFF
+
+`BUILD_BACKEND_WAYLAND_LEASED_DRM` - Build the Wayland leased-DRM backend (drm-lease-v1). Must be paired with a renderer tier - see [Backend Support](#backend-support). Defaults to OFF
 
 `ENABLE_LTO` - Enable Link Time Optimization. Defaults to OFF
 
@@ -202,9 +204,9 @@ Below are some of the flags available for configuring the CMake build. Please no
 
 `BUILD_EGL_ENABLE_3D` - Build with EGL Stencil, Depth, and Stencil config Enabled. Defaults to ON
 
-`BUILD_EGL_ENABLE_MULTISAMPLE` - Build with EGL Sample set to 4. Defaults to ON
+`BUILD_EGL_ENABLE_MULTISAMPLE` - Build with EGL Sample set to 4. Defaults to OFF
 
-`BUILD_BACKEND_WAYLAND_VULKAN` - Build Backed for Vulkan. Defaults to OFF
+`BUILD_BACKEND_WAYLAND_VULKAN` - Build Backend for Vulkan. Declared (default ON) only when `BUILD_BACKEND_WAYLAND_EGL=OFF`; can still be set explicitly alongside EGL
 
 `BUILD_COMPOSITOR` - Enable the `FlutterCompositor` backing-store API so platform-view layers can be interleaved with Flutter UI. See [Platform View Plugins](#platform-view-plugins). Defaults to OFF.
 

--- a/cmake/wayland_cxx.cmake
+++ b/cmake/wayland_cxx.cmake
@@ -93,9 +93,9 @@ _wlcxx_prefer_sysroot(_wlcxx_core_base "wayland.xml")
 set(IVI_WL_CORE_XML "${_wlcxx_core_base}/wayland.xml" CACHE FILEPATH "core wayland.xml")
 
 # --- Shell client options --------------------------------------------------
-# xdg + agl on by default; ivi + simple are opt-in.
+# xdg on by default; agl, ivi, and simple are opt-in.
 option(ENABLE_XDG_CLIENT          "Enable XDG shell client"               ON)
-option(ENABLE_AGL_SHELL_CLIENT    "Enable AGL shell client"               ON)
+option(ENABLE_AGL_SHELL_CLIENT    "Enable AGL shell client"               OFF)
 option(ENABLE_IVI_SHELL_CLIENT    "Enable ivi-shell client"               OFF)
 option(ENABLE_SIMPLE_SHELL_CLIENT "Enable RDK/Westeros simple_shell client" OFF)
 

--- a/docs/specs/ARCHITECTURE.md
+++ b/docs/specs/ARCHITECTURE.md
@@ -431,7 +431,7 @@ codegen, packaging, options, docs). Key structural points:
   tests, and each individual plugin are all CMake toggles. See the README for the
   full option list.
 - **Compositor-protocol shells** are gated separately (`ENABLE_XDG_CLIENT`,
-  `ENABLE_AGL_SHELL_CLIENT`, `ENABLE_IVI_SHELL_CLIENT`, `ENABLE_DRM_LEASE_CLIENT`).
+  `ENABLE_AGL_SHELL_CLIENT`, `ENABLE_IVI_SHELL_CLIENT`, `ENABLE_SIMPLE_SHELL_CLIENT`).
 - **Plugins** are out-of-tree (§7.1), referenced by cloning into the repo root
   or via `-DPLUGIN_DIR`.
 - **`shared/`** builds independently as `ihs_shared` (§7.2).


### PR DESCRIPTION
Supersedes #510 (docs-only). Changes the AGL default to what the README already stated; fixes the remaining README rows to match the build.

## Defaults

| Option | Before | After |
|---|---|---|
| `ENABLE_AGL_SHELL_CLIENT` | ON | OFF |
| `BUILD_EGL_ENABLE_MULTISAMPLE` | OFF | unchanged (README said ON; MSAA stays off for low-end HW) |
| `ENABLE_SIMPLE_SHELL_CLIENT` | OFF | unchanged |
| `BUILD_BACKEND_WAYLAND_LEASED_DRM` | OFF | unchanged |

## Docs

- README: `BUILD_EGL_ENABLE_MULTISAMPLE` defaults OFF; drop `ENABLE_DRM_LEASE_CLIENT` (never declared); add `ENABLE_SIMPLE_SHELL_CLIENT`, `BUILD_BACKEND_WAYLAND_LEASED_DRM`; fix `BUILD_BACKEND_WAYLAND_VULKAN` (declared only when EGL is OFF, still settable alongside EGL).
- ARCHITECTURE.md: shell option list matches declared options.

## Notes

- No CI job sets `-DENABLE_AGL_SHELL_CLIENT=ON`; AGL shell code loses CI compile coverage. Downstream AGL/Yocto builds relying on the old default must set it explicitly.

## Testing

Fresh configure + build, submodules at pinned commits:
- defaults (AGL OFF, compositor OFF): OK
- `-DENABLE_AGL_SHELL_CLIENT=ON -DBUILD_COMPOSITOR=ON` (builds `agl_shell.cc`): OK

No new warnings.
