### PR TITLE
logging: retry a context that was opened before logging started

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -289,6 +289,10 @@ dlt-receive -a localhost
 - **Absent capabilities.** A `NULL` sub-table means the capability is not in the
   running build (e.g. logging in a hypothetical build without it) — check for
   `NULL` rather than assuming presence.
+- **A capability logs nothing at all.** Contexts inside `ihs_shared` resolve on
+  first use and are retried while unresolved, because `ihs_log_context_open()`
+  answers -1 until `ihs_log_start()` has run. A consumer that starts logging
+  late still gets those records once it does.
 - **Logging drops.** If records go missing under load, the per-thread ring
   overflowed. `ihs_log_dropped()` is the cumulative count across all rings, and
   `ihs_log_ring_capacity()` the depth in force for this run, so a consumer can

--- a/shared/src/logging/lazy_context.hpp
+++ b/shared/src/logging/lazy_context.hpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IHS_SHARED_SRC_LOGGING_LAZY_CONTEXT_HPP_
+#define IHS_SHARED_SRC_LOGGING_LAZY_CONTEXT_HPP_
+
+#include <atomic>
+#include <cstdint>
+
+#include "ihs/logging.h"
+
+namespace ihs::dlt {
+
+// A log context resolved on first use, and re-resolved while it is still
+// unresolved.
+//
+// ihs_log_context_open() answers -1 until ihs_log_start() has run. Caching that
+// -1 -- which a plain function-local `static const int32_t` does -- silences
+// the call site for the life of the process, so a capability whose first log
+// happens to precede logging start never logs again. The shell's
+// ihs::log::default_context() hit this and re-attempts while invalid; this is
+// that fix for the library's own call sites, which unlike the shell's have no
+// single-threaded pre-start window to rely on.
+//
+// Thread-safe without a lock: two threads racing the open both get the same
+// index back (the bridge caches contexts by tag), so a duplicate attempt costs
+// a lookup and nothing else. Once resolved the value is stable for the process
+// and every later call is one relaxed load.
+class LazyLogContext {
+ public:
+  explicit constexpr LazyLogContext(const char* tag) noexcept : tag_(tag) {}
+
+  LazyLogContext(const LazyLogContext&) = delete;
+  LazyLogContext& operator=(const LazyLogContext&) = delete;
+
+  // The context index, or -1 while logging is not up yet. A caller gates on
+  // < 0 exactly as it did on the cached value before.
+  [[nodiscard]] int32_t index() noexcept {
+    const int32_t cached = ctx_.load(std::memory_order_relaxed);
+    if (cached >= 0) {
+      return cached;
+    }
+    const int32_t opened = ihs_log_context_open(tag_, nullptr);
+    if (opened >= 0) {
+      ctx_.store(opened, std::memory_order_relaxed);
+    }
+    return opened;
+  }
+
+ private:
+  const char* tag_;
+  std::atomic<int32_t> ctx_{-1};
+};
+
+}  // namespace ihs::dlt
+
+#endif  // IHS_SHARED_SRC_LOGGING_LAZY_CONTEXT_HPP_

--- a/shared/src/mcp_app_tools.cc
+++ b/shared/src/mcp_app_tools.cc
@@ -39,11 +39,15 @@
 
 #include "ihs/logging.h"
 
+#include "logging/lazy_context.hpp"
+
 namespace {
 
+// Re-attempted while unresolved: caching the -1 that ihs_log_context_open()
+// returns before ihs_log_start() would silence this site for the process.
 int32_t TraceContext() {
-  static const int32_t ctx = ihs_log_context_open("MCPA", nullptr);
-  return ctx;
+  static ihs::dlt::LazyLogContext ctx("MCPA");
+  return ctx.index();
 }
 
 void Log(const int32_t level, const std::string& text) {

--- a/shared/src/mcp_semantics_provider.cc
+++ b/shared/src/mcp_semantics_provider.cc
@@ -39,6 +39,8 @@
 #include "ihs/ihs_semantics.h"
 #include "ihs/logging.h"
 
+#include "logging/lazy_context.hpp"
+
 namespace {
 
 // One tool as this provider declares it, paired with the hub action it
@@ -198,10 +200,12 @@ constexpr uint64_t kAllowMask = IHS_SEMANTICS_ACTION_NO_A11Y_FOCUS;
 constexpr size_t kToolCount = sizeof(kTools) / sizeof(kTools[0]);
 
 // Logging goes through the C API for the same reason the rest of ihs_shared
-// does: the library sits below the shell's C++ logging wrapper.
+// does: the library sits below the shell's C++ logging wrapper. Re-attempted
+// while unresolved so a first log before ihs_log_start() does not silence this
+// site for the process.
 int32_t TraceContext() {
-  static const int32_t ctx = ihs_log_context_open("MCPS", nullptr);
-  return ctx;
+  static ihs::dlt::LazyLogContext ctx("MCPS");
+  return ctx.index();
 }
 
 void Log(const int32_t level, const std::string& text) {

--- a/shared/src/mcp_transport.cc
+++ b/shared/src/mcp_transport.cc
@@ -52,13 +52,17 @@
 
 #include "ihs/logging.h"
 
+#include "logging/lazy_context.hpp"
+
 namespace {
 
 // Logging goes through the C API for the same reason the rest of ihs_shared
-// does: the library sits below the shell's C++ logging wrapper.
+// does: the library sits below the shell's C++ logging wrapper. Re-attempted
+// while unresolved so a first log before ihs_log_start() does not silence this
+// site for the process.
 int32_t TraceContext() {
-  static const int32_t ctx = ihs_log_context_open("MCPT", nullptr);
-  return ctx;
+  static ihs::dlt::LazyLogContext ctx("MCPT");
+  return ctx.index();
 }
 
 void Log(const int32_t level, const std::string& text) {

--- a/shared/src/semantics.cc
+++ b/shared/src/semantics.cc
@@ -36,6 +36,8 @@
 
 #include "ihs/logging.h"
 
+#include "logging/lazy_context.hpp"
+
 namespace {
 
 // A published tree. Immutable once built; every pointer a consumer sees points
@@ -101,12 +103,13 @@ Hub& TheHub() {
   return *hub;
 }
 
-// Attribution logging for the dispatch funnel. Opened lazily so a
-// process that never registers a consumer never allocates a log context; the
-// index is stable for the process once opened.
+// Attribution logging for the dispatch funnel. Opened lazily so a process that
+// never registers a consumer never allocates a log context, and re-attempted
+// while unresolved so a first log before ihs_log_start() does not silence this
+// site for the process (see LazyLogContext).
 int32_t TraceContext() {
-  static const int32_t ctx = ihs_log_context_open("SEMA", nullptr);
-  return ctx;
+  static ihs::dlt::LazyLogContext ctx("SEMA");
+  return ctx.index();
 }
 
 // Emits under the hub's context, skipping the formatting entirely when the

--- a/shell/logging/tests/compat-matrix/compat_smoke.cc
+++ b/shell/logging/tests/compat-matrix/compat_smoke.cc
@@ -24,6 +24,7 @@
 #include "logger.hpp"
 
 #include "bridge.hpp"
+#include "lazy_context.hpp"
 #include "ring_registry.hpp"
 #include "thread_ring.hpp"
 
@@ -47,8 +48,16 @@ void check(bool cond, const char* what) {
 }  // namespace
 
 int main() {
+  // 0. A context opened before logging starts must not stay unresolved. A
+  // plain cached static would hold the -1 forever and silence its call site
+  // for the process; LazyLogContext re-attempts.
+  static ihs::dlt::LazyLogContext kEarly("EARL");
+  check(kEarly.index() < 0, "no context before start");
+
   // 1. Lifecycle.
   IHS_LOGGING_START("SMOK", "compat smoke");
+
+  check(kEarly.index() >= 0, "the early context resolves once logging is up");
 
   // 2. Format-string portability. The context is valid regardless of DLT — the
   // console sink is always available — so the format paths always run.


### PR DESCRIPTION
Fixes #525.

## Problem

Four call sites inside `ihs_shared` cached their log context in a function-local static:

```c
static const int32_t ctx = ihs_log_context_open("MCPT", nullptr);
```

`ihs_log_context_open()` answers -1 while the bridge has not started (`bridge.cpp:63-70`). The static caches that -1 for the life of the process, and every `Log()` from that site then returns at `ctx < 0` — permanently silent, with nothing reporting it.

Not the shell's own flow: `main.cc:162` starts logging before plugins load. It bites any other host of `ihs_shared` — a Dart FFI plugin process, an out-of-tree consumer — and any future in-shell call that runs earlier than `IHS_LOGGING_START`.

## Change

`LazyLogContext` (`shared/src/logging/lazy_context.hpp`, internal): re-attempts while the cached index is negative, then caches it.

- **Lock-free.** Two threads racing the open resolve the same index, since the bridge caches contexts by tag, so a duplicate attempt costs a lookup. Once resolved every later call is one relaxed load.
- Mirrors `ihs::log::default_context()`, which already handles this shell-side, but thread-safe: unlike the shell's, these sites have no single-threaded pre-start window.

Switched: `semantics.cc` (SEMA), `mcp_app_tools.cc` (MCPA), `mcp_transport.cc` (MCPT), `mcp_semantics_provider.cc` (MCPS).

No ABI change: internal header, not installed; no new export; no version bump.

## Test

`compat_smoke` is the one harness that runs before `IHS_LOGGING_START`, so it asserts the context is unresolved before start and resolves after. It runs across C++17/20/23 and both DLT settings in the matrix.

## Verified locally

- `cmake -S shared -D BUILD_ACCESSIBILITY=ON -D BUILD_MCP=ON`: builds clean. That is the only configuration that compiles all four edited files — a default `cmake -S shared` compiles none of them.
- compat-matrix 2/2 with `ENABLE_DLT` ON and OFF.
- Default build + consumer smoke pass.
- clang-format clean.