### PR TITLE
ci: measure the OSGi subsystem in the coverage build

### DIFF
--- a/.github/workflows/oss-ivi-homescreen.yml
+++ b/.github/workflows/oss-ivi-homescreen.yml
@@ -520,7 +520,8 @@ jobs:
             -D BUILD_ACCESSIBILITY=ON \
             -D BUILD_CRASH_HANDLER=OFF \
             -D BUILD_WATCHDOG=ON \
-            -D BUILD_SYSTEMD_WATCHDOG=ON
+            -D BUILD_SYSTEMD_WATCHDOG=ON \
+            -D ENABLE_OSGI=ON
 
       - name: Build
         working-directory: ${{github.workspace}}/build/unit-tests


### PR DESCRIPTION
The coverage job enumerates eleven `-D` options and **`ENABLE_OSGI` is not among
them**, so it takes the default of `OFF`. No `shell/osgi/` translation unit is
compiled, none of the seven OSGi test drivers is built, and `ctest` there runs
none of their **118 tests**. Every coverage number this project publishes has
silently excluded the whole subsystem since it was added.

Adding the option builds the drivers and lets ctest run them, so `shell/osgi`
appears in `coverage.info` like everything else.

**The published percentage will fall**, and that is the point: the previous
figure was computed over a tree with an entire subsystem absent. It was not a
smaller number made larger by good tests — it was the wrong denominator.

### Verification

A coverage-shaped configure with `ENABLE_OSGI=ON` succeeds, reports
`OSGi ... Enabled` and `OSGi handshake ... Enabled`, and generates all seven
`*osgi*_ut_test_driver` targets. The same configure without it generates none.

First of six coverage items; the others (C↔Dart ABI conformance, the vkms
harness in CI, an in-process FFI handshake test, `osgi_bridge_plugin` tests, and
dart-side coverage) follow separately.