### PR TITLE
drm_kms_egl: release a GL-composited platform view's frame

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -531,6 +531,29 @@ jobs:
         with:
           packages: lcov
 
+      # The DRM-KMS-EGL compositor test drives a real DrmBackend + DrmCompositor
+      # on a virtual card. Without one it skips every case, so this job built it
+      # and proved nothing. enable_overlay=1 is not optional either: the driver
+      # probe disables the plane compositor without an overlay plane, and the
+      # framed and scene cases -- the paths #530 was found on -- stop existing.
+      #
+      # Best-effort. The Azure CI kernel often strips vkms (same fallback the
+      # vkms-smoke job uses); where it cannot be loaded the cases skip, exactly
+      # as they do on a developer machine without it.
+      - name: Load vkms (compositor tests; skipped without it)
+        run: |
+          if ! sudo modprobe vkms enable_overlay=1 2>/dev/null; then
+            echo "vkms not in $(uname -r); trying linux-modules-extra"
+            sudo apt-get -y install "linux-modules-extra-$(uname -r)" || true
+            sudo modprobe vkms enable_overlay=1 2>/dev/null || true
+          fi
+          if lsmod | grep -q vkms; then
+            echo "vkms loaded; overlay planes:"
+            cat /sys/module/vkms/parameters/enable_overlay
+          else
+            echo "::warning::vkms unavailable on $(uname -r); the DRM compositor cases will skip"
+          fi
+
       - name: Run unit tests (CTest)
         working-directory: ${{github.workspace}}/build/unit-tests
         run: ctest --output-on-failure --test-dir .

--- a/shell/backend/drm_kms_egl/drm_backend.h
+++ b/shell/backend/drm_kms_egl/drm_backend.h
@@ -191,6 +191,13 @@ class DrmBackend : public Backend, public IFlipSink {
 
   // The device-context this backend scans out through (plane reservation).
   [[nodiscard]] DrmDisplay* display() const { return drm_display_; }
+
+#if BUILD_COMPOSITOR
+  // The compositor driving this backend's own CRTC (the implicit view, id 0).
+  // Null before Create finishes. Exposed for tests that drive the compositor
+  // directly; the shell reaches it through the view_id map instead.
+  [[nodiscard]] DrmCompositor* compositor() const { return compositor_.get(); }
+#endif
   ~DrmBackend() override;
 
   DrmBackend(const DrmBackend&) = delete;

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -352,9 +352,10 @@ DrmCompositor::~DrmCompositor() {
 // displaced, once the flip that sampled it has completed.
 //
 // A GL-composited view never reaches a plane, so the scanout retire that fires
-// OnScanoutRelease never happens for it. Without this the producer waits out its
-// release timeout on every frame -- at 100 ms that is a seventh of the display
-// rate, and it reads as the renderer being slow rather than as a missed release.
+// OnScanoutRelease never happens for it. Without this the producer waits out
+// its release timeout on every frame -- at 100 ms that is a seventh of the
+// display rate, and it reads as the renderer being slow rather than as a missed
+// release.
 //
 // Displaced, not current: the compositor re-samples the bound texture on every
 // present until a newer frame arrives, so returning the current one would hand
@@ -381,18 +382,19 @@ void DrmCompositor::NoteGlComposited(
   // The frame just sampled, deferred to after this present's flip -- not the
   // frame it displaced.
   //
-  // Displacement is not enough, and which way it fails depends on the producer's
-  // rate. When it outruns the compositor its frames are superseded before being
-  // bound and the supersede path releases them. When it is slower -- the case
-  // that matters, because that is when a stall costs something -- every frame is
-  // consumed instead, so nothing supersedes, and displacement cannot happen
-  // until the next submit, which is the thing waiting on the release. A heavy
-  // scene deadlocks on its own ring and waits out the timeout every frame.
+  // Displacement is not enough, and which way it fails depends on the
+  // producer's rate. When it outruns the compositor its frames are superseded
+  // before being bound and the supersede path releases them. When it is slower
+  // -- the case that matters, because that is when a stall costs something --
+  // every frame is consumed instead, so nothing supersedes, and displacement
+  // cannot happen until the next submit, which is the thing waiting on the
+  // release. A heavy scene deadlocks on its own ring and waits out the timeout
+  // every frame.
   //
-  // The compositor re-samples a bound texture until a newer one arrives, so this
-  // does hand back a buffer that may still be on screen. The ring is what makes
-  // that safe: the producer has to cycle every other slot before returning to
-  // this one, which is several frames after the flip that read it.
+  // The compositor re-samples a bound texture until a newer one arrives, so
+  // this does hand back a buffer that may still be on screen. The ring is what
+  // makes that safe: the producer has to cycle every other slot before
+  // returning to this one, which is several frames after the flip that read it.
   //
   // Repeat pushes for the same buffer are free -- SignalRelease drops the entry
   // on the first one and a second finds nothing.
@@ -1297,10 +1299,10 @@ bool DrmCompositor::PresentFramed(const FlutterLayer** layers,
   }
 
   // The previous frame's flip has completed, so anything held for a post-flip
-  // release is off the plane -- return it to its producer. PresentLayersViaScene
-  // does the same after its own flip wait; this path did not, so a release
-  // deferred here was queued and never fired, and the producer waited out its
-  // fence timeout on every frame (#530).
+  // release is off the plane -- return it to its producer.
+  // PresentLayersViaScene does the same after its own flip wait; this path did
+  // not, so a release deferred here was queued and never fired, and the
+  // producer waited out its fence timeout on every frame (#530).
   DrainDeferredScanoutReleases();
 
   const uint64_t t1 = profile ? NsNow() : 0;

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -398,26 +398,31 @@ void DrmCompositor::NoteGlComposited(
   //
   // Repeat pushes for the same buffer are free -- SignalRelease drops the entry
   // on the first one and a second finds nothing.
-  {
-    const std::scoped_lock rel(deferred_releases_mu_);
-    deferred_releases_.push_back({surface, bid});
+  const std::scoped_lock rel(deferred_releases_mu_);
+  deferred_releases_.push_back({surface, bid});
+}
+
+std::vector<DrmCompositor::DeferredScanoutRelease>
+DrmCompositor::TakeDeferredScanoutReleases() {
+  std::vector<DeferredScanoutRelease> ready;
+  const std::scoped_lock lock(deferred_releases_mu_);
+  ready.swap(deferred_releases_);
+  return ready;
+}
+
+void DrmCompositor::FireDeferredScanoutReleases(
+    const std::vector<DeferredScanoutRelease>& batch) {
+  for (const DeferredScanoutRelease& r : batch) {
+    if (r.surface) {
+      r.surface->OnScanoutRelease(r.buffer_id);
+    }
   }
-  gl_pv_bound_[id] = bid;
 }
 
 void DrmCompositor::DrainDeferredScanoutReleases() {
   // Take the batch under the lock, then fire the callbacks without it: they run
   // producer code (an eventfd signal) and must not re-enter under our mutex.
-  std::vector<DeferredScanoutRelease> ready;
-  {
-    const std::scoped_lock lock(deferred_releases_mu_);
-    ready.swap(deferred_releases_);
-  }
-  for (const DeferredScanoutRelease& r : ready) {
-    if (r.surface) {
-      r.surface->OnScanoutRelease(r.buffer_id);
-    }
-  }
+  FireDeferredScanoutReleases(TakeDeferredScanoutReleases());
 }
 
 // ─── Init helpers ────────────────────────────────────────────────────────
@@ -1180,6 +1185,18 @@ bool DrmCompositor::PresentViaGlFallback(const FlutterLayer** layers,
     return true;  // ack to Flutter; nothing presented, primary untouched
   }
 
+  // Releases queued by the previous fallback present. Taken now, before the
+  // composite below queues this frame's, and fired once Present has waited out
+  // the flip that sampled them.
+  //
+  // This path had neither half. It queues in NoteGlComposited like the others
+  // but never drained, so on a GL-fallback session -- which is every session
+  // where the plane compositor is unavailable, and every session after the
+  // fallback latches -- no GL-composited platform view ever got a buffer back
+  // and its producer waited out the release-fence timeout on every frame. Same
+  // defect as #530, one path over.
+  std::vector<DeferredScanoutRelease> previous = TakeDeferredScanoutReleases();
+
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glDisable(GL_SCISSOR_TEST);
   glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
@@ -1246,7 +1263,13 @@ bool DrmCompositor::PresentViaGlFallback(const FlutterLayer** layers,
   }
 
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
-  return backend_->Present();
+  const bool presented = backend_->Present();
+  // After Present, not before: its own WaitForPendingFlip is what confirms the
+  // flip that sampled these completed. Fired even when the present failed --
+  // the buffers are off the display either way, and holding them back would
+  // stall the producer behind a frame that is never coming.
+  FireDeferredScanoutReleases(previous);
+  return presented;
 }
 
 // ─── Cursor staging + shared commit settle ──────────────────────────────

--- a/shell/backend/drm_kms_egl/drm_compositor.cc
+++ b/shell/backend/drm_kms_egl/drm_compositor.cc
@@ -348,6 +348,61 @@ DrmCompositor::~DrmCompositor() {
   }
 }
 
+// A platform view was GL-composited this present: return the frame this one
+// displaced, once the flip that sampled it has completed.
+//
+// A GL-composited view never reaches a plane, so the scanout retire that fires
+// OnScanoutRelease never happens for it. Without this the producer waits out its
+// release timeout on every frame -- at 100 ms that is a seventh of the display
+// rate, and it reads as the renderer being slow rather than as a missed release.
+//
+// Displaced, not current: the compositor re-samples the bound texture on every
+// present until a newer frame arrives, so returning the current one would hand
+// the producer a slot still being drawn from. Deferring gives the same "off the
+// plane, one present later" guarantee the scanout path has.
+//
+// Raster thread only, like its three call sites.
+void DrmCompositor::NoteGlComposited(
+    const std::shared_ptr<ICompositorSurface>& surface,
+    FlutterPlatformViewIdentifier id) {
+  if (!surface) {
+    return;
+  }
+  // No zero check. 0 is a valid buffer id -- it is ring slot 0 -- and treating
+  // it as "this surface does not track ids" meant slot 0 was never returned to
+  // the producer, which waited out its fence on every cycle through the ring.
+  // Every timeout in a 100k run was slot 0 and no other.
+  //
+  // This is only called where a texture is bound, so there is always a real
+  // frame to name. A surface that does not override the accessor reports 0 and
+  // has no eventfd registered under it, so the release finds nothing and costs
+  // nothing.
+  const uint32_t bid = surface->GetGlTextureBufferId();
+  // The frame just sampled, deferred to after this present's flip -- not the
+  // frame it displaced.
+  //
+  // Displacement is not enough, and which way it fails depends on the producer's
+  // rate. When it outruns the compositor its frames are superseded before being
+  // bound and the supersede path releases them. When it is slower -- the case
+  // that matters, because that is when a stall costs something -- every frame is
+  // consumed instead, so nothing supersedes, and displacement cannot happen
+  // until the next submit, which is the thing waiting on the release. A heavy
+  // scene deadlocks on its own ring and waits out the timeout every frame.
+  //
+  // The compositor re-samples a bound texture until a newer one arrives, so this
+  // does hand back a buffer that may still be on screen. The ring is what makes
+  // that safe: the producer has to cycle every other slot before returning to
+  // this one, which is several frames after the flip that read it.
+  //
+  // Repeat pushes for the same buffer are free -- SignalRelease drops the entry
+  // on the first one and a second finds nothing.
+  {
+    const std::scoped_lock rel(deferred_releases_mu_);
+    deferred_releases_.push_back({surface, bid});
+  }
+  gl_pv_bound_[id] = bid;
+}
+
 void DrmCompositor::DrainDeferredScanoutReleases() {
   // Take the batch under the lock, then fire the callbacks without it: they run
   // producer code (an eventfd signal) and must not re-enter under our mutex.
@@ -1181,6 +1236,8 @@ bool DrmCompositor::PresentViaGlFallback(const FlutterLayer** layers,
           gl_compositor_->CompositeToDefault(0, tex, sw, sh, dx, dy, dw, dh,
                                              blend, flip_y, external);
           composited_any = true;
+
+          NoteGlComposited(surface_sp, layer->platform_view->identifier);
         }
       }
     }
@@ -1238,6 +1295,14 @@ bool DrmCompositor::PresentFramed(const FlutterLayer** layers,
   if (!WaitForPendingFlip()) {
     return PresentViaGlFallback(layers, count);
   }
+
+  // The previous frame's flip has completed, so anything held for a post-flip
+  // release is off the plane -- return it to its producer. PresentLayersViaScene
+  // does the same after its own flip wait; this path did not, so a release
+  // deferred here was queued and never fired, and the producer waited out its
+  // fence timeout on every frame (#530).
+  DrainDeferredScanoutReleases();
+
   const uint64_t t1 = profile ? NsNow() : 0;
 
   // Composite every Flutter layer into the current comp buffer. Same
@@ -1343,6 +1408,12 @@ bool DrmCompositor::PresentFramed(const FlutterLayer** layers,
           // sources (e.g. NV12 dmabuf or pre-flipped YUV shader) need
           // flip_y=false so their already-top-down bytes land right-side-up.
           const bool flip_y = !surface_sp->TextureIsTopFirst();
+          // GL-composited into the framed buffer: no plane. Report 0 for the
+          // same reason PresentViaGlFallback does -- otherwise the DRM_PLANE
+          // grant accessor keeps whatever plane id the scene path last set, and
+          // anything keyed on "is this view on a plane" reads a stale yes.
+          surface_sp->SetScanoutPlane(0);
+          NoteGlComposited(surface_sp, layer->platform_view->identifier);
           if (backend_->cfg_.debug_backend) {
             ihs::log::debug(
                 "[DrmCompositor] framed layer[{}] PV id={} tex={} "
@@ -2145,6 +2216,7 @@ bool DrmCompositor::PresentLayers(const FlutterLayer** layers,
                 static_cast<GLsizei>(flutter->size.width),
                 static_cast<GLsizei>(flutter->size.height), blend, flip_y,
                 surface_sp->TextureIsExternalOes());
+            NoteGlComposited(surface_sp, flutter->platform_view->identifier);
             any_composited = true;
           }
         }

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -472,10 +472,17 @@ class DrmCompositor : public IFlipSink {
   std::mutex deferred_releases_mu_;
   std::vector<DeferredScanoutRelease> deferred_releases_;
 
-  // Last GL-composited buffer_id per platform view, so PresentViaGlFallback can
-  // tell when a frame has been displaced and is safe to return. Raster thread
-  // only (PresentViaGlFallback), so it needs no lock of its own.
-  std::map<FlutterPlatformViewIdentifier, std::uint32_t> gl_pv_bound_;
+  // The two halves of DrainDeferredScanoutReleases, for the GL fallback.
+  //
+  // That path has no flip wait of its own -- DrmBackend::Present owns it -- so
+  // it cannot simply drain at the top the way the framed and scene paths do.
+  // It takes the batch before its composite queues into it and fires the batch
+  // after Present returns, which is where the displacing flip is known to have
+  // completed. Take holds the mutex; fire must not, because the callbacks run
+  // producer code.
+  std::vector<DeferredScanoutRelease> TakeDeferredScanoutReleases();
+  static void FireDeferredScanoutReleases(
+      const std::vector<DeferredScanoutRelease>& batch);
 
   std::unique_ptr<drm::scene::LayerScene> scene_;
 

--- a/shell/backend/drm_kms_egl/drm_compositor.h
+++ b/shell/backend/drm_kms_egl/drm_compositor.h
@@ -286,6 +286,12 @@ class DrmCompositor : public IFlipSink {
   // that WaitForPendingFlip has confirmed their displacing flip completed.
   void DrainDeferredScanoutReleases();
 
+  // Records that a platform view was GL-composited this present, returning the
+  // frame it displaced. See the definition for why the GL path needs this at
+  // all and why it is the displaced buffer rather than the current one.
+  void NoteGlComposited(const std::shared_ptr<ICompositorSurface>& surface,
+                        FlutterPlatformViewIdentifier id);
+
   // Post-first-commit sanity probe. Confirms the kernel actually honored
   // the modeset by reading CRTC.ACTIVE + primary plane.FB_ID via
   // drmModeObjectGetProperties, then samples vblank sequence across ~2
@@ -465,6 +471,11 @@ class DrmCompositor : public IFlipSink {
   };
   std::mutex deferred_releases_mu_;
   std::vector<DeferredScanoutRelease> deferred_releases_;
+
+  // Last GL-composited buffer_id per platform view, so PresentViaGlFallback can
+  // tell when a frame has been displaced and is safe to return. Raster thread
+  // only (PresentViaGlFallback), so it needs no lock of its own.
+  std::map<FlutterPlatformViewIdentifier, std::uint32_t> gl_pv_bound_;
 
   std::unique_ptr<drm::scene::LayerScene> scene_;
 

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -539,9 +539,19 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
 
   // Producer buffer_id of the frame currently bound as a GL texture. Raster
   // thread, same as GetGlTextureName.
+  //
+  // Guarded: current_egl only exists under IVI_HAVE_EGL, and this accessor sits
+  // outside that block because it is part of the generic surface interface. A
+  // Vulkan-only build has no GL texture to name, so 0 is the honest answer --
+  // the compositor's GL-composite path that consumes this is not built there
+  // either.
   [[nodiscard]] uint32_t GetGlTextureBufferId() const override {
+#if IVI_HAVE_EGL
     const std::lock_guard<std::mutex> lock(mutex);
     return current_egl != nullptr ? current_egl_buffer_id : 0;
+#else
+    return 0;
+#endif
   }
 
   // The DRM scene path retired this frame; wake the producer's release fence
@@ -1232,7 +1242,8 @@ int HostSubmit(void* user_data,
       //
       // drm_plane_id is 0 exactly when the last present GL-composited this view
       // (SetScanoutPlane(0)), which is the case where no retire is coming.
-      const bool on_a_plane = v->drm_plane_id.load(std::memory_order_relaxed) != 0;
+      const bool on_a_plane =
+          v->drm_plane_id.load(std::memory_order_relaxed) != 0;
       if (v->dmabuf_delivered_seq < v->pending_egl.stash_seq || !on_a_plane) {
         v->SignalRelease(v->pending_egl.frame.buffer_id);
       }

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -254,6 +254,10 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
   mutable PendingEglFrame pending_egl;
   mutable std::map<uint32_t, EglDmabufImporter::ImportedTexture> buffers_egl;
   mutable EglDmabufImporter::ImportedTexture* current_egl{nullptr};
+  // Producer buffer_id of the frame current_egl was imported from, for
+  // GetGlTextureBufferId. The GL path has no scanout retire to key a release
+  // off, so the compositor tells one bound frame from the next by this.
+  mutable uint32_t current_egl_buffer_id{0};
   struct RetiredEglImport {
     EglDmabufImporter::ImportedTexture texture;
     uint64_t reap_at{0};
@@ -533,6 +537,13 @@ class IhsPluginView final : public PlatformView, public ICompositorSurface {
     release_fence_fd = fd;
   }
 
+  // Producer buffer_id of the frame currently bound as a GL texture. Raster
+  // thread, same as GetGlTextureName.
+  [[nodiscard]] uint32_t GetGlTextureBufferId() const override {
+    const std::lock_guard<std::mutex> lock(mutex);
+    return current_egl != nullptr ? current_egl_buffer_id : 0;
+  }
+
   // The DRM scene path retired this frame; wake the producer's release fence
   // for its ring slot. Compositor thread.
   void OnScanoutRelease(uint32_t buffer_id) override {
@@ -774,6 +785,7 @@ uint32_t IhsPluginView::GetGlTextureName() const {
         it->second.height == f.height) {
       CloseFrameFds(&f);  // redundant handle to the cached import
       current_egl = &it->second;
+      current_egl_buffer_id = f.buffer_id;
     } else {
       if (it != buffers_egl.end()) {
         retired_egl.push_back({it->second, submit_seq + kImportRetireMargin});
@@ -783,6 +795,7 @@ uint32_t IhsPluginView::GetGlTextureName() const {
       if (g_egl_importer.Import(f, &imported)) {
         auto [pos, ins] = buffers_egl.emplace(f.buffer_id, imported);
         current_egl = &pos->second;
+        current_egl_buffer_id = f.buffer_id;
         // Synthesised ids never repeat, so every earlier entry is dead. Retire
         // them (the reap margin covers a compositor present still binding one)
         // so the cache holds just the current import rather than growing per
@@ -1206,7 +1219,21 @@ int HostSubmit(void* user_data,
       // for it -- signal its release here so the producer reclaims that slot. A
       // frame that WAS delivered rides OnScanoutRelease and must not be
       // double-signalled.
-      if (v->dmabuf_delivered_seq < v->pending_egl.stash_seq) {
+      // Release the superseded frame unless it is on a plane, where
+      // OnScanoutRelease will do it.
+      //
+      // `dmabuf_delivered_seq` alone is the wrong test. It says GetDmabuf
+      // handed the frame over, not that the frame reached a plane -- and on the
+      // GL-composited path the compositor polls GetDmabuf and then composites
+      // through a texture instead, so a frame reads as delivered and is never
+      // scanned out. Nothing then releases it: it was superseded before being
+      // bound, so it is never displaced either, and its eventfd is left for the
+      // producer to wait out. Every frame. See #530.
+      //
+      // drm_plane_id is 0 exactly when the last present GL-composited this view
+      // (SetScanoutPlane(0)), which is the case where no retire is coming.
+      const bool on_a_plane = v->drm_plane_id.load(std::memory_order_relaxed) != 0;
+      if (v->dmabuf_delivered_seq < v->pending_egl.stash_seq || !on_a_plane) {
         v->SignalRelease(v->pending_egl.frame.buffer_id);
       }
       CloseFrameFds(&v->pending_egl.frame);  // superseded before import

--- a/shell/view/compositor_surface_interface.h
+++ b/shell/view/compositor_surface_interface.h
@@ -382,6 +382,20 @@ class ICompositorSurface {
   virtual void OnScanoutRelease(uint32_t /*buffer_id*/) {}
 
   /**
+   * @brief The producer's @c buffer_id for the frame @c GetGlTextureName last
+   * bound, or 0 when nothing is bound or the surface does not track it.
+   *
+   * The GL-composite path has no plane and therefore no scanout retire, so it
+   * cannot use @c OnScanoutRelease's natural trigger. It needs this to tell one
+   * frame from the next: a buffer is finished with once a newer one has
+   * displaced it as the bound texture *and* the flip that sampled it has
+   * completed. Without it a GL-composited producer never learns that a ring
+   * slot is free, waits out its release timeout on every frame, and runs at a
+   * fraction of the display rate for reasons that look like the renderer.
+   */
+  [[nodiscard]] virtual uint32_t GetGlTextureBufferId() const { return 0; }
+
+  /**
    * @brief Report which KMS plane the surface's frame was scanned out on this
    * present, or 0 when it was GL-composited (no plane) this present.
    *

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -186,6 +186,13 @@ if (BUILD_BACKEND_WAYLAND_LEASED_DRM)
         add_subdirectory(leased_drm_vkms-test)
     endif ()
 endif ()
+# The GL-composited platform-view release path, driven through a real
+# DrmCompositor on a vkms card. Needs the DRM-EGL backend (for DrmBackend) and
+# the compositor (for DrmCompositor); skips itself when no vkms card is loaded,
+# so it is safe to build and run unprivileged and in CI.
+if (BUILD_BACKEND_DRM_KMS_EGL AND BUILD_COMPOSITOR)
+    add_subdirectory(drm_backend_vkms-test)
+endif ()
 add_subdirectory(timer-test)
 add_subdirectory(watchdog-test)
 add_subdirectory(wake_event_fd-test)

--- a/test/unit_test/drm_backend_vkms-test/CMakeLists.txt
+++ b/test/unit_test/drm_backend_vkms-test/CMakeLists.txt
@@ -6,6 +6,17 @@ add_executable(${TESTCASE_NAME}
 
 add_sanitizers(${TESTCASE_NAME})
 
+# Frame readback needs drm-cxx's capture module, which is AUTO on blend2d --
+# absent on a CI runner without libblend2d-dev, where drm::capture::snapshot is
+# never compiled and the pixel cases would fail to link. Same probe the shell
+# uses to gate its own SIGUSR1 snapshot.
+find_package(blend2d CONFIG QUIET)
+if (blend2d_FOUND)
+    target_compile_definitions(${TESTCASE_NAME} PRIVATE IHS_TEST_HAVE_CAPTURE=1)
+else ()
+    message(STATUS "blend2d not found; DRM compositor frame-readback cases disabled")
+endif ()
+
 target_link_libraries(${TESTCASE_NAME}
         PRIVATE
         gtest

--- a/test/unit_test/drm_backend_vkms-test/CMakeLists.txt
+++ b/test/unit_test/drm_backend_vkms-test/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(TESTCASE_NAME "homescreen_drm_backend_vkms_ut_test_driver")
+
+add_executable(${TESTCASE_NAME}
+        test_case_drm_backend_vkms.cc
+)
+
+add_sanitizers(${TESTCASE_NAME})
+
+target_link_libraries(${TESTCASE_NAME}
+        PRIVATE
+        gtest
+        homescreen_ut_shell
+        toolchain::toolchain
+)
+
+add_test(
+        NAME ${TESTCASE_NAME}
+        COMMAND ${TESTCASE_NAME}
+)

--- a/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
+++ b/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
@@ -64,9 +64,47 @@ struct VkmsCard {
   std::string path;
   uint32_t mode_w{0};
   uint32_t mode_h{0};
+  // Overlay planes the card exposes. Zero on a default vkms: enable_overlay
+  // defaults off, and without an overlay the driver probe disables the plane
+  // compositor, so the framed path does not exist to be tested.
+  int overlays{0};
 
   [[nodiscard]] bool ok() const { return !path.empty() && mode_w != 0; }
 };
+
+// Overlay planes on @p fd. Needs UNIVERSAL_PLANES, which is also what the
+// backend sets before it counts them.
+int CountOverlayPlanes(int fd) {
+  if (drmSetClientCap(fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1) != 0) {
+    return 0;
+  }
+  drmModePlaneRes* pres = drmModeGetPlaneResources(fd);
+  if (pres == nullptr) {
+    return 0;
+  }
+  int overlays = 0;
+  for (uint32_t i = 0; i < pres->count_planes; ++i) {
+    drmModeObjectProperties* props =
+        drmModeObjectGetProperties(fd, pres->planes[i], DRM_MODE_OBJECT_PLANE);
+    if (props == nullptr) {
+      continue;
+    }
+    for (uint32_t p = 0; p < props->count_props; ++p) {
+      drmModePropertyRes* prop = drmModeGetProperty(fd, props->props[p]);
+      if (prop == nullptr) {
+        continue;
+      }
+      if (std::string(prop->name) == "type" &&
+          props->prop_values[p] == DRM_PLANE_TYPE_OVERLAY) {
+        overlays++;
+      }
+      drmModeFreeProperty(prop);
+    }
+    drmModeFreeObjectProperties(props);
+  }
+  drmModeFreePlaneResources(pres);
+  return overlays;
+}
 
 VkmsCard FindVkms() {
   VkmsCard out;
@@ -87,6 +125,7 @@ VkmsCard FindVkms() {
       continue;
     }
     out.path = path;
+    out.overlays = CountOverlayPlanes(fd);
     if (drmModeRes* res = drmModeGetResources(fd); res != nullptr) {
       for (int c = 0; c < res->count_connectors && out.mode_w == 0; ++c) {
         drmModeConnector* conn = drmModeGetConnector(fd, res->connectors[c]);
@@ -172,8 +211,12 @@ class FakePlatformView : public ICompositorSurface {
 // found in: a framebuffer smaller than the mode puts every present through
 // PresentFramed, the one path that queued platform-view releases and never
 // drained them.
-class DrmBackendVkms : public ::testing::Test {
+class DrmBackendVkmsBase : public ::testing::Test {
  protected:
+  // Which present path this fixture pins. Never left to DriverProbe: see the
+  // comment on cfg.compositor below.
+  virtual void Configure(DrmConfig& cfg) = 0;
+
   void SetUp() override {
     card_ = FindVkms();
     if (!card_.ok()) {
@@ -191,6 +234,20 @@ class DrmBackendVkms : public ::testing::Test {
                   /*debug_backend=*/false};
     cfg.no_seat = true;
     cfg.disable_cursor = true;
+    // Pin the GL compositor rather than letting DriverProbe choose.
+    //
+    // These cases are about the GL-composited platform-view path, and with
+    // kAuto the path is decided by whether the card happens to expose overlay
+    // planes -- which for vkms is a module parameter (enable_overlay). This
+    // test was written against a vkms with no overlays, where the probe fell
+    // back to GL on its own; loading the module with overlays turned it onto
+    // the scene path, where a platform view is driven through GetDmabuf and a
+    // texture-only surface is never presented at all. Three cases went from
+    // passing to failing with no code change on either side.
+    //
+    // The scene path deserves its own fixture and its own fake. What it must
+    // not be is whichever one the host's module parameters select today.
+    Configure(cfg);
     backend_ =
         DrmBackend::Create(cfg, display_->session(), dev, display_.get());
     ASSERT_NE(backend_, nullptr) << "DrmBackend::Create failed on vkms";
@@ -243,6 +300,32 @@ class DrmBackendVkms : public ::testing::Test {
   std::unique_ptr<DrmBackend> backend_;
   DrmCompositor* compositor_{nullptr};
   uint32_t tex_{0};
+};
+
+// The GL compositor, full screen: PresentViaGlFallback.
+class DrmBackendVkms : public DrmBackendVkmsBase {
+ protected:
+  void Configure(DrmConfig& cfg) override {
+    cfg.compositor = drm_config::Compositor::kGl;
+  }
+};
+
+// The plane compositor with a framebuffer smaller than the mode, which is what
+// puts every present through PresentFramed -- the path #530 was found on, and
+// the one the GL fixture above cannot reach. Needs a card with overlay planes;
+// on vkms that is the enable_overlay module parameter, so the fixture checks
+// for one rather than assuming.
+class DrmBackendVkmsFramed : public DrmBackendVkmsBase {
+ protected:
+  void Configure(DrmConfig& cfg) override {
+    if (card_.overlays == 0) {
+      GTEST_SKIP() << "vkms has no overlay plane, so there is no framed path "
+                      "to test (modprobe vkms enable_overlay=1)";
+    }
+    cfg.compositor = drm_config::Compositor::kPlanes;
+    cfg.width = card_.mode_w - 64;
+    cfg.height = card_.mode_h - 64;
+  }
 };
 
 // The whole of #530 in one case: present a GL-composited view twice and its
@@ -306,6 +389,45 @@ TEST_F(DrmBackendVkms, AViewWithNoTextureIsNeverReleased) {
   EXPECT_TRUE(view->released().empty());
 
   compositor_->UnregisterSurface(11);
+}
+
+// The same release contract on PresentFramed. This is the path #530 was found
+// on -- a framed config on a Pi 5 -- and it queued platform-view releases
+// without ever draining them. The GL fixture above cannot reach it: framing
+// requires the atomic plane compositor, so the framed path only exists on a
+// card with overlay planes.
+TEST_F(DrmBackendVkmsFramed, GlCompositedViewGetsItsBufferBack) {
+  auto view = std::make_shared<FakePlatformView>(13);
+  view->set_texture(tex_);
+  compositor_->RegisterSurface(13, view);
+
+  ASSERT_TRUE(PresentPlatformView(13));
+  EXPECT_EQ(view->presents(), 1);
+  EXPECT_TRUE(view->released().empty())
+      << "released during the present that sampled it";
+
+  ASSERT_TRUE(PresentPlatformView(13));
+  const std::vector<uint32_t> released = view->released();
+  ASSERT_FALSE(released.empty())
+      << "the deferred release was queued and never drained (#530)";
+  EXPECT_EQ(released.front(), 0u);
+
+  compositor_->UnregisterSurface(13);
+}
+
+TEST_F(DrmBackendVkmsFramed, GlCompositedViewIsReportedOffAnyPlane) {
+  auto view = std::make_shared<FakePlatformView>(15);
+  view->set_texture(tex_);
+  compositor_->RegisterSurface(15, view);
+
+  ASSERT_TRUE(PresentPlatformView(15));
+
+  const std::vector<uint32_t> planes = view->planes();
+  ASSERT_FALSE(planes.empty()) << "the present never reported a plane at all";
+  EXPECT_EQ(planes.back(), 0u) << "GL-composited into the framed buffer, so "
+                                  "on no plane of its own";
+
+  compositor_->UnregisterSurface(15);
 }
 
 }  // namespace

--- a/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
+++ b/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
@@ -48,8 +48,12 @@ extern "C" {
 
 #include <GLES2/gl2.h>
 
+#include "capture/png.hpp"
+#include "capture/snapshot.hpp"
+
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -187,6 +191,7 @@ class FakePlatformView : public ICompositorSurface {
   }
 
   void set_texture(uint32_t tex) { tex_ = tex; }
+  [[nodiscard]] int32_t width() const { return 16; }
   [[nodiscard]] int presents() const { return presents_; }
 
   [[nodiscard]] std::vector<uint32_t> released() const {
@@ -216,6 +221,11 @@ class DrmBackendVkmsBase : public ::testing::Test {
   // Which present path this fixture pins. Never left to DriverProbe: see the
   // comment on cfg.compositor below.
   virtual void Configure(DrmConfig& cfg) = 0;
+
+  // The framebuffer the compositor draws into, which a full-size layer has to
+  // match. Set by Configure; the backend keeps its own copy privately.
+  uint32_t content_w_{0};
+  uint32_t content_h_{0};
 
   void SetUp() override {
     card_ = FindVkms();
@@ -278,6 +288,57 @@ class DrmBackendVkmsBase : public ::testing::Test {
     display_.reset();
   }
 
+  // Paint the fixture's texture a flat colour, so a snapshot can say whether
+  // the compositor actually sampled it. Bytes are R,G,B,A in GL memory order.
+  void PaintTexture(uint8_t r, uint8_t g, uint8_t b) {
+    std::array<uint8_t, 16 * 16 * 4> px{};
+    for (size_t i = 0; i < px.size(); i += 4) {
+      px[i + 0] = r;
+      px[i + 1] = g;
+      px[i + 2] = b;
+      px[i + 3] = 0xFF;
+    }
+    ASSERT_TRUE(backend_->MakeCurrent());
+    glBindTexture(GL_TEXTURE_2D, tex_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, px.data());
+    ASSERT_EQ(glGetError(), static_cast<GLenum>(GL_NO_ERROR));
+  }
+
+  // Read the CRTC's plane composition back. drm-cxx maps each scanout FB and
+  // composites in zpos order, so this is what the display is actually showing
+  // -- not what the compositor believes it drew.
+  //
+  // Writes a PNG alongside when IHS_TEST_CAPTURE_DIR names a directory, which
+  // is how a frame from this test gets looked at rather than only asserted on.
+  drm::capture::Image Snapshot(const char* name) {
+    auto shot = drm::capture::snapshot(backend_->device(), backend_->crtc_id());
+    if (!shot) {
+      ADD_FAILURE() << "snapshot failed: " << shot.error().message();
+      return {};
+    }
+    drm::capture::Image image = std::move(shot.value());
+    if (const char* dir = std::getenv("IHS_TEST_CAPTURE_DIR"); dir != nullptr) {
+      const std::string path = std::string(dir) + "/" + name + ".png";
+      if (auto w = drm::capture::write_png(image, path); !w) {
+        ADD_FAILURE() << "write_png: " << w.error().message();
+      } else {
+        std::cerr << "capture: " << path << "\n";
+      }
+    }
+    return image;
+  }
+
+  // The pixel at the centre of the CRTC, as 0xAARRGGBB.
+  static uint32_t CentrePixel(const drm::capture::Image& img) {
+    if (img.empty()) {
+      return 0;
+    }
+    const size_t i =
+        static_cast<size_t>(img.height() / 2) * img.width() + img.width() / 2;
+    return img.pixels()[i];
+  }
+
   // One frame carrying nothing but the platform view.
   bool PresentPlatformView(FlutterPlatformViewIdentifier id) {
     FlutterPlatformView pv{};
@@ -289,7 +350,8 @@ class DrmBackendVkmsBase : public ::testing::Test {
     layer.type = kFlutterLayerContentTypePlatformView;
     layer.platform_view = &pv;
     layer.offset = FlutterPoint{0.0, 0.0};
-    layer.size = FlutterSize{16.0, 16.0};
+    layer.size = FlutterSize{static_cast<double>(layer_w_),
+                             static_cast<double>(layer_h_)};
 
     const FlutterLayer* layers[] = {&layer};
     return compositor_->PresentLayers(layers, 1);
@@ -300,6 +362,11 @@ class DrmBackendVkmsBase : public ::testing::Test {
   std::unique_ptr<DrmBackend> backend_;
   DrmCompositor* compositor_{nullptr};
   uint32_t tex_{0};
+  // Layer extent for PresentPlatformView. Small by default; the pixel cases
+  // set it to the whole framebuffer so the centre of the CRTC lands inside it
+  // whatever the letterboxing.
+  uint32_t layer_w_{16};
+  uint32_t layer_h_{16};
 };
 
 // The GL compositor, full screen: PresentViaGlFallback.
@@ -307,6 +374,8 @@ class DrmBackendVkms : public DrmBackendVkmsBase {
  protected:
   void Configure(DrmConfig& cfg) override {
     cfg.compositor = drm_config::Compositor::kGl;
+    content_w_ = card_.mode_w;
+    content_h_ = card_.mode_h;
   }
 };
 
@@ -325,6 +394,8 @@ class DrmBackendVkmsFramed : public DrmBackendVkmsBase {
     cfg.compositor = drm_config::Compositor::kPlanes;
     cfg.width = card_.mode_w - 64;
     cfg.height = card_.mode_h - 64;
+    content_w_ = *cfg.width;
+    content_h_ = *cfg.height;
   }
 };
 
@@ -428,6 +499,59 @@ TEST_F(DrmBackendVkmsFramed, GlCompositedViewIsReportedOffAnyPlane) {
                                   "on no plane of its own";
 
   compositor_->UnregisterSurface(15);
+}
+
+// The compositor drew the plugin's texture, not just bookkeeping around it.
+//
+// Every other case here asserts on which callbacks fired, which says nothing
+// about whether a pixel moved. This reads the CRTC's plane composition back --
+// drm-cxx maps each scanout FB and composites in zpos order -- and checks the
+// colour the fake uploaded is the colour on screen at the centre of the
+// display. A view that is registered, presented and released correctly but
+// composited from the wrong texture, at the wrong scale, or into a buffer
+// nothing scans out would pass everything above and fail here.
+TEST_F(DrmBackendVkms, TheViewsTextureReachesTheDisplay) {
+  auto view = std::make_shared<FakePlatformView>(17);
+  view->set_texture(tex_);
+  PaintTexture(0x20, 0x80, 0xC0);
+  layer_w_ = content_w_;
+  layer_h_ = content_h_;
+  compositor_->RegisterSurface(17, view);
+
+  ASSERT_TRUE(PresentPlatformView(17));
+
+  const drm::capture::Image image = Snapshot("gl_platform_view");
+  ASSERT_FALSE(image.empty());
+  EXPECT_EQ(image.width(), card_.mode_w);
+  EXPECT_EQ(image.height(), card_.mode_h);
+  // RGB only: the primary is XRGB8888, so the alpha byte carries no meaning.
+  EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, 0x002080C0u)
+      << "the centre of the display is not the colour the view uploaded";
+
+  compositor_->UnregisterSurface(17);
+}
+
+TEST_F(DrmBackendVkmsFramed, TheViewsTextureReachesTheDisplay) {
+  auto view = std::make_shared<FakePlatformView>(19);
+  view->set_texture(tex_);
+  PaintTexture(0xC0, 0x40, 0x20);
+  layer_w_ = content_w_;
+  layer_h_ = content_h_;
+  compositor_->RegisterSurface(19, view);
+
+  ASSERT_TRUE(PresentPlatformView(19));
+
+  const drm::capture::Image image = Snapshot("framed_platform_view");
+  ASSERT_FALSE(image.empty());
+  // The CRTC is the mode; the content is the smaller FB centred in it. The
+  // centre pixel is inside the content either way, which is the point of
+  // sampling there rather than at a corner.
+  EXPECT_EQ(image.width(), card_.mode_w);
+  EXPECT_EQ(image.height(), card_.mode_h);
+  EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, 0x00C04020u)
+      << "the centre of the display is not the colour the view uploaded";
+
+  compositor_->UnregisterSurface(19);
 }
 
 }  // namespace

--- a/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
+++ b/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
@@ -40,7 +40,9 @@
 #include "view/compositor_surface_interface.h"
 
 extern "C" {
+#include <drm_fourcc.h>
 #include <fcntl.h>
+#include <gbm.h>
 #include <unistd.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
@@ -212,6 +214,173 @@ class FakePlatformView : public ICompositorSurface {
   std::vector<uint32_t> planes_;
 };
 
+// A scanout-capable dma-buf filled with a flat colour.
+//
+// Allocated through GBM on the card itself. vkms has no render node, so there
+// is no GPU to render into it -- but the scene path never renders a platform
+// view's buffer, it hands it straight to a KMS plane, which is the whole point
+// of that path and exactly what this has to exercise. Linear and XRGB8888
+// because that is what the plane accepts and what makes the CPU fill trivial.
+class GbmSolidBuffer {
+ public:
+  bool Create(int card_fd, uint32_t w, uint32_t h, uint32_t argb) {
+    dev_ = gbm_create_device(card_fd);
+    if (dev_ == nullptr) {
+      return false;
+    }
+    bo_ = gbm_bo_create(dev_, w, h, GBM_FORMAT_XRGB8888,
+                        GBM_BO_USE_SCANOUT | GBM_BO_USE_LINEAR);
+    if (bo_ == nullptr) {
+      return false;
+    }
+    void* map_data = nullptr;
+    uint32_t stride = 0;
+    void* ptr =
+        gbm_bo_map(bo_, 0, 0, w, h, GBM_BO_TRANSFER_WRITE, &stride, &map_data);
+    if (ptr == nullptr) {
+      return false;
+    }
+    for (uint32_t y = 0; y < h; ++y) {
+      auto* row = reinterpret_cast<uint32_t*>(static_cast<uint8_t*>(ptr) +
+                                              static_cast<size_t>(y) * stride);
+      for (uint32_t x = 0; x < w; ++x) {
+        row[x] = argb;
+      }
+    }
+    gbm_bo_unmap(bo_, map_data);
+    w_ = w;
+    h_ = h;
+    stride_ = gbm_bo_get_stride(bo_);
+    return true;
+  }
+
+  ~GbmSolidBuffer() {
+    if (bo_ != nullptr) {
+      gbm_bo_destroy(bo_);
+    }
+    if (dev_ != nullptr) {
+      gbm_device_destroy(dev_);
+    }
+  }
+
+  GbmSolidBuffer() = default;
+  GbmSolidBuffer(const GbmSolidBuffer&) = delete;
+  GbmSolidBuffer& operator=(const GbmSolidBuffer&) = delete;
+
+  // A fresh owned handle each call, which is the ownership GetDmabuf promises.
+  [[nodiscard]] int ExportFd() const {
+    return bo_ != nullptr ? gbm_bo_get_fd(bo_) : -1;
+  }
+  [[nodiscard]] uint32_t width() const { return w_; }
+  [[nodiscard]] uint32_t height() const { return h_; }
+  [[nodiscard]] uint32_t stride() const { return stride_; }
+
+ private:
+  gbm_device* dev_{nullptr};
+  gbm_bo* bo_{nullptr};
+  uint32_t w_{0};
+  uint32_t h_{0};
+  uint32_t stride_{0};
+};
+
+// A platform view whose content is a dma-buf, which is what the scene path
+// drives. The texture-only fake above is invisible to it: GetDmabuf defaults to
+// kNotScanoutCapable, so the scene path never presents such a surface at all.
+class FakeDmabufPlatformView : public ICompositorSurface {
+ public:
+  FakeDmabufPlatformView(FlutterPlatformViewIdentifier id,
+                         const GbmSolidBuffer& buffer,
+                         uint32_t buffer_id)
+      : id_(id), buffer_(&buffer), buffer_id_(buffer_id) {}
+
+  bool OnCreateBackingStore(const FlutterBackingStoreConfig*,
+                            FlutterBackingStore*) override {
+    return false;
+  }
+  bool OnCollectBackingStore(const FlutterBackingStore*) override {
+    return true;
+  }
+  bool OnPresent(const FlutterLayer*) override {
+    presents_++;
+    return true;
+  }
+  [[nodiscard]] FlutterPlatformViewIdentifier GetIdentifier() const override {
+    return id_;
+  }
+
+  // Deliver-once, like the real producer: a frame reaches the scanout path at
+  // most once, and a present with nothing new says so rather than handing the
+  // same buffer over twice.
+  [[nodiscard]] DmabufState GetDmabuf(Dmabuf* out) const override {
+    const std::lock_guard<std::mutex> lock(mu_);
+    if (!fresh_) {
+      return DmabufState::kNoNewFrame;
+    }
+    const int fd = buffer_->ExportFd();
+    if (fd < 0) {
+      return DmabufState::kNotScanoutCapable;
+    }
+    fresh_ = false;
+    out->fd[0] = fd;
+    out->fourcc = DRM_FORMAT_XRGB8888;
+    out->modifier = DRM_FORMAT_MOD_LINEAR;
+    out->width = buffer_->width();
+    out->height = buffer_->height();
+    out->plane_count = 1;
+    out->offset[0] = 0;
+    out->stride[0] = buffer_->stride();
+    out->acquire_fence_fd = -1;  // filled by the CPU, already synced
+    out->buffer_id = buffer_id_;
+    delivered_++;
+    return DmabufState::kFrame;
+  }
+
+  void OnScanoutRelease(uint32_t buffer_id) override {
+    const std::lock_guard<std::mutex> lock(mu_);
+    released_.push_back(buffer_id);
+  }
+  void SetScanoutPlane(uint32_t plane_id) override {
+    const std::lock_guard<std::mutex> lock(mu_);
+    planes_.push_back(plane_id);
+  }
+
+  // Stand in for the producer submitting again, optionally from a different
+  // ring slot -- which is what makes the previous slot releasable.
+  void Submit(const GbmSolidBuffer* buffer = nullptr, uint32_t buffer_id = 0) {
+    const std::lock_guard<std::mutex> lock(mu_);
+    if (buffer != nullptr) {
+      buffer_ = buffer;
+      buffer_id_ = buffer_id;
+    }
+    fresh_ = true;
+  }
+
+  [[nodiscard]] int presents() const { return presents_; }
+  [[nodiscard]] int delivered() const {
+    const std::lock_guard<std::mutex> lock(mu_);
+    return delivered_;
+  }
+  [[nodiscard]] std::vector<uint32_t> released() const {
+    const std::lock_guard<std::mutex> lock(mu_);
+    return released_;
+  }
+  [[nodiscard]] std::vector<uint32_t> planes() const {
+    const std::lock_guard<std::mutex> lock(mu_);
+    return planes_;
+  }
+
+ private:
+  const FlutterPlatformViewIdentifier id_;
+  const GbmSolidBuffer* buffer_;
+  uint32_t buffer_id_;
+  int presents_{0};
+  mutable std::mutex mu_;
+  mutable bool fresh_{true};
+  mutable int delivered_{0};
+  std::vector<uint32_t> released_;
+  std::vector<uint32_t> planes_;
+};
+
 // A backend on vkms with a framed output, which is the configuration #530 was
 // found in: a framebuffer smaller than the mode puts every present through
 // PresentFramed, the one path that queued platform-view releases and never
@@ -264,6 +433,18 @@ class DrmBackendVkmsBase : public ::testing::Test {
 
     compositor_ = backend_->compositor();
     ASSERT_NE(compositor_, nullptr) << "built without BUILD_COMPOSITOR";
+
+    // Start the card's flip reader, exactly as register_backends.cc does right
+    // after Create.
+    //
+    // Not optional bookkeeping: WaitForPendingFlip waits on a flag that only
+    // this thread clears, so without it every present after the first burns the
+    // full 100 ms timeout and logs "PAGE_FLIP_EVENT likely lost". The GL and
+    // framed cases still passed that way -- the wait returns true on timeout
+    // and the drain runs regardless -- but the scene path's scanout release is
+    // driven by the flip completion itself, so it never fired at all.
+    display_->SetFlipHandler(&DrmBackend::UnifiedPageFlipHandler);
+    display_->StartFlipReader();
 
     // A texture the compositor can actually sample. It never has to contain
     // anything: the assertions are about the release bookkeeping around the
@@ -339,6 +520,28 @@ class DrmBackendVkmsBase : public ::testing::Test {
     return img.pixels()[i];
   }
 
+  // Present until @p done holds, or give up after @p max frames.
+  //
+  // The scanout release is asynchronous by construction: the pool fires it when
+  // the flip that displaced the buffer completes, on the card's flip-reader
+  // thread, and the compositor drains the queue at the top of a later present.
+  // How many presents that takes is a scheduling detail -- measured here as two
+  // or three -- so a test that pins the count is pinning the weather. What is
+  // contractual is that it arrives.
+  bool PumpUntil(FlutterPlatformViewIdentifier id,
+                 const std::function<bool()>& done,
+                 int max = 10) {
+    for (int i = 0; i < max; ++i) {
+      if (!PresentPlatformView(id)) {
+        return false;
+      }
+      if (done()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // One frame carrying nothing but the platform view.
   bool PresentPlatformView(FlutterPlatformViewIdentifier id) {
     FlutterPlatformView pv{};
@@ -367,6 +570,23 @@ class DrmBackendVkmsBase : public ::testing::Test {
   // whatever the letterboxing.
   uint32_t layer_w_{16};
   uint32_t layer_h_{16};
+};
+
+// The plane compositor, full screen: PresentLayersViaScene -- the zero-copy
+// path, where a platform view's own buffer goes on a KMS plane and the
+// compositor never touches its pixels. Needs overlay planes, same as the framed
+// fixture.
+class DrmBackendVkmsScene : public DrmBackendVkmsBase {
+ protected:
+  void Configure(DrmConfig& cfg) override {
+    if (card_.overlays == 0) {
+      GTEST_SKIP() << "vkms has no overlay plane, so there is no scene path "
+                      "to test (modprobe vkms enable_overlay=1)";
+    }
+    cfg.compositor = drm_config::Compositor::kPlanes;
+    content_w_ = card_.mode_w;
+    content_h_ = card_.mode_h;
+  }
 };
 
 // The GL compositor, full screen: PresentViaGlFallback.
@@ -552,6 +772,83 @@ TEST_F(DrmBackendVkmsFramed, TheViewsTextureReachesTheDisplay) {
       << "the centre of the display is not the colour the view uploaded";
 
   compositor_->UnregisterSurface(19);
+}
+
+// The zero-copy path end to end: a producer's own dma-buf lands on a KMS plane
+// and its pixels reach the display without the compositor drawing anything.
+//
+// This is the path the other fixtures cannot reach. A texture-only surface is
+// invisible to it -- GetDmabuf defaults to kNotScanoutCapable, so the scene
+// path routes the whole frame to GL and the view is never placed at all, which
+// is exactly what happened when overlay planes first appeared on this host.
+TEST_F(DrmBackendVkmsScene, AProducersBufferScansOutOnItsOwnPlane) {
+  GbmSolidBuffer buffer;
+  ASSERT_TRUE(buffer.Create(backend_->device().fd(), content_w_, content_h_,
+                            0xFF1E7A46u))
+      << "could not allocate a scanout dma-buf on the card";
+
+  auto view = std::make_shared<FakeDmabufPlatformView>(21, buffer, 0);
+  layer_w_ = content_w_;
+  layer_h_ = content_h_;
+  compositor_->RegisterSurface(21, view);
+
+  ASSERT_TRUE(PresentPlatformView(21));
+  EXPECT_EQ(view->delivered(), 1) << "the scene path never pulled the frame";
+
+  const std::vector<uint32_t> planes = view->planes();
+  ASSERT_FALSE(planes.empty())
+      << "the view was never told which plane it is on";
+  EXPECT_NE(planes.back(), 0u)
+      << "reported off any plane, so it was GL-composited rather than scanned "
+         "out -- the zero-copy path did not run";
+
+  const drm::capture::Image image = Snapshot("scene_platform_view");
+  ASSERT_FALSE(image.empty());
+  EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, 0x001E7A46u)
+      << "the producer's buffer is not what the display is showing";
+
+  compositor_->UnregisterSurface(21);
+}
+
+// The scanout release, which is the mechanism the GL paths lack and had to
+// emulate. A second buffer displaces the first; once the flip that sampled it
+// has completed, the first slot comes back to the producer.
+TEST_F(DrmBackendVkmsScene, TheDisplacedSlotComesBackToTheProducer) {
+  GbmSolidBuffer first;
+  GbmSolidBuffer second;
+  ASSERT_TRUE(first.Create(backend_->device().fd(), content_w_, content_h_,
+                           0xFF1E7A46u));
+  ASSERT_TRUE(second.Create(backend_->device().fd(), content_w_, content_h_,
+                            0xFF7A1E46u));
+
+  // Slot 0 first, deliberately: 0 is a ring slot like any other, and it is the
+  // value that was mistaken for "no id" on the GL side.
+  auto view = std::make_shared<FakeDmabufPlatformView>(23, first, 0);
+  layer_w_ = content_w_;
+  layer_h_ = content_h_;
+  compositor_->RegisterSurface(23, view);
+
+  ASSERT_TRUE(PresentPlatformView(23));
+  EXPECT_TRUE(view->released().empty())
+      << "released while it was the frame on the plane";
+
+  view->Submit(&second, 1);
+  ASSERT_TRUE(PumpUntil(23, [&] { return !view->released().empty(); }))
+      << "slot 0 never came back";
+
+  const std::vector<uint32_t> released = view->released();
+  EXPECT_EQ(released.front(), 0u)
+      << "buffer id 0 is ring slot 0, not a sentinel for 'no id'";
+  EXPECT_EQ(view->delivered(), 2)
+      << "GetDmabuf is deliver-once; a present with no new frame must not "
+         "pull the same buffer again";
+
+  // And the newer buffer is what is on screen.
+  const drm::capture::Image image = Snapshot("scene_second_buffer");
+  ASSERT_FALSE(image.empty());
+  EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, 0x007A1E46u);
+
+  compositor_->UnregisterSurface(23);
 }
 
 }  // namespace

--- a/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
+++ b/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The GL-composited platform-view release path, on a real compositor.
+//
+// #530: a platform view that the compositor draws through a texture never
+// reaches a plane, so the scanout retire that fires OnScanoutRelease never
+// happens for it. Three separate things had to be right before a producer got
+// its buffer back, and each hid the next -- the frame has to be queued at the
+// composite site, the queue has to be drained on the path that present
+// actually takes, and the plane id has to be cleared so nothing downstream
+// reads a stale "still on a plane".
+//
+// None of that is reachable from a mock. It needs a DrmCompositor, which needs
+// a DrmBackend, which needs a card, GBM and EGL. vkms supplies the card: it is
+// display-only, needs no root beyond membership of the video group, and is
+// already what the leased-lease tier uses. Every case skips rather than fails
+// when it is absent.
+//
+//   sudo modprobe vkms
+//   ./homescreen_drm_backend_vkms_ut_test_driver
+
+#include "backend/drm_kms_egl/drm_backend.h"
+#include "backend/drm_kms_egl/drm_compositor.h"
+#include "display/drm_display.h"
+#include "logging/logger.hpp"
+#include "view/compositor_surface_interface.h"
+
+extern "C" {
+#include <fcntl.h>
+#include <unistd.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+}
+
+#include <GLES2/gl2.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+// The vkms card and the connector's preferred mode, or empty when there is no
+// vkms to be had.
+struct VkmsCard {
+  std::string path;
+  uint32_t mode_w{0};
+  uint32_t mode_h{0};
+
+  [[nodiscard]] bool ok() const { return !path.empty() && mode_w != 0; }
+};
+
+VkmsCard FindVkms() {
+  VkmsCard out;
+  for (int i = 0; i < 8; ++i) {
+    const std::string path = "/dev/dri/card" + std::to_string(i);
+    const int fd = ::open(path.c_str(), O_RDWR | O_CLOEXEC);
+    if (fd < 0) {
+      continue;
+    }
+    drmVersionPtr v = drmGetVersion(fd);
+    const bool is_vkms =
+        v != nullptr && v->name != nullptr && std::string(v->name) == "vkms";
+    if (v != nullptr) {
+      drmFreeVersion(v);
+    }
+    if (!is_vkms) {
+      ::close(fd);
+      continue;
+    }
+    out.path = path;
+    if (drmModeRes* res = drmModeGetResources(fd); res != nullptr) {
+      for (int c = 0; c < res->count_connectors && out.mode_w == 0; ++c) {
+        drmModeConnector* conn = drmModeGetConnector(fd, res->connectors[c]);
+        if (conn == nullptr) {
+          continue;
+        }
+        if (conn->connection == DRM_MODE_CONNECTED && conn->count_modes > 0) {
+          out.mode_w = conn->modes[0].hdisplay;
+          out.mode_h = conn->modes[0].vdisplay;
+        }
+        drmModeFreeConnector(conn);
+      }
+      drmModeFreeResources(res);
+    }
+    ::close(fd);
+    break;
+  }
+  return out;
+}
+
+// A platform-view surface that reports a GL texture and records what the
+// compositor did to it.
+//
+// The buffer id it reports is 0 on purpose. 0 is ring slot 0, not a "this
+// surface does not track ids" sentinel, and treating it as one is what left
+// slot 0 unreleased: every release-fence timeout in a 100k-splat run was slot
+// 0 and no other. A fake that reported 1 would pass against the broken code.
+class FakePlatformView : public ICompositorSurface {
+ public:
+  explicit FakePlatformView(FlutterPlatformViewIdentifier id) : id_(id) {}
+
+  bool OnCreateBackingStore(const FlutterBackingStoreConfig*,
+                            FlutterBackingStore*) override {
+    return false;
+  }
+  bool OnCollectBackingStore(const FlutterBackingStore*) override {
+    return true;
+  }
+  bool OnPresent(const FlutterLayer*) override {
+    presents_++;
+    return true;
+  }
+  [[nodiscard]] FlutterPlatformViewIdentifier GetIdentifier() const override {
+    return id_;
+  }
+
+  [[nodiscard]] uint32_t GetGlTextureName() const override { return tex_; }
+  [[nodiscard]] int32_t GetGlTextureWidth() const override { return 16; }
+  [[nodiscard]] int32_t GetGlTextureHeight() const override { return 16; }
+  [[nodiscard]] uint32_t GetGlTextureBufferId() const override { return 0; }
+
+  void OnScanoutRelease(uint32_t buffer_id) override {
+    const std::lock_guard<std::mutex> lock(mu_);
+    released_.push_back(buffer_id);
+  }
+  void SetScanoutPlane(uint32_t plane_id) override {
+    const std::lock_guard<std::mutex> lock(mu_);
+    planes_.push_back(plane_id);
+  }
+
+  void set_texture(uint32_t tex) { tex_ = tex; }
+  [[nodiscard]] int presents() const { return presents_; }
+
+  [[nodiscard]] std::vector<uint32_t> released() const {
+    const std::lock_guard<std::mutex> lock(mu_);
+    return released_;
+  }
+  [[nodiscard]] std::vector<uint32_t> planes() const {
+    const std::lock_guard<std::mutex> lock(mu_);
+    return planes_;
+  }
+
+ private:
+  const FlutterPlatformViewIdentifier id_;
+  uint32_t tex_{0};
+  int presents_{0};
+  mutable std::mutex mu_;
+  std::vector<uint32_t> released_;
+  std::vector<uint32_t> planes_;
+};
+
+// A backend on vkms with a framed output, which is the configuration #530 was
+// found in: a framebuffer smaller than the mode puts every present through
+// PresentFramed, the one path that queued platform-view releases and never
+// drained them.
+class DrmBackendVkms : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    card_ = FindVkms();
+    if (!card_.ok()) {
+      GTEST_SKIP() << "no connected vkms card (sudo modprobe vkms)";
+    }
+
+    display_ = std::make_unique<DrmDisplay>(0, 0, 0.0, card_.path,
+                                            /*no_seat=*/true);
+    drm::Device* dev = display_->SharedDevice();
+    if (dev == nullptr) {
+      GTEST_SKIP() << "no DRM master on " << card_.path;
+    }
+
+    DrmConfig cfg{card_.path, std::nullopt, std::nullopt,
+                  /*debug_backend=*/false};
+    cfg.no_seat = true;
+    cfg.disable_cursor = true;
+    backend_ =
+        DrmBackend::Create(cfg, display_->session(), dev, display_.get());
+    ASSERT_NE(backend_, nullptr) << "DrmBackend::Create failed on vkms";
+
+    compositor_ = backend_->compositor();
+    ASSERT_NE(compositor_, nullptr) << "built without BUILD_COMPOSITOR";
+
+    // A texture the compositor can actually sample. It never has to contain
+    // anything: the assertions are about the release bookkeeping around the
+    // composite, not about pixels.
+    ASSERT_TRUE(backend_->MakeCurrent());
+    glGenTextures(1, &tex_);
+    glBindTexture(GL_TEXTURE_2D, tex_);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    ASSERT_EQ(glGetError(), static_cast<GLenum>(GL_NO_ERROR));
+    ASSERT_NE(tex_, 0u);
+  }
+
+  void TearDown() override {
+    if (backend_ && tex_ != 0) {
+      backend_->MakeCurrent();
+      glDeleteTextures(1, &tex_);
+    }
+    backend_.reset();
+    display_.reset();
+  }
+
+  // One frame carrying nothing but the platform view.
+  bool PresentPlatformView(FlutterPlatformViewIdentifier id) {
+    FlutterPlatformView pv{};
+    pv.struct_size = sizeof(FlutterPlatformView);
+    pv.identifier = id;
+
+    FlutterLayer layer{};
+    layer.struct_size = sizeof(FlutterLayer);
+    layer.type = kFlutterLayerContentTypePlatformView;
+    layer.platform_view = &pv;
+    layer.offset = FlutterPoint{0.0, 0.0};
+    layer.size = FlutterSize{16.0, 16.0};
+
+    const FlutterLayer* layers[] = {&layer};
+    return compositor_->PresentLayers(layers, 1);
+  }
+
+  VkmsCard card_;
+  std::unique_ptr<DrmDisplay> display_;
+  std::unique_ptr<DrmBackend> backend_;
+  DrmCompositor* compositor_{nullptr};
+  uint32_t tex_{0};
+};
+
+// The whole of #530 in one case: present a GL-composited view twice and its
+// producer gets buffer 0 back.
+//
+// Twice because the release is deferred by design -- the compositor re-samples
+// a bound texture until a newer one arrives, so handing it back during the
+// present that sampled it would return a slot still being drawn from. The
+// second present's flip wait is what makes it safe, and draining there is
+// exactly what PresentFramed did not do.
+TEST_F(DrmBackendVkms, GlCompositedViewGetsItsBufferBack) {
+  auto view = std::make_shared<FakePlatformView>(7);
+  view->set_texture(tex_);
+  compositor_->RegisterSurface(7, view);
+
+  ASSERT_TRUE(PresentPlatformView(7));
+  EXPECT_EQ(view->presents(), 1);
+  EXPECT_TRUE(view->released().empty())
+      << "released during the present that sampled it";
+
+  ASSERT_TRUE(PresentPlatformView(7));
+  const std::vector<uint32_t> released = view->released();
+  ASSERT_FALSE(released.empty())
+      << "the deferred release was queued and never drained (#530)";
+  EXPECT_EQ(released.front(), 0u) << "buffer id 0 is ring slot 0, not a "
+                                     "sentinel for 'no id'";
+
+  compositor_->UnregisterSurface(7);
+}
+
+// A GL-composited view is on no plane, and has to be told so. Anything keyed
+// on "is this view on a plane" -- the supersede guard in the view host, the
+// DRM_PLANE grant accessor -- otherwise keeps whatever id the scene path last
+// set and reads a stale yes.
+TEST_F(DrmBackendVkms, GlCompositedViewIsReportedOffAnyPlane) {
+  auto view = std::make_shared<FakePlatformView>(9);
+  view->set_texture(tex_);
+  compositor_->RegisterSurface(9, view);
+
+  ASSERT_TRUE(PresentPlatformView(9));
+
+  const std::vector<uint32_t> planes = view->planes();
+  ASSERT_FALSE(planes.empty()) << "the present never reported a plane at all";
+  EXPECT_EQ(planes.back(), 0u) << "GL-composited, so no plane";
+
+  compositor_->UnregisterSurface(9);
+}
+
+// A surface that exposes no texture is not composited, so nothing is queued
+// against it and nothing is released. Guards the other direction of the
+// buffer-id-0 fix: dropping the zero check must not start releasing frames
+// for views the compositor never sampled.
+TEST_F(DrmBackendVkms, AViewWithNoTextureIsNeverReleased) {
+  auto view = std::make_shared<FakePlatformView>(11);  // texture stays 0
+  compositor_->RegisterSurface(11, view);
+
+  ASSERT_TRUE(PresentPlatformView(11));
+  ASSERT_TRUE(PresentPlatformView(11));
+
+  EXPECT_EQ(view->presents(), 2);
+  EXPECT_TRUE(view->released().empty());
+
+  compositor_->UnregisterSurface(11);
+}
+
+}  // namespace
+
+// Own main rather than gtest_main: the shell's logging has to be started
+// before any of it runs, and a compositor failure that logs nothing is very
+// hard to tell apart from one that did not happen. IHS_LOG_LEVEL=debug shows
+// the per-layer decisions PresentFramed makes.
+int main(int argc, char** argv) {
+  IHS_LOGGING_START("TEST", "drm_backend vkms test");
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
+++ b/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
@@ -50,8 +50,10 @@ extern "C" {
 
 #include <GLES2/gl2.h>
 
+#if IHS_TEST_HAVE_CAPTURE
 #include "capture/png.hpp"
 #include "capture/snapshot.hpp"
+#endif
 
 #include <gtest/gtest.h>
 
@@ -486,6 +488,7 @@ class DrmBackendVkmsBase : public ::testing::Test {
     ASSERT_EQ(glGetError(), static_cast<GLenum>(GL_NO_ERROR));
   }
 
+#if IHS_TEST_HAVE_CAPTURE
   // Read the CRTC's plane composition back. drm-cxx maps each scanout FB and
   // composites in zpos order, so this is what the display is actually showing
   // -- not what the compositor believes it drew.
@@ -519,6 +522,18 @@ class DrmBackendVkmsBase : public ::testing::Test {
         static_cast<size_t>(img.height() / 2) * img.width() + img.width() / 2;
     return img.pixels()[i];
   }
+
+  // Assert the CRTC's center pixel is @p rgb, and save the frame when asked.
+  void ExpectCenterColor(const char* name, uint32_t rgb) {
+    const drm::capture::Image image = Snapshot(name);
+    ASSERT_FALSE(image.empty());
+    EXPECT_EQ(image.width(), card_.mode_w);
+    EXPECT_EQ(image.height(), card_.mode_h);
+    // RGB only: the primary is XRGB8888, so the alpha byte carries no meaning.
+    EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, rgb)
+        << "the center of the display is not the color that was expected";
+  }
+#endif  // IHS_TEST_HAVE_CAPTURE
 
   // Present until @p done holds, or give up after @p max frames.
   //
@@ -721,6 +736,7 @@ TEST_F(DrmBackendVkmsFramed, GlCompositedViewIsReportedOffAnyPlane) {
   compositor_->UnregisterSurface(15);
 }
 
+#if IHS_TEST_HAVE_CAPTURE
 // The compositor drew the plugin's texture, not just bookkeeping around it.
 //
 // Every other case here asserts on which callbacks fired, which says nothing
@@ -740,13 +756,7 @@ TEST_F(DrmBackendVkms, TheViewsTextureReachesTheDisplay) {
 
   ASSERT_TRUE(PresentPlatformView(17));
 
-  const drm::capture::Image image = Snapshot("gl_platform_view");
-  ASSERT_FALSE(image.empty());
-  EXPECT_EQ(image.width(), card_.mode_w);
-  EXPECT_EQ(image.height(), card_.mode_h);
-  // RGB only: the primary is XRGB8888, so the alpha byte carries no meaning.
-  EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, 0x002080C0u)
-      << "the centre of the display is not the colour the view uploaded";
+  ExpectCenterColor("gl_platform_view", 0x002080C0u);
 
   compositor_->UnregisterSurface(17);
 }
@@ -761,18 +771,14 @@ TEST_F(DrmBackendVkmsFramed, TheViewsTextureReachesTheDisplay) {
 
   ASSERT_TRUE(PresentPlatformView(19));
 
-  const drm::capture::Image image = Snapshot("framed_platform_view");
-  ASSERT_FALSE(image.empty());
-  // The CRTC is the mode; the content is the smaller FB centred in it. The
-  // centre pixel is inside the content either way, which is the point of
+  // The CRTC is the mode; the content is the smaller FB centered in it. The
+  // center pixel is inside the content either way, which is the point of
   // sampling there rather than at a corner.
-  EXPECT_EQ(image.width(), card_.mode_w);
-  EXPECT_EQ(image.height(), card_.mode_h);
-  EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, 0x00C04020u)
-      << "the centre of the display is not the colour the view uploaded";
+  ExpectCenterColor("framed_platform_view", 0x00C04020u);
 
   compositor_->UnregisterSurface(19);
 }
+#endif  // IHS_TEST_HAVE_CAPTURE
 
 // The zero-copy path end to end: a producer's own dma-buf lands on a KMS plane
 // and its pixels reach the display without the compositor drawing anything.
@@ -802,10 +808,11 @@ TEST_F(DrmBackendVkmsScene, AProducersBufferScansOutOnItsOwnPlane) {
       << "reported off any plane, so it was GL-composited rather than scanned "
          "out -- the zero-copy path did not run";
 
-  const drm::capture::Image image = Snapshot("scene_platform_view");
-  ASSERT_FALSE(image.empty());
-  EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, 0x001E7A46u)
-      << "the producer's buffer is not what the display is showing";
+#if IHS_TEST_HAVE_CAPTURE
+  // The producer's buffer is what the display is showing. Only available with
+  // blend2d; the plane assertions above run either way.
+  ExpectCenterColor("scene_platform_view", 0x001E7A46u);
+#endif
 
   compositor_->UnregisterSurface(21);
 }
@@ -843,10 +850,10 @@ TEST_F(DrmBackendVkmsScene, TheDisplacedSlotComesBackToTheProducer) {
       << "GetDmabuf is deliver-once; a present with no new frame must not "
          "pull the same buffer again";
 
+#if IHS_TEST_HAVE_CAPTURE
   // And the newer buffer is what is on screen.
-  const drm::capture::Image image = Snapshot("scene_second_buffer");
-  ASSERT_FALSE(image.empty());
-  EXPECT_EQ(CentrePixel(image) & 0x00FFFFFFu, 0x007A1E46u);
+  ExpectCenterColor("scene_second_buffer", 0x007A1E46u);
+#endif
 
   compositor_->UnregisterSurface(23);
 }
@@ -859,6 +866,12 @@ TEST_F(DrmBackendVkmsScene, TheDisplacedSlotComesBackToTheProducer) {
 // the per-layer decisions PresentFramed makes.
 int main(int argc, char** argv) {
   IHS_LOGGING_START("TEST", "drm_backend vkms test");
+#if IHS_TEST_HAVE_CAPTURE
+  std::cerr << "frame readback: available\n";
+#else
+  std::cerr << "frame readback: unavailable (built without blend2d, so drm-cxx "
+               "has no capture module); pixel cases are compiled out\n";
+#endif
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Fixes #530.

A GL-composited view never reaches a plane, so the scanout retire that fires
`OnScanoutRelease` never happens for it, and its producer was left waiting out
the full 100 ms release-fence timeout **on every frame**. On a Pi 5 that pinned
the producer at 8.6 fps — 60/7 — whether a frame cost 1.8 ms or 14.3 ms. It read
as the renderer being slow.

| splats | before | after | gpu ms |
| ---: | ---: | ---: | ---: |
| 1,000 | 8.6 | **60.7** | 1.8 |
| 4,000 | 8.6 | **59.9** | 3.8 |
| 20,000 | 8.6 | **60.4** | 14.9 |
| 50,000 | 8.6 | **20.0** | 37.6 |
| 100,000 | 6.7 | **12.0** | 70.2 |

Release-fence timeouts go from **120 of 122** waits to **0 of 1077**, and the
period now tracks GPU cost instead of sitting on a constant: a sweep that read
`FIXED COST: 83.1 ms per frame is not GPU work` now reads `ok: 2.1 ms`.

## Four things were wrong, and each hid the next

**The frame is never queued for release.** The supersede branch can't do it — it
is guarded on `dmabuf_delivered_seq`, which says `GetDmabuf` handed the frame
over, not that it reached a plane, and on this path the compositor polls
`GetDmabuf` then composites through a texture instead. So the frame is queued at
the composite site, with a `GetGlTextureBufferId()` accessor to tell one bound
frame from the next.

**`PresentFramed` never drained the queue.** `DrainDeferredScanoutReleases` runs
in `PresentLayersViaScene` and in the destructor, but not in the path a framed
present takes — 24 pushes, 0 drains. This is a latent bug beyond this issue: a
plane-based view presenting in framed mode loses its scanout releases the same
way.

**`PresentFramed` never reported the plane.** `SetScanoutPlane` is called only
from `PresentViaGlFallback` and `PresentLayersViaScene`, so `drm_plane_id` kept
whatever the scene path last set and anything keyed on "is this view on a plane"
read a stale yes — including the `DRM_PLANE` grant accessor.

**The release was keyed on the displaced frame, not the sampled one.** Which way
that fails depends on the producer's rate: when it outruns the compositor its
frames are superseded before being bound and the supersede path covers them; when
it is *slower* — the case where a stall costs something — every frame is consumed
instead and the release can't happen until the next submit, which is what's
waiting on it. The ring deadlocks against itself.

## A note on the last bug

`NoteGlComposited` originally early-returned on `bid == 0`, treating zero as "this
surface does not track buffer ids". **Zero is a valid buffer id — it is ring slot
0.** Every timeout in a 100k run was slot 0 and no other; nothing else ever
timed out. The accessor is only called where a texture is bound, so there is
always a real frame to name.

## Testing

Verified on a Pi 5 (`drm-kms-egl`, V3D, no compositor) across the sweep above.
Two independent instruments agree and both are in the consumer rather than here:
a release-fence wait/timeout counter pair, and a check that flags per-frame cost
the GPU does not explain. Before the fix they read 120/122 timeouts and 83.1 ms
of fixed cost; after, 0/1077 and 2.1 ms.

The bugs were all in the call sites — the eventfd table itself was always
correct, so a narrow test of it would have stayed green throughout. The test
added here drives the call sites instead, through a real `DrmCompositor`:
`homescreen_drm_backend_vkms_ut_test_driver` opens a vkms card with `DrmDisplay`
in no-seat mode, brings up `DrmBackend` (GBM + EGL) on it, and presents a frame
carrying a fake `ICompositorSurface` that reports a GL texture. Unprivileged,
~0.5 s, and skipped rather than failed when no vkms card is loaded.

It reports **buffer id 0** deliberately: 0 is ring slot 0, not a "no id"
sentinel, so a fake reporting 1 would pass against the broken code. Each fix was
confirmed load-bearing by backing it out and watching the case go red.

## A fourth path

Writing that test turned up one more instance of the same defect.
`PresentViaGlFallback` queues in `NoteGlComposited` like the others and never
drained either — and that is the path taken whenever the plane compositor is
unavailable or the fallback has latched, so for the rest of such a session no
GL-composited view gets a buffer back at all. It cannot drain at the top the way
the framed and scene paths do, because `DrmBackend::Present` owns its flip wait;
the batch is taken before the composite and fired after `Present` returns.

Also drops `gl_pv_bound_`, which recorded the last buffer id per view for a
displacement test that no longer exists. Nothing had read it since the release
was keyed on the sampled frame.
