### PR TITLE
osgi: the activator never sees the framework port

### DIFF
--- a/test/integration/osgi_activator_test/README.md
+++ b/test/integration/osgi_activator_test/README.md
@@ -26,6 +26,12 @@ shell was.
 Both come from `dart:ffi`, not `dart:ui` — `NativeApi` and the `nativePort`
 extension on `SendPort` both live there.
 
+The framework port comes back as a **`SendPort`**, not as the port id that was
+sent out. That asymmetry is forced: Dart offers no way to turn a port id back
+into a `SendPort`, so an integer would leave the bundle with nothing it could
+send to. The shell posts a `Dart_CObject_kSendPort` for exactly that reason, and
+a bundle that tests the message for `int` will simply never see it.
+
 ## Symbolic name
 
 Read from `--dart-entrypoint-args`, so one build stands in for any bundle in a

--- a/test/integration/osgi_activator_test/lib/main.dart
+++ b/test/integration/osgi_activator_test/lib/main.dart
@@ -32,7 +32,6 @@ import 'dart:async';
 import 'dart:ffi';
 import 'dart:isolate';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -71,7 +70,11 @@ class _Activator {
   /// isolate's port here, and closing it would strand that message.
   final ReceivePort _fromShell = ReceivePort();
 
-  int? frameworkPort;
+  /// The framework isolate's port, once the shell posts it.
+  ///
+  /// A [SendPort] rather than an int: a port id would be useless here, since
+  /// Dart offers no way to turn one back into a [SendPort].
+  SendPort? frameworkPort;
 
   /// Repaints steadily so the bundle keeps presenting.
   ///
@@ -82,19 +85,26 @@ class _Activator {
   /// that never presented at all. A real cluster or navigation view animates;
   /// this stands in for that.
   final ValueNotifier<int> tick = ValueNotifier<int>(0);
-  Timer? _ticker;
 
   Future<void> start() async {
-    _ticker = Timer.periodic(const Duration(milliseconds: 100),
-        (_) => tick.value = tick.value + 1);
+    // Never cancelled, deliberately: the bundle presents for as long as its
+    // isolate lives, and there is no teardown path here to cancel it from.
+    Timer.periodic(
+        const Duration(milliseconds: 100), (_) => tick.value = tick.value + 1);
 
     _fromShell.listen((dynamic message) {
-      // The framework port arrives as a bare int (Dart_PostCObject_DL with an
-      // int64 payload). Everything after this is SendPort traffic between
-      // isolates, off the platform thread.
-      if (message is int) {
+      // Arrives as a SendPort, because the shell posts a
+      // Dart_CObject_kSendPort. It used to post a bare int64, and this checked
+      // for one -- which silently stopped matching when the shell changed, so
+      // the bundle reached ACTIVE while never learning the framework port.
+      // An int is useless here in any case: Dart cannot turn a port id back
+      // into a SendPort, so a bundle handed one has nothing to send to.
+      //
+      // Everything after this is SendPort traffic between isolates, off the
+      // platform thread.
+      if (message is SendPort) {
         frameworkPort = message;
-        detail.value = 'framework port $message';
+        detail.value = 'framework port received';
       }
     });
 
@@ -132,7 +142,7 @@ class _Activator {
       state.value = _BundleState.active;
       detail.value = frameworkPort == null
           ? 'ACTIVE (awaiting framework port)'
-          : 'ACTIVE (framework port $frameworkPort)';
+          : 'ACTIVE (framework port received)';
     } on PlatformException catch (e) {
       state.value = _BundleState.failed;
       detail.value = 'active rejected: ${e.code}';


### PR DESCRIPTION
#531 changed the bridge to post the framework isolate's port as a
`Dart_CObject_kSendPort` instead of a bare int64 — because Dart cannot turn a
port id back into a `SendPort`, so a bundle handed an integer has nothing it can
send to. **The activator bundle in this repo was not updated with it**, and still
tested the message for `int`:

```dart
// The framework port arrives as a bare int (Dart_PostCObject_DL with an
// int64 payload).
if (message is int) {
```

That branch stopped matching the moment the shell changed. `frameworkPort` stays
null for the life of the process, the panel reads "ACTIVE (awaiting framework
port)" forever, and the bundle can never reach the framework isolate at all.

### Why nothing caught it

The ACTIVE report travels over the channel, so `osgi_multi_bundle.sh`'s B3
assertion passes exactly as before. No CI job analyzes this app — which is also
why two analyzer complaints have sat in it since it was added. And the failure is
silent by construction: a bundle that never learns the framework port looks
identical, from outside, to one with no interest in its peers.

The activator's only commit (`eebe3652`) predates `de47fd21`, so this has been
broken since #531 merged.

### Also cleared, kept separate from the fix

An unnecessary `foundation.dart` import (`widgets.dart` re-exports what is used),
and an unused `_ticker` field — the timer it held was never read or cancelled, so
it is no longer stored, with a note that nothing cancels it because the bundle
presents for as long as its isolate lives.

The README gains the part that was easy to get wrong: the port comes back as a
`SendPort` rather than the id that was sent out, the asymmetry is forced, and a
bundle testing for `int` will never see it.

### Verification

- `flutter analyze` — **no issues**, down from the two reported before this change
- `dart format` deliberately **not** applied: the file at `HEAD` was never
  dart-format-clean, so running it would reformat untouched lines and bury a
  one-line fix. The lines changed here already match its output.
- Still unproven on hardware, as before: this needs a target with two connected
  outputs and DRM master to exercise end to end.