### PR TITLE
logging: expose ring capacity and drop count

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ registered plugins — `ihs_shared` exposes neither a registrar nor a messenger.
 
 | Capability | Status | Toggle / scope |
 |---|---|---|
-| Logging (generic `ihs_log_*` surface: ring registry, drain worker, console + file + level-floor sinks) | Built-in | Always compiled; `IhsApi::logging` always present |
+| Logging (generic `ihs_log_*` surface: ring registry, drain worker, console + file + level-floor sinks, ring depth and drop count) | Built-in | Always compiled; `IhsApi::logging` always present |
 | DLT logging sink | Optional | `ENABLE_DLT` (default `ON`); adds `dlt` as an `IHS_LOG_SINK` value, `dlopen`s `libdlt` at runtime |
 | Tracing (`ihs_trace_*`: duration / instant / counter / flow) | Built-in | Always; engine trace procs → kernel `trace_marker` → nop |
 | Platform-view surface negotiation (`ihs_pv_*`) | Built-in | Always; inert until the shell installs an `IhsPvHost` |
@@ -237,6 +237,7 @@ The logging sinks are selected from the environment at `ihs_log_start()`:
 | `IHS_LOG_FILE` | — | Path for the `file` sink |
 | `IHS_LOG_FILE_MAX_BYTES` | — | Rotation size for the `file` sink |
 | `IHS_LOG_FILE_MAX_FILES` | — | Rotation count for the `file` sink |
+| `IHS_LOG_RING_CAPACITY` | `256` | Per-thread ring depth, in slots; clamped to `[16, 65536]` and rounded up to a power of two. Read back with `ihs_log_ring_capacity()` |
 
 ### DLT sink
 
@@ -289,9 +290,12 @@ dlt-receive -a localhost
   running build (e.g. logging in a hypothetical build without it) — check for
   `NULL` rather than assuming presence.
 - **Logging drops.** If records go missing under load, the per-thread ring
-  overflowed (records drop silently and bump a per-ring counter); reduce volume
-  or gate with `ihs_log_enabled()` before formatting. Use `ihs_log_flush()` to
-  force pending records out before inspecting a sink.
+  overflowed. `ihs_log_dropped()` is the cumulative count across all rings, and
+  `ihs_log_ring_capacity()` the depth in force for this run, so a consumer can
+  assert on drops in a test build or warn when the depth is too small. Raise
+  `IHS_LOG_RING_CAPACITY`, reduce volume, or gate with `ihs_log_enabled()`
+  before formatting. Use `ihs_log_flush()` to force pending records out before
+  inspecting a sink.
 - **Tracing sink.** `ihs_trace_enabled()` reports whether *any* sink is active.
   With no engine procs installed, traces go to the kernel `trace_marker`
   (`/sys/kernel/tracing/trace_marker`); if neither is available, emits are nops.

--- a/shared/include/ihs/ihs_version.h
+++ b/shared/include/ihs/ihs_version.h
@@ -29,7 +29,7 @@
  * ihs_get_api().
  */
 #define IHS_SHARED_ABI_MAJOR 1u
-#define IHS_SHARED_ABI_MINOR 4u
+#define IHS_SHARED_ABI_MINOR 5u
 #define IHS_SHARED_ABI_VERSION \
   ((IHS_SHARED_ABI_MAJOR << 16) | IHS_SHARED_ABI_MINOR)
 

--- a/shared/include/ihs/logging.h
+++ b/shared/include/ihs/logging.h
@@ -52,9 +52,12 @@ typedef enum IhsLogLevel {
 } IhsLogLevel;
 
 /*
- * Maximum text length carried in one log record; longer messages are
- * truncated. A convenience wrapper sizing a stack buffer for a formatted line
- * should use this.
+ * Bytes of text one ring slot carries, NUL included. ihs_log() takes a message
+ * of any length: a longer one is split across slots of
+ * IHS_LOG_TEXT_CAPACITY - 1 bytes and reassembled by the drain, so a message
+ * costs one slot per piece. It is clipped, and marked as clipped, only when the
+ * ring lacks room for every piece or the message passes 64 KiB. A convenience
+ * wrapper sizing a stack buffer for a formatted line may use this.
  */
 #define IHS_LOG_TEXT_CAPACITY 240
 
@@ -114,6 +117,24 @@ IHS_EXPORT int ihs_log(int32_t ctx_index,
                        size_t text_len);
 
 /*
+ * Per-thread ring depth, in slots (ABI 1.5). Each logging thread buffers at
+ * most this many slots between drains. Set by IHS_LOG_RING_CAPACITY (clamped to
+ * [16, 65536] and rounded up to a power of two; default 256), resolved once at
+ * first use, and fixed for the life of the process: read it once and cache it.
+ * Valid before ihs_log_start().
+ */
+IHS_EXPORT uint32_t ihs_log_ring_capacity(void);
+
+/*
+ * Records dropped because a thread's ring was full, summed over every ring
+ * since process start (ABI 1.5). Monotonic, so report the difference between
+ * two reads. Each ihs_log() call refused for a full ring adds exactly one.
+ * Counts ring overflow only: not records below the IHS_LOG_LEVEL floor, and not
+ * a message clipped to fit.
+ */
+IHS_EXPORT uint64_t ihs_log_dropped(void);
+
+/*
  * The logging capability sub-table reachable through IhsApi::logging. The
  * function pointers alias the flat entry points above; a consumer may use
  * either. Grows additively behind struct_size.
@@ -127,6 +148,9 @@ typedef struct IhsLoggingApi {
   int (*log)(int32_t ctx_index, uint8_t level, const char* text, size_t len);
   /* Appended after log (additive; guarded by struct_size). */
   int (*enabled)(int32_t ctx_index, uint8_t level);
+  /* Appended in ABI 1.5 (additive; guarded by struct_size). */
+  uint32_t (*ring_capacity)(void);
+  uint64_t (*dropped)(void);
 } IhsLoggingApi;
 
 #ifdef __cplusplus

--- a/shared/src/logging/ffi_shim.cpp
+++ b/shared/src/logging/ffi_shim.cpp
@@ -18,12 +18,19 @@
 
 #include "bridge.hpp"
 #include "log_level.hpp"
+#include "ring_registry.hpp"
+#include "ring_slot.hpp"
+#include "thread_ring.hpp"
 
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <string_view>
+
+// The public header documents the slot size; keep it the size the ring uses.
+static_assert(ihs::dlt::kSlotTextCapacity == IHS_LOG_TEXT_CAPACITY,
+              "IHS_LOG_TEXT_CAPACITY must match the ring slot text size");
 
 namespace {
 
@@ -122,14 +129,32 @@ extern "C" int ihs_log(int32_t ctx_index,
              : 0;
 }
 
+extern "C" uint32_t ihs_log_ring_capacity() {
+  return static_cast<uint32_t>(ihs::dlt::ring_capacity());
+}
+
+extern "C" uint64_t ihs_log_dropped() {
+  // Rings are pooled and never freed, and each counter only grows, so the sum
+  // is cumulative for the process and never decreases between reads. The list
+  // is push-front with next set before publication, as the worker walks it.
+  uint64_t total = 0;
+  for (const ihs::dlt::ThreadRing* ring =
+           ihs::dlt::RingRegistry::instance().head();
+       ring != nullptr; ring = ring->next) {
+    total += ring->dropped();
+  }
+  return total;
+}
+
 namespace ihs::dlt {
 
 // The logging capability sub-table, wired into IhsApi::logging by
 // ihs_get_api(). Function pointers alias the flat entry points above.
 const IhsLoggingApi* logging_api() noexcept {
   static const IhsLoggingApi api = {
-      sizeof(IhsLoggingApi), &ihs_log_start, &ihs_log_stop,    &ihs_log_flush,
-      &ihs_log_context_open, &ihs_log,       &ihs_log_enabled,
+      sizeof(IhsLoggingApi), &ihs_log_start,         &ihs_log_stop,
+      &ihs_log_flush,        &ihs_log_context_open,  &ihs_log,
+      &ihs_log_enabled,      &ihs_log_ring_capacity, &ihs_log_dropped,
   };
   return &api;
 }

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -140,6 +140,17 @@ int main(void) {
     const char line[] = "consumer smoke line";
     api->logging->log(ctx, IHS_LEVEL_INFO, line, sizeof(line) - 1);
     api->logging->flush();
+    /* Ring stats (ABI 1.5 table fields), read only when struct_size covers
+     * them, as a consumer must against an older library. */
+    if (api->logging->struct_size >=
+        offsetof(IhsLoggingApi, dropped) + sizeof(api->logging->dropped)) {
+      const uint32_t cap = api->logging->ring_capacity();
+      CHECK(cap >= 16u && cap <= 65536u && (cap & (cap - 1u)) == 0u,
+            "ring_capacity is a power of two in [16, 65536]");
+      CHECK(cap == ihs_log_ring_capacity(),
+            "table and flat ring_capacity agree");
+      CHECK(api->logging->dropped() == 0u, "no drops after one line");
+    }
     api->logging->stop();
   }
 

--- a/shared/tests/sink_integration/CMakeLists.txt
+++ b/shared/tests/sink_integration/CMakeLists.txt
@@ -32,6 +32,6 @@ set_target_properties(sink_integration PROPERTIES
 target_link_libraries(sink_integration PRIVATE ivi_homescreen::ihs_shared)
 
 enable_testing()
-foreach (scenario console file level fallback)
+foreach (scenario console file level fallback drops)
     add_test(NAME sink_${scenario} COMMAND sink_integration ${scenario})
 endforeach ()

--- a/shared/tests/sink_integration/sink_integration.c
+++ b/shared/tests/sink_integration/sink_integration.c
@@ -24,6 +24,8 @@
  *   sink_integration level     -- IHS_LOG_LEVEL floor drops verbose records
  *   sink_integration fallback  -- IHS_LOG_SINK=dlt with no libdlt warns + falls
  *                                 back to console (missing-list #17 contract)
+ *   sink_integration drops     -- a burst into a 16-slot ring: capacity reads
+ *                                 back, and the drop count matches refusals
  *
  * The scenarios that inspect console output redirect stderr to a temp file,
  * flush, then read it back.
@@ -250,9 +252,61 @@ static int scenario_fallback(void) {
   return 0;
 }
 
+static int scenario_drops(void) {
+  const char* cap = capture_stderr(); /* keep the flood out of the test log */
+  if (!cap) {
+    FAILF("could not capture stderr");
+  }
+  /* Ring depth resolves at first use, so set it before anything logs. 16 is
+   * the floor: one thread flooding it outruns the drain and has to shed. */
+  setenv("IHS_LOG_SINK", "console", 1);
+  setenv("IHS_LOG_RING_CAPACITY", "16", 1);
+  const uint32_t capacity = ihs_log_ring_capacity();
+  if (ihs_log_start("SINK", "sink integration") != 1) {
+    FAILF("ihs_log_start");
+  }
+  const int32_t ctx = ihs_log_context_open("DROP", NULL);
+  if (ctx < 0) {
+    FAILF("context_open");
+  }
+  const uint64_t before = ihs_log_dropped();
+  uint64_t refused = 0;
+  for (int i = 0; i < 20000; ++i) {
+    char line[32];
+    const int n = snprintf(line, sizeof(line), "drop-line-%05d", i);
+    if (ihs_log(ctx, IHS_LEVEL_INFO, line, (size_t)n) == 0) {
+      ++refused;
+    }
+  }
+  const uint64_t after = ihs_log_dropped();
+  ihs_log_flush();
+  ihs_log_stop();
+  const uint64_t later = ihs_log_dropped();
+  remove(cap);
+
+  if (capacity != 16) {
+    FAILF("ring capacity %u, want 16", (unsigned)capacity);
+  }
+  if (refused == 0) {
+    FAILF("a 20000-record burst into a 16-slot ring was never refused");
+  }
+  /* Exact, however fast the drain ran: every refusal is one overflow. */
+  if (after - before != refused) {
+    FAILF("dropped delta %llu != refused %llu",
+          (unsigned long long)(after - before), (unsigned long long)refused);
+  }
+  if (later < after) {
+    FAILF("drop count went backward: %llu -> %llu", (unsigned long long)after,
+          (unsigned long long)later);
+  }
+  printf("OK drops (capacity=%u refused=%llu)\n", (unsigned)capacity,
+         (unsigned long long)refused);
+  return 0;
+}
+
 int main(int argc, char** argv) {
   if (argc < 2) {
-    fprintf(stdout, "usage: %s console|file|level|fallback\n", argv[0]);
+    fprintf(stdout, "usage: %s console|file|level|fallback|drops\n", argv[0]);
     return 2;
   }
   if (strcmp(argv[1], "console") == 0) {
@@ -266,6 +320,9 @@ int main(int argc, char** argv) {
   }
   if (strcmp(argv[1], "fallback") == 0) {
     return scenario_fallback();
+  }
+  if (strcmp(argv[1], "drops") == 0) {
+    return scenario_drops();
   }
   fprintf(stdout, "unknown scenario: %s\n", argv[1]);
   return 2;

--- a/shell/logging/README.md
+++ b/shell/logging/README.md
@@ -191,8 +191,10 @@ DLT is implemented via [`ihs_shared`](../../shared/src/logging/sink_dlt.cpp) and
   level.
 - **A line was dropped under load.** `ihs_log` is wait-free and drops on ring
   overflow (producer outrunning the drain worker), bumping a per-ring counter.
-  The load test ([`tests/load/`](tests/load/)) reports drops; keep bursts under
-  the ring capacity or reduce rate.
+  `ihs_log_dropped()` returns the process-wide total and
+  `ihs_log_ring_capacity()` the depth in force, so a run can report drops
+  against capacity. The load test ([`tests/load/`](tests/load/)) reports drops
+  too; raise `IHS_LOG_RING_CAPACITY`, keep bursts under it, or reduce rate.
 - **An error line didn't survive a crash.** Error/fatal records auto-flush
   (`level ≤ IHS_LEVEL_ERROR`); info/debug/verbose are async. Call
   `IHS_LOGGING_FLUSH()` before a controlled exit if you need pending records

--- a/shell/logging/tests/compat-matrix/compat_smoke.cc
+++ b/shell/logging/tests/compat-matrix/compat_smoke.cc
@@ -119,6 +119,11 @@ int main() {
     }
   }
 
+  // 6. The C ABI reports the same depth, and a drop count that covers this
+  // thread's ring (it sums every ring, so it can only be larger).
+  check(ihs_log_ring_capacity() == capacity, "ihs_log_ring_capacity matches");
+  check(ihs_log_dropped() >= ring.dropped(), "ihs_log_dropped covers the ring");
+
   IHS_LOGGING_FLUSH();
   IHS_LOGGING_STOP();
 


### PR DESCRIPTION
Fixes #509.

## Change

New exports, also appended to `IhsLoggingApi` behind `struct_size`:

```c
uint32_t ihs_log_ring_capacity(void); /* slots per thread ring; fixed for the process */
uint64_t ihs_log_dropped(void);       /* ring-overflow drops, all rings, since start */
```

- Two shapes, per the issue: capacity is resolved once and constant (read once, cache); drops are a monotonic sum over the pooled, never-freed rings (report deltas).
- `ihs_log_dropped()` counts overflow only. Each `ihs_log()` refused for a full ring adds exactly one; level-floor drops and clipped messages do not count.
- ABI minor 1.4 -> 1.5. +2 exports (`ihs_*` now 55).
- Per-slot text capacity: already public as `IHS_LOG_TEXT_CAPACITY`. Added a `static_assert` that it equals the ring's slot size, so no runtime getter is needed. Its comment said longer messages are truncated; they are split across slots and reassembled (clipped only when the ring lacks room for every piece, or past 64 KiB). Comment fixed.

## Tests

- `sink_integration drops`: `IHS_LOG_RING_CAPACITY=16`, 20000-record burst from one thread; asserts capacity reads back 16, `dropped()` delta == refused calls (exact regardless of drain speed), and no decrease after stop.
- `consumer` smoke: table fields read only when `struct_size` covers them; power-of-two bounds; table == flat; 0 drops after one line.
- `compat_smoke`: flat capacity == `ring_capacity()`; `dropped()` >= this thread's ring.

## Verified locally

- `cmake -S shared`, `ENABLE_DLT` ON and OFF: builds clean; both symbols exported.
- consumer smoke: pass (both). `sink_integration`: 5/5 (both); `drops` refused 19984 / 17114, equal to the drop delta.
- `compat-matrix`: 2/2 (both), including `IHS_LOG_RING_CAPACITY=1024`.
- clang-format clean on changed files.

## ABI baseline

Not re-dumped, as with ABI 1.1-1.4: the gate fails only on an incompatible change, and appended exports / trailing table fields are additive. `abi-gate` in this PR's CI confirms.