### PR TITLE
docs: explain the dart_api_dl requirement in the OSGi README

### DIFF
--- a/shell/osgi/README.md
+++ b/shell/osgi/README.md
@@ -148,6 +148,22 @@ ctest --test-dir build -R osgi
 the missing file named if they are absent. See that directory's `PROVENANCE.md`
 for how they are pinned.
 
+The dependency is `dart_api_dl`, the dynamically-linked Dart embedding API, and
+it is what makes the bridge handshake possible at all. Native code cannot call
+`Dart_PostCObject` directly: the engine is loaded at runtime, so the symbol is
+not linkable. `dart_api_dl.c` defines a symbol table that
+`Dart_InitializeApiDL()` populates from the address an activator hands over in
+its `init` call, after which `BridgeRegistry` posts the framework isolate's
+`SendPort` to each bundle through `Dart_PostCObject_DL`. That is why an activator sends
+`NativeApi.initializeApiDLData` and its own receive port, and why both come
+from `dart:ffi` rather than `dart:ui`.
+
+`third_party/CMakeLists.txt` builds those sources into a small static
+`dart_api_dl` target, which `shell/CMakeLists.txt` links only under
+`ENABLE_OSGI`; `bridge_registry.cc` is the one translation unit that includes
+`dart_api_dl.h`. With `ENABLE_OSGI=OFF` neither the target nor the include is
+reached, which is what keeps the non-OSGi binary byte-for-byte unchanged.
+
 ---
 
 ## Running


### PR DESCRIPTION
Fixes #518.

#534 added `shell/osgi/README.md` and covered nearly everything the issue asked for -- lifecycle, the `dev.osgi/bridge` handshake, `[[osgi.bundles]]`, critical-first ordering, the test harnesses. The one item left out was the `dart_api_dl` requirement, which the issue called out explicitly and which is a hard `ENABLE_OSGI` dependency.

The README mentioned the vendored Dart DL headers as a configure-time prerequisite. What was missing is why they exist and what they do at runtime -- the part a reader reaches for when an activator's handshake fails.

## Added

- **Why**: `Dart_PostCObject` is not linkable, because the engine is loaded at runtime. `dart_api_dl.c` defines a symbol table that `Dart_InitializeApiDL()` fills in from the address an activator sends as `NativeApi.initializeApiDLData`; `BridgeRegistry` then posts the framework isolate's `SendPort` through `Dart_PostCObject_DL`. That explains why the activator sends that address plus its receive port, and why both come from `dart:ffi` rather than `dart:ui`.
- **Build wiring**: `third_party/CMakeLists.txt` builds the static `dart_api_dl` target, `shell/CMakeLists.txt` links it only under `ENABLE_OSGI`, and `bridge_registry.cc` is the single TU including the header -- which is what keeps an `ENABLE_OSGI=OFF` binary byte-for-byte unchanged, as the option's own comment claims.

Checked against `bridge_registry.cc`: the address arrives as `dl_data_address`, reaches `Dart_InitializeApiDL` via the injectable `DartPortApi` (`RealDartPortApi()`), and posting goes through `Dart_PostCObject_DL`.

Docs only. Links and anchors resolve.