### PR TITLE
osgi: let the activator complete the handshake over FFI

### DIFF
--- a/test/integration/osgi_activator_test/README.md
+++ b/test/integration/osgi_activator_test/README.md
@@ -1,8 +1,9 @@
 # osgi_activator_test
 
 Minimal OSGi bundle activator. This is the smallest thing that makes a bundle a
-*bundle* rather than an ordinary Flutter app: it completes the `dev.osgi/bridge`
-handshake and declares itself ACTIVE.
+*bundle* rather than an ordinary Flutter app: it completes the shell's handshake
+— over `dev.osgi/bridge` or over the `ihs_osgi_*` C ABI — and declares itself
+ACTIVE.
 
 ## Why it exists
 
@@ -32,6 +33,32 @@ into a `SendPort`, so an integer would leave the bundle with nothing it could
 send to. The shell posts a `Dart_CObject_kSendPort` for exactly that reason, and
 a bundle that tests the message for `int` will simply never see it.
 
+## Two transports, one app
+
+The second entrypoint argument picks the path: `channel` (the default) or `ffi`.
+
+| | |
+|---|---|
+| `channel` | `dev.osgi/bridge`. Proven on hardware and needs nothing of the shell that is not already there — at the cost of a UI binding even for a headless bundle, and an ACTIVE report marshalled through the platform task runner during the busiest part of start-up, while the startup deadline is running. |
+| `ffi` | `ihs_osgi_register_bundle` / `ihs_osgi_report_active` in `libihs_shared`, opened by its versioned SONAME. Synchronous, no binding, no task runner. Reports through an opaque handle the shell mints rather than a name, because any code in the process can reach those symbols. Needs `ENABLE_OSGI=ON`. |
+
+One app rather than two, because a bundle directory must not ship its own
+`lib/libflutter_engine.so` (see the note at the end) — a second activator bundle
+would collide with this one for reasons unrelated to what is being tested.
+
+The FFI path still runs a widget tree and still repaints. Its point is "no
+channel, no platform thread", not headlessness: `B5` counts page flips, so a
+bundle that stopped presenting would fail it.
+
+Both paths end at the same `BridgeRegistry` and drive the same lifecycle state
+machine, which is why every assertion in the harness is identical either way —
+`B3` greps the state-machine transition (`bundle '…': STARTING -> ACTIVE`), not
+a transport's own log line.
+
+Bindings are hand-rolled rather than taken from the `osgi_ffi` package, which
+lives in another repository: this fixture stays self-contained, exactly as the
+channel path does not depend on `osgi_flutter`.
+
 ## Symbolic name
 
 Read from `--dart-entrypoint-args`, so one build stands in for any bundle in a
@@ -42,7 +69,7 @@ config:
 symbolic_name = "com.ivi.cluster"
 
   [osgi.bundles.args]
-  dart = ["com.ivi.cluster"]
+  dart = ["com.ivi.cluster", "ffi"]   # second arg optional; default "channel"
 ```
 
 It **must** match the `[[osgi.bundles]]` entry: the shell refuses an `active`
@@ -82,6 +109,18 @@ DRM_DEVICE=/dev/dri/cardN ACTIVATOR=1 COUNT_FLIPS=1 \
 
 `ACTIVATOR=1` tells the harness this bundle can report ACTIVE, which is what
 lets it make the first bundle critical and assert `B3`.
+
+To exercise the FFI path instead, add `TRANSPORT=ffi` — against a shell built
+with `ENABLE_OSGI=ON`, so `libihs_shared` exports the `ihs_osgi_*` symbols:
+
+```sh
+HOMESCREEN=./homescreen BUNDLE=/tmp/activator-bundle \
+DRM_DEVICE=/dev/dri/cardN ACTIVATOR=1 COUNT_FLIPS=1 TRANSPORT=ffi \
+    test/osgi_multi_bundle.sh
+```
+
+The panel shows which path ran (`via channel` / `via ffi`), so a photograph of
+the screen is enough to tell them apart without reading the log.
 
 > The bundle ships `lib/libflutter_engine.so`, and **two bundles cannot each
 > carry their own copy**: `LibFlutterEngine::Load()` is one-shot and keyed on the

--- a/test/integration/osgi_activator_test/lib/main.dart
+++ b/test/integration/osgi_activator_test/lib/main.dart
@@ -1,8 +1,8 @@
 // Minimal OSGi bundle activator for ivi-homescreen.
 //
 // This is the smallest thing that makes a bundle a *bundle* rather than an
-// ordinary Flutter app: it completes the `dev.osgi/bridge` handshake and then
-// declares itself ACTIVE.
+// ordinary Flutter app: it completes the shell's handshake and then declares
+// itself ACTIVE.
 //
 // That declaration is the whole point. A critical bundle's startup wait is
 // released by ACTIVE and nothing else -- not by the engine coming up, which the
@@ -13,33 +13,276 @@
 //
 // The handshake, in order:
 //
-//   1. init    hands over the two things native code cannot obtain by itself:
-//              the address of NativeApi.initializeApiDLData (so the shell can
-//              bind Dart_PostCObject_DL) and this isolate's receive port. The
-//              shell replies once it has recorded them, and posts the framework
-//              isolate's port back to that receive port whenever it knows it --
-//              which may be before or after this call returns.
-//   2. active  sent after the activator's own start-up work finishes. Here that
-//              work is trivial; in a real bundle it is whatever must be true
-//              before the bundle is fit to be seen.
+//   1. register  hands over the two things native code cannot obtain by
+//                itself: the address of NativeApi.initializeApiDLData (so the
+//                shell can bind Dart_PostCObject_DL) and this isolate's receive
+//                port. The shell posts the framework isolate's port back to
+//                that receive port whenever it knows it -- which may be before
+//                or after this call returns.
+//   2. active    sent after the activator's own start-up work finishes. Here
+//                that work is trivial; in a real bundle it is whatever must be
+//                true before the bundle is fit to be seen.
+//
+// TWO TRANSPORTS, ONE APP
+//
+// The same handshake travels either over the dev.osgi/bridge MethodChannel or
+// over the ihs_osgi_* C ABI in libihs_shared, chosen by the second Dart
+// entrypoint argument. One app rather than two because a bundle directory must
+// not ship its own lib/libflutter_engine.so -- LibFlutterEngine::Load is
+// one-shot and keyed on the path it first binds -- so a second activator bundle
+// would collide with this one for reasons that have nothing to do with what is
+// being tested.
+//
+// The FFI path still runs a widget tree and still repaints. The point of it is
+// "no channel, no platform thread", not headlessness: the harness proves both
+// CRTCs are live by counting page flips, so a bundle that stopped presenting
+// would take B5 with it.
 //
 // Symbolic name comes from --dart-entrypoint-args so one build can stand in for
 // any bundle in a config; it must match the [[osgi.bundles]] entry, because the
-// shell refuses a report from a name it does not know.
+// shell refuses a registration naming anything the configuration does not
+// declare.
 
 // NativeApi and SendPort.nativePort both come from dart:ffi, not dart:ui.
+//
+// Imported twice, unprefixed and as `ffi`, on purpose: dart:ui exports a Size
+// of its own (the geometry one) through package:flutter/widgets.dart, so a bare
+// @Size() on a struct field resolves to that and fails as "not a const
+// annotation". The prefix is only needed where the two collide.
 import 'dart:async';
 import 'dart:ffi';
+import 'dart:ffi' as ffi;
 import 'dart:isolate';
 
+import 'package:ffi/ffi.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-
-const MethodChannel _bridge = MethodChannel('dev.osgi/bridge');
 
 /// Result of the handshake, surfaced on screen so a failure is visible on the
 /// panel rather than only in the log.
 enum _BundleState { starting, active, failed }
+
+/// Raised by a transport when the shell refuses or cannot be reached. The
+/// message is what lands on the panel.
+class _HandshakeFailure implements Exception {
+  _HandshakeFailure(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// How this bundle talks to the shell.
+///
+/// The seam exists for the same reason the Dart framework's `ShellTransport`
+/// does: which transport a bundle gets is a property of how far it is trusted
+/// -- `dart:ffi` grants arbitrary access to the process address space -- not of
+/// what the bundle needs. The activator's own code is identical either way.
+abstract class _Transport {
+  String get name;
+
+  /// Announce this bundle. [replyTo] is where the shell posts the framework
+  /// isolate's port.
+  Future<void> register(String symbolicName, SendPort replyTo);
+
+  /// Report that start-up finished. This is what releases the critical wait.
+  Future<void> reportActive(String symbolicName);
+}
+
+// ---------------------------------------------------------------------------
+// MethodChannel
+// ---------------------------------------------------------------------------
+
+const MethodChannel _bridge = MethodChannel('dev.osgi/bridge');
+
+/// The default. Proven on hardware, and needs nothing of the shell that is not
+/// already there -- at the cost of a UI binding even for a headless bundle, and
+/// an ACTIVE report marshalled through the platform task runner during the
+/// busiest part of start-up, while the startup deadline is running.
+class _ChannelTransport implements _Transport {
+  @override
+  String get name => 'channel';
+
+  @override
+  Future<void> register(String symbolicName, SendPort replyTo) async {
+    try {
+      await _bridge.invokeMethod<bool>('init', <String, dynamic>{
+        'role': 'bundle',
+        'symbolic_name': symbolicName,
+        // The shell binds its Dart DL symbol table from this. Every isolate
+        // sends it because any of them may be the first to arrive; the shell
+        // makes all but the first a no-op.
+        'dl_data': NativeApi.initializeApiDLData.address,
+        'port': replyTo.nativePort,
+      });
+    } on PlatformException catch (e) {
+      // Most likely a symbolic_name with no matching [[osgi.bundles]] entry, or
+      // a shell built without ENABLE_OSGI.
+      throw _HandshakeFailure('init rejected: ${e.code} ${e.message ?? ''}');
+    } on MissingPluginException {
+      throw _HandshakeFailure(
+          'no dev.osgi/bridge (shell built without ENABLE_OSGI?)');
+    }
+  }
+
+  @override
+  Future<void> reportActive(String symbolicName) async {
+    try {
+      await _bridge.invokeMethod<bool>('active', <String, dynamic>{
+        'symbolic_name': symbolicName,
+      });
+    } on PlatformException catch (e) {
+      throw _HandshakeFailure('active rejected: ${e.code}');
+    } on MissingPluginException {
+      throw _HandshakeFailure('no dev.osgi/bridge');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FFI
+// ---------------------------------------------------------------------------
+
+/// `IhsOsgiStatus`. Negative values are errors.
+const int _ihsOsgiOk = 0;
+const int _ihsOsgiInvalid = -1;
+const int _ihsOsgiDartApi = -2;
+const int _ihsOsgiRejected = -3;
+const int _ihsOsgiUnavailable = -4;
+
+String _statusName(int status) => switch (status) {
+      _ihsOsgiOk => 'OK',
+      _ihsOsgiInvalid => 'INVALID',
+      _ihsOsgiDartApi => 'DART_API',
+      _ihsOsgiRejected => 'REJECTED',
+      _ihsOsgiUnavailable => 'UNAVAILABLE',
+      _ => 'status $status',
+    };
+
+/// `IhsOsgiPeerInfo`.
+final class _PeerInfo extends Struct {
+  @ffi.Size()
+  external int structSize;
+
+  external Pointer<Void> dartApiDlData;
+
+  @Int64()
+  external int port;
+}
+
+/// `IhsOsgiBundleInfo`.
+final class _BundleInfo extends Struct {
+  @ffi.Size()
+  external int structSize;
+
+  external _PeerInfo peer;
+
+  external Pointer<Utf8> symbolicName;
+}
+
+typedef _RegisterBundleNative = Int32 Function(
+    Pointer<_BundleInfo>, Pointer<Pointer<Void>>);
+typedef _RegisterBundleDart = int Function(
+    Pointer<_BundleInfo>, Pointer<Pointer<Void>>);
+typedef _ReportNative = Int32 Function(Pointer<Void>);
+typedef _ReportDart = int Function(Pointer<Void>);
+
+/// The same handshake through `libihs_shared`: synchronous, no UI binding
+/// required, and never routed through the platform task runner.
+///
+/// Bindings are hand-rolled rather than taken from the `osgi_ffi` package, which
+/// lives in another repository: this fixture stays self-contained, exactly as
+/// the channel path does not depend on `osgi_flutter`.
+class _FfiTransport implements _Transport {
+  _FfiTransport._(this._registerBundle, this._reportActive);
+
+  /// The versioned SONAME, which is the open string PLUGIN_ABI.md documents.
+  /// The shell links this library, so it is already resident and this resolves
+  /// the copy already in the process.
+  static const String _library = 'libihs_shared.so.1';
+
+  /// Bind the surface, or explain why it is not there.
+  ///
+  /// A shell built without ENABLE_OSGI exports no ihs_osgi_* symbol at all, so
+  /// a missing symbol is the ordinary "no OSGi here" answer rather than a
+  /// broken installation -- and saying which it is beats a bare lookup failure
+  /// on the panel.
+  factory _FfiTransport.open() {
+    final DynamicLibrary library;
+    try {
+      library = DynamicLibrary.open(_library);
+    } on ArgumentError catch (e) {
+      throw _HandshakeFailure('cannot open $_library: $e');
+    }
+    try {
+      return _FfiTransport._(
+        library.lookupFunction<_RegisterBundleNative, _RegisterBundleDart>(
+            'ihs_osgi_register_bundle'),
+        library.lookupFunction<_ReportNative, _ReportDart>(
+            'ihs_osgi_report_active'),
+      );
+    } on ArgumentError {
+      throw _HandshakeFailure(
+          '$_library has no ihs_osgi_* symbols (ENABLE_OSGI off?)');
+    }
+  }
+
+  final _RegisterBundleDart _registerBundle;
+  final _ReportDart _reportActive;
+
+  /// The capability the shell mints at registration. Opaque: it is never
+  /// dereferenced here, and reporting ACTIVE needs it rather than a name,
+  /// because any code in the process can reach these symbols and a name would
+  /// be no barrier at all.
+  Pointer<Void> _handle = nullptr;
+
+  @override
+  String get name => 'ffi';
+
+  @override
+  Future<void> register(String symbolicName, SendPort replyTo) async {
+    final Pointer<_BundleInfo> info = calloc<_BundleInfo>();
+    final Pointer<Pointer<Void>> outBundle = calloc<Pointer<Void>>();
+    final Pointer<Utf8> name = symbolicName.toNativeUtf8();
+    try {
+      info.ref.structSize = sizeOf<_BundleInfo>();
+      info.ref.peer.structSize = sizeOf<_PeerInfo>();
+      info.ref.peer.dartApiDlData = NativeApi.initializeApiDLData;
+      info.ref.peer.port = replyTo.nativePort;
+      info.ref.symbolicName = name;
+
+      final int status = _registerBundle(info, outBundle);
+      if (status != _ihsOsgiOk) {
+        throw _HandshakeFailure('register rejected: ${_statusName(status)}');
+      }
+      _handle = outBundle.value;
+      if (_handle == nullptr) {
+        // Accepted with nothing to report through: every later call would fail
+        // with no explanation, so refuse it here instead.
+        throw _HandshakeFailure('register returned no handle');
+      }
+    } finally {
+      // The shell copies the name, so it need not outlive the call.
+      calloc.free(name);
+      calloc.free(outBundle);
+      calloc.free(info);
+    }
+  }
+
+  @override
+  Future<void> reportActive(String symbolicName) async {
+    if (_handle == nullptr) {
+      throw _HandshakeFailure('no registration to report ACTIVE for');
+    }
+    final int status = _reportActive(_handle);
+    if (status != _ihsOsgiOk) {
+      throw _HandshakeFailure('active rejected: ${_statusName(status)}');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 
 Future<void> main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -49,8 +292,9 @@ Future<void> main(List<String> args) async {
   // other bundle.
   final String symbolicName =
       args.isNotEmpty ? args.first : 'com.ivi.unnamed-bundle';
+  final String transportName = args.length > 1 ? args[1] : 'channel';
 
-  final _Activator activator = _Activator(symbolicName);
+  final _Activator activator = _Activator(symbolicName, transportName);
   runApp(_ActivatorApp(activator: activator));
 
   // Deliberately after runApp: the channel needs the binding running, and there
@@ -59,9 +303,10 @@ Future<void> main(List<String> args) async {
 }
 
 class _Activator {
-  _Activator(this.symbolicName);
+  _Activator(this.symbolicName, this.transportName);
 
   final String symbolicName;
+  final String transportName;
   final ValueNotifier<_BundleState> state =
       ValueNotifier<_BundleState>(_BundleState.starting);
   final ValueNotifier<String> detail = ValueNotifier<String>('registering');
@@ -94,39 +339,36 @@ class _Activator {
 
     _fromShell.listen((dynamic message) {
       // Arrives as a SendPort, because the shell posts a
-      // Dart_CObject_kSendPort. It used to post a bare int64, and this checked
-      // for one -- which silently stopped matching when the shell changed, so
-      // the bundle reached ACTIVE while never learning the framework port.
-      // An int is useless here in any case: Dart cannot turn a port id back
-      // into a SendPort, so a bundle handed one has nothing to send to.
+      // Dart_CObject_kSendPort. An int would be useless here: Dart cannot turn
+      // a port id back into a SendPort, so a bundle handed one has nothing to
+      // send to.
       //
       // Everything after this is SendPort traffic between isolates, off the
-      // platform thread.
+      // platform thread -- and the same on both transports, since only the
+      // bootstrap differs.
       if (message is SendPort) {
         frameworkPort = message;
         detail.value = 'framework port received';
       }
     });
 
+    final _Transport transport;
     try {
-      await _bridge.invokeMethod<bool>('init', <String, dynamic>{
-        'role': 'bundle',
-        'symbolic_name': symbolicName,
-        // The shell binds its Dart DL symbol table from this. Every isolate
-        // sends it because any of them may be the first to arrive; the shell
-        // makes all but the first a no-op.
-        'dl_data': NativeApi.initializeApiDLData.address,
-        'port': _fromShell.sendPort.nativePort,
-      });
-    } on PlatformException catch (e) {
-      // Most likely a symbolic_name with no matching [[osgi.bundles]] entry, or
-      // a shell built without ENABLE_OSGI.
-      state.value = _BundleState.failed;
-      detail.value = 'init rejected: ${e.code} ${e.message ?? ''}';
+      transport = switch (transportName) {
+        'ffi' => _FfiTransport.open(),
+        'channel' => _ChannelTransport(),
+        _ => throw _HandshakeFailure(
+            "unknown transport '$transportName' (expected channel|ffi)"),
+      };
+    } on _HandshakeFailure catch (e) {
+      _fail(e.message);
       return;
-    } on MissingPluginException {
-      state.value = _BundleState.failed;
-      detail.value = 'no dev.osgi/bridge (shell built without ENABLE_OSGI?)';
+    }
+
+    try {
+      await transport.register(symbolicName, _fromShell.sendPort);
+    } on _HandshakeFailure catch (e) {
+      _fail(e.message);
       return;
     }
 
@@ -136,17 +378,21 @@ class _Activator {
     await _startupWork();
 
     try {
-      await _bridge.invokeMethod<bool>('active', <String, dynamic>{
-        'symbolic_name': symbolicName,
-      });
-      state.value = _BundleState.active;
-      detail.value = frameworkPort == null
-          ? 'ACTIVE (awaiting framework port)'
-          : 'ACTIVE (framework port received)';
-    } on PlatformException catch (e) {
-      state.value = _BundleState.failed;
-      detail.value = 'active rejected: ${e.code}';
+      await transport.reportActive(symbolicName);
+    } on _HandshakeFailure catch (e) {
+      _fail(e.message);
+      return;
     }
+
+    state.value = _BundleState.active;
+    detail.value = frameworkPort == null
+        ? 'ACTIVE (awaiting framework port)'
+        : 'ACTIVE (framework port received)';
+  }
+
+  void _fail(String why) {
+    state.value = _BundleState.failed;
+    detail.value = why;
   }
 
   Future<void> _startupWork() async {
@@ -208,6 +454,16 @@ class _ActivatorApp extends StatelessWidget {
                         style: const TextStyle(
                           color: Color(0xCCFFFFFF),
                           fontSize: 22,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      // Which path actually ran, so a photograph of the panel
+                      // says so without cross-referencing the log.
+                      Text(
+                        'via ${activator.transportName}',
+                        style: const TextStyle(
+                          color: Color(0xCCFFFFFF),
+                          fontSize: 20,
                         ),
                       ),
                       const SizedBox(height: 12),

--- a/test/integration/osgi_activator_test/pubspec.yaml
+++ b/test/integration/osgi_activator_test/pubspec.yaml
@@ -1,9 +1,10 @@
 name: osgi_activator_test
 description: >
   Minimal OSGi bundle activator for ivi-homescreen. Registers with the shell
-  over dev.osgi/bridge and reports ACTIVE, which is what releases a critical
-  bundle's startup wait. Exists so the multi-bundle harness can assert the
-  critical-first ordering guarantee.
+  over dev.osgi/bridge or the ihs_osgi_* C ABI, and reports ACTIVE, which is
+  what releases a critical bundle's startup wait. Exists so the multi-bundle
+  harness can assert the critical-first ordering guarantee, over either
+  transport.
 publish_to: none
 version: 1.0.0
 
@@ -11,6 +12,9 @@ environment:
   sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
+  # calloc and Utf8 for the FFI transport's struct marshalling; dart:ffi alone
+  # has no allocator.
+  ffi: ^2.1.0
   flutter:
     sdk: flutter
 

--- a/test/osgi_multi_bundle.sh
+++ b/test/osgi_multi_bundle.sh
@@ -51,6 +51,13 @@
 #                    app cannot report ACTIVE, so the critical wait would always
 #                    time out and tear the bundle down, taking B1/B2 with it.
 #                    With 0 both bundles run at normal priority and B3 skips.
+#   TRANSPORT        channel (default) or ffi: which path the activator uses to
+#                    register and report ACTIVE. Both end at the same registry
+#                    and drive the same lifecycle state machine, so every
+#                    assertion below is identical either way -- B3 greps the
+#                    state-machine transition, not a transport's own log line.
+#                    ffi needs a shell whose libihs_shared exports ihs_osgi_*
+#                    (ENABLE_OSGI=ON), and an activator bundle built with it.
 #   COUNT_FLIPS      1 = prove page flips via strace (default 0)
 #   SOFTWARE_RENDER  1 = LIBGL_ALWAYS_SOFTWARE=1 (vkms/llvmpipe)
 #   --check          verify prerequisites only, do not launch
@@ -68,8 +75,18 @@ DURATION="${DURATION:-6}"
 STARTUP_GRACE="${STARTUP_GRACE:-3}"
 STARTUP_TIMEOUT="${STARTUP_TIMEOUT:-4000}"
 ACTIVATOR="${ACTIVATOR:-0}"
+TRANSPORT="${TRANSPORT:-channel}"
 COUNT_FLIPS="${COUNT_FLIPS:-0}"
 SOFTWARE_RENDER="${SOFTWARE_RENDER:-0}"
+
+# Checked here rather than at the point of use, so --check catches a typo
+# before anyone sets up a rig. Refused rather than defaulted: falling back to
+# the channel would report a pass for a transport that was never exercised.
+case "$TRANSPORT" in
+    channel|ffi) ;;
+    *) echo "FAIL: TRANSPORT must be 'channel' or 'ffi', got '$TRANSPORT'" >&2
+       exit 1 ;;
+esac
 
 RESULTS=(); PASS=0; FAIL=0
 log()  { echo "[osgi-mb] $*"; }
@@ -169,7 +186,7 @@ else
     CLUSTER_PRIORITY="normal"
 fi
 log "card $DRM_DEVICE ($DEVICE_SOURCE); connectors $CONNECTOR_A + $CONNECTOR_B"
-log "cluster priority: $CLUSTER_PRIORITY (ACTIVATOR=$ACTIVATOR)"
+log "cluster priority: $CLUSTER_PRIORITY (ACTIVATOR=$ACTIVATOR, TRANSPORT=$TRANSPORT)"
 
 # Throwaway copies so a config can be dropped in without touching the source
 # bundle. Two directories because each bundle is a distinct OSGi bundle with its
@@ -222,7 +239,7 @@ priority = "normal"
   # in for any bundle, and the name must match this entry or the shell refuses
   # the ACTIVE report.
   [osgi.bundles.args]
-  dart = ["com.ivi.navigation"]
+  dart = ["com.ivi.navigation", "$TRANSPORT"]
 
   [osgi.bundles.backend]
   type = "drm-kms-egl"
@@ -238,7 +255,7 @@ priority = "$CLUSTER_PRIORITY"
 startup_timeout_ms = $STARTUP_TIMEOUT
 
   [osgi.bundles.args]
-  dart = ["com.ivi.cluster"]
+  dart = ["com.ivi.cluster", "$TRANSPORT"]
 
   [osgi.bundles.backend]
   type = "drm-kms-egl"


### PR DESCRIPTION
The `ihs_osgi_*` path is complete on both sides and **has never been run**. Every
test of it fakes one half: the shell suites fake the Dart DL calls,
`ihs_osgi-test` fakes the host, `osgi_host-test` joins two real halves and still
fakes the VM, and `osgi_ffi` is tested against a fake of the C surface.

**This does not run it either.** It makes running it possible, which is the step
that was missing: the activator bundle — the only bundle that can report ACTIVE,
and therefore the only one the multi-bundle harness can assert ordering with —
could speak the channel and nothing else.

It now takes a second Dart entrypoint argument, `channel` (default) or `ffi`, and
`osgi_multi_bundle.sh` passes it through as `TRANSPORT`.

### Why no assertion changes

`B3` greps the lifecycle state machine's transition (`bundle_state.cc`:
`bundle '{}': {} -> {}`), not a transport's own log line, and both transports
reach that state machine through the same `BridgeRegistry`. Had `B3` keyed on the
bridge plugin's message instead, an FFI run would have **skipped** — a
benign-looking green that proved nothing. That was checked before any of this was
written.

### One app, not two

A bundle directory must not ship its own `lib/libflutter_engine.so`
(`LibFlutterEngine::Load` is one-shot and keyed on the path it first binds), so a
second activator bundle would collide with this one for reasons unrelated to what
is being tested. One build, one argument.

The FFI path still runs a widget tree and still repaints — its point is "no
channel, no platform thread", not headlessness, and `B5` counts page flips. The
panel names the transport, so a photograph of the screen says which path ran.

Bindings are hand-rolled rather than taken from `osgi_ffi` (another repository):
the fixture stays self-contained, exactly as the channel path does not depend on
`osgi_flutter`.

### A trap worth recording

`@Size()` on a struct field **does not compile in a Flutter app**. `dart:ui`
exports a `Size` of its own — the geometry one — via
`package:flutter/widgets.dart`, so the annotation resolves to that and fails as
"not a const annotation", taking the native-type check down with it. `dart:ffi`
is imported twice, plain and as `ffi`, so the collision is spelled away where it
happens. This is why `osgi_ffi` compiled clean in the Dart repo and this did not:
that package has no Flutter import to collide with.

`TRANSPORT` is validated beside the other defaults rather than at the point of
use, so `--check` rejects a typo before anyone sets up a rig — and it is refused
rather than defaulted, since falling back to the channel would report a pass for
a transport that was never exercised.

### Verification

- `flutter analyze` — no issues (six errors first, all from the `Size` collision)
- `dart format` — file unchanged
- `bash -n` parses the harness; `TRANSPORT=ffy` exits 1 from `--check` with the
  reason; `TRANSPORT=ffi` passes validation and reaches the ordinary prerequisite
  checks

### Still unproven

No FFI handshake has run against a live Dart VM. That needs a target with two
connected outputs and DRM master, and a shell built with `ENABLE_OSGI=ON`.