### PR TITLE
osgi: hand each bundle a SendPort, not a port id

### DIFF
--- a/shell/osgi/bridge_registry.cc
+++ b/shell/osgi/bridge_registry.cc
@@ -24,17 +24,23 @@ namespace ihs::osgi {
 
 namespace {
 
-bool PostInt64(const int64_t port, const int64_t value) {
+bool PostSendPort(const int64_t target_port, const int64_t send_port_id) {
   Dart_CObject message;
-  message.type = Dart_CObject_kInt64;
-  message.value.as_int64 = value;
-  return Dart_PostCObject_DL(static_cast<Dart_Port_DL>(port), &message);
+  // A SendPort rather than an int64: the receiving isolate materializes a real
+  // SendPort from this, which is the only way it can reach the framework --
+  // Dart offers no way to build one from a port id. See DartPortApi.
+  message.type = Dart_CObject_kSendPort;
+  message.value.as_send_port.id = static_cast<Dart_Port_DL>(send_port_id);
+  // Unset. origin_id names the port a SendPort was derived from, which matters
+  // only for identity comparisons the bundle has no use for; it just sends.
+  message.value.as_send_port.origin_id = 0;
+  return Dart_PostCObject_DL(static_cast<Dart_Port_DL>(target_port), &message);
 }
 
 }  // namespace
 
 const DartPortApi& RealDartPortApi() {
-  static constexpr DartPortApi kApi{&Dart_InitializeApiDL, &PostInt64};
+  static constexpr DartPortApi kApi{&Dart_InitializeApiDL, &PostSendPort};
   return kApi;
 }
 
@@ -83,7 +89,7 @@ bool BridgeRegistry::DeliverLocked(const std::string& symbolic_name,
   if (!framework_port_.has_value()) {
     return false;
   }
-  if (!api_.post_int64(port, *framework_port_)) {
+  if (!api_.post_send_port(port, *framework_port_)) {
     // The port is closed or invalid: the isolate went away between registering
     // and now. Not fatal to the process -- the bundle is simply unreachable.
     ihs::log::error(

--- a/shell/osgi/bridge_registry.h
+++ b/shell/osgi/bridge_registry.h
@@ -36,9 +36,18 @@ struct DartPortApi {
   // mismatch between these headers and the running VM.
   intptr_t (*initialize_api)(void* data);
 
-  // Wraps Dart_PostCObject_DL with an int64 payload. Returns true when the
-  // message was enqueued; false when @port is closed or invalid.
-  bool (*post_int64)(int64_t port, int64_t value);
+  // Posts the framework isolate's port to @target_port as a Dart SendPort.
+  //
+  // Deliberately not an int64. Dart cannot turn a port id back into a
+  // SendPort: dart:ffi's `nativePort` runs one way only, and SendPort is an
+  // abstract interface with no constructor. A bundle handed an integer has
+  // nothing it can send to, so the framework would be unreachable from Dart.
+  // Dart_CObject_kSendPort is what makes the receiving isolate materialize a
+  // real SendPort.
+  //
+  // Returns true when the message was enqueued; false when @target_port is
+  // closed or invalid.
+  bool (*post_send_port)(int64_t target_port, int64_t send_port_id);
 };
 
 // The real Dart DL calls.

--- a/test/unit_test/osgi_bridge-test/test_case_osgi_bridge.cc
+++ b/test/unit_test/osgi_bridge-test/test_case_osgi_bridge.cc
@@ -27,8 +27,14 @@
 
 namespace {
 
-// Records what the registry would have posted to Dart. The real calls need a
-// live VM; the ordering logic under test does not.
+// Records what the registry would have posted to Dart, as (target port, send
+// port id) pairs. The real calls need a live VM; the ordering logic under test
+// does not.
+//
+// What the real implementation puts on the wire -- a Dart_CObject_kSendPort
+// rather than an int64 -- is not observable from here for the same reason:
+// building and posting the CObject needs a VM to receive it. That part is
+// covered by the multi-bundle integration harness, not by this file.
 struct FakeDart {
   static inline std::vector<std::pair<int64_t, int64_t>> posts;
   static inline intptr_t init_result = 0;
@@ -47,17 +53,18 @@ struct FakeDart {
     return init_result;
   }
 
-  static bool Post(const int64_t port, const int64_t value) {
+  static bool PostSendPort(const int64_t target_port,
+                           const int64_t send_port_id) {
     if (!post_succeeds) {
       return false;
     }
-    posts.emplace_back(port, value);
+    posts.emplace_back(target_port, send_port_id);
     return true;
   }
 };
 
 ihs::osgi::DartPortApi FakeApi() {
-  return {&FakeDart::Initialize, &FakeDart::Post};
+  return {&FakeDart::Initialize, &FakeDart::PostSendPort};
 }
 
 // A registry with the DL API already initialized, which is the precondition for


### PR DESCRIPTION
The bridge posts the framework isolate's port to each bundle as a `Dart_CObject_kInt64`, and a bundle cannot do anything with that.

Dart has no way to turn a port id back into a `SendPort`: `dart:ffi`'s `nativePort` runs one direction only (`ffi.dart`), and `SendPort` is an `abstract interface class` with no constructor and no factory anywhere in the SDK. So the one message whose entire purpose is to let a bundle reach the framework arrives as a number the bundle has nothing to send to — and no Dart-side framework can be reached from a bundle the shell spawned.

## The change

`Dart_CObject_kSendPort` is what the vendored ABI provides for exactly this. Fill `as_send_port.id` with the port the framework isolate registered and the receiving isolate materializes a real `SendPort`.

`origin_id` is left unset: it names the port a `SendPort` was derived from, which matters only for identity comparisons a bundle has no use for, since it only ever sends.

The `DartPortApi` seam changes shape with it — `post_int64` becomes `post_send_port` — so the type states what crosses, and the fake in the unit tests cannot drift from what the real implementation does.

## This changes the wire format

A bundle built against the old shape sees a `SendPort` where it expected an `int`. The Dart side is being updated to match, and its MethodChannel transport ignores a message it does not recognize, so a stale bundle ends up without a framework port rather than crashing on an unexpected type.

`test/integration/osgi_activator_test` does not read the framework port at all — it completes `init` and reports `active` — so it is unaffected.

## What the unit tests can and cannot show

They show what they can: the framework port id still reaches the seam for every bundle, in both registration orders, exactly once, including the concurrent case.

They cannot show the `Dart_CObject` type itself — building and posting one needs a live VM to receive it. That stays covered by the multi-bundle integration harness, and the test file now says so rather than implying more.

## Verification

Configured with `-DENABLE_OSGI=ON -DBUILD_UNIT_TESTS=ON`:

- all five OSGi unit test drivers build; `ctest -R osgi` passes 5/5, including `osgi_orchestrator`, which builds its own `DartPortApi` and so is affected by the rename
- the `homescreen` binary links
- `clang-format --style=file --dry-run --Werror` clean on all three files
