### PR TITLE
platform-views: wait on a producer's acquire fence with EGL explicit sync

### DIFF
--- a/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
+++ b/shell/platform/homescreen/platform_views/egl_dmabuf_import.cc
@@ -109,6 +109,44 @@ bool EglDmabufImporter::Init(void* egl_display) {
     egl_display_ = nullptr;
     return false;
   }
+
+  // Native fence sync is probed separately and is allowed to fail: a display
+  // can import dma-bufs without being able to wait on a producer's sync_file,
+  // and that combination still imports fine — it just paces implicitly.
+  //
+  // Check the extension string as well as the entry points. eglGetProcAddress
+  // can return non-null for an extension the display does not actually support,
+  // which is the same trap DrmCompositor::InitEglExtensions guards against for
+  // IN_FENCE_FD, so the check here has the same three parts.
+  const char* exts =
+      eglQueryString(static_cast<EGLDisplay>(egl_display_), EGL_EXTENSIONS);
+  const bool has_fence_sync =
+      exts != nullptr && std::strstr(exts, "EGL_KHR_fence_sync") != nullptr;
+  const bool has_native_fence =
+      exts != nullptr &&
+      std::strstr(exts, "EGL_ANDROID_native_fence_sync") != nullptr;
+  const bool has_wait_sync =
+      exts != nullptr && std::strstr(exts, "EGL_KHR_wait_sync") != nullptr;
+  if (has_fence_sync && has_native_fence && has_wait_sync) {
+    create_sync_ =
+        reinterpret_cast<void*>(eglGetProcAddress("eglCreateSyncKHR"));
+    destroy_sync_ =
+        reinterpret_cast<void*>(eglGetProcAddress("eglDestroySyncKHR"));
+    wait_sync_ = reinterpret_cast<void*>(eglGetProcAddress("eglWaitSyncKHR"));
+  }
+  // All three or none: a half-resolved set would let WaitAcquireFence create a
+  // sync it cannot wait on or destroy, leaking the producer's fd every frame.
+  if (!has_native_fence_sync()) {
+    create_sync_ = nullptr;
+    destroy_sync_ = nullptr;
+    wait_sync_ = nullptr;
+  }
+  ihs::log::debug(
+      "[EglDmabufImporter] explicit-sync acquire: {} (fence_sync={}, "
+      "native_fence_sync={}, wait_sync={})",
+      has_native_fence_sync() ? "available" : "unavailable",
+      has_fence_sync ? "y" : "n", has_native_fence ? "y" : "n",
+      has_wait_sync ? "y" : "n");
   return true;
 }
 
@@ -234,4 +272,46 @@ void EglDmabufImporter::Destroy(ImportedTexture* out) const {
                   static_cast<EGLImageKHR>(out->egl_image));
     out->egl_image = nullptr;
   }
+}
+
+bool EglDmabufImporter::WaitAcquireFence(int fence_fd) const {
+  if (!has_native_fence_sync() || fence_fd < 0) {
+    return false;
+  }
+  auto create_sync = reinterpret_cast<PFNEGLCREATESYNCKHRPROC>(create_sync_);
+  auto destroy_sync = reinterpret_cast<PFNEGLDESTROYSYNCKHRPROC>(destroy_sync_);
+  auto wait_sync = reinterpret_cast<PFNEGLWAITSYNCKHRPROC>(wait_sync_);
+  const auto dpy = static_cast<EGLDisplay>(egl_display_);
+
+  // eglCreateSyncKHR takes ownership of the fd on success and closes it when
+  // the sync is destroyed; on failure the fd is left to us. Reporting that
+  // split back through the return value is this function's whole contract --
+  // get it backwards and every frame either double-closes or leaks an fd.
+  const EGLint attribs[] = {EGL_SYNC_NATIVE_FENCE_FD_ANDROID, fence_fd,
+                            EGL_NONE};
+  const EGLSyncKHR sync =  // NOLINT(misc-misplaced-const)
+      create_sync(dpy, EGL_SYNC_NATIVE_FENCE_ANDROID, attribs);
+  if (sync == EGL_NO_SYNC_KHR) {
+    ihs::log::warn(
+        "[EglDmabufImporter] eglCreateSyncKHR(NATIVE_FENCE, fd={}): 0x{:x}; "
+        "falling back to a CPU wait",
+        fence_fd, eglGetError());
+    return false;  // fd untouched — still the caller's to close
+  }
+
+  // Server-side wait: queues the wait into the GL command stream so the GPU
+  // blocks before sampling, and this thread does not block at all. Destroying
+  // the sync afterwards does not cancel a wait already queued against it.
+  const EGLint rc = wait_sync(dpy, sync, 0);
+  destroy_sync(dpy, sync);
+  if (rc != EGL_TRUE) {
+    // The fd is gone either way (EGL took it with the sync), so there is
+    // nothing to fall back to. Sample best-effort and say so, matching the CPU
+    // path's policy on a timed-out fence.
+    ihs::log::warn(
+        "[EglDmabufImporter] eglWaitSyncKHR: 0x{:x}; sampling anyway — frame "
+        "may tear",
+        eglGetError());
+  }
+  return true;
 }

--- a/shell/platform/homescreen/platform_views/egl_dmabuf_import.h
+++ b/shell/platform/homescreen/platform_views/egl_dmabuf_import.h
@@ -57,12 +57,39 @@ class EglDmabufImporter {
   // EGL_EXT_image_dma_buf_import / glEGLImageTargetTexture2DOES (the plugin
   // then falls back to the software floor). Call once before Import; no GL
   // context needs to be current for Init.
+  //
+  // Also probes the native-fence-sync entry points, which are optional: a
+  // display that imports dma-bufs but cannot wait on a producer's sync_file
+  // still returns true here and simply reports has_native_fence_sync() false.
   bool Init(void* egl_display);
 
   [[nodiscard]] bool ready() const {
     return egl_display_ != nullptr && create_image_ != nullptr &&
            image_target_texture_ != nullptr;
   }
+
+  // Whether this display can wait on a producer's sync_file, i.e. whether
+  // WaitAcquireFence does anything. Independent of ready(): import and
+  // explicit-sync acquire are separate driver capabilities, and this is what
+  // backs IhsPvCapabilities::explicit_sync on an EGL backend (#513).
+  [[nodiscard]] bool has_native_fence_sync() const {
+    return egl_display_ != nullptr && create_sync_ != nullptr &&
+           destroy_sync_ != nullptr && wait_sync_ != nullptr;
+  }
+
+  // Make the GL driver wait for @fence_fd (a producer acquire sync_file) before
+  // any subsequent draw samples the import, by wrapping it in an
+  // EGL_SYNC_NATIVE_FENCE_ANDROID and issuing a server-side eglWaitSyncKHR.
+  // The GPU does the waiting; this call does not block.
+  //
+  // Returns true when the fence was handed to EGL, which CONSUMES @fence_fd
+  // (EGL takes ownership and closes it) — the caller must not close it. Returns
+  // false when there is no native fence sync or the sync could not be created,
+  // leaving @fence_fd untouched and owned by the caller, which is the signal to
+  // fall back to a CPU wait.
+  //
+  // GL context must be current, same as Import.
+  [[nodiscard]] bool WaitAcquireFence(int fence_fd) const;
 
   // Import @frame's dma-buf planes into a texture in @out. On success the
   // texture owns the import; @frame.plane_fd[*] are consumed (EGL dup's them,
@@ -84,4 +111,10 @@ class EglDmabufImporter {
   void* create_image_{nullptr};          // PFNEGLCREATEIMAGEKHRPROC
   void* destroy_image_{nullptr};         // PFNEGLDESTROYIMAGEKHRPROC
   void* image_target_texture_{nullptr};  // PFNGLEGLIMAGETARGETTEXTURE2DOESPROC
+  // Native fence sync, for the explicit-sync acquire wait. Optional: null on a
+  // display without EGL_KHR_fence_sync / EGL_ANDROID_native_fence_sync /
+  // EGL_KHR_wait_sync, which leaves has_native_fence_sync() false.
+  void* create_sync_{nullptr};   // PFNEGLCREATESYNCKHRPROC
+  void* destroy_sync_{nullptr};  // PFNEGLDESTROYSYNCKHRPROC
+  void* wait_sync_{nullptr};     // PFNEGLWAITSYNCKHRPROC
 };

--- a/shell/platform/homescreen/platform_views/platform_view_host.cc
+++ b/shell/platform/homescreen/platform_views/platform_view_host.cc
@@ -755,6 +755,15 @@ uint32_t IhsPluginView::GetGlTextureName() const {
     while (pending_egl.valid && pending_egl.acquire_fence_fd >= 0) {
       const int fence = pending_egl.acquire_fence_fd;
       pending_egl.acquire_fence_fd = -1;
+      // Explicit sync (#513): hand the fence to the GL driver and let the GPU
+      // wait on it. Cheap and non-blocking, so it runs under the lock — unlike
+      // the CPU wait below, there is nothing to drop the lock across. On
+      // success EGL owns the fd, so we must not close it here.
+      if (g_egl_importer.WaitAcquireFence(fence)) {
+        continue;
+      }
+      // No native fence sync on this display (or the sync failed): fall back to
+      // the CPU wait, which still owns the fd.
       lock.unlock();
       pollfd pfd{fence, POLLIN, 0};
       int pr = 0;
@@ -1032,6 +1041,17 @@ int HostQueryCapabilities(void* user_data, IhsPvCapabilities* out) {
     BackendEglContext egl{};
     if (backend->GetEglContext(&egl)) {
       out->kinds |= IHS_PV_KIND_TEXTURE_DMABUF_IMPORT;
+      // Explicit-sync acquire on EGL: the GL-composite path waits on the
+      // producer's sync_file with eglWaitSyncKHR before sampling the import
+      // (GetGlTextureName), which needs EGL_ANDROID_native_fence_sync on the
+      // backend's display. The importer probed that at host install, so ask it
+      // rather than re-querying here. Advertise it only when the wait is
+      // actually wired: ihs_pv_negotiate refuses EXPLICIT_REQUIRED and caps the
+      // granted sync on this flag, so claiming it without honoring it hands the
+      // producer a fence nothing waits on (#513).
+      if (g_egl_importer.has_native_fence_sync()) {
+        out->explicit_sync = 1;
+      }
       // The DRM-KMS-EGL backend (gbm_device set; wayland-egl leaves it null)
       // runs the plane compositor, which can scan out a submitted dma-buf
       // directly on a KMS overlay plane — offer the zero-copy DRM_PLANE kind.

--- a/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
+++ b/test/unit_test/drm_backend_vkms-test/test_case_drm_backend_vkms.cc
@@ -37,7 +37,11 @@
 #include "backend/drm_kms_egl/drm_compositor.h"
 #include "display/drm_display.h"
 #include "logging/logger.hpp"
+#include "platform/homescreen/platform_views/egl_dmabuf_import.h"
 #include "view/compositor_surface_interface.h"
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
 
 extern "C" {
 #include <drm_fourcc.h>
@@ -856,6 +860,102 @@ TEST_F(DrmBackendVkmsScene, TheDisplacedSlotComesBackToTheProducer) {
 #endif
 
   compositor_->UnregisterSurface(23);
+}
+
+// ─── Explicit-sync acquire (#513) ────────────────────────────────────────
+//
+// EglDmabufImporter::WaitAcquireFence is what lets an EGL backend advertise
+// IhsPvCapabilities::explicit_sync: instead of the raster thread blocking in
+// poll() on the producer's sync_file, the fence is handed to the GL driver and
+// the GPU waits.
+//
+// These drive the importer directly. The call site is IhsPluginView::
+// GetGlTextureName, which lives in an anonymous namespace in the view host and
+// cannot be constructed from a test -- the FakePlatformView above implements
+// GetGlTextureName itself, so presenting it never reaches the real wait. What
+// is coverable, and what is worth covering, is the fd-ownership contract:
+// eglCreateSyncKHR takes the fd on success and leaves it on failure, and the
+// caller closes it only in the second case. Get that backwards and the GL path
+// either double-closes or leaks one fd per frame.
+class EglAcquireFence : public DrmBackendVkmsBase {
+ protected:
+  void Configure(DrmConfig& cfg) override {
+    cfg.compositor = drm_config::Compositor::kGl;
+    content_w_ = card_.mode_w;
+    content_h_ = card_.mode_h;
+  }
+
+  // Mint a real sync_file by fencing GL work on the backend's own context,
+  // which is the same shape a producer's acquire fence has.
+  [[nodiscard]] int MintFence() {
+    auto create = reinterpret_cast<PFNEGLCREATESYNCKHRPROC>(
+        eglGetProcAddress("eglCreateSyncKHR"));
+    auto destroy = reinterpret_cast<PFNEGLDESTROYSYNCKHRPROC>(
+        eglGetProcAddress("eglDestroySyncKHR"));
+    auto dup_fd = reinterpret_cast<PFNEGLDUPNATIVEFENCEFDANDROIDPROC>(
+        eglGetProcAddress("eglDupNativeFenceFDANDROID"));
+    if (create == nullptr || destroy == nullptr || dup_fd == nullptr) {
+      return -1;
+    }
+    const EGLDisplay dpy = backend_->egl_display();
+    glClear(GL_COLOR_BUFFER_BIT);
+    EGLSyncKHR s = create(dpy, EGL_SYNC_NATIVE_FENCE_ANDROID, nullptr);
+    if (s == EGL_NO_SYNC_KHR) {
+      return -1;
+    }
+    glFlush();
+    const int fd = dup_fd(dpy, s);
+    destroy(dpy, s);
+    return fd;
+  }
+
+  static bool FdOpen(int fd) {
+    return fcntl(fd, F_GETFD) != -1 || errno != EBADF;
+  }
+};
+
+// On success EGL owns the fence: the caller must not close it, and after the
+// sync is destroyed the fd is gone. This is the branch the GL path takes on any
+// driver with native fence sync, so a leak here is a leak every frame.
+TEST_F(EglAcquireFence, ASuccessfulWaitConsumesTheProducersFence) {
+  ASSERT_TRUE(backend_->MakeCurrent());
+  EglDmabufImporter importer;
+  ASSERT_TRUE(importer.Init(backend_->egl_display()));
+  if (!importer.has_native_fence_sync()) {
+    GTEST_SKIP() << "display has no EGL_ANDROID_native_fence_sync; the GL path "
+                    "falls back to the CPU wait here";
+  }
+
+  const int fence = MintFence();
+  ASSERT_GE(fence, 0) << "could not mint a sync_file to stand in for the "
+                         "producer's acquire fence";
+  ASSERT_TRUE(FdOpen(fence));
+
+  EXPECT_TRUE(importer.WaitAcquireFence(fence));
+  EXPECT_FALSE(FdOpen(fence))
+      << "EGL took ownership of the fence, so it must be closed -- the caller "
+         "skipping its close() depends on exactly this";
+}
+
+// The importer reports the capability separately from ready(): a display that
+// imports dma-bufs but cannot wait on a sync_file still imports, and is what
+// leaves IhsPvCapabilities::explicit_sync at 0.
+TEST_F(EglAcquireFence, ImportStaysAvailableIndependentOfFenceSync) {
+  ASSERT_TRUE(backend_->MakeCurrent());
+  EglDmabufImporter importer;
+  ASSERT_TRUE(importer.Init(backend_->egl_display()));
+  EXPECT_TRUE(importer.ready())
+      << "dma-buf import is what Init's return value is about";
+}
+
+// A negative fd is the implicit-sync submit -- the producer stalled
+// synchronously and handed over no fence. Nothing to wait on, and nothing to
+// close, so the caller must not be told the fd was consumed.
+TEST_F(EglAcquireFence, NoFenceIsNotConsumed) {
+  ASSERT_TRUE(backend_->MakeCurrent());
+  EglDmabufImporter importer;
+  ASSERT_TRUE(importer.Init(backend_->egl_display()));
+  EXPECT_FALSE(importer.WaitAcquireFence(-1));
 }
 
 }  // namespace

--- a/test/unit_test/ihs_pv-test/test_case_ihs_pv.cc
+++ b/test/unit_test/ihs_pv-test/test_case_ihs_pv.cc
@@ -227,8 +227,10 @@ TEST(IhsPvSurface, RegisterForwardsToHost) {
 }
 
 // Explicit sync is granted only when the backend advertises the capability.
-// This is the contract #513 turns on for the EGL backends, which advertise
-// explicit_sync = 0 today and so downgrade every producer.
+// The EGL backends advertise it when the display has
+// EGL_ANDROID_native_fence_sync, so the GL-composite path can wait on the
+// producer's sync_file before sampling (#513); a display without it still
+// downgrades every producer here.
 TEST(IhsPvSurface, ExplicitSyncGrantedWhenBackendAdvertisesIt) {
   MockHost host_state;
   host_state.explicit_sync = 1;


### PR DESCRIPTION
Closes part of #513: the capability and the acquire wait. The release half is left out, see below.

## The problem

`HostQueryCapabilities` set `explicit_sync` only in the Vulkan branch, so `shared/src/platform_view.cc` downgraded every EGL producer to `IHS_PV_SYNC_IMPLICIT`. `HandBackReleaseFence` never fired, the producer got `out_release_fence_fd = -1`, and it paced on a timer.

## Why the flag could not land on its own

Neither EGL backend used the fence hooks: `TakeAcquireFenceFd` was consumed only by `wayland_vulkan` and `drm_kms_vulkan`, `SetReleaseFenceFd` only by `wayland_vulkan`. Advertising the capability alone would have handed producers an acquire fence nothing waited on, which is worse than the conservative downgrade — `ihs_pv_negotiate` refuses `EXPLICIT_REQUIRED` and caps the granted sync on this flag, so it is the producer's contract rather than a hint. So the wait is in the same change.

## What it does

`EglDmabufImporter::Init` resolves the native-fence-sync entry points and checks the display's extension string as well, since `eglGetProcAddress` returns non-null for extensions a display does not support — the same trap `InitEglExtensions` already guards for `IN_FENCE_FD`. `has_native_fence_sync()` is separate from `ready()`: a display that imports dma-bufs but cannot wait on a sync_file still imports.

`GetGlTextureName` wraps the producer's sync_file in an `EGL_SYNC_NATIVE_FENCE_ANDROID` and issues a server-side `eglWaitSyncKHR`, so the GPU waits and the raster thread does not block. A display without the extension keeps the existing bounded CPU `poll()`, and is where `explicit_sync` stays 0.

Both EGL backends get it from one path — the wait is in the shared view host, not in a backend.

## fd ownership

`eglCreateSyncKHR` takes the producer's fd on success and closes it with the sync; on failure it leaves it. `WaitAcquireFence`'s return value says which happened, and the caller closes only when it kept it. Backwards in either direction is a double close or one leaked fd per frame, so it is asserted against a real driver rather than taken from the spec.

## Tests

Three cases on the vkms fixture, which has a real EGL context. 12/12 pass locally (9 existing + 3 new, none skipped); the unit-tests job loads vkms as of c9ce3681, and the cases skip rather than fail where the extension is absent.

They drive the importer directly. `GetGlTextureName`'s call site is in `IhsPluginView`, in an anonymous namespace no test can construct — the vkms fake implements `GetGlTextureName` itself — so that half is covered by inspection, not by the suite.

## Not included

The release half: a native fence after the draw, into `SetReleaseFenceFd`. It touches the GL composite path in two backends and wants its own review. Producers keep implicit release until then, which is what `HandBackReleaseFence` already does when there is no fence.

Unrelated to this change, `drm_config::explicit_sync` (`auto|yes|no`) governs `IN_FENCE_FD`/`OUT_FENCE_PTR` on KMS commits, which is a different question from whether a producer can exchange fences. The two are deliberately not coupled here.

## Not verified

No producer-side measurement. The real producer is out of tree, so the change is verified by the fence-ownership assertions and by inspection of the wait, not by a before/after frame rate.
