### PR TITLE
osgi: add the ihs_osgi_* handshake surface to ihs_shared

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -39,6 +39,10 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     if (NOT DEFINED BUILD_MCP)
         option(BUILD_MCP "Build the MCP provider registry into ihs_shared" OFF)
     endif ()
+    if (NOT DEFINED ENABLE_OSGI)
+        option(ENABLE_OSGI
+                "Build the OSGi bundle handshake into ihs_shared" OFF)
+    endif ()
 endif ()
 
 include(GNUInstallDirs)
@@ -217,6 +221,30 @@ else ()
     message(STATUS "MCP provider registry . Disabled")
 endif ()
 
+#
+# OSGi bundle handshake (the ihs_osgi_* C ABI).
+#
+# Forwarders only: this library holds no OSGi state. The registry behind them
+# lives in the shell, which is an executable rather than a shared object a
+# dlopen'd plugin can bind to -- the same reason the FlutterDesktop* forwarders
+# are here -- so the shell installs a proc table and these call through it.
+#
+# It exists because the dev.osgi/bridge MethodChannel drags Flutter into the
+# dependency graph of every bundle, including headless ones with no views, and
+# marshals the ACTIVE report through the platform task runner at its busiest
+# moment -- while the critical bundle's startup deadline is running.
+#
+# Gated because the surface is meaningless without that shell: with ENABLE_OSGI
+# off no source here is compiled, no ihs_osgi_* symbol is exported, and
+# ihs_osgi.h is not installed, so an out-of-tree consumer finds out at the
+# include rather than at the link.
+if (ENABLE_OSGI)
+    target_sources(ihs_shared PRIVATE src/osgi_api.cc)
+    message(STATUS "OSGi handshake ........ Enabled")
+else ()
+    message(STATUS "OSGi handshake ........ Disabled")
+endif ()
+
 # Location service (the ihs_location_* C ABI): the gpsd and geoclue providers
 # and their gpsd-primary/geoclue-fallback combiner. geoclue talks D-Bus through
 # sd-bus, which it loads from libsystemd.so.0 at runtime via dlopen — exactly as
@@ -299,6 +327,7 @@ install(TARGETS ihs_shared EXPORT ihs_shared_targets
 #                          over the wire, not to this.
 #   ihs_mcp_semantics.h    "SHELL-ONLY lifecycle ... Not part of the plugin ABI"
 #   platform_view_host.h   "SHELL-ONLY host seam ... NOT part of the plugin ABI"
+#   ihs_osgi_host.h        "SHELL-ONLY host seam ... NOT part of the plugin ABI"
 #
 # Installing them publishes a producer surface as though it were supported, and
 # invites an out-of-tree caller to install a second semantics host or platform
@@ -308,6 +337,7 @@ install(TARGETS ihs_shared EXPORT ihs_shared_targets
 set(_ihs_header_excludes
         PATTERN "flutter_desktop_bridge.h" EXCLUDE
         PATTERN "ihs_semantics_host.h" EXCLUDE
+        PATTERN "ihs_osgi_host.h" EXCLUDE
         PATTERN "ihs_mcp_registry.h" EXCLUDE
         PATTERN "ihs_mcp_transport.h" EXCLUDE
         PATTERN "ihs_mcp_semantics.h" EXCLUDE
@@ -319,6 +349,11 @@ if (NOT BUILD_MCP)
     list(APPEND _ihs_header_excludes
             PATTERN "ihs_mcp_provider.h" EXCLUDE
             PATTERN "ihs_mcp_app_tools.h" EXCLUDE)
+endif ()
+# No forwarders are compiled without ENABLE_OSGI, so installing the header would
+# let a consumer declare against symbols this build does not export.
+if (NOT ENABLE_OSGI)
+    list(APPEND _ihs_header_excludes PATTERN "ihs_osgi.h" EXCLUDE)
 endif ()
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ihs
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/shared/README.md
+++ b/shared/README.md
@@ -23,6 +23,7 @@ registered plugins — `ihs_shared` exposes neither a registrar nor a messenger.
 | Platform-view surface negotiation (`ihs_pv_*`) | Built-in | Always; inert until the shell installs an `IhsPvHost` |
 | Config read-back (`ihs_config_*` snapshots) | Built-in | Always; shell publishes, plugins read |
 | Location service (`ihs_location_*`: gpsd / geoclue / capture replay, caller-registered sources, `kalman.cv` / `kalman.ctrv` filters) | Built-in | Always; geoclue `dlopen`s `libsystemd` at runtime. See [src/location/README.md](src/location/README.md) |
+| OSGi bundle handshake (`ihs_osgi_*`: framework and bundle registration, ACTIVE / STOPPED reports) | Optional | `ENABLE_OSGI` (default `OFF`); forwards to a shell-installed `IhsOsgiHost` and reports `IHS_OSGI_ERR_UNAVAILABLE` without one. See [shell/osgi/README.md](../shell/osgi/README.md) |
 | Versioned ABI handshake (`ihs_get_api`) | Built-in | Always; `IHS_SHARED_ABI_VERSION` |
 
 ---
@@ -120,12 +121,15 @@ Module responsibilities:
 | [shared/include/ihs/platform_view.h](include/ihs/platform_view.h) | Platform-view plugin surface: kinds, requirements, grants, factory/callbacks, frame submit |
 | [shared/include/ihs/platform_view_host.h](include/ihs/platform_view_host.h) | **Shell-only** host seam (`IhsPvHost`, `ihs_pv_set_host`) — not part of the plugin ABI |
 | [shared/include/ihs/config.h](include/ihs/config.h) | Config read surface + builder (`IhsConfigApi`); refcounted snapshots by flattened key |
+| [shared/include/ihs/ihs_osgi.h](include/ihs/ihs_osgi.h) | OSGi bundle handshake C ABI (`ENABLE_OSGI` only; not installed otherwise); registration, ACTIVE / STOPPED reports, opaque `IhsOsgiBundle` handle |
+| [shared/include/ihs/ihs_osgi_host.h](include/ihs/ihs_osgi_host.h) | **Shell-only** host seam (`IhsOsgiHost`, `ihs_osgi_set_host`) — not part of the plugin ABI |
 | [shared/include/ihs/format.h](include/ihs/format.h) | Header-only `ihs::format_to` (`std::format_to_n` or `snprintf`); C++ convenience, not ABI |
 | `shared/include/ihs/ihs_export.h` | Generated at configure time by `generate_export_header` — defines `IHS_EXPORT` |
 | [shared/src/ihs_api.cc](src/ihs_api.cc) | Entry point + capability-table assembly + last-error string |
 | [shared/src/trace.cc](src/trace.cc) | Tracing implementation |
 | [shared/src/config.cc](src/config.cc) | Config snapshot store + builder |
 | [shared/src/platform_view.cc](src/platform_view.cc) | Platform-view forwarder + negotiate scoring |
+| [shared/src/osgi_api.cc](src/osgi_api.cc) | OSGi handshake forwarders — validate arguments, then call through the shell's table; hold no state |
 | [shared/src/ihs_internal.hpp](src/ihs_internal.hpp) | Non-installed sub-table accessors shared between TUs |
 | `shared/src/logging/` | Logging internals: ring, registry, worker, context cache, sinks, DLT loader, FFI shim |
 | [shared/abi/libihs_shared.so.abi](abi/libihs_shared.so.abi) | Committed `libabigail` baseline — the CI ABI gate diffs against it |

--- a/shared/include/ihs/ihs_osgi.h
+++ b/shared/include/ihs/ihs_osgi.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The OSGi bundle handshake, re-exported from libihs_shared.so.
+ *
+ * A bundle is a Flutter engine running Dart code, and it has to tell the shell
+ * two things native code cannot obtain for itself: the address of Dart's
+ * NativeApi.initializeApiDLData, so the shell can bind Dart_PostCObject_DL, and
+ * a receive port to post to. It later reports that its activator finished,
+ * which is what releases a critical bundle's startup wait.
+ *
+ * That already works over the dev.osgi/bridge MethodChannel. This surface
+ * exists because the channel drags Flutter into the dependency graph of every
+ * bundle, including headless ones with no views: a bundle that wants only to
+ * decode CAN frames must still initialize a UI binding to send three integers,
+ * and its package must resolve against the Flutter SDK to do it. Over FFI the
+ * same handshake needs nothing but dart:ffi, so a service bundle is an ordinary
+ * Dart package that `dart test` can exercise.
+ *
+ * The second reason is the platform thread. A MethodChannel reply is marshalled
+ * through the platform task runner, which is at its busiest during exactly the
+ * window an ACTIVE report has to cross -- first frame, pipeline warm-up -- and
+ * the critical bundle's startup deadline is running the whole time. These calls
+ * are synchronous and touch no task runner.
+ *
+ * WHY THESE ARE FORWARDERS, AND WHERE THE STATE IS
+ *
+ * The registry that backs this lives in the shell (shell/osgi/bridge_registry),
+ * not in this library, and these functions only forward to it over a proc table
+ * the shell installs -- the same shape as the FlutterDesktop* re-exports (see
+ * flutter_desktop_bridge.h) and for the same reason: the implementation is in
+ * the executable, which is not a shared object a dlopen'd plugin can bind to.
+ *
+ * The state stays shell-side deliberately, and this is the one design decision
+ * here worth defending. Bundle lifecycle is not self-contained bookkeeping the
+ * way the MCP provider registry is: the startup orchestrator owns which bundles
+ * are critical, what their deadlines are, and which thread the reactor waits
+ * on. Moving the registry into this library would put a C ABI through the
+ * middle of that state machine, would drag the Dart DL headers into a library
+ * whose whole value is that it builds standalone with almost no dependencies,
+ * and would strand the registry's existing unit tests, which fake the two Dart
+ * DL entry points to test the ordering hazard without a VM.
+ *
+ * So: this library holds no OSGi state at all. Every function below reads one
+ * atomic pointer and calls through it.
+ *
+ * SAFE DEFAULTS
+ *
+ * Until the shell installs its table, every call returns
+ * IHS_OSGI_ERR_UNAVAILABLE. That is the honest answer in a build with
+ * ENABLE_OSGI off, or in a process that is not ivi-homescreen at all, and it is
+ * the state a plugin should expect to handle: an OSGi bundle running under a
+ * shell that does not do OSGi is a configuration mistake, not a crash.
+ *
+ * THREADING
+ *
+ * Every function may be called from any thread. Bundles call from their own
+ * isolate's thread, and there is one per engine. The registry serializes
+ * internally.
+ *
+ * A bundle must not call back into this surface from inside a shell callback;
+ * there are none in this direction today, and that is deliberate.
+ *
+ * Built only when ENABLE_OSGI is on. With it off, nothing here is compiled, no
+ * ihs_osgi_* symbol is exported, and this header is not installed -- so an
+ * out-of-tree consumer finds out at the include rather than at the link.
+ */
+
+#ifndef IHS_OSGI_H_
+#define IHS_OSGI_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ihs/ihs_export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * A registered bundle. Valid until ihs_osgi_unregister returns.
+ *
+ * This is a capability, not a convenience. Reporting ACTIVE releases the
+ * shell's critical-bundle wait, so a caller that can do it by naming a string
+ * can release the wait for a bundle that is not ready -- and because that path
+ * is meant to unblock startup, nothing downstream would look wrong. Every
+ * ihs_* symbol is reachable by anything in the process that dlopens this
+ * library, so a name would be no barrier at all.
+ *
+ * Requiring the handle means forging a report costs a completed registration
+ * under a symbolic name the shell's config declares, which is a materially
+ * higher bar. The handle is minted by the registry, is not derived from the
+ * name or the port, and is never sent to Dart as anything but an opaque
+ * integer.
+ */
+typedef struct IhsOsgiBundle IhsOsgiBundle;
+
+/*
+ * Status codes. Negative values are errors. Returned as int so the enum's
+ * underlying width is not part of the ABI.
+ */
+typedef enum IhsOsgiStatus {
+  IHS_OSGI_OK = 0,
+  /* A required argument was null, a struct_size was not recognized, or a port
+   * was zero. */
+  IHS_OSGI_ERR_INVALID = -1,
+  /* Dart_InitializeApiDL failed: the shell's vendored Dart DL headers do not
+   * match the running VM. Nothing else on this surface will work. */
+  IHS_OSGI_ERR_DART_API = -2,
+  /* The shell declined. For a bundle the usual cause is a symbolic_name
+   * matching no [[osgi.bundles]] entry, or one already registered -- a config
+   * mismatch, surfaced early rather than left to run unmanaged. */
+  IHS_OSGI_ERR_REJECTED = -3,
+  /* No OSGi host: built without ENABLE_OSGI, not an ivi-homescreen process, or
+   * the shell is shutting down. */
+  IHS_OSGI_ERR_UNAVAILABLE = -4
+} IhsOsgiStatus;
+
+/*
+ * Common to both registrations.
+ *
+ * @dart_api_dl_data is the address of Dart's NativeApi.initializeApiDLData, as
+ * an integer widened to a pointer. Every caller supplies it because any isolate
+ * may be the first to arrive; the shell makes all but the first a no-op. It is
+ * a VM-global and identical for every isolate in the process, since all the
+ * engines here share one VM.
+ *
+ * @port is the caller's SendPort.nativePort. Zero is rejected: a closed or
+ * never-opened port would look like a successful handshake and then silently
+ * deliver nothing.
+ */
+typedef struct IhsOsgiPeerInfo {
+  size_t struct_size; /* sizeof(IhsOsgiPeerInfo) */
+  void* dart_api_dl_data;
+  int64_t port;
+} IhsOsgiPeerInfo;
+
+/*
+ * Register the framework isolate and hand its port to every bundle already
+ * waiting for it.
+ *
+ * Exactly one framework per process. @out_served, when non-null, receives the
+ * number of bundles that were waiting and have now been served; it is a
+ * diagnostic, and zero is normal when the framework wins the race.
+ *
+ * Registration is commutative with ihs_osgi_register_bundle on purpose: the
+ * framework isolate and the bundle engines start concurrently, so either order
+ * happens, and whichever arrives second triggers delivery. Nothing here depends
+ * on startup order.
+ */
+IHS_EXPORT int ihs_osgi_register_framework(const IhsOsgiPeerInfo* info,
+                                           size_t* out_served);
+
+/*
+ * A bundle's registration.
+ *
+ * @symbolic_name must match an [[osgi.bundles]] entry in the shell's config.
+ * The shell refuses a name it does not know rather than accepting it, because
+ * the likeliest cause is a config mismatch and that should be loud.
+ */
+typedef struct IhsOsgiBundleInfo {
+  size_t struct_size; /* sizeof(IhsOsgiBundleInfo) */
+  IhsOsgiPeerInfo peer;
+  const char* symbolic_name; /* copied; need not outlive the call */
+} IhsOsgiBundleInfo;
+
+/*
+ * Register a bundle. On IHS_OSGI_OK, *out_bundle holds the handle every later
+ * call needs.
+ *
+ * The framework port is not returned here, and not because it would be
+ * inconvenient: it may not exist yet. It is posted to @info->peer.port when the
+ * framework registers, which may be before or after this call. A bundle waits
+ * on its receive port either way, and a bundle with no interest in other
+ * bundles never waits at all.
+ */
+IHS_EXPORT int ihs_osgi_register_bundle(const IhsOsgiBundleInfo* info,
+                                        IhsOsgiBundle** out_bundle);
+
+/*
+ * Report that the bundle's activator finished start().
+ *
+ * This is what ACTIVE means in the OSGi lifecycle. Not that the engine is up,
+ * which the shell already knows, and not that a frame was presented, which says
+ * nothing about whether the bundle's own code is ready. A critical bundle's
+ * startup wait is released by this and nothing else, so sending it before
+ * start-up work is genuinely finished defeats the guarantee the shell is
+ * holding the reactor for.
+ */
+IHS_EXPORT int ihs_osgi_report_active(IhsOsgiBundle* bundle);
+
+/*
+ * Report that the bundle's activator finished stop().
+ *
+ * The bundle stays registered: STOPPING returns to RESOLVED, from which it can
+ * start again. Call ihs_osgi_unregister only when the bundle is going away.
+ */
+IHS_EXPORT int ihs_osgi_report_stopped(IhsOsgiBundle* bundle);
+
+/*
+ * Release the registration, so a restart can re-register the same symbolic
+ * name. The handle is invalid once this returns.
+ *
+ * Idempotent against a null handle, so a teardown path that runs after a failed
+ * registration needs no special case -- teardown is usually running because
+ * something else already failed, and a second failure there buries the first.
+ */
+IHS_EXPORT int ihs_osgi_unregister(IhsOsgiBundle* bundle);
+
+/*
+ * Whether an OSGi host is installed. Lets a bundle choose a transport at
+ * start-up instead of provoking an error to find out.
+ *
+ * Advisory only: the host can go away between this call and the next, and every
+ * other function reports IHS_OSGI_ERR_UNAVAILABLE for itself.
+ */
+IHS_EXPORT bool ihs_osgi_available(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* IHS_OSGI_H_ */

--- a/shared/include/ihs/ihs_osgi_host.h
+++ b/shared/include/ihs/ihs_osgi_host.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * SHELL-ONLY host seam for the OSGi bundle handshake. This is NOT part of the
+ * plugin ABI (docs/PLUGIN_ABI.md) -- a consumer sees only ihs/ihs_osgi.h. It is
+ * the private contract between libihs_shared, which owns the published
+ * ihs_osgi_* surface, and the one in-process shell that owns the bundle
+ * registry and the startup orchestrator.
+ *
+ *   bundle  --ihs_osgi_*-->  libihs_shared  --IhsOsgiHost-->  shell
+ *
+ * The split follows what each side actually knows, and here it is lopsided in a
+ * way the semantics seam is not: libihs_shared owns nothing but the table
+ * pointer. It validates arguments, then forwards. The shell owns all of it --
+ * the port table, the ordering rule that makes registration commutative, the
+ * Dart DL binding, and the orchestrator that decides what a critical bundle's
+ * ACTIVE report releases.
+ *
+ * That is on purpose. Bundle lifecycle is a state machine the shell drives; a
+ * copy of it on the far side of a C ABI would be a second source of truth for
+ * which bundles exist, and the two would disagree exactly when it mattered.
+ *
+ * Threading: install the host once, at OSGi bring-up, before any bundle engine
+ * is spawned. Every callback may be invoked from any thread -- each bundle
+ * calls from its own isolate's thread -- so the implementation behind them
+ * serializes for itself; BridgeRegistry already does.
+ *
+ * The shell must not call back into libihs_shared from inside a host callback.
+ * The registry's lifecycle observer is dispatched outside the registry lock for
+ * the same reason, and re-entering here would defeat that.
+ */
+
+#ifndef IHS_OSGI_HOST_H_
+#define IHS_OSGI_HOST_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ihs/ihs_export.h"
+#include "ihs/ihs_osgi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Operations libihs_shared forwards to the shell. Each receives @user_data.
+ *
+ * Every entry returns an IhsOsgiStatus as int. A NULL entry means the
+ * capability is absent: the forwarder reports IHS_OSGI_ERR_UNAVAILABLE rather
+ * than pretending it succeeded.
+ *
+ *   register_framework
+ *       Bind the Dart DL symbol table if it is not already bound, record the
+ *       framework isolate's port, and post it to every bundle waiting for it.
+ *       Write the number served to @out_served when non-null.
+ *
+ *   register_bundle
+ *       Bind the Dart DL symbol table if needed, then record the bundle. The
+ *       shell mints the handle; libihs_shared treats it as opaque and never
+ *       dereferences it. Reject an unknown or duplicate symbolic name.
+ *
+ *       The handle must not be a cast of anything a caller could reconstruct --
+ *       not the port, not a hash of the name, not an index into a vector.
+ *       Reporting ACTIVE releases a critical bundle's startup wait, and any
+ *       plugin in the process can reach these symbols; the handle is the only
+ *       thing standing between that and a forged report. Treat it as a
+ *       capability and mint it accordingly.
+ *
+ *   report_active / report_stopped
+ *       The bundle's activator finished start() or stop(). The shell resolves
+ *       the handle and routes to the orchestrator. An unrecognized handle is
+ *       IHS_OSGI_ERR_REJECTED, not a crash: it is reachable from out-of-tree
+ *       code and must be treated as untrusted input.
+ *
+ *   unregister
+ *       Forget the bundle so a restart can re-register the same symbolic name,
+ *       and invalidate the handle. Must tolerate a handle it does not know.
+ */
+typedef struct IhsOsgiHost {
+  size_t struct_size; /* sizeof(IhsOsgiHost) */
+  void* user_data;
+
+  int (*register_framework)(void* user_data,
+                            void* dart_api_dl_data,
+                            int64_t port,
+                            size_t* out_served);
+
+  int (*register_bundle)(void* user_data,
+                         void* dart_api_dl_data,
+                         int64_t port,
+                         const char* symbolic_name,
+                         IhsOsgiBundle** out_bundle);
+
+  int (*report_active)(void* user_data, IhsOsgiBundle* bundle);
+  int (*report_stopped)(void* user_data, IhsOsgiBundle* bundle);
+  int (*unregister)(void* user_data, IhsOsgiBundle* bundle);
+} IhsOsgiHost;
+
+/*
+ * Install the host. Exactly one per process, at OSGi bring-up and before the
+ * first bundle engine is spawned. Pass NULL to uninstall during teardown, after
+ * which every ihs_osgi_* call reports IHS_OSGI_ERR_UNAVAILABLE rather than
+ * calling into a shell that is going away.
+ *
+ * Unlike ihs_semantics_set_host, the struct is NOT copied: the table is read on
+ * every forwarded call, and it must remain valid until uninstalled. A table
+ * whose struct_size is smaller than this definition is refused outright -- the
+ * struct only grows by appending, so a short one means an older shell against a
+ * newer libihs_shared, and the trailing entries would be absent rather than
+ * NULL. Leaving the forwarders on their safe defaults is degraded but
+ * well-defined; calling through an absent entry is not.
+ */
+IHS_EXPORT void ihs_osgi_set_host(const IhsOsgiHost* host);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* IHS_OSGI_HOST_H_ */

--- a/shared/src/osgi_api.cc
+++ b/shared/src/osgi_api.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Forwarders for the OSGi bundle handshake (see ihs/ihs_osgi.h).
+//
+// This library holds no OSGi state. The registry that backs these calls lives
+// in the shell (shell/osgi/bridge_registry), which is an executable rather than
+// a shared object a dlopen'd plugin can bind to -- the same situation the
+// FlutterDesktop* forwarders exist for, and handled the same way: the shell
+// installs a proc table, and every function here reads one atomic pointer and
+// calls through it.
+//
+// Until the shell installs that table every call reports
+// IHS_OSGI_ERR_UNAVAILABLE. That is the honest answer in a build with
+// ENABLE_OSGI off, and in a process that is not ivi-homescreen at all.
+
+#include "ihs/ihs_osgi.h"
+
+#include "ihs/ihs_osgi_host.h"
+
+#include <atomic>
+
+namespace {
+
+// Installed once by the shell; read on every forwarded call. Acquire/release
+// pairs with the store so a bundle's isolate thread sees a fully-published
+// table rather than a half-written one.
+std::atomic<const IhsOsgiHost*> g_host{nullptr};
+
+const IhsOsgiHost* host() {
+  return g_host.load(std::memory_order_acquire);
+}
+
+}  // namespace
+
+extern "C" void ihs_osgi_set_host(const IhsOsgiHost* host) {
+  // Refuse a table too small to cover every entry the forwarders call through.
+  // The struct only ever grows by appending, so a short one means an older
+  // shell against a newer ihs_shared: the trailing entries would be absent
+  // rather than NULL, and calling through them is undefined. Leaving the
+  // forwarders on their safe defaults is degraded but well-defined.
+  //
+  // Unlike ihs_semantics_set_host the table is not copied -- it is read on
+  // every call and must stay valid until uninstalled.
+  if (host != nullptr && host->struct_size < sizeof(IhsOsgiHost)) {
+    host = nullptr;
+  }
+  g_host.store(host, std::memory_order_release);
+}
+
+extern "C" bool ihs_osgi_available(void) {
+  return host() != nullptr;
+}
+
+extern "C" int ihs_osgi_register_framework(const IhsOsgiPeerInfo* info,
+                                           size_t* out_served) {
+  // Validated before the host is consulted: a malformed argument is the
+  // caller's mistake either way, and reporting it identically with and without
+  // a host keeps the surface predictable.
+  if (info == nullptr || info->struct_size < sizeof(IhsOsgiPeerInfo) ||
+      info->port == 0) {
+    return IHS_OSGI_ERR_INVALID;
+  }
+  const IhsOsgiHost* h = host();
+  if (h == nullptr || h->register_framework == nullptr) {
+    return IHS_OSGI_ERR_UNAVAILABLE;
+  }
+  return h->register_framework(h->user_data, info->dart_api_dl_data, info->port,
+                               out_served);
+}
+
+extern "C" int ihs_osgi_register_bundle(const IhsOsgiBundleInfo* info,
+                                        IhsOsgiBundle** out_bundle) {
+  if (info == nullptr || info->struct_size < sizeof(IhsOsgiBundleInfo) ||
+      info->peer.struct_size < sizeof(IhsOsgiPeerInfo) ||
+      info->peer.port == 0 || info->symbolic_name == nullptr ||
+      info->symbolic_name[0] == '\0' || out_bundle == nullptr) {
+    return IHS_OSGI_ERR_INVALID;
+  }
+  // Cleared up front so a caller that ignores the status never reads a stale
+  // handle out of its own uninitialized variable.
+  *out_bundle = nullptr;
+  const IhsOsgiHost* h = host();
+  if (h == nullptr || h->register_bundle == nullptr) {
+    return IHS_OSGI_ERR_UNAVAILABLE;
+  }
+  return h->register_bundle(h->user_data, info->peer.dart_api_dl_data,
+                            info->peer.port, info->symbolic_name, out_bundle);
+}
+
+extern "C" int ihs_osgi_report_active(IhsOsgiBundle* bundle) {
+  if (bundle == nullptr) {
+    return IHS_OSGI_ERR_INVALID;
+  }
+  const IhsOsgiHost* h = host();
+  if (h == nullptr || h->report_active == nullptr) {
+    return IHS_OSGI_ERR_UNAVAILABLE;
+  }
+  return h->report_active(h->user_data, bundle);
+}
+
+extern "C" int ihs_osgi_report_stopped(IhsOsgiBundle* bundle) {
+  if (bundle == nullptr) {
+    return IHS_OSGI_ERR_INVALID;
+  }
+  const IhsOsgiHost* h = host();
+  if (h == nullptr || h->report_stopped == nullptr) {
+    return IHS_OSGI_ERR_UNAVAILABLE;
+  }
+  return h->report_stopped(h->user_data, bundle);
+}
+
+extern "C" int ihs_osgi_unregister(IhsOsgiBundle* bundle) {
+  // Idempotent against a null handle, and deliberately OK rather than INVALID:
+  // a teardown path that runs after a failed registration needs no special
+  // case. Teardown is usually running because something else already failed,
+  // and a second failure there buries the first.
+  if (bundle == nullptr) {
+    return IHS_OSGI_OK;
+  }
+  const IhsOsgiHost* h = host();
+  if (h == nullptr || h->unregister == nullptr) {
+    return IHS_OSGI_ERR_UNAVAILABLE;
+  }
+  return h->unregister(h->user_data, bundle);
+}

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -161,6 +161,9 @@ if (ENABLE_OSGI)
     add_subdirectory(osgi_orchestrator-test)
     add_subdirectory(osgi_bridge-test)
     add_subdirectory(osgi_vsync-test)
+    # Links libihs_shared rather than the shell: the ihs_osgi_* forwarders are
+    # only compiled into it when ENABLE_OSGI is on.
+    add_subdirectory(ihs_osgi-test)
 endif ()
 add_subdirectory(output_resolver-test)
 add_subdirectory(ihs_pv-test)

--- a/test/unit_test/ihs_osgi-test/CMakeLists.txt
+++ b/test/unit_test/ihs_osgi-test/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Lean unit test for the ihs_shared OSGi handshake surface. Like ihs_pv-test it
+# does NOT compile the shell: it links libihs_shared directly and drives the
+# exported C ABI with a mock host, so it needs no Dart VM, engine, or display.
+set(TESTCASE_NAME "homescreen_ihs_osgi_ut_test_driver")
+
+add_executable(${TESTCASE_NAME}
+        test_case_ihs_osgi.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        ivi_homescreen::ihs_shared
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/ihs_osgi-test/test_case_ihs_osgi.cc
+++ b/test/unit_test/ihs_osgi-test/test_case_ihs_osgi.cc
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Unit tests for the ihs_shared OSGi handshake surface (ihs/ihs_osgi.h and the
+ * shell-only ihs/ihs_osgi_host.h).
+ *
+ * libihs_shared holds no OSGi state: every entry point validates its arguments,
+ * reads one atomic pointer, and calls through it. So what is testable here is
+ * exactly that -- argument validation, the safe defaults with no host, a host
+ * table too short to call through, and that a real table is forwarded to with
+ * the arguments unchanged. The registry behaviour behind the table is the
+ * shell's, and is covered by osgi_bridge-test.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ihs/ihs_osgi.h"
+#include "ihs/ihs_osgi_host.h"
+
+namespace {
+
+// A stand-in for the shell-owned opaque handle. libihs_shared only ever passes
+// it through, so any distinguishable address will do.
+int g_bundle_object = 0;
+IhsOsgiBundle* FakeHandle() {
+  return reinterpret_cast<IhsOsgiBundle*>(&g_bundle_object);
+}
+
+// Records what the forwarders passed through.
+struct FakeHost {
+  static inline int framework_calls = 0;
+  static inline int bundle_calls = 0;
+  static inline int active_calls = 0;
+  static inline int stopped_calls = 0;
+  static inline int unregister_calls = 0;
+  static inline std::string last_name;
+  static inline int64_t last_port = 0;
+  static inline void* last_dl_data = nullptr;
+  static inline void* last_user_data = nullptr;
+  static inline IhsOsgiBundle* last_handle = nullptr;
+
+  static void Reset() {
+    framework_calls = 0;
+    bundle_calls = 0;
+    active_calls = 0;
+    stopped_calls = 0;
+    unregister_calls = 0;
+    last_name.clear();
+    last_port = 0;
+    last_dl_data = nullptr;
+    last_user_data = nullptr;
+    last_handle = nullptr;
+  }
+
+  static int RegisterFramework(void* user_data,
+                               void* dart_api_dl_data,
+                               int64_t port,
+                               size_t* out_served) {
+    ++framework_calls;
+    last_user_data = user_data;
+    last_dl_data = dart_api_dl_data;
+    last_port = port;
+    if (out_served != nullptr) {
+      *out_served = 3;
+    }
+    return IHS_OSGI_OK;
+  }
+
+  static int RegisterBundle(void* user_data,
+                            void* dart_api_dl_data,
+                            int64_t port,
+                            const char* symbolic_name,
+                            IhsOsgiBundle** out_bundle) {
+    ++bundle_calls;
+    last_user_data = user_data;
+    last_dl_data = dart_api_dl_data;
+    last_port = port;
+    last_name = symbolic_name != nullptr ? symbolic_name : "";
+    *out_bundle = FakeHandle();
+    return IHS_OSGI_OK;
+  }
+
+  static int ReportActive(void* user_data, IhsOsgiBundle* bundle) {
+    ++active_calls;
+    last_user_data = user_data;
+    last_handle = bundle;
+    return IHS_OSGI_OK;
+  }
+
+  static int ReportStopped(void* user_data, IhsOsgiBundle* bundle) {
+    ++stopped_calls;
+    last_user_data = user_data;
+    last_handle = bundle;
+    return IHS_OSGI_OK;
+  }
+
+  static int Unregister(void* user_data, IhsOsgiBundle* bundle) {
+    ++unregister_calls;
+    last_user_data = user_data;
+    last_handle = bundle;
+    return IHS_OSGI_OK;
+  }
+};
+
+int g_user_data = 0;
+
+IhsOsgiHost MakeHost() {
+  IhsOsgiHost host{};
+  host.struct_size = sizeof(IhsOsgiHost);
+  host.user_data = &g_user_data;
+  host.register_framework = &FakeHost::RegisterFramework;
+  host.register_bundle = &FakeHost::RegisterBundle;
+  host.report_active = &FakeHost::ReportActive;
+  host.report_stopped = &FakeHost::ReportStopped;
+  host.unregister = &FakeHost::Unregister;
+  return host;
+}
+
+IhsOsgiPeerInfo MakePeer() {
+  IhsOsgiPeerInfo peer{};
+  peer.struct_size = sizeof(IhsOsgiPeerInfo);
+  peer.dart_api_dl_data = &g_user_data;
+  peer.port = 4242;
+  return peer;
+}
+
+IhsOsgiBundleInfo MakeBundleInfo(const char* name) {
+  IhsOsgiBundleInfo info{};
+  info.struct_size = sizeof(IhsOsgiBundleInfo);
+  info.peer = MakePeer();
+  info.symbolic_name = name;
+  return info;
+}
+
+// The host is process-global, so every test installs and removes its own.
+class IhsOsgiTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    FakeHost::Reset();
+    ihs_osgi_set_host(nullptr);
+  }
+  void TearDown() override { ihs_osgi_set_host(nullptr); }
+};
+
+}  // namespace
+
+// --- Safe defaults ----------------------------------------------------------
+//
+// A bundle running under a shell that does not do OSGi is a configuration
+// mistake, not a crash. Every call has to answer for itself rather than assume
+// a host is there.
+
+TEST_F(IhsOsgiTest, WithoutAHostEverythingIsUnavailable) {
+  EXPECT_FALSE(ihs_osgi_available());
+
+  const IhsOsgiPeerInfo peer = MakePeer();
+  EXPECT_EQ(ihs_osgi_register_framework(&peer, nullptr),
+            IHS_OSGI_ERR_UNAVAILABLE);
+
+  const IhsOsgiBundleInfo info = MakeBundleInfo("com.ivi.cluster");
+  IhsOsgiBundle* bundle = FakeHandle();
+  EXPECT_EQ(ihs_osgi_register_bundle(&info, &bundle), IHS_OSGI_ERR_UNAVAILABLE);
+  EXPECT_EQ(bundle, nullptr) << "out_bundle is cleared before the host check";
+
+  EXPECT_EQ(ihs_osgi_report_active(FakeHandle()), IHS_OSGI_ERR_UNAVAILABLE);
+  EXPECT_EQ(ihs_osgi_report_stopped(FakeHandle()), IHS_OSGI_ERR_UNAVAILABLE);
+  EXPECT_EQ(ihs_osgi_unregister(FakeHandle()), IHS_OSGI_ERR_UNAVAILABLE);
+}
+
+TEST_F(IhsOsgiTest, UninstallingTheHostRestoresTheSafeDefaults) {
+  const IhsOsgiHost host = MakeHost();
+  ihs_osgi_set_host(&host);
+  ASSERT_TRUE(ihs_osgi_available());
+
+  // Teardown: the shell is going away, and a call must not follow it there.
+  ihs_osgi_set_host(nullptr);
+  EXPECT_FALSE(ihs_osgi_available());
+  EXPECT_EQ(ihs_osgi_report_active(FakeHandle()), IHS_OSGI_ERR_UNAVAILABLE);
+  EXPECT_EQ(FakeHost::active_calls, 0);
+}
+
+// A table shorter than this build's definition means an older shell against a
+// newer ihs_shared: the trailing entries are absent rather than NULL, so
+// calling through them would be undefined.
+TEST_F(IhsOsgiTest, AShortHostTableIsRefusedOutright) {
+  IhsOsgiHost host = MakeHost();
+  host.struct_size = sizeof(IhsOsgiHost) - 1;
+  ihs_osgi_set_host(&host);
+
+  EXPECT_FALSE(ihs_osgi_available());
+  EXPECT_EQ(ihs_osgi_report_active(FakeHandle()), IHS_OSGI_ERR_UNAVAILABLE);
+  EXPECT_EQ(FakeHost::active_calls, 0);
+}
+
+// A NULL entry means the capability is absent, which is reported rather than
+// pretended.
+TEST_F(IhsOsgiTest, ANullEntryReportsUnavailableRatherThanCrashing) {
+  IhsOsgiHost host = MakeHost();
+  host.report_active = nullptr;
+  ihs_osgi_set_host(&host);
+
+  ASSERT_TRUE(ihs_osgi_available());
+  EXPECT_EQ(ihs_osgi_report_active(FakeHandle()), IHS_OSGI_ERR_UNAVAILABLE);
+  // The rest of the table still works.
+  EXPECT_EQ(ihs_osgi_report_stopped(FakeHandle()), IHS_OSGI_OK);
+}
+
+// --- Argument validation ----------------------------------------------------
+//
+// Checked before the host is consulted, so the answer is the same with and
+// without one.
+
+TEST_F(IhsOsgiTest, RejectsMalformedArgumentsBeforeReachingTheHost) {
+  const IhsOsgiHost host = MakeHost();
+  ihs_osgi_set_host(&host);
+
+  EXPECT_EQ(ihs_osgi_register_framework(nullptr, nullptr),
+            IHS_OSGI_ERR_INVALID);
+
+  IhsOsgiPeerInfo short_peer = MakePeer();
+  short_peer.struct_size = sizeof(IhsOsgiPeerInfo) - 1;
+  EXPECT_EQ(ihs_osgi_register_framework(&short_peer, nullptr),
+            IHS_OSGI_ERR_INVALID);
+
+  // A closed or never-opened port would look like a successful handshake and
+  // then silently deliver nothing.
+  IhsOsgiPeerInfo zero_port = MakePeer();
+  zero_port.port = 0;
+  EXPECT_EQ(ihs_osgi_register_framework(&zero_port, nullptr),
+            IHS_OSGI_ERR_INVALID);
+
+  EXPECT_EQ(FakeHost::framework_calls, 0);
+}
+
+TEST_F(IhsOsgiTest, RejectsABundleWithNoNameOrNoOutParameter) {
+  const IhsOsgiHost host = MakeHost();
+  ihs_osgi_set_host(&host);
+
+  IhsOsgiBundle* bundle = nullptr;
+  EXPECT_EQ(ihs_osgi_register_bundle(nullptr, &bundle), IHS_OSGI_ERR_INVALID);
+
+  IhsOsgiBundleInfo no_name = MakeBundleInfo(nullptr);
+  EXPECT_EQ(ihs_osgi_register_bundle(&no_name, &bundle), IHS_OSGI_ERR_INVALID);
+
+  IhsOsgiBundleInfo empty_name = MakeBundleInfo("");
+  EXPECT_EQ(ihs_osgi_register_bundle(&empty_name, &bundle),
+            IHS_OSGI_ERR_INVALID);
+
+  const IhsOsgiBundleInfo ok = MakeBundleInfo("com.ivi.cluster");
+  EXPECT_EQ(ihs_osgi_register_bundle(&ok, nullptr), IHS_OSGI_ERR_INVALID);
+
+  EXPECT_EQ(FakeHost::bundle_calls, 0);
+}
+
+TEST_F(IhsOsgiTest, AReportNeedsAHandle) {
+  const IhsOsgiHost host = MakeHost();
+  ihs_osgi_set_host(&host);
+
+  EXPECT_EQ(ihs_osgi_report_active(nullptr), IHS_OSGI_ERR_INVALID);
+  EXPECT_EQ(ihs_osgi_report_stopped(nullptr), IHS_OSGI_ERR_INVALID);
+  EXPECT_EQ(FakeHost::active_calls, 0);
+  EXPECT_EQ(FakeHost::stopped_calls, 0);
+}
+
+// Unregister is the exception, and deliberately so: a teardown path running
+// after a failed registration has nothing to release and needs no special case.
+TEST_F(IhsOsgiTest, UnregisteringANullHandleSucceedsWithOrWithoutAHost) {
+  EXPECT_EQ(ihs_osgi_unregister(nullptr), IHS_OSGI_OK);
+
+  const IhsOsgiHost host = MakeHost();
+  ihs_osgi_set_host(&host);
+  EXPECT_EQ(ihs_osgi_unregister(nullptr), IHS_OSGI_OK);
+  EXPECT_EQ(FakeHost::unregister_calls, 0) << "nothing to release";
+}
+
+// --- Forwarding -------------------------------------------------------------
+
+TEST_F(IhsOsgiTest, ForwardsEveryArgumentToTheHostUnchanged) {
+  const IhsOsgiHost host = MakeHost();
+  ihs_osgi_set_host(&host);
+
+  const IhsOsgiPeerInfo peer = MakePeer();
+  size_t served = 0;
+  EXPECT_EQ(ihs_osgi_register_framework(&peer, &served), IHS_OSGI_OK);
+  EXPECT_EQ(FakeHost::framework_calls, 1);
+  EXPECT_EQ(FakeHost::last_port, 4242);
+  EXPECT_EQ(FakeHost::last_dl_data, &g_user_data);
+  EXPECT_EQ(FakeHost::last_user_data, &g_user_data);
+  EXPECT_EQ(served, 3u) << "out_served is written through";
+
+  const IhsOsgiBundleInfo info = MakeBundleInfo("com.ivi.cluster");
+  IhsOsgiBundle* bundle = nullptr;
+  EXPECT_EQ(ihs_osgi_register_bundle(&info, &bundle), IHS_OSGI_OK);
+  EXPECT_EQ(FakeHost::bundle_calls, 1);
+  EXPECT_EQ(FakeHost::last_name, "com.ivi.cluster");
+  EXPECT_EQ(bundle, FakeHandle()) << "the shell mints the handle, not this lib";
+
+  EXPECT_EQ(ihs_osgi_report_active(bundle), IHS_OSGI_OK);
+  EXPECT_EQ(FakeHost::last_handle, bundle);
+  EXPECT_EQ(ihs_osgi_report_stopped(bundle), IHS_OSGI_OK);
+  EXPECT_EQ(FakeHost::last_handle, bundle);
+  EXPECT_EQ(ihs_osgi_unregister(bundle), IHS_OSGI_OK);
+  EXPECT_EQ(FakeHost::unregister_calls, 1);
+}
+
+// out_served is a diagnostic; a caller with no interest passes NULL and the
+// forwarder must not invent a place to write it.
+TEST_F(IhsOsgiTest, ANullOutServedIsAccepted) {
+  const IhsOsgiHost host = MakeHost();
+  ihs_osgi_set_host(&host);
+
+  const IhsOsgiPeerInfo peer = MakePeer();
+  EXPECT_EQ(ihs_osgi_register_framework(&peer, nullptr), IHS_OSGI_OK);
+  EXPECT_EQ(FakeHost::framework_calls, 1);
+}


### PR DESCRIPTION
A bundle has to tell the shell the address of Dart's
`NativeApi.initializeApiDLData` and a receive port to post to, then later report
that its activator finished — which is what releases a critical bundle's startup
wait.

That already works over the `dev.osgi/bridge` MethodChannel. This surface exists
for two reasons the channel cannot fix:

- **It drags Flutter into every bundle.** A headless bundle that only decodes CAN
  frames must still initialize a UI binding to send three integers, and its
  package must resolve against the Flutter SDK. Over FFI the same handshake needs
  nothing but `dart:ffi`, so a service bundle is an ordinary Dart package that
  `dart test` can exercise.
- **It rides the platform thread.** A MethodChannel reply is marshalled through
  the platform task runner, busiest during exactly the window an ACTIVE report
  must cross — first frame, pipeline warm-up — while the critical bundle's
  deadline is running. These calls are synchronous and touch no task runner.

### Where the state is

Nowhere in this library. The registry lives in the shell, which is an executable
rather than a shared object a dlopen'd plugin can bind to, so this follows the
`FlutterDesktop*` pattern: the shell installs a proc table, and every function
reads one atomic pointer and calls through it. A copy of the lifecycle behind a C
ABI would be a second source of truth for which bundles exist, disagreeing
exactly when it mattered.

Until the shell installs that table every call reports
`IHS_OSGI_ERR_UNAVAILABLE` — the honest answer in an `ENABLE_OSGI=OFF` build, and
in a process that is not ivi-homescreen at all.

**The shell half — installing the host table and minting handles out of
`BridgeRegistry` — is not in this PR and follows separately.**

### Gating

With `ENABLE_OSGI` off no source here is compiled, no `ihs_osgi_*` symbol is
exported, and `ihs_osgi.h` is not installed, so an out-of-tree consumer finds out
at the include rather than at the link. `ihs_osgi_host.h` is never installed — a
shell-only seam, like `ihs_semantics_host.h` and `platform_view_host.h`.

### Verification

- 10/10 unit tests pass (they link `libihs_shared` directly with a mock host: safe
  defaults, uninstall, a short host table refused, a NULL entry, argument
  validation ahead of the host, and every argument forwarded unchanged)
- `ENABLE_OSGI=ON` exports exactly the seven entry points; `ENABLE_OSGI=OFF`
  exports none
- the standalone `shared/` tree configures and builds both ways — that is the
  configuration `abi-gate` uses, and it passes no `-DENABLE_OSGI`, so the
  committed baseline sees an unchanged symbol set (and `abidiff --no-added-syms`
  would ignore additions regardless)
- `scripts/format.sh --check` — all files correctly formatted