### PR TITLE
location: make a filter that did not bind visible

### DIFF
--- a/shared/include/ihs/ihs_version.h
+++ b/shared/include/ihs/ihs_version.h
@@ -29,7 +29,7 @@
  * ihs_get_api().
  */
 #define IHS_SHARED_ABI_MAJOR 1u
-#define IHS_SHARED_ABI_MINOR 5u
+#define IHS_SHARED_ABI_MINOR 6u
 #define IHS_SHARED_ABI_VERSION \
   ((IHS_SHARED_ABI_MAJOR << 16) | IHS_SHARED_ABI_MINOR)
 

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -182,6 +182,19 @@ IHS_EXPORT void ihs_location_set_callback(IhsLocationService* service,
 IHS_EXPORT void ihs_location_stop(IhsLocationService* service);
 
 /*
+ * Whether @service is running a filter (ABI 1.6): 1 when the filter_key given
+ * to ihs_location_start_filtered() resolved and its create() returned an
+ * instance, 0 otherwise -- an unknown key, a create() that failed, no key at
+ * all, or a NULL service.
+ *
+ * ihs_location_start_filtered() degrades to the unfiltered path rather than
+ * failing, so a non-NULL handle does not mean the named filter is running, and
+ * this is how a caller tells the two apart. The library also names the key on
+ * stderr when it cannot bind it. Settled once the service has started.
+ */
+IHS_EXPORT int ihs_location_filter_active(IhsLocationService* service);
+
+/*
  * --- Measurement source / filter registry ----------------------------------
  *
  * A second, composable way to build the service, mirroring ihs_pv's factory

--- a/shared/src/location/README.md
+++ b/shared/src/location/README.md
@@ -30,6 +30,7 @@ The header is the normative reference for each call's contract.
 | Fix time on `CLOCK_MONOTONIC` and 1-sigma accuracy | Built-in | `ihs_location_latest2` |
 | Polling: latest fix, generation counter | Built-in | `ihs_location_latest`, `_latest2`, `_generation` |
 | Push callback on each fix | Built-in | `ihs_location_set_callback` |
+| Filter binding is visible: named on stderr when it fails, queryable after | Built-in | `ihs_location_filter_active()` |
 | Caller-registered filters | Built-in | `ihs_location_register_filter` |
 | Caller-registered measurement sources | Partial | `ihs_location_register_source`; not yet bound by a start call (see [Known limitations](#known-limitations)) |
 
@@ -233,6 +234,11 @@ required; `destroy` is optional. Registering an existing key, `kalman.cv`
 included, replaces it. Ops structs are copied bounded by `struct_size`, so a
 caller built against an older header is never over-read.
 
+A key that does not resolve, or a `create` that returns NULL, leaves the
+service running unfiltered rather than failing the start. The library names the
+key on stderr when that happens, and `ihs_location_filter_active()` reports
+whether a filter is bound, so the degrade is visible either way.
+
 ---
 
 ## Diagnostics/Debug
@@ -247,8 +253,10 @@ caller built against an older header is never over-read.
   geoclue's configuration allows the `DesktopId` `ihs-location`. geoclue fixes often
   report `speed_mps` < 0 (unknown).
 - **Filter seems inactive:** an unknown filter key, or a filter whose `create`
-  fails, degrades to passthrough without an error. A non-NULL handle does not
-  prove the filter is running.
+  fails, degrades to passthrough. The library names the key on stderr
+  (`[ihs.location] filter "..." is not registered`), and
+  `ihs_location_filter_active()` answers it directly. A non-NULL handle on its
+  own does not prove the filter is running.
 - **Accuracy:** `sigma_e_m` / `sigma_n_m` come from gpsd `epx`/`epy` (or `eph`)
   and geoclue `Accuracy`. With a filter they are the filter's own estimate,
   which grows while coasting.
@@ -287,8 +295,6 @@ position noise. Each test uses its own track and seed, so compare within a row.
 - With the built-in sources a filter sees GNSS position only. `kalman.ctrv`'s
   speed and yaw-rate updates need a CAN or gyro source, which needs the item
   above; today only the unit tests exercise them.
-- An unknown filter key, or a failing `create`, degrades to passthrough without
-  an error.
 - gpsd `config` takes a numeric IPv4 address; host names are not resolved.
 - geoclue needs `libsystemd.so.0` at runtime and the `DesktopId` `ihs-location` to be
   allowed; geoclue-only fixes usually carry no speed.

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -367,4 +367,17 @@ void ihs_location_stop(IhsLocationService* service) {
   delete service;
 }
 
+int ihs_location_filter_active(IhsLocationService* service) {
+  if (service == nullptr || service->manager == nullptr) {
+    return 0;
+  }
+  // No exception may cross the C ABI; the accessor takes the Manager's mutex,
+  // which throws only on a system error.
+  try {
+    return service->manager->filter_active() ? 1 : 0;
+  } catch (...) {
+    return 0;
+  }
+}
+
 }  // extern "C"

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -17,6 +17,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdio>
 #include <cstring>
 #include <utility>
 
@@ -138,10 +139,28 @@ bool Manager::Start() {
       void* const inst = fe.ops.create(
           fe.user_data,
           filter_config_.empty() ? nullptr : filter_config_.c_str());
-      const std::lock_guard<std::mutex> lock(mutex_);
-      filter_ops_ = fe.ops;
-      filter_user_data_ = fe.user_data;
-      filter_instance_ = inst;
+      {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        filter_ops_ = fe.ops;
+        filter_user_data_ = fe.user_data;
+        filter_instance_ = inst;
+      }
+      // Report outside the lock: create() rejecting its config is the caller's
+      // to know about, and an unfiltered service looks exactly like a working
+      // filtered one from the outside.
+      if (inst == nullptr) {
+        std::fprintf(stderr,
+                     "[ihs.location] filter \"%s\" failed to initialize; "
+                     "continuing unfiltered\n",
+                     filter_key_.c_str());
+      }
+    } else {
+      // Not registered: a typo, or a build without that filter. Name it rather
+      // than run unfiltered in silence.
+      std::fprintf(stderr,
+                   "[ihs.location] filter \"%s\" is not registered; "
+                   "continuing unfiltered\n",
+                   filter_key_.c_str());
     }
     // A configured-but-missing (or create-failed) filter leaves
     // filter_instance_ null, so the built-in passthrough is used instead of
@@ -169,6 +188,11 @@ bool Manager::Start() {
   // re-queried, so registering one after Start() has no effect.
   started_ = true;
   return true;
+}
+
+bool Manager::filter_active() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return filter_instance_ != nullptr;
 }
 
 void Manager::Stop() {

--- a/shared/src/location/manager.hpp
+++ b/shared/src/location/manager.hpp
@@ -101,6 +101,11 @@ class Manager : public ILocationProvider {
   // Returns false until a fix exists. Thread-safe.
   bool Estimate(Position& out, uint64_t at_monotonic_ns);
 
+  // Whether a registered filter is actually bound: true only when the
+  // configured key resolved and its create() returned an instance. False for
+  // the built-in passthrough, including the degrade cases. Thread-safe.
+  [[nodiscard]] bool filter_active() const;
+
  private:
   // C sink trampoline: sink_user_data is the Manager*.
   static void SinkThunk(void* sink_user_data, const IhsMeasurement* m);

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -172,6 +172,10 @@ int main(void) {
   ihs_location_set_callback(loc, smoke_location_cb, NULL);
   ihs_location_set_callback(loc, NULL, NULL);               /* clear */
   ihs_location_set_callback(NULL, smoke_location_cb, NULL); /* NULL is safe */
+  /* No filter was requested, so none is active (ABI 1.6). */
+  CHECK(ihs_location_filter_active(loc) == 0,
+        "no filter requested, none active");
+  CHECK(ihs_location_filter_active(NULL) == 0, "filter_active(NULL) is safe");
   ihs_location_stop(loc);
   CHECK(ihs_location_latest(NULL, &pos) == 0, "latest(NULL) is safe");
   CHECK(ihs_location_latest2(NULL, &pos, sizeof(pos)) == 0,

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -122,6 +122,7 @@ void TestFileThroughKalman() {
 
   // Wait for most of the track to replay (realtime, ~1 s).
   Check(c.WaitFor(30, std::chrono::seconds(5)), "filtered fixes delivered");
+  Check(ihs_location_filter_active(svc) == 1, "kalman.cv reports active");
 
   ihs_location_stop(svc);
   std::filesystem::remove(path);
@@ -241,7 +242,11 @@ void TestBadPathAndKeys() {
       IHS_LOCATION_FILE, path.string().c_str(), "no.such.filter", nullptr);
   Check(svc2 != nullptr,
         "unknown filter key still starts (degrades to passthrough)");
+  Check(ihs_location_filter_active(nullptr) == 0,
+        "filter_active(NULL) is safe");
   if (svc2 != nullptr) {
+    Check(ihs_location_filter_active(svc2) == 0,
+          "unknown filter key reports no active filter");
     ihs_location_set_callback(svc2, &Collector::Thunk, &c);
     Check(c.WaitFor(10, std::chrono::seconds(5)),
           "degraded path delivers fixes");


### PR DESCRIPTION
Fixes #517.

`ihs_location_start_filtered()` runs unfiltered when the key does not resolve or `create()` returns NULL. Nothing reported it, and the handle is non-NULL either way, so a typo like `"kalman.ctv"` looked like a working filter.

## Change

- **Warn, naming the key.** Two cases, separately: not registered, and `create()` failed. `[ihs.location] filter "..." is not registered; continuing unfiltered`, on stderr, matching the geoclue provider's idiom. Printed outside the Manager's lock.
- **Query.** `int ihs_location_filter_active(IhsLocationService*)` — 1 when a filter is bound, 0 for an unknown key, a failed `create()`, no key, or NULL. Settled once the service starts.
- Behavior unchanged otherwise: degrade-don't-fail stays, so an unknown key still starts and still delivers fixes.
- ABI minor 1.5 -> 1.6; +1 export (`ihs_*` now 56). Baseline not re-dumped: additive, as with 1.1-1.5. `abi-gate` confirms.

## Tests

- `wire_test`: `kalman.cv` reports active; unknown key reports inactive and still delivers; `filter_active(NULL)` is safe. 26 -> 29 checks.
- `consumer` smoke: unfiltered service reports no filter; NULL is safe.

## Verified locally

- Location tests 9/9; `wire_test` prints the warning exactly once, with the expected text.
- `cmake -S shared` with `ENABLE_DLT` ON and OFF: builds clean, `ihs_location_filter_active` exported in both, consumer smoke passes.
- clang-format clean.

## Still open from the same review

#516 (registered sources are never bound) and #519 (filters see position only) are untouched here.