### PR TITLE
test: pin the OSGi struct layout from the C side

### DIFF
--- a/.github/workflows/ihs-shared.yml
+++ b/.github/workflows/ihs-shared.yml
@@ -48,8 +48,14 @@ jobs:
 
       - name: Build + install ihs_shared
         run: |
+          # ENABLE_OSGI so ihs_osgi.h is installed: it is what the osgi_abi
+          # conformance step below builds against, and it puts that header
+          # through the C11 check that follows -- which is what keeps it
+          # parseable by ffigen, the tool that would remove the hand-written
+          # Dart mirrors entirely.
           cmake -S shared -B build -G Ninja \
             -DENABLE_DLT=${{ matrix.enable_dlt }} \
+            -DENABLE_OSGI=ON \
             -DCMAKE_INSTALL_PREFIX="$PWD/prefix"
           cmake --build build
           cmake --install build
@@ -80,6 +86,20 @@ jobs:
           cmake --build sbuild
           export LD_LIBRARY_PATH="$PWD/prefix/lib:$PWD/prefix/lib64:$PWD/prefix/lib/x86_64-linux-gnu"
           ctest --test-dir sbuild --output-on-failure
+
+      - name: OSGi ABI conformance (struct layout + status values)
+        # dart:ffi cannot read a C header, so every Dart caller mirrors
+        # IhsOsgiPeerInfo / IhsOsgiBundleInfo by hand. struct_size catches a
+        # struct that shrank; it cannot catch a field that moved, which keeps
+        # the same size and then writes a port id over a pointer. This pins the
+        # layout from the C side; the Dart side pins the same numbers in
+        # packages/osgi_ffi/test/abi_conformance_test.dart over in dart_osgi.
+        run: |
+          cmake -S shared/tests/osgi_abi -B obuild -G Ninja \
+            -DCMAKE_PREFIX_PATH="$PWD/prefix"
+          cmake --build obuild
+          export LD_LIBRARY_PATH="$PWD/prefix/lib:$PWD/prefix/lib64:$PWD/prefix/lib/x86_64-linux-gnu"
+          ctest --test-dir obuild --output-on-failure
 
       - name: Location unit tests (parser / registry / manager / fallback / filter / file / kalman / ctrv / wire)
         # Standalone: compiles the internal location sources directly (ParseTpv,

--- a/shared/tests/osgi_abi/CMakeLists.txt
+++ b/shared/tests/osgi_abi/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# Copyright 2026 Toyota Connected North America
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ABI conformance for the OSGi handshake structs. Standalone (like
+# tests/consumer): configured from an empty tree against the INSTALLED package,
+# which means it only builds when that package was installed with
+# ENABLE_OSGI=ON -- ihs_osgi.h is not installed otherwise. Driven by
+# .github/workflows/ihs-shared.yml.
+#
+# Most of the work happens at compile time: the assertions are _Static_assert,
+# so a field that moved fails the build rather than the run.
+
+cmake_minimum_required(VERSION 3.16)
+project(ihs_osgi_abi LANGUAGES C)
+
+find_package(ivi-homescreen-shared CONFIG REQUIRED)
+
+add_executable(ihs_osgi_abi osgi_abi.c)
+# Strict C11, for the same reason as tests/consumer: the installed headers must
+# stay C-clean, which is what keeps them parseable by ffigen.
+set_target_properties(ihs_osgi_abi PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON
+        C_EXTENSIONS OFF)
+target_link_libraries(ihs_osgi_abi PRIVATE ivi_homescreen::ihs_shared)
+
+enable_testing()
+add_test(NAME ihs_osgi_abi COMMAND ihs_osgi_abi)

--- a/shared/tests/osgi_abi/osgi_abi.c
+++ b/shared/tests/osgi_abi/osgi_abi.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Toyota Connected North America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * ABI conformance for the OSGi handshake structs.
+ *
+ * WHY THIS EXISTS
+ *
+ * dart:ffi cannot read a C header, so every Dart caller of this surface mirrors
+ * IhsOsgiPeerInfo and IhsOsgiBundleInfo by hand -- today in two places, the
+ * osgi_ffi package and ivi-homescreen's own activator fixture. Nothing connects
+ * those declarations to this header.
+ *
+ * struct_size does not close the gap. The forwarder refuses a struct smaller
+ * than it expects, so a Dart side that lost a field is caught -- but a field
+ * that *moved* keeps the same size, passes that check, and then writes a port
+ * id over a pointer. That failure is memory corruption at a boundary, not a
+ * failed assertion, and it would surface as an unrelated crash somewhere else.
+ *
+ * So the layout is pinned from both sides. These are the numbers
+ * packages/osgi_ffi/test/abi_conformance_test.dart asserts against in the
+ * dart_osgi repository. Changing either struct means changing both, and this
+ * fails first -- at compile time, since the assertions are _Static_assert.
+ *
+ * PLATFORM
+ *
+ * The literals are LP64 (64-bit pointers, 8-byte size_t), which is what
+ * ivi-homescreen targets on every supported board. A 32-bit port would fail
+ * here rather than silently disagreeing with the Dart side, which is the
+ * correct outcome: the Dart mirrors would need their own review before that
+ * port could work at all.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "ihs/ihs_osgi.h"
+
+/* IhsOsgiPeerInfo: size_t struct_size; void* dart_api_dl_data; int64_t port; */
+_Static_assert(sizeof(IhsOsgiPeerInfo) == 24,
+               "IhsOsgiPeerInfo changed size; update the Dart mirrors");
+_Static_assert(offsetof(IhsOsgiPeerInfo, struct_size) == 0,
+               "IhsOsgiPeerInfo.struct_size moved");
+_Static_assert(offsetof(IhsOsgiPeerInfo, dart_api_dl_data) == 8,
+               "IhsOsgiPeerInfo.dart_api_dl_data moved");
+_Static_assert(offsetof(IhsOsgiPeerInfo, port) == 16,
+               "IhsOsgiPeerInfo.port moved");
+
+/* IhsOsgiBundleInfo: size_t struct_size; IhsOsgiPeerInfo peer; const char* */
+_Static_assert(sizeof(IhsOsgiBundleInfo) == 40,
+               "IhsOsgiBundleInfo changed size; update the Dart mirrors");
+_Static_assert(offsetof(IhsOsgiBundleInfo, struct_size) == 0,
+               "IhsOsgiBundleInfo.struct_size moved");
+_Static_assert(offsetof(IhsOsgiBundleInfo, peer) == 8,
+               "IhsOsgiBundleInfo.peer moved");
+_Static_assert(offsetof(IhsOsgiBundleInfo, symbolic_name) == 32,
+               "IhsOsgiBundleInfo.symbolic_name moved");
+
+/* The status values are hardcoded on the Dart side too -- twice -- so they are
+ * part of the same contract as the layout. */
+_Static_assert(IHS_OSGI_OK == 0, "IHS_OSGI_OK changed");
+_Static_assert(IHS_OSGI_ERR_INVALID == -1, "IHS_OSGI_ERR_INVALID changed");
+_Static_assert(IHS_OSGI_ERR_DART_API == -2, "IHS_OSGI_ERR_DART_API changed");
+_Static_assert(IHS_OSGI_ERR_REJECTED == -3, "IHS_OSGI_ERR_REJECTED changed");
+_Static_assert(IHS_OSGI_ERR_UNAVAILABLE == -4,
+               "IHS_OSGI_ERR_UNAVAILABLE changed");
+
+int main(void) {
+  /* Printed, not just asserted: when a port does fail the static assertions
+   * above, the first question is "what are the numbers now", and the answer
+   * should not require rebuilding this by hand. */
+  printf("IhsOsgiPeerInfo   size=%zu struct_size@%zu dart_api_dl_data@%zu port@%zu\n",
+         sizeof(IhsOsgiPeerInfo), offsetof(IhsOsgiPeerInfo, struct_size),
+         offsetof(IhsOsgiPeerInfo, dart_api_dl_data),
+         offsetof(IhsOsgiPeerInfo, port));
+  printf("IhsOsgiBundleInfo size=%zu struct_size@%zu peer@%zu symbolic_name@%zu\n",
+         sizeof(IhsOsgiBundleInfo), offsetof(IhsOsgiBundleInfo, struct_size),
+         offsetof(IhsOsgiBundleInfo, peer),
+         offsetof(IhsOsgiBundleInfo, symbolic_name));
+
+  /* The surface is inert without a host, which is the state this test runs in:
+   * no shell has installed one. Asserting that here keeps the "safe default"
+   * promise covered from an out-of-tree C consumer as well as from the unit
+   * tests inside the tree. */
+  if (ihs_osgi_available()) {
+    printf("FAIL: ihs_osgi_available() is true with no host installed\n");
+    return 1;
+  }
+  if (ihs_osgi_report_active(NULL) != IHS_OSGI_ERR_INVALID) {
+    printf("FAIL: a null handle should be IHS_OSGI_ERR_INVALID\n");
+    return 1;
+  }
+  if (ihs_osgi_unregister(NULL) != IHS_OSGI_OK) {
+    printf("FAIL: unregister(NULL) should be IHS_OSGI_OK\n");
+    return 1;
+  }
+  printf("PASS\n");
+  return 0;
+}


### PR DESCRIPTION
`dart:ffi` cannot read a C header, so every Dart caller of the `ihs_osgi_*`
surface mirrors `IhsOsgiPeerInfo` and `IhsOsgiBundleInfo` **by hand** — today in
two places, the `osgi_ffi` package and this repository's own activator fixture.
Nothing connected those declarations to `ihs_osgi.h`.

**`struct_size` does not close that gap.** The forwarder refuses a struct
*smaller* than it expects, so a mirror that lost a field is caught. A field that
**moved** keeps the same size, passes the check, and then writes a port id over a
pointer — memory corruption at the boundary, surfacing later as an unrelated
crash.

`shared/tests/osgi_abi` pins it. The assertions are `_Static_assert`, so a field
that moves **fails the build, not the run**: sizes and every offset for both
structs, plus the five `IhsOsgiStatus` values (which Dart hardcodes in two
places, so they are part of the same contract). The numbers are LP64 — a 32-bit
port fails here rather than silently disagreeing with Dart, which is correct,
since those mirrors would need review first.

It also asserts the safe defaults from an out-of-tree C consumer: with no host
installed, `ihs_osgi_available()` is false, a null handle is `INVALID`, and
`unregister(NULL)` is `OK`. Covered in-tree already, but not from outside the
build.

The workflow installs with `ENABLE_OSGI=ON`, which puts `ihs_osgi.h` in the
prefix — with a useful second effect: the existing "installed headers compile as
C11" loop now covers it, which is what keeps it parseable by **ffigen**, the tool
that would delete the hand-written mirrors entirely and make this test
unnecessary.

The matching Dart assertions land in `packages/osgi_ffi/test/abi_conformance_test.dart`
in dart_osgi. Change either struct and the other side fails.

### Verification

- `shared/` installs `ihs_osgi.h` under `ENABLE_OSGI=ON`
- the conformance project configures and builds **against the installed prefix**,
  so the static assertions were checked against the real header rather than a
  transcription of it
- `ctest` passes 1/1
- `scripts/format.sh --check` clean (`shared/` is in its scope, so the new C file
  was genuinely checked)

Item 2 of six coverage items; #546 is item 1.