### PR TITLE
osgi: refuse a bundle name the configuration does not declare

### DIFF
--- a/shell/main.cc
+++ b/shell/main.cc
@@ -375,6 +375,19 @@ int main(const int argc, char** argv) {
     if (!osgi_config.empty()) {
       orchestrator = std::make_unique<ihs::osgi::BundleStartupOrchestrator>(
           bundle_host, osgi_config.bundles);
+      // Tell the bridge which symbolic names the configuration declares, so a
+      // bundle announcing anything else is refused at init. Installed before
+      // any bundle starts: a name the shell does not know would otherwise
+      // complete the handshake and then be dropped by the orchestrator,
+      // surfacing as the correctly named bundle's deadline expiring instead of
+      // as an error at the call that made it.
+      std::vector<std::string> declared_bundles;
+      declared_bundles.reserve(osgi_config.bundles.size());
+      for (const auto& manifest : osgi_config.bundles) {
+        declared_bundles.push_back(manifest.symbolic_name);
+      }
+      ihs::osgi::BridgeRegistry::Instance().SetDeclaredBundles(
+          std::move(declared_bundles));
       // Connect the bridge to the orchestrator. Without this a bundle can call
       // init, register its port, run its activator to completion and report
       // ACTIVE -- and the critical wait would still time out, because nothing

--- a/shell/osgi/README.md
+++ b/shell/osgi/README.md
@@ -24,6 +24,7 @@ here is built and the binary carries no `ihs::osgi` symbols.
 | Normal bundles staggered after the reactor; background launched immediately | Built-in | `priority = 'normal' \| 'background'` |
 | Per-bundle startup deadline, torn down on expiry | Built-in | `startup_timeout_ms` (1…3600000) |
 | `dev.osgi/bridge` handshake: a bundle announces itself and reports ACTIVE | Built-in | `OsgiBridgePlugin` |
+| Registration refused for a `symbolic_name` the configuration does not declare | Built-in | `[[osgi.bundles]]` |
 | Framework isolate port delivered to every bundle, either registration order | Built-in | `BridgeRegistry` |
 | One presentation source fanned out to N engines in priority order | Built-in | `VsyncCoordinator` |
 | Engine-thread CPU affinity, validated against the process mask | Built-in | `cpu_core`, `framework_core` |
@@ -93,7 +94,8 @@ to completion and still have its critical wait expire.
   commutative: a bundle and the framework isolate start concurrently, so
   whichever arrives second triggers delivery. The framework port is posted as a
   `Dart_CObject_kSendPort`, because Dart cannot rebuild a `SendPort` from a port
-  id.
+  id. It also holds the declared `symbolic_name`s, installed from the
+  configuration at bring-up, and refuses a registration naming anything else.
 - **`vsync_coordinator`** — one vblank in, N ordered batons out.
 - **`bundle_state`** — the lifecycle graph, mirrored by the Dart side so a state
   crosses the boundary as an int with no translation.
@@ -185,10 +187,11 @@ Two deployment rules that are not obvious from the schema:
   a second bundle carrying its own copy is refused and its view aborts — however
   identical the files are. The engine is supplied once, process-wide; bundle
   directories carry assets and `libapp.so`.
-- **A `symbolic_name` must match an `[[osgi.bundles]]` entry.** A name the shell
-  does not know is accepted by the bridge and then ignored by the orchestrator,
-  so a typo shows up as the correctly named bundle's deadline expiring, with a
-  warning in the log rather than an error at the call.
+- **A `symbolic_name` must match an `[[osgi.bundles]]` entry.** The bridge is
+  given the declared names at bring-up and refuses `init` for anything else, so
+  a typo fails at the call that made it. Before that it was accepted and then
+  dropped by the orchestrator, which surfaced as the *correctly* named bundle's
+  deadline expiring -- a symptom pointing nowhere near the cause.
 
 ---
 
@@ -208,9 +211,11 @@ Two deployment rules that are not obvious from the schema:
 
 ## Known limitations
 
-- The bridge trusts the `symbolic_name` in a call. `HandleMethodCall` is static
-  and reads the name from the arguments, so a bundle can report ACTIVE for
-  another bundle — the plugin instance already identifies the engine, so binding
+- The bridge trusts the `symbolic_name` in a call, within the declared set.
+  `HandleMethodCall` is static and reads the name from the arguments, so a
+  bundle can still report ACTIVE for *another declared* bundle; what the
+  declared set rules out is an undeclared name, not impersonation of a
+  configured one. The plugin instance already identifies the engine, so binding
   identity to it would be strictly stronger.
 - A bundle whose isolate dies without calling `shutdown` stays registered until
   something else releases it; the bridge learns a bundle is gone only when it

--- a/shell/osgi/bridge_registry.cc
+++ b/shell/osgi/bridge_registry.cc
@@ -16,6 +16,8 @@
 
 #include "bridge_registry.h"
 
+#include <utility>
+
 #include "dart_api_dl.h"
 
 #include "logging/logging.h"
@@ -145,6 +147,22 @@ std::optional<int64_t> BridgeRegistry::framework_port() const {
   return framework_port_;
 }
 
+void BridgeRegistry::SetDeclaredBundles(
+    std::vector<std::string> symbolic_names) {
+  std::set<std::string> declared;
+  for (std::string& name : symbolic_names) {
+    declared.insert(std::move(name));
+  }
+  std::lock_guard lock(mutex_);
+  declared_ = std::move(declared);
+}
+
+bool BridgeRegistry::IsDeclared(const std::string& symbolic_name) const {
+  std::lock_guard lock(mutex_);
+  return !declared_.has_value() ||
+         declared_->find(symbolic_name) != declared_->end();
+}
+
 bool BridgeRegistry::RegisterBundle(const std::string& symbolic_name,
                                     const int64_t port) {
   std::lock_guard lock(mutex_);
@@ -157,6 +175,18 @@ bool BridgeRegistry::RegisterBundle(const std::string& symbolic_name,
   }
   if (symbolic_name.empty()) {
     ihs::log::error("[osgi] bridge: bundle registered with an empty name");
+    return false;
+  }
+  // A name the configuration does not declare is refused here rather than
+  // accepted and dropped later by the orchestrator. The likeliest cause is a
+  // typo on one side or the other, and the failure it would otherwise produce
+  // -- some *other* bundle's deadline expiring -- points nowhere near it.
+  if (declared_.has_value() &&
+      declared_->find(symbolic_name) == declared_->end()) {
+    ihs::log::error(
+        "[osgi] bridge: bundle '{}' is not declared in [[osgi.bundles]]; "
+        "refusing registration",
+        symbolic_name);
     return false;
   }
   if (port == 0) {
@@ -253,6 +283,7 @@ void BridgeRegistry::ResetForTesting() {
   std::lock_guard lock(mutex_);
   bundles_.clear();
   framework_port_.reset();
+  declared_.reset();
   observer_ = nullptr;
 }
 

--- a/shell/osgi/bridge_registry.h
+++ b/shell/osgi/bridge_registry.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -111,6 +112,27 @@ class BridgeRegistry {
 
   [[nodiscard]] std::optional<int64_t> framework_port() const;
 
+  // Record the symbolic names the configuration declares, so a registration
+  // naming anything else is refused. Installed once at OSGi bring-up, before
+  // any bundle engine is spawned.
+  //
+  // Until it is installed the registry accepts any name, which is what keeps a
+  // build with no [osgi] table -- and every test that does not care about
+  // configuration -- behaving as it did. Installing an *empty* set therefore
+  // means "nothing is declared" and refuses everything; that is not the same
+  // state as never installing one.
+  //
+  // Without this a name absent from [[osgi.bundles]] completes the whole
+  // handshake and is then dropped by the orchestrator, so a typo surfaces as
+  // the correctly named bundle's deadline expiring rather than as an error at
+  // the call that made it. Gating registration gates the lifecycle reports
+  // too: ReportActive already requires a registration.
+  void SetDeclaredBundles(std::vector<std::string> symbolic_names);
+
+  // Whether @symbolic_name may register: true when no declarations are
+  // installed, otherwise whether the declared set contains it.
+  [[nodiscard]] bool IsDeclared(const std::string& symbolic_name) const;
+
   // Record a bundle's receive port. When the framework port is already known it
   // is delivered immediately; otherwise the bundle is served by the next
   // SetFrameworkPort. Returns false on a duplicate symbolic name, an invalid
@@ -152,6 +174,9 @@ class BridgeRegistry {
   mutable std::mutex mutex_;
   bool dart_api_ready_{false};
   std::optional<int64_t> framework_port_;
+  // nullopt until the shell installs the configured set; see
+  // SetDeclaredBundles for why that is permissive rather than empty.
+  std::optional<std::set<std::string>> declared_;
   IBundleLifecycleObserver* observer_{nullptr};
 
   struct Bundle {

--- a/test/unit_test/osgi_bridge-test/test_case_osgi_bridge.cc
+++ b/test/unit_test/osgi_bridge-test/test_case_osgi_bridge.cc
@@ -204,6 +204,39 @@ TEST_F(BridgeRegistryTest, RejectsInvalidPortAndEmptyName) {
   EXPECT_FALSE(registry_->RegisterBundle("", 7));
 }
 
+// --- Declared bundles -------------------------------------------------------
+//
+// The configuration is the authority on which bundles exist. Without it the
+// bridge accepts any name and the orchestrator quietly drops what it does not
+// recognize, so a typo is reported as some *other* bundle's deadline expiring
+// -- a symptom pointing nowhere near the cause.
+
+// The no-[osgi]-table build, and every test that does not care about
+// configuration: nothing is declared, so nothing is filtered.
+TEST_F(BridgeRegistryTest, AcceptsAnyNameUntilDeclarationsAreInstalled) {
+  EXPECT_TRUE(registry_->IsDeclared("com.ivi.anything"));
+  EXPECT_TRUE(registry_->RegisterBundle("com.ivi.anything", 7));
+}
+
+TEST_F(BridgeRegistryTest, RefusesANameTheConfigurationDoesNotDeclare) {
+  registry_->SetDeclaredBundles({"com.ivi.cluster", "com.ivi.navigation"});
+  EXPECT_TRUE(registry_->IsDeclared("com.ivi.cluster"));
+  EXPECT_FALSE(registry_->IsDeclared("com.ivi.clustre"));
+
+  EXPECT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  // One transposition away from a declared name, which is the realistic case.
+  EXPECT_FALSE(registry_->RegisterBundle("com.ivi.clustre", 8));
+  EXPECT_FALSE(registry_->PortFor("com.ivi.clustre").has_value());
+}
+
+// Installing an empty set means "nothing is declared", which is deliberately
+// not the same state as never installing one.
+TEST_F(BridgeRegistryTest, AnEmptyDeclarationSetRefusesEverything) {
+  registry_->SetDeclaredBundles({});
+  EXPECT_FALSE(registry_->IsDeclared("com.ivi.cluster"));
+  EXPECT_FALSE(registry_->RegisterBundle("com.ivi.cluster", 7));
+}
+
 // A restart re-registers the same symbolic name, which requires an explicit
 // unregister first.
 TEST_F(BridgeRegistryTest, UnregisterAllowsReRegistration) {
@@ -283,6 +316,18 @@ TEST_F(BridgeRegistryTest, ForwardsActiveAndStoppedToTheObserver) {
 TEST_F(BridgeRegistryTest, RejectsActiveFromAnUnregisteredBundle) {
   RecordingObserver observer;
   registry_->SetLifecycleObserver(&observer);
+  EXPECT_FALSE(registry_->ReportActive("com.ivi.ghost"));
+  EXPECT_TRUE(observer.active.empty());
+}
+
+// An undeclared bundle is stopped at registration, so the report it would have
+// sent has nothing to advance. Gating the one path gates both.
+TEST_F(BridgeRegistryTest, AnUndeclaredBundleCannotReportActive) {
+  RecordingObserver observer;
+  registry_->SetLifecycleObserver(&observer);
+  registry_->SetDeclaredBundles({"com.ivi.cluster"});
+
+  EXPECT_FALSE(registry_->RegisterBundle("com.ivi.ghost", 7));
   EXPECT_FALSE(registry_->ReportActive("com.ivi.ghost"));
   EXPECT_TRUE(observer.active.empty());
 }


### PR DESCRIPTION
The bridge accepted any `symbolic_name`. A name absent from `[[osgi.bundles]]`
completed the whole handshake — `init` succeeded, the port was registered, the
framework port was delivered — and was then dropped by the orchestrator with a
warning, because no state machine of that name exists. The bundle that *was*
configured never reports ACTIVE, so its critical wait burns its full deadline
and the shell tears it down. The operator sees the correctly named bundle time
out, which points nowhere near the typo that caused it.

`BridgeRegistry` now holds the declared names, installed in `main.cc` from
`osgi_config.bundles` before any bundle engine is spawned, and `RegisterBundle`
refuses anything else. The failure lands on the call that made it.

**Permissive until installed, deliberately.** A build with no `[osgi]` table —
and every test that does not care about configuration — must behave as before,
so `nullopt` means "no declarations, no filtering". An empty set is a different
state and refuses everything; `main.cc` only installs one inside the
`!osgi_config.empty()` branch, where the set is never empty.

Gating registration gates the lifecycle reports too: `ReportActive` already
requires a registration, so an undeclared bundle has nothing to report through.

**What this does not fix**, and the README now says so rather than implying
otherwise: a declared bundle can still report ACTIVE for another *declared*
bundle. `HandleMethodCall` is static and reads the name from the arguments, so
binding identity to the plugin instance — which already identifies the engine —
remains strictly stronger, and remains unwritten.

### Verification

- `scripts/format.sh --check` — all files correctly formatted
- `homescreen` compiles and links with `-DENABLE_OSGI=ON`
- `osgi_bridge` unit suite passes 24/24, including four new tests: an undeclared
  name refused while a declared one registers, a name one transposition away
  refused, an empty declaration set refusing everything, and an undeclared
  bundle unable to report ACTIVE