### PR TITLE
docs: fix readthedocs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ subsystems that implement it:
 - [Read the documentation on Read the Docs](https://ivi-homescreen.readthedocs.io/en/latest/)
 - [Architecture document](docs/specs/ARCHITECTURE.md)
 - [Plugin ABI](docs/PLUGIN_ABI.md)
-- [Subsystem documentation](https://github.com/toyota-connected/ivi-homescreen/blob/main/docs/specs/ARCHITECTURE.md#4-features)
+- [Subsystem documentation](docs/specs/ARCHITECTURE.md#4-features)
 
 ---
 
@@ -192,7 +192,7 @@ Below are some of the flags available for configuring the CMake build. Please no
 
 `ENABLE_SIMPLE_SHELL_CLIENT` - Enable RDK/Westeros simple_shell Client. Defaults to OFF
 
-`BUILD_BACKEND_WAYLAND_LEASED_DRM` - Build the Wayland leased-DRM backend (drm-lease-v1). Must be paired with a renderer tier - see [Backend Support](#backend-support). Defaults to OFF
+`BUILD_BACKEND_WAYLAND_LEASED_DRM` - Build the Wayland leased-DRM backend (drm-lease-v1). Must be paired with a renderer tier - see the [build matrix](shell/backend/README.md#build-matrix). Defaults to OFF
 
 `ENABLE_LTO` - Enable Link Time Optimization. Defaults to OFF
 
@@ -208,7 +208,7 @@ Below are some of the flags available for configuring the CMake build. Please no
 
 `BUILD_BACKEND_WAYLAND_VULKAN` - Build Backend for Vulkan. Declared (default ON) only when `BUILD_BACKEND_WAYLAND_EGL=OFF`; can still be set explicitly alongside EGL
 
-`BUILD_COMPOSITOR` - Enable the `FlutterCompositor` backing-store API so platform-view layers can be interleaved with Flutter UI. See [Platform View Plugins](#platform-view-plugins). Defaults to OFF.
+`BUILD_COMPOSITOR` - Enable the `FlutterCompositor` backing-store API so platform-view layers can be interleaved with Flutter UI. See [Compositor Mode and Platform Views](docs/specs/ARCHITECTURE.md#51-compositor-mode-and-platform-views). Defaults to OFF.
 
 `BUILD_COMPOSITOR_DMABUF_EXPORT` - When the Vulkan backend is active and `BUILD_COMPOSITOR=ON`, export each `VulkanBackingStore`'s memory as a DMA-BUF fd so plugins can import it zero-copy (requires `VK_KHR_external_memory_fd` at runtime; silently falls back to a plain allocation if unavailable). Defaults to OFF.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,9 +3,17 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import os
+import re
 
 # Check if we're running on Read the Docs' servers
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
+
+# Links into the source tree. On Read the Docs, pin to the commit being built
+# so every version, branch or PR build links to files that exist in it.
+github_ref = os.environ.get('READTHEDOCS_GIT_COMMIT_HASH', 'v3.0')
+github_blob = ('https://github.com/toyota-connected/ivi-homescreen/blob/'
+               + github_ref)
+extlinks = {'gh': (github_blob + '/%s', '%s')}
 
 breathe_projects = {}
 
@@ -26,6 +34,7 @@ release = '"0.1"'
 extensions = [
     'myst_parser',
     'sphinx_rtd_theme',
+    'sphinx.ext.extlinks',
     'breathe'
 ]
 
@@ -48,3 +57,17 @@ html_static_path = ['../sphinx/_static']
 
 # Breathe Configuration
 breathe_default_project = "ivi-homescreen"
+
+# readme.md is a symlink to the top-level README, whose links are relative to
+# the repo root. Rewrite them to GitHub so they resolve here too.
+_relative_link = re.compile(r'\]\((?!https?:|mailto:|#)([^)\s]+)\)')
+
+
+def _rewrite_readme_links(app, docname, source):
+    if docname == 'readme':
+        source[0] = _relative_link.sub(
+            lambda m: '](' + github_blob + '/' + m.group(1) + ')', source[0])
+
+
+def setup(app):
+    app.connect('source-read', _rewrite_readme_links)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,45 +15,45 @@ Architecture
 
 The main architectural overview is maintained with the source documentation:
 
-* `Architecture document <https://github.com/toyota-connected/ivi-homescreen/blob/main/docs/specs/ARCHITECTURE.md>`_
-* `Plugin ABI <https://github.com/toyota-connected/ivi-homescreen/blob/main/docs/PLUGIN_ABI.md>`_
+* :gh:`Architecture document <docs/specs/ARCHITECTURE.md>`
+* :gh:`Plugin ABI <docs/PLUGIN_ABI.md>`
 
 Core subsystems
 ---------------
 
-* `Configuration <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/configuration/README.md>`_
-* `Views <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/view/README.md>`_
-* `Displays <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/display/README.md>`_
-* `Input <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/input/README.md>`_
-* `Vsync <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/vsync/README.md>`_
-* `Frame profiling <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/profiling/README.md>`_
-* `Wayland integration <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/wayland/README.md>`_
-* `Logging and tracing <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/logging/README.md>`_
+* :gh:`Configuration <shell/configuration/README.md>`
+* :gh:`Views <shell/view/README.md>`
+* :gh:`Displays <shell/display/README.md>`
+* :gh:`Input <shell/input/README.md>`
+* :gh:`Vsync <shell/vsync/README.md>`
+* :gh:`Frame profiling <shell/profiling/README.md>`
+* :gh:`Wayland integration <docs/specs/ARCHITECTURE.md#442-wayland-integration-and-compositor-protocol-shells>`
+* :gh:`Logging and tracing <shell/logging/README.md>`
 
 Rendering and presentation backends
 -----------------------------------
 
-* `Backend overview <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/backend/README.md>`_
-* `Wayland EGL <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/backend/wayland_egl/README.md>`_
-* `Wayland Vulkan <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/backend/wayland_vulkan/README.md>`_
-* `DRM/KMS EGL <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/backend/drm_kms_egl/README.md>`_
-* `DRM/KMS Vulkan <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/backend/drm_kms_vulkan/README.md>`_
-* `Software backend <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/backend/software/README.md>`_
-* `HUD overlay <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/backend/hud/README.md>`_
+* :gh:`Backend overview <shell/backend/README.md>`
+* :gh:`Wayland EGL <shell/backend/wayland_egl/README.md>`
+* :gh:`Wayland Vulkan <shell/backend/wayland_vulkan/README.md>`
+* :gh:`DRM/KMS EGL <shell/backend/drm_kms_egl/README.md>`
+* :gh:`DRM/KMS Vulkan <shell/backend/drm_kms_vulkan/README.md>`
+* :gh:`Software backend <shell/backend/software/README.md>`
+* :gh:`HUD overlay <shell/backend/hud/README.md>`
 
 Platform integration
 --------------------
 
-* `Platform channels and embedder API <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/platform/homescreen/README.md>`_
-* `Platform views <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/platform/homescreen/platform_views/README.md>`_
-* `Accessibility <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/accessibility/README.md>`_
-* `Shared plugin ABI library <https://github.com/toyota-connected/ivi-homescreen/blob/main/shared/README.md>`_
+* :gh:`Platform channels and embedder API <docs/specs/ARCHITECTURE.md#5-platform-channels--embedder-api>`
+* :gh:`Platform views <shell/platform/homescreen/platform_views/README.md>`
+* :gh:`Accessibility <docs/specs/ARCHITECTURE.md#63-accessibility>`
+* :gh:`Shared plugin ABI library <shared/README.md>`
 
 Optional features
 -----------------
 
-* `Watchdog <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/watchdog/README.md>`_
-* `Crash handler <https://github.com/toyota-connected/ivi-homescreen/blob/main/shell/crash_handler/README.md>`_
+* :gh:`Watchdog <shell/watchdog/README.md>`
+* :gh:`Crash handler <shell/crash_handler/README.md>`
 
 Generated references
 --------------------


### PR DESCRIPTION
Fixes #511.

## Problem

- `index.rst` linked `github.com/.../blob/main/...`. `main` lacks these files: all 23 links 404.
- Three targets never existed on any branch: `shell/wayland/README.md`, `shell/platform/homescreen/README.md`, `shell/accessibility/README.md`.
- `readme.md` symlinks the top-level README. Its repo-relative links render as dead same-page anchors (`href="#shell/backend/README.md"`).
- README in-page anchors `#backend-support` and `#platform-view-plugins` point at headings that don't exist (broken on GitHub too).

## Change

- `conf.py`: GitHub ref from `READTHEDOCS_GIT_COMMIT_HASH`, `v3.0` locally. Links match the build on every version / PR build; no branch name to rot.
- `index.rst`: `:gh:` extlinks role on that ref. The three missing targets point at ARCHITECTURE.md §4.4.2, §5, §6.3.
- `conf.py`: `source-read` hook rewrites the README's relative links to GitHub. README keeps relative links for GitHub rendering; line 65 made relative to match its neighbors.
- README: `#backend-support` -> `shell/backend/README.md#build-matrix`, `#platform-view-plugins` -> ARCHITECTURE.md §5.1.

## Verified

Local `sphinx-build` (8.2.3, myst 5.0.0), with and without `READTHEDOCS_GIT_COMMIT_HASH`:
- index: 23 links, all on the expected ref
- readme: no `#path` anchors left, no myst xref warnings
- all distinct GitHub URLs: 200
