### PR TITLE
location: submit the source's speed to the filter

### DIFF
--- a/shared/src/location/README.md
+++ b/shared/src/location/README.md
@@ -63,9 +63,10 @@ D-Bus signal, the next line of a capture). Nothing polls.
 
 Without a filter, the Manager stores each fix whole and atomically
 (`PublishFix`), so a consumer never sees a half-updated position. With a
-filter, each fix becomes one position measurement (`SubmitPositionFix`) routed
-to the filter's `update()`, and every read asks the filter to `estimate()` the
-state at the time of the read. `ihs_location_start()` is the unfiltered case.
+filter, each fix becomes a position measurement, plus a speed measurement when
+the fix carries one (`SubmitPositionFix`), routed to the filter's `update()`,
+and every read asks the filter to `estimate()` the state at the time of the
+read. `ihs_location_start()` is the unfiltered case.
 
 Consumers poll (`latest2`, with `generation` to notice a new fix) or subscribe
 (`set_callback`). Subscribe first, then read the current fix: that order cannot
@@ -105,7 +106,7 @@ miss an update.
 | Key | Model and state | Corrects from | `filter_config` |
 |---|---|---|---|
 | `kalman.cv` | Constant velocity, `[e, n, v_e, v_n]`; linear | GNSS position | `q=<value>` process-noise density; default `1.0` |
-| `kalman.ctrv` | Constant turn rate and velocity EKF, `[e, n, ψ, v, ω]`; follows an arc, so a turning vehicle does not lag the corner | GNSS position; ground speed and yaw rate from a source that provides them | `qa=<σ>` acceleration, m/s², default `2.0`; `qw=<σ>` yaw acceleration, rad/s², default `0.15` |
+| `kalman.ctrv` | Constant turn rate and velocity EKF, `[e, n, ψ, v, ω]`; follows an arc, so a turning vehicle does not lag the corner | GNSS position, and ground speed when the source reports it; yaw rate from a source that provides one | `qa=<σ>` acceleration, m/s², default `2.0`; `qw=<σ>` yaw acceleration, rad/s², default `0.15` |
 
 Both run in a local east/north tangent plane in meters, anchored at the first
 fix and re-anchored past 10 km, on fixed-size matrix code with no Eigen. Both
@@ -292,9 +293,9 @@ position noise. Each test uses its own track and seed, so compare within a row.
 - A source registered with `ihs_location_register_source()` is never bound: the
   start calls build the Manager from the built-in sources only. Registered
   filters do work.
-- With the built-in sources a filter sees GNSS position only. `kalman.ctrv`'s
-  speed and yaw-rate updates need a CAN or gyro source, which needs the item
-  above; today only the unit tests exercise them.
+- With the built-in sources a filter sees position and ground speed.
+  `kalman.ctrv`'s yaw-rate update still needs a CAN or gyro source, which needs
+  the item above; today only the unit tests exercise it.
 - gpsd `config` takes a numeric IPv4 address; host names are not resolved.
 - geoclue needs `libsystemd.so.0` at runtime and the `DesktopId` `ihs-location` to be
   allowed; geoclue-only fixes usually carry no speed.

--- a/shared/src/location/manager.cc
+++ b/shared/src/location/manager.cc
@@ -116,6 +116,27 @@ void Manager::SubmitPositionFix(const Position& fix) {
   m.variance[1] = fix.sigma_n_m >= 0.0 ? fix.sigma_n_m * fix.sigma_n_m : -1.0;
   m.variance[2] = -1.0;
   OnMeasurement(m);
+
+  // The source's ground speed, when it reported one. A position-only filter
+  // (kalman.cv) ignores this kind; kalman.ctrv corrects its speed state from
+  // the measurement instead of re-deriving speed from position differences.
+  //
+  // After the position, never before: a scalar that reaches a filter with no
+  // position anchor is dropped (KalmanCtrv::UpdateScalar returns while
+  // have_state_ is false). Same timestamp, so the filter predicts dt = 0 for
+  // it. OnMeasurement counts a generation for a position only, so this second
+  // submission neither bumps it nor fires the notify twice.
+  if (fix.speed_mps >= 0.0) {
+    IhsMeasurement s{};
+    s.struct_size = sizeof(s);
+    s.kind = IHS_MEAS_SPEED;
+    s.t_monotonic_ns = fix.t_monotonic_ns;
+    s.value_count = 1;
+    s.value[0] = fix.speed_mps;
+    s.variance[0] =
+        fix.sigma_v_mps >= 0.0 ? fix.sigma_v_mps * fix.sigma_v_mps : -1.0;
+    OnMeasurement(s);
+  }
 }
 
 void Manager::SetFixNotify(std::function<void()> notify) {

--- a/shared/tests/location/manager_test.cc
+++ b/shared/tests/location/manager_test.cc
@@ -110,9 +110,20 @@ struct FakeFilter {
   double lat = 0.0;
   double lon = 0.0;
   int updates = 0;
+  int position_updates = 0;
+  int speed_updates = 0;
+  double last_speed = -1.0;
+  double last_speed_variance = 0.0;
 };
+
+// The most recently created fake filter, so a test can inspect what the Manager
+// handed it (this file already reaches filter state through a global).
+FakeFilter* g_last_filter = nullptr;
+
 void* FakeFilterCreate(void* /*ud*/, const char* /*config*/) {
-  return new FakeFilter();
+  auto* f = new FakeFilter();
+  g_last_filter = f;
+  return f;
 }
 void FakeFilterDestroy(void* inst) {
   delete static_cast<FakeFilter*>(inst);
@@ -123,6 +134,12 @@ void FakeFilterUpdate(void* inst, const IhsMeasurement* m) {
   if (m->kind == IHS_MEAS_POSITION_LLA && m->value_count >= 2) {
     f->lat = m->value[0];
     f->lon = m->value[1];
+    ++f->position_updates;
+  }
+  if (m->kind == IHS_MEAS_SPEED && m->value_count >= 1) {
+    f->last_speed = m->value[0];
+    f->last_speed_variance = m->variance[0];
+    ++f->speed_updates;
   }
   ++f->updates;
 }
@@ -357,6 +374,48 @@ int main() {
           "estimate carries the measurement");
     Check(pos.mode == 3, "estimate mode from the filter");
     m.Stop();  // destroys the filter instance (no leak)
+  }
+
+  // --- filter route: a whole fix also submits its speed as a measurement ----
+  {
+    IhsLocationFilterOps fops{};
+    fops.struct_size = sizeof(fops);
+    fops.create = &FakeFilterCreate;
+    fops.destroy = &FakeFilterDestroy;
+    fops.update = &FakeFilterUpdate;
+    fops.estimate = &FakeFilterEstimate;
+    ihs_location_register_filter("kalman.speed", &fops, nullptr);
+
+    Manager m({}, "kalman.speed", "");
+    Check(m.Start(), "Start with a filter (no sources; fixes submitted here)");
+    FakeFilter* const f = g_last_filter;
+    Check(f != nullptr, "filter instance created");
+
+    Position fix;
+    fix.latitude = 48.75;
+    fix.longitude = -122.48;
+    fix.mode = 3;
+    fix.t_monotonic_ns = 1000;
+    fix.speed_mps = 12.5;
+    fix.sigma_v_mps = 2.0;
+    m.SubmitPositionFix(fix);
+    Check(f->position_updates == 1, "the position reached the filter");
+    Check(f->speed_updates == 1, "the speed reached the filter too");
+    Check(f->last_speed == 12.5, "speed value carried");
+    Check(f->last_speed_variance == 4.0, "speed variance is sigma squared");
+    Check(m.generation() == 1, "one generation per fix, not one per component");
+
+    // A source that reported no speed submits the position alone.
+    Position no_speed;
+    no_speed.latitude = 48.76;
+    no_speed.longitude = -122.49;
+    no_speed.mode = 2;
+    no_speed.t_monotonic_ns = 2000;
+    m.SubmitPositionFix(no_speed);
+    Check(f->position_updates == 2, "second position reached the filter");
+    Check(f->speed_updates == 1, "no speed measurement when none was reported");
+    Check(m.generation() == 2, "the second fix bumps the generation once");
+    m.Stop();
   }
 
   // --- filter route: Latest() and generation() stay consistent — no fix is

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -161,9 +161,12 @@ void TestFileThroughCtrv() {
   std::filesystem::remove(path);
   if (c.count() > 0) {
     const IhsPosition p = c.last();
-    Check(std::isfinite(p.latitude) && std::isfinite(p.longitude) &&
-              p.speed_mps > 15.0 * 0.5,
-          "ctrv delivers a finite fix with recovered speed");
+    Check(std::isfinite(p.latitude) && std::isfinite(p.longitude),
+          "ctrv delivers a finite fix");
+    // The capture reports speed, which now reaches the filter as a scalar
+    // measurement rather than being re-derived from position differences.
+    Check(std::abs(p.speed_mps - 15.0) < 1.5,
+          "ctrv tracks the speed the source reported");
   }
 }
 


### PR DESCRIPTION
Part of #519. Leaves the issue open: the yaw-rate half is still blocked.

## Problem

With a filter bound, `Manager::SubmitPositionFix` turned each fix into a single `IHS_MEAS_POSITION_LLA` measurement. gpsd reports `speed` (and `eps`), and `ParseTpv` already parses both, but the filter never saw them. `kalman.ctrv` has a scalar speed update (`kalman_ctrv.cc:134`) that nothing outside the unit tests could reach.

## Change

Submit `IHS_MEAS_SPEED` after the position when the fix carries one (`speed_mps >= 0`), variance `sigma_v_mps^2`, or -1 when the source reported no error (the filter then uses its own default).

Safe by construction:
- **After the position, never before.** `KalmanCtrv::UpdateScalar` drops a scalar while `have_state_` is false, so the anchor has to land first.
- **Same timestamp**, so the filter predicts `dt = 0` for it.
- **One generation per fix.** `OnMeasurement` counts a generation and fires the notify for a position only, so the second submission does neither.
- **`kalman.cv` unaffected**: it returns early on any non-position kind (`kalman_cv.cc:109`).
- **Passthrough unaffected**: this path runs only when a filter is bound.

No ABI change: no new export, no header change, no version bump.

## Tests

- `manager_test`, driving `SubmitPositionFix` directly against a fake filter: the position and the speed both arrive, value and variance are right (`sigma^2`), a fix with no speed submits position only, and the generation bumps once per fix either way. 56 -> 66 checks.
- `wire_test`: the ctrv leg now asserts the estimate tracks the speed the capture reported, rather than the old "greater than half of it" bound. 29 -> 30 checks.

## Verified locally

- Location tests 9/9; `manager_test` 66/66, `wire_test` 30/30.
- `cmake -S shared` builds clean.
- clang-format clean.

## Still open in #519

- **Yaw rate**: needs a CAN or gyro source, which cannot be bound until #516.
- **Heading**: `IHS_MEAS_HEADING` stays unsubmitted, since no filter consumes it today.