### PR TITLE
osgi: install the host that makes the ihs_osgi_* surface work

### DIFF
--- a/shell/CMakeLists.txt
+++ b/shell/CMakeLists.txt
@@ -515,6 +515,7 @@ if (ENABLE_OSGI)
             osgi/cpu_affinity.cc
             osgi/osgi_bridge_plugin.cc
             osgi/osgi_config.cc
+            osgi/osgi_host.cc
             osgi/priority.cc
             osgi/startup_orchestrator.cc
             osgi/startup_plan.cc

--- a/shell/main.cc
+++ b/shell/main.cc
@@ -32,6 +32,7 @@
 #include "osgi/app_bundle_host.h"
 #include "osgi/bridge_registry.h"
 #include "osgi/osgi_config.h"
+#include "osgi/osgi_host.h"
 #include "osgi/startup_orchestrator.h"
 #endif
 #include "ihs/config.h"
@@ -395,6 +396,13 @@ int main(const int argc, char** argv) {
       // cannot report into a null observer.
       ihs::osgi::BridgeRegistry::Instance().SetLifecycleObserver(
           orchestrator.get());
+      // Install the FFI host, so a bundle can complete the same handshake
+      // through libihs_shared instead of the channel: no UI binding for a
+      // headless bundle, and an ACTIVE report that never crosses the platform
+      // thread while its own startup deadline is running. Both transports end
+      // at this one registry, so which a bundle uses changes nothing the
+      // orchestrator sees.
+      ihs::osgi::InstallOsgiHost(ihs::osgi::BridgeRegistry::Instance());
       for (const auto& outcome : orchestrator->StartCriticalPhase()) {
         if (!outcome.ok()) {
           // Reported, not fatal: one broken cluster must not stop the rest of
@@ -417,6 +425,18 @@ int main(const int argc, char** argv) {
     // (main) thread and blocks until the shutdown signal stops the io_context.
     const int ret = app.Run();
     (void)ret;
+
+#if ENABLE_OSGI
+    // Before the orchestrator is destroyed at the end of this scope. The
+    // registry is a process-lifetime singleton but dispatches lifecycle reports
+    // to the orchestrator by raw pointer, so a report arriving after this point
+    // would reach a destroyed object. Uninstalling the host first means a late
+    // ihs_osgi_* call answers IHS_OSGI_ERR_UNAVAILABLE instead of racing the
+    // teardown -- which matters more now that a bundle can report over FFI as
+    // well as over the channel.
+    ihs::osgi::UninstallOsgiHost();
+    ihs::osgi::BridgeRegistry::Instance().SetLifecycleObserver(nullptr);
+#endif
   }
 
   IHS_LOGGING_FLUSH();

--- a/shell/osgi/README.md
+++ b/shell/osgi/README.md
@@ -25,6 +25,7 @@ here is built and the binary carries no `ihs::osgi` symbols.
 | Per-bundle startup deadline, torn down on expiry | Built-in | `startup_timeout_ms` (1…3600000) |
 | `dev.osgi/bridge` handshake: a bundle announces itself and reports ACTIVE | Built-in | `OsgiBridgePlugin` |
 | Registration refused for a `symbolic_name` the configuration does not declare | Built-in | `[[osgi.bundles]]` |
+| FFI handshake: the same registration and reports through `libihs_shared`, no channel and no UI binding | Built-in | `ihs_osgi_*`, `osgi_host.{h,cc}` |
 | Framework isolate port delivered to every bundle, either registration order | Built-in | `BridgeRegistry` |
 | One presentation source fanned out to N engines in priority order | Built-in | `VsyncCoordinator` |
 | Engine-thread CPU affinity, validated against the process mask | Built-in | `cpu_core`, `framework_core` |
@@ -96,6 +97,12 @@ to completion and still have its critical wait expire.
   `Dart_CObject_kSendPort`, because Dart cannot rebuild a `SendPort` from a port
   id. It also holds the declared `symbolic_name`s, installed from the
   configuration at bring-up, and refuses a registration naming anything else.
+- **`osgi_host`** — installs the `IhsOsgiHost` proc table so the `ihs_osgi_*`
+  surface in `libihs_shared` reaches the same `BridgeRegistry` the channel does.
+  The library holds no OSGi state and answers `IHS_OSGI_ERR_UNAVAILABLE` until
+  this is installed. Reports arrive bearing an opaque handle the registry minted
+  rather than a name, since every `ihs_*` symbol is reachable by anything that
+  `dlopen`s the library.
 - **`vsync_coordinator`** — one vblank in, N ordered batons out.
 - **`bundle_state`** — the lifecycle graph, mirrored by the Dart side so a state
   crosses the boundary as an int with no translation.
@@ -117,6 +124,7 @@ shell/osgi/
 ├── app_bundle_host.{h,cc}       production host; bundles as App views
 ├── osgi_bridge_plugin.{h,cc}    dev.osgi/bridge method channel
 ├── bridge_registry.{h,cc}       isolate ports, framework port, observer seam
+├── osgi_host.{h,cc}             IhsOsgiHost table: the ihs_osgi_* FFI path
 ├── vsync_coordinator.{h,cc}     one source -> N engines, priority ordered
 └── bundle_state.{h,cc}          OSGi lifecycle states and legal transitions
 ```
@@ -216,7 +224,9 @@ Two deployment rules that are not obvious from the schema:
   bundle can still report ACTIVE for *another declared* bundle; what the
   declared set rules out is an undeclared name, not impersonation of a
   configured one. The plugin instance already identifies the engine, so binding
-  identity to it would be strictly stronger.
+  identity to it would be strictly stronger. This is the channel's limitation
+  specifically: over FFI a bundle reports through an unforgeable handle the
+  registry mints, so it can only report for itself.
 - A bundle whose isolate dies without calling `shutdown` stays registered until
   something else releases it; the bridge learns a bundle is gone only when it
   says so.

--- a/shell/osgi/bridge_registry.cc
+++ b/shell/osgi/bridge_registry.cc
@@ -16,6 +16,7 @@
 
 #include "bridge_registry.h"
 
+#include <random>
 #include <utility>
 
 #include "dart_api_dl.h"
@@ -212,8 +213,60 @@ bool BridgeRegistry::RegisterBundle(const std::string& symbolic_name,
   return true;
 }
 
+uint64_t BridgeRegistry::MintTokenLocked() {
+  // Follows NewSessionId() in shared/src/mcp_transport.cc -- the same problem,
+  // a value that authorizes something must not be guessable, and the same
+  // source, rather than a second randomness convention for one call site. Two
+  // draws because std::random_device yields 32 bits at a time.
+  static std::random_device source;
+  for (;;) {
+    const uint64_t token = (static_cast<uint64_t>(source()) << 32) |
+                           static_cast<uint64_t>(source());
+    // Zero is the null handle. A collision would let one bundle's report land
+    // on another's registration, which is the whole thing this guards against.
+    if (token != 0 && handles_.find(token) == handles_.end()) {
+      return token;
+    }
+  }
+}
+
+uint64_t BridgeRegistry::MintHandle(const std::string& symbolic_name) {
+  std::lock_guard lock(mutex_);
+  if (bundles_.find(symbolic_name) == bundles_.end()) {
+    return 0;
+  }
+  for (const auto& [token, name] : handles_) {
+    if (name == symbolic_name) {
+      return token;
+    }
+  }
+  const uint64_t token = MintTokenLocked();
+  handles_.emplace(token, symbolic_name);
+  return token;
+}
+
+std::optional<std::string> BridgeRegistry::BundleForHandle(
+    const uint64_t handle) const {
+  std::lock_guard lock(mutex_);
+  const auto it = handles_.find(handle);
+  if (it == handles_.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
 bool BridgeRegistry::UnregisterBundle(const std::string& symbolic_name) {
   std::lock_guard lock(mutex_);
+  // The capability goes with the registration. A handle outliving its bundle
+  // would report for whatever later took the name -- and a restart taking the
+  // same name is the ordinary case, not a rare one.
+  for (auto it = handles_.begin(); it != handles_.end();) {
+    if (it->second == symbolic_name) {
+      it = handles_.erase(it);
+    } else {
+      ++it;
+    }
+  }
   return bundles_.erase(symbolic_name) > 0;
 }
 
@@ -282,6 +335,7 @@ bool BridgeRegistry::ReportStopped(const std::string& symbolic_name) {
 void BridgeRegistry::ResetForTesting() {
   std::lock_guard lock(mutex_);
   bundles_.clear();
+  handles_.clear();
   framework_port_.reset();
   declared_.reset();
   observer_ = nullptr;

--- a/shell/osgi/bridge_registry.h
+++ b/shell/osgi/bridge_registry.h
@@ -162,12 +162,38 @@ class BridgeRegistry {
   // A bundle reported that it stopped.
   bool ReportStopped(const std::string& symbolic_name);
 
+  // Mint the opaque handle the FFI surface reports through, for a bundle that
+  // is already registered. Returns 0 when it is not.
+  //
+  // A capability, not a convenience. Reporting ACTIVE releases a critical
+  // bundle's startup wait, and every ihs_* symbol is reachable by anything in
+  // the process that dlopens libihs_shared, so a symbolic name would be no
+  // barrier at all. The token is random rather than derived from the name, the
+  // port, or an index, so forging a report costs guessing 64 bits instead of
+  // reading the configuration.
+  //
+  // Idempotent for a name that already holds one: RegisterBundle refuses a
+  // duplicate name, so a second mint for a live registration does not arise,
+  // and returning the existing handle beats either minting a second capability
+  // for one bundle or revoking the first out from under it.
+  [[nodiscard]] uint64_t MintHandle(const std::string& symbolic_name);
+
+  // The bundle a handle names, or nullopt when this registry did not mint it or
+  // has since dropped it. Handles arrive from out-of-tree code, so an unknown
+  // one is ordinary untrusted input rather than an error.
+  [[nodiscard]] std::optional<std::string> BundleForHandle(
+      uint64_t handle) const;
+
   // Test seam: drop all state (not the DL binding, which is a VM-global).
   void ResetForTesting();
 
  private:
   // Caller holds mutex_.
   bool DeliverLocked(const std::string& symbolic_name, int64_t port);
+
+  // A token no caller can predict, and not one already in use. Caller holds
+  // mutex_.
+  uint64_t MintTokenLocked();
 
   const DartPortApi& api_;
 
@@ -186,6 +212,11 @@ class BridgeRegistry {
   // Ordered so PendingBundles() is deterministic, which keeps the startup log
   // reproducible across runs.
   std::map<std::string, Bundle> bundles_;
+
+  // Capabilities handed to the FFI surface, token -> bundle. One per registered
+  // bundle at most, so dropping by name is a scan rather than a second index
+  // that could fall out of step with this one.
+  std::map<uint64_t, std::string> handles_;
 };
 
 }  // namespace ihs::osgi

--- a/shell/osgi/osgi_host.cc
+++ b/shell/osgi/osgi_host.cc
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "osgi_host.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "ihs/ihs_osgi.h"
+#include "ihs/ihs_osgi_host.h"
+
+#include "bridge_registry.h"
+#include "logging/logging.h"
+
+namespace ihs::osgi {
+
+namespace {
+
+BridgeRegistry& RegistryOf(void* user_data) {
+  return *static_cast<BridgeRegistry*>(user_data);
+}
+
+// The token, as the opaque pointer the C surface carries. Neither side ever
+// dereferences it: it is a capability that happens to be pointer-sized, not an
+// address, which is also why a forged one is harmless beyond being refused.
+IhsOsgiBundle* ToHandle(const uint64_t token) {
+  return reinterpret_cast<IhsOsgiBundle*>(static_cast<uintptr_t>(token));
+}
+
+uint64_t FromHandle(IhsOsgiBundle* bundle) {
+  return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(bundle));
+}
+
+int64_t AddressOf(void* dart_api_dl_data) {
+  return static_cast<int64_t>(reinterpret_cast<uintptr_t>(dart_api_dl_data));
+}
+
+int RegisterFramework(void* user_data,
+                      void* dart_api_dl_data,
+                      const int64_t port,
+                      size_t* out_served) {
+  BridgeRegistry& registry = RegistryOf(user_data);
+  if (!registry.InitializeDartApi(AddressOf(dart_api_dl_data))) {
+    return IHS_OSGI_ERR_DART_API;
+  }
+  const std::optional<size_t> served = registry.SetFrameworkPort(port);
+  if (!served.has_value()) {
+    return IHS_OSGI_ERR_REJECTED;
+  }
+  if (out_served != nullptr) {
+    *out_served = *served;
+  }
+  ihs::log::debug("[osgi] ffi: framework registered; served {} bundle(s)",
+                  *served);
+  return IHS_OSGI_OK;
+}
+
+int RegisterBundle(void* user_data,
+                   void* dart_api_dl_data,
+                   const int64_t port,
+                   const char* symbolic_name,
+                   IhsOsgiBundle** out_bundle) {
+  BridgeRegistry& registry = RegistryOf(user_data);
+  if (!registry.InitializeDartApi(AddressOf(dart_api_dl_data))) {
+    return IHS_OSGI_ERR_DART_API;
+  }
+  const std::string name(symbolic_name);
+  if (!registry.RegisterBundle(name, port)) {
+    return IHS_OSGI_ERR_REJECTED;
+  }
+  const uint64_t token = registry.MintHandle(name);
+  if (token == 0) {
+    // Unreachable unless the bundle vanished between the two calls. Either way
+    // do not leave a registration holding the name with nothing able to report
+    // through it -- that would burn the bundle's startup deadline for a reason
+    // nothing logs.
+    registry.UnregisterBundle(name);
+    return IHS_OSGI_ERR_REJECTED;
+  }
+  *out_bundle = ToHandle(token);
+  ihs::log::debug("[osgi] ffi: bundle '{}' registered", name);
+  return IHS_OSGI_OK;
+}
+
+int ReportActive(void* user_data, IhsOsgiBundle* bundle) {
+  BridgeRegistry& registry = RegistryOf(user_data);
+  const std::optional<std::string> name =
+      registry.BundleForHandle(FromHandle(bundle));
+  if (!name.has_value()) {
+    // Reachable by anything in the process that dlopens libihs_shared, so an
+    // unrecognized handle is untrusted input to refuse rather than a reason to
+    // crash -- and refusing it is the point of the handle existing.
+    ihs::log::warn("[osgi] ffi: ACTIVE from an unrecognized handle");
+    return IHS_OSGI_ERR_REJECTED;
+  }
+  return registry.ReportActive(*name) ? IHS_OSGI_OK : IHS_OSGI_ERR_REJECTED;
+}
+
+int ReportStopped(void* user_data, IhsOsgiBundle* bundle) {
+  BridgeRegistry& registry = RegistryOf(user_data);
+  const std::optional<std::string> name =
+      registry.BundleForHandle(FromHandle(bundle));
+  if (!name.has_value()) {
+    ihs::log::warn("[osgi] ffi: STOPPED from an unrecognized handle");
+    return IHS_OSGI_ERR_REJECTED;
+  }
+  return registry.ReportStopped(*name) ? IHS_OSGI_OK : IHS_OSGI_ERR_REJECTED;
+}
+
+int Unregister(void* user_data, IhsOsgiBundle* bundle) {
+  BridgeRegistry& registry = RegistryOf(user_data);
+  const std::optional<std::string> name =
+      registry.BundleForHandle(FromHandle(bundle));
+  if (!name.has_value()) {
+    // Tolerated rather than refused: releasing what is already released is the
+    // state the caller asked for, and teardown is usually running because
+    // something else has already failed.
+    return IHS_OSGI_OK;
+  }
+  registry.UnregisterBundle(*name);
+  return IHS_OSGI_OK;
+}
+
+}  // namespace
+
+void InstallOsgiHost(BridgeRegistry& registry) {
+  // ihs_osgi_set_host does not copy the table -- it is read on every forwarded
+  // call -- so it has to outlive the installation. A function-local static
+  // does, and the registry it points at is itself immortal.
+  static IhsOsgiHost host{};
+  host.struct_size = sizeof(IhsOsgiHost);
+  host.user_data = &registry;
+  host.register_framework = &RegisterFramework;
+  host.register_bundle = &RegisterBundle;
+  host.report_active = &ReportActive;
+  host.report_stopped = &ReportStopped;
+  host.unregister = &Unregister;
+  ihs_osgi_set_host(&host);
+  ihs::log::debug("[osgi] ffi: host installed");
+}
+
+void UninstallOsgiHost() {
+  ihs_osgi_set_host(nullptr);
+}
+
+}  // namespace ihs::osgi

--- a/shell/osgi/osgi_host.h
+++ b/shell/osgi/osgi_host.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace ihs::osgi {
+
+class BridgeRegistry;
+
+// Install the IhsOsgiHost proc table, so the ihs_osgi_* surface in
+// libihs_shared reaches @registry.
+//
+// This is what turns that surface from inert into working: the library holds no
+// OSGi state at all and answers IHS_OSGI_ERR_UNAVAILABLE until a table is
+// installed. Both transports end at the same registry, so which one a bundle
+// uses changes nothing the orchestrator sees.
+//
+// Call once at OSGi bring-up, before any bundle engine is spawned, and pair it
+// with UninstallOsgiHost. @registry must outlive the installation; in practice
+// it is BridgeRegistry::Instance(), which outlives everything.
+void InstallOsgiHost(BridgeRegistry& registry);
+
+// Remove the table. Every ihs_osgi_* call then reports
+// IHS_OSGI_ERR_UNAVAILABLE rather than reaching into a shell that is going
+// away. Safe to call without a matching install.
+void UninstallOsgiHost();
+
+}  // namespace ihs::osgi

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -164,6 +164,9 @@ if (ENABLE_OSGI)
     # Links libihs_shared rather than the shell: the ihs_osgi_* forwarders are
     # only compiled into it when ENABLE_OSGI is on.
     add_subdirectory(ihs_osgi-test)
+    # Links both: the C surface driven against a real registry through the host
+    # table, which is the only place the two halves of the FFI path meet.
+    add_subdirectory(osgi_host-test)
 endif ()
 add_subdirectory(output_resolver-test)
 add_subdirectory(ihs_pv-test)

--- a/test/unit_test/osgi_bridge-test/test_case_osgi_bridge.cc
+++ b/test/unit_test/osgi_bridge-test/test_case_osgi_bridge.cc
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <thread>
@@ -235,6 +236,70 @@ TEST_F(BridgeRegistryTest, AnEmptyDeclarationSetRefusesEverything) {
   registry_->SetDeclaredBundles({});
   EXPECT_FALSE(registry_->IsDeclared("com.ivi.cluster"));
   EXPECT_FALSE(registry_->RegisterBundle("com.ivi.cluster", 7));
+}
+
+// --- Handles ----------------------------------------------------------------
+//
+// The FFI surface reports through an opaque handle rather than a name, because
+// a name is no barrier there: every ihs_* symbol is reachable by anything in
+// the process that dlopens libihs_shared, and reporting ACTIVE releases a
+// critical bundle's startup wait. The handle is what makes forging one cost
+// guessing 64 bits instead of reading the configuration.
+
+TEST_F(BridgeRegistryTest, MintsAHandleOnlyForARegisteredBundle) {
+  EXPECT_EQ(registry_->MintHandle("com.ivi.ghost"), 0u);
+
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  const uint64_t handle = registry_->MintHandle("com.ivi.cluster");
+  EXPECT_NE(handle, 0u);
+  EXPECT_EQ(registry_->BundleForHandle(handle), "com.ivi.cluster");
+}
+
+// RegisterBundle refuses a duplicate name, so a second mint cannot arise for a
+// live registration -- but if it did, one bundle must not end up holding two
+// capabilities, nor have its first revoked out from under it.
+TEST_F(BridgeRegistryTest, MintingTwiceReturnsTheSameHandle) {
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  const uint64_t first = registry_->MintHandle("com.ivi.cluster");
+  EXPECT_NE(first, 0u);
+  EXPECT_EQ(registry_->MintHandle("com.ivi.cluster"), first);
+}
+
+TEST_F(BridgeRegistryTest, DistinctBundlesGetDistinctHandles) {
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.navigation", 8));
+  const uint64_t cluster = registry_->MintHandle("com.ivi.cluster");
+  const uint64_t navigation = registry_->MintHandle("com.ivi.navigation");
+
+  EXPECT_NE(cluster, 0u);
+  EXPECT_NE(navigation, 0u);
+  EXPECT_NE(cluster, navigation);
+  EXPECT_EQ(registry_->BundleForHandle(cluster), "com.ivi.cluster");
+  EXPECT_EQ(registry_->BundleForHandle(navigation), "com.ivi.navigation");
+}
+
+// Handles arrive from out-of-tree code, so one this registry never minted has
+// to resolve to nothing rather than to whatever sits nearby.
+TEST_F(BridgeRegistryTest, AnUnmintedHandleResolvesToNothing) {
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  const uint64_t handle = registry_->MintHandle("com.ivi.cluster");
+
+  EXPECT_FALSE(registry_->BundleForHandle(0).has_value()) << "the null handle";
+  EXPECT_FALSE(registry_->BundleForHandle(handle ^ 1u).has_value())
+      << "one bit away from a live capability";
+}
+
+// The capability goes with the registration. A restart takes the same symbolic
+// name, and a handle that outlived its bundle would report for the new one.
+TEST_F(BridgeRegistryTest, UnregisterDropsTheHandle) {
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 7));
+  const uint64_t handle = registry_->MintHandle("com.ivi.cluster");
+  ASSERT_TRUE(registry_->UnregisterBundle("com.ivi.cluster"));
+  EXPECT_FALSE(registry_->BundleForHandle(handle).has_value());
+
+  ASSERT_TRUE(registry_->RegisterBundle("com.ivi.cluster", 8));
+  EXPECT_NE(registry_->MintHandle("com.ivi.cluster"), handle)
+      << "a restart must not inherit the previous incarnation's capability";
 }
 
 // A restart re-registers the same symbolic name, which requires an explicit

--- a/test/unit_test/osgi_host-test/CMakeLists.txt
+++ b/test/unit_test/osgi_host-test/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Drives the real ihs_osgi_* C surface against a real BridgeRegistry through the
+# host table the shell installs -- the only test where both halves of the FFI
+# path meet. Links libihs_shared for the forwarders as well as the shell objects
+# for the registry and the adapter behind them.
+set(TESTCASE_NAME "homescreen_osgi_host_ut_test_driver")
+set(TESTCASE_CC test_case_osgi_host.cc;)
+
+add_executable(${TESTCASE_NAME} ${TESTCASE_CC})
+add_sanitizers(${TESTCASE_NAME})
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest_main
+        homescreen_ut_shell
+        ivi_homescreen::ihs_shared
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/osgi_host-test/test_case_osgi_host.cc
+++ b/test/unit_test/osgi_host-test/test_case_osgi_host.cc
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The FFI path end to end, minus the VM: a bundle calls the ihs_osgi_* C
+ * surface in libihs_shared, the forwarders read the proc table the shell
+ * installed, and the adapter drives a real BridgeRegistry.
+ *
+ * osgi_bridge-test covers the registry alone and ihs_osgi-test covers the
+ * forwarders alone, against a mock host each. This is the only place the two
+ * halves meet, so it is where a mismatch between them shows up -- a status
+ * mapped wrongly, a handle not minted, a registration left behind.
+ *
+ * The Dart DL calls are faked for the same reason as in osgi_bridge-test: they
+ * need a live VM, and nothing here depends on what they do.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ihs/ihs_osgi.h"
+
+#include "osgi/bridge_registry.h"
+#include "osgi/osgi_host.h"
+
+namespace {
+
+struct FakeDart {
+  static inline std::vector<std::pair<int64_t, int64_t>> posts;
+  static inline int init_calls = 0;
+
+  static void Reset() {
+    posts.clear();
+    init_calls = 0;
+  }
+
+  static intptr_t Initialize(void*) {
+    ++init_calls;
+    return 0;
+  }
+
+  static bool PostSendPort(const int64_t target_port,
+                           const int64_t send_port_id) {
+    posts.emplace_back(target_port, send_port_id);
+    return true;
+  }
+};
+
+ihs::osgi::DartPortApi FakeApi() {
+  return {&FakeDart::Initialize, &FakeDart::PostSendPort};
+}
+
+class RecordingObserver final : public ihs::osgi::IBundleLifecycleObserver {
+ public:
+  void OnBundleActive(const std::string& name) override {
+    active.push_back(name);
+  }
+  void OnBundleStopped(const std::string& name) override {
+    stopped.push_back(name);
+  }
+  std::vector<std::string> active;
+  std::vector<std::string> stopped;
+};
+
+// Each test installs its own registry rather than the process singleton, which
+// is what InstallOsgiHost taking a reference is for. The host itself is
+// process-global, so it has to come back out again in teardown.
+class OsgiHostTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    FakeDart::Reset();
+    api_ = FakeApi();
+    registry_ = std::make_unique<ihs::osgi::BridgeRegistry>(api_);
+    registry_->SetLifecycleObserver(&observer_);
+    ihs::osgi::InstallOsgiHost(*registry_);
+  }
+
+  void TearDown() override { ihs::osgi::UninstallOsgiHost(); }
+
+  IhsOsgiPeerInfo Peer(const int64_t port) {
+    IhsOsgiPeerInfo peer{};
+    peer.struct_size = sizeof(IhsOsgiPeerInfo);
+    peer.dart_api_dl_data = &dl_data_;
+    peer.port = port;
+    return peer;
+  }
+
+  IhsOsgiBundleInfo BundleInfo(const char* name, const int64_t port) {
+    IhsOsgiBundleInfo info{};
+    info.struct_size = sizeof(IhsOsgiBundleInfo);
+    info.peer = Peer(port);
+    info.symbolic_name = name;
+    return info;
+  }
+
+  int dl_data_ = 0;
+  ihs::osgi::DartPortApi api_{};
+  RecordingObserver observer_;
+  std::unique_ptr<ihs::osgi::BridgeRegistry> registry_;
+};
+
+constexpr int64_t kFrameworkPort = 1001;
+
+}  // namespace
+
+// Uninstalling has to be what the forwarders see, or teardown would leave the
+// next test talking to a destroyed registry.
+TEST_F(OsgiHostTest, UninstallingTheHostMakesTheSurfaceUnavailable) {
+  EXPECT_TRUE(ihs_osgi_available());
+  ihs::osgi::UninstallOsgiHost();
+
+  EXPECT_FALSE(ihs_osgi_available());
+  const IhsOsgiPeerInfo peer = Peer(kFrameworkPort);
+  EXPECT_EQ(ihs_osgi_register_framework(&peer, nullptr),
+            IHS_OSGI_ERR_UNAVAILABLE);
+}
+
+// The startup race, driven through the C surface: a bundle registers before the
+// framework exists and is served the moment it does.
+TEST_F(OsgiHostTest, RegistersTheFrameworkAndServesWaitingBundles) {
+  IhsOsgiBundle* bundle = nullptr;
+  const IhsOsgiBundleInfo info = BundleInfo("com.ivi.cluster", 7);
+  ASSERT_EQ(ihs_osgi_register_bundle(&info, &bundle), IHS_OSGI_OK);
+  EXPECT_TRUE(FakeDart::posts.empty()) << "no framework port to deliver yet";
+
+  const IhsOsgiPeerInfo peer = Peer(kFrameworkPort);
+  size_t served = 0;
+  ASSERT_EQ(ihs_osgi_register_framework(&peer, &served), IHS_OSGI_OK);
+  EXPECT_EQ(served, 1u);
+
+  ASSERT_EQ(FakeDart::posts.size(), 1u);
+  EXPECT_EQ(FakeDart::posts[0].first, 7);
+  EXPECT_EQ(FakeDart::posts[0].second, kFrameworkPort);
+}
+
+TEST_F(OsgiHostTest, RegistersABundleAndReportsThroughItsHandle) {
+  IhsOsgiBundle* bundle = nullptr;
+  const IhsOsgiBundleInfo info = BundleInfo("com.ivi.cluster", 7);
+  ASSERT_EQ(ihs_osgi_register_bundle(&info, &bundle), IHS_OSGI_OK);
+  ASSERT_NE(bundle, nullptr);
+
+  EXPECT_EQ(ihs_osgi_report_active(bundle), IHS_OSGI_OK);
+  EXPECT_EQ(observer_.active, std::vector<std::string>{"com.ivi.cluster"});
+
+  EXPECT_EQ(ihs_osgi_report_stopped(bundle), IHS_OSGI_OK);
+  EXPECT_EQ(observer_.stopped, std::vector<std::string>{"com.ivi.cluster"});
+}
+
+// The declared set gates this path exactly as it gates the channel: both end at
+// the same registry.
+TEST_F(OsgiHostTest, AnUndeclaredNameIsRefused) {
+  registry_->SetDeclaredBundles({"com.ivi.cluster"});
+
+  IhsOsgiBundle* bundle = nullptr;
+  const IhsOsgiBundleInfo info = BundleInfo("com.ivi.clustre", 7);
+  EXPECT_EQ(ihs_osgi_register_bundle(&info, &bundle), IHS_OSGI_ERR_REJECTED);
+  EXPECT_EQ(bundle, nullptr);
+}
+
+// The reason the handle exists. Anything in the process can reach these
+// symbols, so a report that did not come with a minted capability must be
+// refused rather than advance someone else's startup.
+TEST_F(OsgiHostTest, AForgedHandleCannotReportActive) {
+  IhsOsgiBundle* real = nullptr;
+  const IhsOsgiBundleInfo info = BundleInfo("com.ivi.cluster", 7);
+  ASSERT_EQ(ihs_osgi_register_bundle(&info, &real), IHS_OSGI_OK);
+
+  const uintptr_t token = reinterpret_cast<uintptr_t>(real);
+  auto* forged = reinterpret_cast<IhsOsgiBundle*>(token ^ 1u);
+  EXPECT_EQ(ihs_osgi_report_active(forged), IHS_OSGI_ERR_REJECTED);
+  EXPECT_TRUE(observer_.active.empty());
+}
+
+TEST_F(OsgiHostTest, UnregisterFreesTheNameAndInvalidatesTheHandle) {
+  IhsOsgiBundle* bundle = nullptr;
+  const IhsOsgiBundleInfo info = BundleInfo("com.ivi.cluster", 7);
+  ASSERT_EQ(ihs_osgi_register_bundle(&info, &bundle), IHS_OSGI_OK);
+
+  EXPECT_EQ(ihs_osgi_unregister(bundle), IHS_OSGI_OK);
+  EXPECT_EQ(ihs_osgi_report_active(bundle), IHS_OSGI_ERR_REJECTED)
+      << "the capability died with the registration";
+
+  // Which is what a restart needs.
+  IhsOsgiBundle* restarted = nullptr;
+  const IhsOsgiBundleInfo again = BundleInfo("com.ivi.cluster", 8);
+  EXPECT_EQ(ihs_osgi_register_bundle(&again, &restarted), IHS_OSGI_OK);
+  EXPECT_NE(restarted, nullptr);
+  EXPECT_NE(restarted, bundle);
+}
+
+// Teardown is usually running because something else already failed; a second
+// failure there would bury the first.
+TEST_F(OsgiHostTest, UnregisteringAnUnknownHandleIsTolerated) {
+  auto* unknown = reinterpret_cast<IhsOsgiBundle*>(uintptr_t{0xDEAD});
+  EXPECT_EQ(ihs_osgi_unregister(unknown), IHS_OSGI_OK);
+  EXPECT_EQ(ihs_osgi_unregister(nullptr), IHS_OSGI_OK);
+}


### PR DESCRIPTION
The C surface landed in #538 holding no OSGi state: every entry point reads one
atomic pointer and calls through it, and until something installs that table
every call answers `IHS_OSGI_ERR_UNAVAILABLE`. **This is the something.**

`osgi_host` installs an `IhsOsgiHost` over `BridgeRegistry`, so a bundle
completing the handshake over FFI reaches the same registry the
`dev.osgi/bridge` channel does. Both transports end at one place: the
declared-name check from #537 gates the FFI path without being written twice,
and the orchestrator cannot tell which transport a bundle used.

### The handle

The C surface reports through an opaque `IhsOsgiBundle*` rather than a name, and
the registry now mints it. A name would be no barrier: every `ihs_*` symbol is
reachable by anything that `dlopen`s `libihs_shared`, and reporting ACTIVE
releases a critical bundle's startup wait — a path meant to unblock startup, so
nothing downstream would look wrong if it were forged.

The token is 64 random bits, following `NewSessionId()` in `mcp_transport.cc`
(same problem, same source, rather than a second randomness convention for one
call site). It is never derived from the name, the port, or an index, and
neither side ever dereferences it — a capability that happens to be
pointer-sized, which is why a forged one is merely refused. It dies with the
registration, since a restart takes the same symbolic name.

### A teardown hazard this widens

`BridgeRegistry` is a process-lifetime singleton that dispatches lifecycle
reports to the orchestrator **by raw pointer, and the observer was never
cleared** — so a report arriving after the orchestrator's scope closed would
reach a destroyed object. That predates this change, but a second path to
`ReportActive` makes it easier to hit, so `main.cc` now uninstalls the host and
clears the observer before the orchestrator goes.

### Tests

- **5** in `osgi_bridge-test` for the registry: minted only for a registered
  bundle, idempotent per name, distinct per bundle, an unminted handle (null, or
  one bit from a live one) resolving to nothing, and dropped on unregister so a
  restart cannot inherit it.
- **7** in a new `osgi_host-test` — the only place the two halves of the FFI path
  meet. `osgi_bridge-test` covers the registry against a fake VM and
  `ihs_osgi-test` covers the forwarders against a mock host, so a mismatch
  between them surfaces here and nowhere else.

### Still not proven

Nothing has run this with a live Dart VM. The DL calls are faked here as in
`osgi_bridge-test`, and the Dart side (`osgi_ffi`, in the dart_osgi repo) binds
the surface against a fake of it. The first real FFI handshake needs both
together on hardware.

### Verification

- `ctest -R osgi` — **7/7 pass**, including the five suites this change does not
  touch but recompiles
- shell builds and links with `-DENABLE_OSGI=ON`
- `scripts/format.sh --check` — all files correctly formatted