### PR TITLE
docs: note caller-registered location sources

### DIFF
--- a/docs/specs/ARCHITECTURE.md
+++ b/docs/specs/ARCHITECTURE.md
@@ -477,11 +477,13 @@ Details: [`shared/README.md`](../../shared/README.md).
 ### 7.3. Location Service
 
 `ihs_location_*` in `ihs_shared`: one position service that any consumer polls
-or subscribes to, instead of each plugin re-implementing acquisition. Sources
-are gpsd, geoclue (sd-bus loaded from `libsystemd` at runtime), gpsd with
-geoclue fallback, or a replayed gpsd capture. Fixes are reported as received or
-fused through a constant-velocity (`kalman.cv`) or CTRV (`kalman.ctrv`) Kalman
-filter. Always compiled in.
+or subscribes to, instead of each plugin re-implementing acquisition. Built-in
+sources are gpsd, geoclue (sd-bus loaded from `libsystemd` at runtime), gpsd
+with geoclue fallback, or a replayed gpsd capture. A consumer can also register
+its own measurement source — a CAN speed or gyro yaw rate — and bind it through
+`ihs_location_start_options()`, alone or fused with a built-in source. Fixes
+are reported as received or fused through a constant-velocity (`kalman.cv`) or
+CTRV (`kalman.ctrv`) Kalman filter. Always compiled in.
 
 Details: [`shared/src/location/README.md`](../../shared/src/location/README.md).
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -22,7 +22,7 @@ registered plugins — `ihs_shared` exposes neither a registrar nor a messenger.
 | Tracing (`ihs_trace_*`: duration / instant / counter / flow) | Built-in | Always; engine trace procs → kernel `trace_marker` → nop |
 | Platform-view surface negotiation (`ihs_pv_*`) | Built-in | Always; inert until the shell installs an `IhsPvHost` |
 | Config read-back (`ihs_config_*` snapshots) | Built-in | Always; shell publishes, plugins read |
-| Location service (`ihs_location_*`: gpsd / geoclue / capture replay, `kalman.cv` / `kalman.ctrv` filters) | Built-in | Always; geoclue `dlopen`s `libsystemd` at runtime. See [src/location/README.md](src/location/README.md) |
+| Location service (`ihs_location_*`: gpsd / geoclue / capture replay, caller-registered sources, `kalman.cv` / `kalman.ctrv` filters) | Built-in | Always; geoclue `dlopen`s `libsystemd` at runtime. See [src/location/README.md](src/location/README.md) |
 | Versioned ABI handshake (`ihs_get_api`) | Built-in | Always; `IHS_SHARED_ABI_VERSION` |
 
 ---


### PR DESCRIPTION
Follow-up to #527, which added `ihs_location_start_options()`.

## Why

`ARCHITECTURE.md` §7.3 and the `shared/README.md` feature row both list the location service's sources as gpsd / geoclue / capture replay. Since #527 a consumer can also register its own measurement source and bind it — alone (`IHS_LOCATION_NONE`) or fused with a built-in one, which is what lets GNSS position and a CAN yaw rate reach `kalman.ctrv` together.

Neither doc was wrong, just incomplete: both read as the map of what the service can do, and the registry path was invisible in them. `shared/src/location/README.md` already covers the options call in full.

## Change

- §7.3: name the built-in sources as built-in, and add the registered-source path with the call that binds it.
- `shared/README.md`: add caller-registered sources to the capability row.

Docs only.

## Verified

All relative links and anchors in `ARCHITECTURE.md` resolve.