### PR TITLE
platform-views: honor EXPLICIT_REQUIRED, and cover sync negotiation

### DIFF
--- a/docs/PLATFORM_VIEW_NEGOTIATION.md
+++ b/docs/PLATFORM_VIEW_NEGOTIATION.md
@@ -95,7 +95,7 @@ rather than hard-coding it.
 | --- | --- |
 | `IHS_PV_SYNC_IMPLICIT` | no fence exchange |
 | `IHS_PV_SYNC_EXPLICIT_PREFERRED` | explicit if available, silently implicit if not |
-| `IHS_PV_SYNC_EXPLICIT_REQUIRED` | the grant must honor explicit sync |
+| `IHS_PV_SYNC_EXPLICIT_REQUIRED` | the grant must honor explicit sync; negotiation fails with `IHS_PV_ERR_UNSUPPORTED` when the backend has none, before anything is granted |
 
 A grant may honor a **weaker** mode than requested unless `EXPLICIT_REQUIRED`
 was set. A plugin that cannot cope with implicit sync must ask for

--- a/shared/include/ihs/platform_view.h
+++ b/shared/include/ihs/platform_view.h
@@ -190,8 +190,9 @@ typedef enum IhsPvZOrder {
   IHS_PV_Z_INLINE = 2 /* interleaved with Flutter layers (hybrid composition) */
 } IhsPvZOrder;
 
-/* Result codes. Negotiation returns UNSUPPORTED only when the requirement
- * excludes even the floor (SOFTWARE_SHM bit unset and no granted higher kind).
+/* Result codes. Negotiation returns UNSUPPORTED when the requirement excludes
+ * even the floor (SOFTWARE_SHM bit unset and no granted higher kind), and when
+ * EXPLICIT_REQUIRED was asked for on a backend with no explicit sync.
  */
 typedef enum IhsPvResult {
   IHS_PV_OK = 0,

--- a/shared/src/platform_view.cc
+++ b/shared/src/platform_view.cc
@@ -211,6 +211,15 @@ extern "C" int ihs_pv_negotiate(IhsPlatformView* view,
     return IHS_PV_ERR_UNSUPPORTED;
   }
 
+  // EXPLICIT_REQUIRED is a demand, not a preference: a plugin asks for it
+  // precisely so it is not handed a weaker grant it cannot service. Refuse
+  // here, before grant(), so no plane id or shm fd is allocated for a
+  // negotiation that cannot be honored.
+  if (requirements->sync == IHS_PV_SYNC_EXPLICIT_REQUIRED &&
+      caps.explicit_sync == 0) {
+    return IHS_PV_ERR_UNSUPPORTED;
+  }
+
   const IhsFormatModifier fmt = choose_format(requirements, &caps);
   uint32_t plane_id = 0;
   int shm_fd = -1;

--- a/test/unit_test/ihs_pv-test/test_case_ihs_pv.cc
+++ b/test/unit_test/ihs_pv-test/test_case_ihs_pv.cc
@@ -226,6 +226,99 @@ TEST(IhsPvSurface, RegisterForwardsToHost) {
   detach_host();
 }
 
+// Explicit sync is granted only when the backend advertises the capability.
+// This is the contract #513 turns on for the EGL backends, which advertise
+// explicit_sync = 0 today and so downgrade every producer.
+TEST(IhsPvSurface, ExplicitSyncGrantedWhenBackendAdvertisesIt) {
+  MockHost host_state;
+  host_state.explicit_sync = 1;
+  const IhsPvHost host = make_host(&host_state);
+  ihs_pv_set_host(&host);
+
+  IhsPvRequirements req = make_req(IHS_PV_KIND_TEXTURE_DMABUF_IMPORT);
+  req.sync = IHS_PV_SYNC_EXPLICIT_PREFERRED;
+  IhsPvGrant grant{};
+  grant.struct_size = sizeof(grant);
+  ASSERT_EQ(ihs_pv_negotiate(fake_view(), &req, &grant), IHS_PV_OK);
+  EXPECT_EQ(grant.sync, static_cast<uint32_t>(IHS_PV_SYNC_EXPLICIT_PREFERRED));
+
+  detach_host();
+}
+
+// PREFERRED is documented as "explicit if available, silently implicit if
+// not", so a backend without the capability downgrades rather than failing.
+TEST(IhsPvSurface, ExplicitSyncPreferredDowngradesWhenUnavailable) {
+  MockHost host_state;
+  host_state.explicit_sync = 0;
+  const IhsPvHost host = make_host(&host_state);
+  ihs_pv_set_host(&host);
+
+  IhsPvRequirements req = make_req(IHS_PV_KIND_TEXTURE_DMABUF_IMPORT);
+  req.sync = IHS_PV_SYNC_EXPLICIT_PREFERRED;
+  IhsPvGrant grant{};
+  grant.struct_size = sizeof(grant);
+  ASSERT_EQ(ihs_pv_negotiate(fake_view(), &req, &grant), IHS_PV_OK);
+  EXPECT_EQ(grant.sync, static_cast<uint32_t>(IHS_PV_SYNC_IMPLICIT));
+
+  detach_host();
+}
+
+// A grant honors at most what was asked for: a plugin that asked for implicit
+// sync is never handed an explicit-sync grant it is not prepared to service.
+TEST(IhsPvSurface, ImplicitRequestIsNeverUpgraded) {
+  MockHost host_state;
+  host_state.explicit_sync = 1;
+  const IhsPvHost host = make_host(&host_state);
+  ihs_pv_set_host(&host);
+
+  IhsPvRequirements req = make_req(IHS_PV_KIND_TEXTURE_DMABUF_IMPORT);
+  req.sync = IHS_PV_SYNC_IMPLICIT;
+  IhsPvGrant grant{};
+  grant.struct_size = sizeof(grant);
+  ASSERT_EQ(ihs_pv_negotiate(fake_view(), &req, &grant), IHS_PV_OK);
+  EXPECT_EQ(grant.sync, static_cast<uint32_t>(IHS_PV_SYNC_IMPLICIT));
+
+  detach_host();
+}
+
+// REQUIRED is a demand: a backend with no explicit sync fails the negotiation
+// rather than quietly handing back an implicit grant.
+TEST(IhsPvSurface, ExplicitSyncRequiredFailsWhenUnavailable) {
+  MockHost host_state;
+  host_state.explicit_sync = 0;
+  const IhsPvHost host = make_host(&host_state);
+  ihs_pv_set_host(&host);
+
+  IhsPvRequirements req = make_req(IHS_PV_KIND_TEXTURE_DMABUF_IMPORT);
+  req.sync = IHS_PV_SYNC_EXPLICIT_REQUIRED;
+  IhsPvGrant grant{};
+  grant.struct_size = sizeof(grant);
+  EXPECT_EQ(ihs_pv_negotiate(fake_view(), &req, &grant),
+            IHS_PV_ERR_UNSUPPORTED);
+  // Refused before grant(), so the host allocated no plane id or shm fd for a
+  // negotiation it could not honor.
+  EXPECT_EQ(host_state.grant_calls, 0);
+
+  detach_host();
+}
+
+TEST(IhsPvSurface, ExplicitSyncRequiredGrantedWhenAvailable) {
+  MockHost host_state;
+  host_state.explicit_sync = 1;
+  const IhsPvHost host = make_host(&host_state);
+  ihs_pv_set_host(&host);
+
+  IhsPvRequirements req = make_req(IHS_PV_KIND_TEXTURE_DMABUF_IMPORT);
+  req.sync = IHS_PV_SYNC_EXPLICIT_REQUIRED;
+  IhsPvGrant grant{};
+  grant.struct_size = sizeof(grant);
+  ASSERT_EQ(ihs_pv_negotiate(fake_view(), &req, &grant), IHS_PV_OK);
+  EXPECT_EQ(grant.sync, static_cast<uint32_t>(IHS_PV_SYNC_EXPLICIT_REQUIRED));
+  EXPECT_EQ(host_state.grant_calls, 1);
+
+  detach_host();
+}
+
 // query_capabilities/vulkan_context forward and surface the host's answers.
 TEST(IhsPvSurface, ContextQueriesForwardToHost) {
   MockHost host_state;


### PR DESCRIPTION
Part of #513. Does not close it: the EGL capability and the fence wiring are still to come.

## The bug

Two documents promise `EXPLICIT_REQUIRED` is honored:

- `platform_view.h:179` — a grant "may honor a weaker mode than requested unless `EXPLICIT_REQUIRED` was set"
- `docs/PLATFORM_VIEW_NEGOTIATION.md:98-102` — "the grant **must** honor explicit sync", and a plugin that cannot cope with implicit sync "must ask for `EXPLICIT_REQUIRED` rather than asking for `PREFERRED` and assuming"

`platform_view.cc` treated REQUIRED exactly like PREFERRED:

```c
out->sync = (requirements->sync != IHS_PV_SYNC_IMPLICIT && caps.explicit_sync != 0)
                ? requirements->sync : IHS_PV_SYNC_IMPLICIT;
```

So a plugin that followed the documented advice got a silent implicit grant — the precise outcome the doc told it to avoid. Same shape as the silent degrades fixed in #517 and #525.

## Change

REQUIRED against a backend with no explicit sync returns `IHS_PV_ERR_UNSUPPORTED`, **before** `grant()` runs, so no plane id or shm fd is allocated for a negotiation that cannot be honored. PREFERRED still downgrades silently, as documented.

Nothing in the tree requests REQUIRED — the only mentions are the enum and the two docs — so no caller changes. `platform_view.h`'s result-code comment claimed UNSUPPORTED was returned *only* for a kind mismatch; corrected, along with the negotiation doc's table row.

## Tests

The sync contract had no coverage at all. Five cases in `ihs_pv-test` (lean: links `libihs_shared` and a mock host, no backend or bundle):

- PREFERRED granted when the backend advertises explicit sync
- PREFERRED downgraded when it does not — the EGL case today
- an IMPLICIT request never upgraded
- REQUIRED refused without the capability, and `grant_calls == 0`
- REQUIRED granted with it

Checked the REQUIRED test is load-bearing: with the new guard removed it fails, with it restored it passes.

## Verified locally

- 14/14 in `ihs_pv-test`, built against the installed `ihs_shared`.
- `cmake -S shared` with `-D BUILD_ACCESSIBILITY=ON -D BUILD_MCP=ON`: clean, no warnings.
- clang-format clean.

## Next in #513

Advertise `explicit_sync` in the EGL branch of `HostQueryCapabilities` when `EGL_ANDROID_native_fence_sync` is present, then wire acquire and release fences. Worth recording from the testing survey: llvmpipe returns a real dup-able fence fd, so the fd plumbing is testable in CI with no GPU — `headless_egl` is the natural host. Ordering (release signalling only after sampling) still needs real hardware; there is no GL equivalent of the Vulkan sync validation layer used for #319.