### PR TITLE
location: bind registered sources through a start options struct

### DIFF
--- a/shared/include/ihs/ihs_version.h
+++ b/shared/include/ihs/ihs_version.h
@@ -29,7 +29,7 @@
  * ihs_get_api().
  */
 #define IHS_SHARED_ABI_MAJOR 1u
-#define IHS_SHARED_ABI_MINOR 6u
+#define IHS_SHARED_ABI_MINOR 7u
 #define IHS_SHARED_ABI_VERSION \
   ((IHS_SHARED_ABI_MAJOR << 16) | IHS_SHARED_ABI_MINOR)
 

--- a/shared/include/ihs/location.h
+++ b/shared/include/ihs/location.h
@@ -69,6 +69,7 @@ typedef enum IhsLocationSource {
   IHS_LOCATION_GEOCLUE = 1, /* geoclue over D-Bus */
   IHS_LOCATION_AUTO = 2,    /* gpsd primary, geoclue fallback */
   IHS_LOCATION_FILE = 3,    /* replay a captured gpsd file (@config below) */
+  IHS_LOCATION_NONE = 4,    /* no built-in source; registered keys only (1.7) */
 } IhsLocationSource;
 /* @config for IHS_LOCATION_FILE is a captured gpsd JSON path, optionally
  * followed by "?" and one or more replay flags separated by ',' or '&':
@@ -116,6 +117,42 @@ IHS_EXPORT IhsLocationService* ihs_location_start_filtered(
     const char* config,
     const char* filter_key,
     const char* filter_config);
+
+/*
+ * How to build a service (ABI 1.7). The general form of the two calls above:
+ * a built-in source, measurement sources registered with
+ * ihs_location_register_source(), or both fused through one filter -- which is
+ * what lets GNSS position and a CAN/gyro yaw rate reach kalman.ctrv together.
+ *
+ * ABI: struct_size-first, fields only ever APPENDED. The library reads
+ * min(struct_size, its own sizeof), so a caller built against an older header
+ * is never over-read. Zero the struct, set struct_size = sizeof, then the
+ * fields you need.
+ */
+typedef struct IhsLocationStartOptions {
+  size_t struct_size;
+  uint32_t source; /* IhsLocationSource; NONE = registered keys only */
+  const char* source_config; /* @config for `source`; NULL for none/ignored */
+  const char* const* source_keys; /* registered source keys to bind, or NULL */
+  size_t source_key_count;        /* entries in source_keys */
+  const char* filter_key;         /* registered filter, or NULL for none */
+  const char* filter_config;      /* filter tuning string, or NULL */
+} IhsLocationStartOptions;
+
+/*
+ * Start a service per @options. Returns NULL when @options is NULL, its
+ * struct_size is too small to carry `source`, `source` is not an
+ * IhsLocationSource, source_keys is NULL with a non-zero count, or the built-in
+ * source cannot start. A key that is not registered is skipped, and an
+ * unusable filter degrades to the passthrough (see
+ * ihs_location_filter_active), so a returned handle does not promise every
+ * requested part bound.
+ *
+ * A service with no source at all (NONE and no registered keys) is legal and
+ * simply never reports a fix.
+ */
+IHS_EXPORT IhsLocationService* ihs_location_start_options(
+    const IhsLocationStartOptions* options);
 
 /*
  * Copy the most recent fix into @out, filling only the original six fields

--- a/shared/src/location/README.md
+++ b/shared/src/location/README.md
@@ -32,7 +32,8 @@ The header is the normative reference for each call's contract.
 | Push callback on each fix | Built-in | `ihs_location_set_callback` |
 | Filter binding is visible: named on stderr when it fails, queryable after | Built-in | `ihs_location_filter_active()` |
 | Caller-registered filters | Built-in | `ihs_location_register_filter` |
-| Caller-registered measurement sources | Partial | `ihs_location_register_source`; not yet bound by a start call (see [Known limitations](#known-limitations)) |
+| Caller-registered measurement sources | Built-in | `ihs_location_register_source`, bound by `ihs_location_start_options()` |
+| A built-in source and registered sources fused in one service | Built-in | `ihs_location_start_options()` |
 
 ---
 
@@ -67,6 +68,10 @@ filter, each fix becomes a position measurement, plus a speed measurement when
 the fix carries one (`SubmitPositionFix`), routed to the filter's `update()`,
 and every read asks the filter to `estimate()` the state at the time of the
 read. `ihs_location_start()` is the unfiltered case.
+
+`ihs_location_start_options()` is the general form: it takes a built-in source,
+registered source keys, or both, so GNSS position and a CAN or gyro yaw rate
+reach one filter together. The two older calls are that call with no keys.
 
 Consumers poll (`latest2`, with `generation` to notice a new fix) or subscribe
 (`set_callback`). Subscribe first, then read the current fix: that order cannot
@@ -223,8 +228,32 @@ built against an older header.
 | `IHS_LOCATION_GEOCLUE` | GeoClue2 | D-Bus address, or `user` for the session bus; default the system bus |
 | `IHS_LOCATION_AUTO` | gpsd; geoclue after 5 s of gpsd silence | Ignored |
 | `IHS_LOCATION_FILE` | A captured gpsd JSON stream | `<path>[?<flags>]`; flags `fast`, `realtime` (default), `loop`, separated by `,` or `&` |
+| `IHS_LOCATION_NONE` | Nothing built in; registered sources only | Ignored |
 
 Examples: `drive.jsonl`, `drive.jsonl?fast`, `drive.jsonl?loop,fast`.
+
+### Custom sources
+
+Register an `IhsLocationSourceOps` under a key with
+`ihs_location_register_source()`, then name that key in
+`ihs_location_start_options()`. `start` is required; `stop` is optional. The
+source pushes `IhsMeasurement` records into the sink it is handed, on whatever
+thread it likes.
+
+```c
+const char* keys[] = {"can.yaw"};
+IhsLocationStartOptions o = {0};
+o.struct_size = sizeof(o);
+o.source = IHS_LOCATION_GPSD;   /* position from gpsd ... */
+o.source_keys = keys;           /* ... yaw rate from CAN */
+o.source_key_count = 1;
+o.filter_key = "kalman.ctrv";   /* fused by one filter */
+IhsLocationService* svc = ihs_location_start_options(&o);
+```
+
+Keys are bound once, at start: registering a source afterwards has no effect on
+a running service, and a key that is not registered is skipped rather than
+failing the start.
 
 ### Custom filters
 
@@ -290,12 +319,11 @@ position noise. Each test uses its own track and seed, so compare within a row.
 
 ## Known limitations
 
-- A source registered with `ihs_location_register_source()` is never bound: the
-  start calls build the Manager from the built-in sources only. Registered
-  filters do work.
-- With the built-in sources a filter sees position and ground speed.
-  `kalman.ctrv`'s yaw-rate update still needs a CAN or gyro source, which needs
-  the item above; today only the unit tests exercise it.
+- A built-in source feeds a filter position and ground speed only.
+  `kalman.ctrv`'s yaw-rate update needs a CAN or gyro source registered and
+  named in `ihs_location_start_options()`; no built-in source produces one.
+- Source keys bind once at start. A source registered later is not picked up by
+  a running service.
 - gpsd `config` takes a numeric IPv4 address; host names are not resolved.
 - geoclue needs `libsystemd.so.0` at runtime and the `DesktopId` `ihs-location` to be
   allowed; geoclue-only fixes usually carry no speed.

--- a/shared/src/location/location_api.cc
+++ b/shared/src/location/location_api.cc
@@ -150,6 +150,93 @@ struct IhsLocationService {
   std::unique_ptr<ihs::location::IEventSource> source;
 };
 
+namespace {
+
+// The one start path behind every ihs_location_start* call. @o is already
+// bounded-copied and validated by the caller.
+IhsLocationService* StartService(const IhsLocationStartOptions& o) {
+  // No exception may cross the C ABI boundary above: construction and Start()
+  // (allocations, std::thread) can throw, so translate any failure to NULL.
+  try {
+    const bool use_filter = o.filter_key != nullptr && o.filter_key[0] != '\0';
+    if (use_filter) {
+      // Make the requested filter available if it is a built-in the caller did
+      // not already register. An unknown key resolves to nothing and degrades
+      // to the passthrough inside Manager.
+      EnsureBuiltinFilter(o.filter_key);
+    }
+    std::vector<std::string> keys;
+    for (size_t i = 0; i < o.source_key_count; ++i) {
+      if (o.source_keys[i] != nullptr && o.source_keys[i][0] != '\0') {
+        keys.emplace_back(o.source_keys[i]);
+      }
+    }
+    // Declare the Manager before the source: the source's worker calls into the
+    // Manager, so on any early return or exception after the source starts,
+    // reverse-order destruction must tear down the source first (joining its
+    // worker) and only then the Manager it points at.
+    auto manager = std::make_unique<Manager>(
+        std::move(keys), use_filter ? std::string(o.filter_key) : std::string{},
+        o.filter_config != nullptr ? std::string(o.filter_config)
+                                   : std::string{});
+    std::unique_ptr<IEventSource> src;
+    switch (static_cast<IhsLocationSource>(o.source)) {
+      case IHS_LOCATION_NONE:
+        break;  // registered sources only
+      case IHS_LOCATION_GEOCLUE:
+        src = MakeGeoclue(o.source_config);
+        break;
+      case IHS_LOCATION_FILE:
+        src = MakeFile(o.source_config);
+        break;
+      case IHS_LOCATION_AUTO:
+        // gpsd primary, geoclue fallback — the same composition as before, now
+        // an event-driven combiner.
+        src = std::make_unique<ihs::location::FallbackSource>(
+            MakeGpsd(nullptr), MakeGeoclue(nullptr));
+        break;
+      case IHS_LOCATION_GPSD:
+      default:
+        src = MakeGpsd(o.source_config);
+        break;
+    }
+    if (!src && static_cast<IhsLocationSource>(o.source) != IHS_LOCATION_NONE) {
+      return nullptr;
+    }
+    Manager* const mgr = manager.get();
+    // Drive the Manager on each fix the source pushes (worker thread).
+    // SetOnFix must precede the source's Start(). With a filter, route the fix
+    // through the measurement path so the filter processes it; without one,
+    // PublishFix stores the whole fix atomically (and keeps the source's
+    // speed/heading a position-only filter would otherwise re-estimate).
+    if (src) {
+      if (use_filter) {
+        src->SetOnFix([mgr](const Position& p) { mgr->SubmitPositionFix(p); });
+      } else {
+        src->SetOnFix([mgr](const Position& p) { mgr->PublishFix(p); });
+      }
+    }
+    // Arm the Manager before any source begins pushing, honoring the
+    // Start()/Stop() lifecycle (ihs_location_stop calls Stop()). Registered
+    // sources are bound and started here.
+    if (!manager->Start()) {
+      return nullptr;
+    }
+    if (src && !src->Start()) {
+      return nullptr;  // could not begin acquisition at all
+    }
+    auto service = std::make_unique<IhsLocationService>();
+    service->manager = mgr;  // alias before the unique_ptr is moved
+    service->provider = std::move(manager);
+    service->source = std::move(src);
+    return service.release();
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+}  // namespace
+
 extern "C" {
 
 IhsLocationService* ihs_location_start(IhsLocationSource source,
@@ -161,74 +248,45 @@ IhsLocationService* ihs_location_start_filtered(IhsLocationSource source,
                                                 const char* config,
                                                 const char* filter_key,
                                                 const char* filter_config) {
-  // No exception may cross this C ABI boundary: construction and Start()
-  // (allocations, std::thread) can throw, so translate any failure to a NULL
-  // return.
-  try {
-    const bool use_filter = filter_key != nullptr && filter_key[0] != '\0';
-    if (use_filter) {
-      // Make the requested filter available if it is a built-in the caller did
-      // not already register. An unknown key resolves to nothing and degrades
-      // to the passthrough inside Manager.
-      EnsureBuiltinFilter(filter_key);
-    }
-    // Declare the Manager before the source: the source's worker calls into the
-    // Manager, so on any early return or exception after the source starts,
-    // reverse-order destruction must tear down the source first (joining its
-    // worker) and only then the Manager it points at.
-    auto manager = std::make_unique<Manager>(
-        std::vector<std::string>{},
-        use_filter ? std::string(filter_key) : std::string{},
-        filter_config != nullptr ? std::string(filter_config) : std::string{});
-    std::unique_ptr<IEventSource> src;
-    switch (source) {
-      case IHS_LOCATION_GEOCLUE:
-        src = MakeGeoclue(config);
-        break;
-      case IHS_LOCATION_FILE:
-        src = MakeFile(config);
-        break;
-      case IHS_LOCATION_AUTO:
-        // gpsd primary, geoclue fallback — the same composition as before, now
-        // an event-driven combiner.
-        src = std::make_unique<ihs::location::FallbackSource>(
-            MakeGpsd(nullptr), MakeGeoclue(nullptr));
-        break;
-      case IHS_LOCATION_GPSD:
-      default:
-        src = MakeGpsd(config);
-        break;
-    }
-    if (!src) {
-      return nullptr;
-    }
-    Manager* const mgr = manager.get();
-    // Drive the Manager on each fix the source pushes (worker thread).
-    // SetOnFix must precede the source's Start(). With a filter, route the fix
-    // through the measurement path so the filter processes it; without one,
-    // PublishFix stores the whole fix atomically (and keeps the source's
-    // speed/heading a position-only filter would otherwise re-estimate).
-    if (use_filter) {
-      src->SetOnFix([mgr](const Position& p) { mgr->SubmitPositionFix(p); });
-    } else {
-      src->SetOnFix([mgr](const Position& p) { mgr->PublishFix(p); });
-    }
-    // Arm the Manager before the source begins pushing, honoring the
-    // Start()/Stop() lifecycle (ihs_location_stop calls Stop()).
-    if (!manager->Start()) {
-      return nullptr;
-    }
-    if (!src->Start()) {
-      return nullptr;  // could not begin acquisition at all
-    }
-    auto service = std::make_unique<IhsLocationService>();
-    service->manager = mgr;  // alias before the unique_ptr is moved
-    service->provider = std::move(manager);
-    service->source = std::move(src);
-    return service.release();
-  } catch (...) {
+  // The enum form is the options form with no registered source keys. An
+  // out-of-range @source keeps its long-standing behavior (falls to gpsd in
+  // StartService) rather than becoming a new error.
+  IhsLocationStartOptions o{};
+  o.struct_size = sizeof(o);
+  o.source = static_cast<uint32_t>(source);
+  o.source_config = config;
+  o.filter_key = filter_key;
+  o.filter_config = filter_config;
+  return StartService(o);
+}
+
+IhsLocationService* ihs_location_start_options(
+    const IhsLocationStartOptions* options) {
+  if (options == nullptr) {
     return nullptr;
   }
+  // Bounded copy: a caller built against an older header passes a shorter
+  // struct, so read only what it carries and leave the rest zeroed. Reject one
+  // too short to hold `source`, which every other field is interpreted against.
+  constexpr size_t kMinSize =
+      offsetof(IhsLocationStartOptions, source) + sizeof(uint32_t);
+  const size_t given = options->struct_size;
+  if (given < kMinSize) {
+    return nullptr;
+  }
+  IhsLocationStartOptions o{};
+  std::memcpy(&o, options, given < sizeof(o) ? given : sizeof(o));
+  o.struct_size = sizeof(o);
+  // Unlike the enum call, an unknown source is an error here rather than a
+  // silent fall back to gpsd: this entry point is new, so nothing depends on
+  // the old leniency.
+  if (o.source > static_cast<uint32_t>(IHS_LOCATION_NONE)) {
+    return nullptr;
+  }
+  if (o.source_key_count > 0 && o.source_keys == nullptr) {
+    return nullptr;
+  }
+  return StartService(o);
 }
 
 namespace {

--- a/shared/tests/consumer/consumer.c
+++ b/shared/tests/consumer/consumer.c
@@ -177,6 +177,24 @@ int main(void) {
         "no filter requested, none active");
   CHECK(ihs_location_filter_active(NULL) == 0, "filter_active(NULL) is safe");
   ihs_location_stop(loc);
+
+  /* Options start (ABI 1.7): NULL and a too-short struct are refused, and a
+   * valid one behaves like ihs_location_start. */
+  CHECK(ihs_location_start_options(NULL) == NULL, "start_options(NULL) safe");
+  IhsLocationStartOptions lopts;
+  memset(&lopts, 0, sizeof(lopts));
+  lopts.struct_size = sizeof(size_t); /* below `source` */
+  CHECK(ihs_location_start_options(&lopts) == NULL, "short options refused");
+  memset(&lopts, 0, sizeof(lopts));
+  lopts.struct_size = sizeof(lopts);
+  lopts.source = IHS_LOCATION_GPSD;
+  lopts.source_config = "127.0.0.1:9";
+  IhsLocationService* loc2 = ihs_location_start_options(&lopts);
+  CHECK(loc2 != NULL, "start_options returns a handle for a dead port");
+  CHECK(ihs_location_generation(loc2) == 0, "no fix from a dead port");
+  CHECK(ihs_location_filter_active(loc2) == 0, "no filter requested");
+  ihs_location_stop(loc2);
+
   CHECK(ihs_location_latest(NULL, &pos) == 0, "latest(NULL) is safe");
   CHECK(ihs_location_latest2(NULL, &pos, sizeof(pos)) == 0,
         "latest2(NULL) is safe");

--- a/shared/tests/location/wire_test.cc
+++ b/shared/tests/location/wire_test.cc
@@ -42,6 +42,46 @@ void Check(bool cond, const char* what) {
   }
 }
 
+// A registered measurement source, standing in for a CAN / gyro feed. start()
+// keeps the sink so the test can push on its own thread, deterministically.
+struct FakeMeasSource {
+  IhsMeasSink sink = nullptr;
+  void* sink_ud = nullptr;
+  int starts = 0;
+};
+int FakeMeasStart(void* ud, IhsMeasSink sink, void* sink_ud) {
+  auto* s = static_cast<FakeMeasSource*>(ud);
+  s->sink = sink;
+  s->sink_ud = sink_ud;
+  ++s->starts;
+  return 1;
+}
+void FakeMeasStop(void* ud) {
+  static_cast<FakeMeasSource*>(ud)->sink = nullptr;
+}
+IhsLocationSourceOps FakeMeasOps() {
+  IhsLocationSourceOps ops{};
+  ops.struct_size = sizeof(ops);
+  ops.start = &FakeMeasStart;
+  ops.stop = &FakeMeasStop;
+  return ops;
+}
+void PushPosition(const FakeMeasSource& s,
+                  double lat,
+                  double lon,
+                  uint64_t t_ns) {
+  IhsMeasurement m{};
+  m.struct_size = sizeof(m);
+  m.kind = IHS_MEAS_POSITION_LLA;
+  m.t_monotonic_ns = t_ns;
+  m.value_count = 2;
+  m.value[0] = lat;
+  m.value[1] = lon;
+  m.variance[0] = -1.0;
+  m.variance[1] = -1.0;
+  s.sink(s.sink_ud, &m);
+}
+
 constexpr double kLat0 = 48.0;
 constexpr double kLon0 = -122.0;
 constexpr double kMetersPerDegLat = 111320.0;
@@ -262,6 +302,113 @@ void TestBadPathAndKeys() {
   std::filesystem::remove(path);
 }
 
+// A built-in source and a registered one in a single service, fused by one
+// filter: what ihs_location_start_options() exists for (#516).
+void TestOptionsFusedSources() {
+  const auto path = WriteTrackFixture("ihs_wire_options.jsonl", 12.0, 30, 0.02);
+  const std::string path_str = path.string();  // outlives the options struct
+
+  FakeMeasSource can;
+  IhsLocationSourceOps sops = FakeMeasOps();
+  Check(ihs_location_register_source("can.fused", &sops, &can) == 1,
+        "register can.fused");
+
+  const char* keys[] = {"can.fused"};
+  IhsLocationStartOptions o{};
+  o.struct_size = sizeof(o);
+  o.source = IHS_LOCATION_FILE;
+  o.source_config = path_str.c_str();
+  o.source_keys = keys;
+  o.source_key_count = 1;
+  o.filter_key = "kalman.ctrv";
+
+  Collector c;
+  IhsLocationService* svc = ihs_location_start_options(&o);
+  Check(svc != nullptr,
+        "start_options with a built-in and a registered source");
+  if (svc == nullptr) {
+    std::filesystem::remove(path);
+    return;
+  }
+  ihs_location_set_callback(svc, &Collector::Thunk, &c);
+  Check(can.starts == 1, "the registered source was bound and started");
+  Check(can.sink != nullptr, "the registered source holds a sink");
+  Check(ihs_location_filter_active(svc) == 1, "kalman.ctrv is active");
+  Check(c.WaitFor(20, std::chrono::seconds(5)), "fused service delivers fixes");
+
+  // A yaw rate from the registered source reaches the filter alongside the
+  // file's positions. It must not disturb delivery.
+  if (can.sink != nullptr) {
+    IhsMeasurement m{};
+    m.struct_size = sizeof(m);
+    m.kind = IHS_MEAS_YAW_RATE;
+    m.t_monotonic_ns = 0;
+    m.value_count = 1;
+    m.value[0] = 0.05;
+    m.variance[0] = -1.0;
+    can.sink(can.sink_ud, &m);
+  }
+  Check(c.WaitFor(25, std::chrono::seconds(5)),
+        "fixes continue after a yaw-rate measurement");
+  ihs_location_stop(svc);
+  std::filesystem::remove(path);
+}
+
+// No built-in source at all: positions come from a registered source.
+void TestOptionsRegisteredOnly() {
+  FakeMeasSource gnss;
+  IhsLocationSourceOps sops = FakeMeasOps();
+  Check(ihs_location_register_source("gnss.only", &sops, &gnss) == 1,
+        "register gnss.only");
+
+  const char* keys[] = {"gnss.only"};
+  IhsLocationStartOptions o{};
+  o.struct_size = sizeof(o);
+  o.source = IHS_LOCATION_NONE;
+  o.source_keys = keys;
+  o.source_key_count = 1;
+
+  IhsLocationService* svc = ihs_location_start_options(&o);
+  Check(svc != nullptr, "start_options with NONE + a registered source");
+  if (svc == nullptr) {
+    return;
+  }
+  Check(gnss.sink != nullptr, "registry-only source started");
+  IhsPosition p{};
+  Check(ihs_location_latest2(svc, &p, sizeof(p)) == 0, "no fix before a push");
+  if (gnss.sink != nullptr) {
+    PushPosition(gnss, 48.5, -122.5, 1000);
+  }
+  Check(ihs_location_latest2(svc, &p, sizeof(p)) == 1, "fix after a push");
+  Check(p.latitude == 48.5 && p.longitude == -122.5, "the pushed fix is read");
+  Check(ihs_location_generation(svc) == 1, "one generation for one position");
+  ihs_location_stop(svc);
+}
+
+// Rejections that keep a malformed options struct from being guessed at.
+void TestOptionsRejections() {
+  Check(ihs_location_start_options(nullptr) == nullptr,
+        "start_options(NULL) is safe");
+
+  IhsLocationStartOptions small{};
+  small.struct_size = sizeof(size_t);  // too short to carry `source`
+  Check(ihs_location_start_options(&small) == nullptr,
+        "a struct_size below `source` is rejected");
+
+  IhsLocationStartOptions bad_source{};
+  bad_source.struct_size = sizeof(bad_source);
+  bad_source.source = 99;
+  Check(ihs_location_start_options(&bad_source) == nullptr,
+        "an unknown source is rejected");
+
+  IhsLocationStartOptions bad_keys{};
+  bad_keys.struct_size = sizeof(bad_keys);
+  bad_keys.source = IHS_LOCATION_NONE;
+  bad_keys.source_key_count = 2;  // with source_keys NULL
+  Check(ihs_location_start_options(&bad_keys) == nullptr,
+        "a key count with no keys is rejected");
+}
+
 }  // namespace
 
 int main() {
@@ -271,6 +418,9 @@ int main() {
   TestFileFastPacing();
   TestFileLoop();
   TestBadPathAndKeys();
+  TestOptionsFusedSources();
+  TestOptionsRegisteredOnly();
+  TestOptionsRejections();
 
   if (g_failures == 0) {
     std::printf("wire_test: all %d checks passed\n", g_tests);


### PR DESCRIPTION
Fixes #516. Unblocks the yaw-rate half of #519.

## Problem

`ihs_location_register_source()` took a source that nothing could bind. `Manager::Start()` has the bind loop (`manager.cc:153`), but `location_api.cc` always constructed the Manager with an empty key vector, so the loop had nothing to walk. A CAN or gyro feed could register and never be used.

## Change

`IhsLocationStartOptions` (struct_size-first, append-only) and `ihs_location_start_options()`. One call covers a built-in source, registered source keys, or both fused through a single filter:

```c
const char* keys[] = {"can.yaw"};
IhsLocationStartOptions o = {0};
o.struct_size = sizeof(o);
o.source = IHS_LOCATION_GPSD;   /* position from gpsd ... */
o.source_keys = keys;           /* ... yaw rate from CAN */
o.source_key_count = 1;
o.filter_key = "kalman.ctrv";   /* fused by one filter */
```

- `IHS_LOCATION_NONE` appended, for a service with no built-in source.
- `ihs_location_start()` / `_start_filtered()` now delegate to one shared `StartService` path rather than a second copy of the source/filter wiring.
- Bounded copy of the options struct. NULL, a `struct_size` below `source`, an unknown `source`, and a non-zero key count with NULL keys are refused rather than guessed at. The enum call keeps its long-standing leniency for an out-of-range source, so nothing that works today changes.
- An unregistered key is skipped, not fatal, matching the filter contract; `ihs_location_filter_active()` still reports what actually bound.
- ABI 1.6 -> 1.7; +1 export (`ihs_*` now 57). Baseline not re-dumped: additive, as with 1.1-1.6.

## Tests

`wire_test`, 30 -> 49 checks:
- **fused**: FILE positions + a registered source + `kalman.ctrv` in one service; asserts the registered source was bound and started, the filter is active, fixes flow, and a yaw-rate push does not disturb delivery.
- **registry only**: `IHS_LOCATION_NONE` + a registered source; no fix before a push, the pushed fix reads back, one generation per position.
- **rejections**: NULL, short `struct_size`, unknown source, key count with no keys.

`consumer` smoke covers NULL, a short struct, and a valid options start as strict C11.

## Verified locally

- Location tests 9/9; `wire_test` 49/49.
- `cmake -S shared` with `ENABLE_DLT` ON and OFF: builds clean, `ihs_location_start_options` exported in both, consumer smoke passes (also the strict-C11 header check and the ABI 1.7 handshake).
- clang-format clean; README links and anchors resolve.

## Follow-up

The yaw-rate half of #519 is now implementable: register a CAN or gyro source and name it here. No built-in source produces a yaw rate, so #519 stays open until such a source exists.