### PR TITLE
ci: actually run the OSGi multi-bundle harness on vkms

### DIFF
--- a/.github/workflows/drm-kms.yml
+++ b/.github/workflows/drm-kms.yml
@@ -108,6 +108,12 @@ jobs:
         run: |
           # The census and input harness exercise both the DRM-KMS-EGL and the
           # software (drm-dumb sink) backends, so build both here.
+          #
+          # ENABLE_OSGI because the OSGi multi-bundle harness is already wired
+          # into vkms_harness_integration.sh and was skipping itself: without
+          # the option the binary carries no [osgi] strings, which the harness
+          # reads as "not an OSGi build" and honestly reports as a skip. This is
+          # the flip that comment anticipated.
           cmake -GNinja \
             -B ${{github.workspace}}/build \
             -D CMAKE_BUILD_TYPE=Debug \
@@ -117,6 +123,7 @@ jobs:
             -D BUILD_BACKEND_WAYLAND_EGL=OFF \
             -D BUILD_BACKEND_WAYLAND_VULKAN=OFF \
             -D BUILD_COMPOSITOR=ON \
+            -D ENABLE_OSGI=ON \
             -D BUILD_NUMBER=${GITHUB_RUN_ID}
           ninja -C ${{github.workspace}}/build
 

--- a/scripts/vkms_harness_integration.sh
+++ b/scripts/vkms_harness_integration.sh
@@ -44,6 +44,32 @@ shopt -u nullglob
 export BUNDLE="${bundles[0]}"
 echo "bundle: ${BUNDLE}"
 
+# ---------------------------------------------------------------------------
+# The OSGi harness needs a different bundle. scroll_bench is an ordinary
+# Flutter app: it never reports ACTIVE, so B3 -- the critical-first ordering
+# guarantee, which is the one property the unit tests can only assert against a
+# fake -- skips however correct the shell is. Running the OSGi leg on it lights
+# up B1/B2/B4/B5 and quietly proves nothing about ordering.
+#
+# The activator bundle does report ACTIVE, over either transport, so it is
+# built separately and used only for that leg.
+# ---------------------------------------------------------------------------
+echo "== building osgi_activator_test bundle =="
+emb bundle --app-path "${IVI_SRC}/test/integration/osgi_activator_test" \
+    -m debug --build
+shopt -s nullglob
+osgi_bundles=( "${BUNDLE_ROOT}"/osgi_activator_test-debug-* )
+shopt -u nullglob
+if [[ ${#osgi_bundles[@]} -ge 1 ]]; then
+    OSGI_BUNDLE="${osgi_bundles[0]}"
+    echo "osgi bundle: ${OSGI_BUNDLE}"
+else
+    # Not fatal: the OSGi legs below skip honestly rather than failing the
+    # whole integration run for a bundle the other harnesses do not need.
+    OSGI_BUNDLE=""
+    echo "::warning::no osgi_activator_test bundle; OSGi legs will skip"
+fi
+
 # Append a section to the job summary (or stdout when run outside Actions).
 emit() { if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then cat >>"${GITHUB_STEP_SUMMARY}"; else cat; fi; }
 
@@ -95,8 +121,24 @@ run_harness "event-driven input harness" \
 # on a real GPU). The harness auto-detects vkms by its connector signature and
 # reads the connectors off that card, so nothing here has to guess. It skips
 # honestly when there is no vkms card or the binary lacks ENABLE_OSGI.
-run_harness "osgi multi-bundle" \
-    env SOFTWARE_RENDER=1 "${IVI_SRC}/test/osgi_multi_bundle.sh"
+#
+# Run once per transport. Both end at the same BridgeRegistry and drive the same
+# lifecycle state machine, so B3 greps the state-machine transition rather than
+# a transport's own log line and asserts identically either way -- which is what
+# makes the ffi leg the first end-to-end exercise of the ihs_osgi_* path against
+# a live Dart VM, rather than against a fake of one half.
+#
+# ACTIVATOR=1 with the activator bundle: without it B3 skips, which is the
+# difference between proving the ordering guarantee and merely not failing.
+if [[ -n "${OSGI_BUNDLE}" ]]; then
+    for transport in channel ffi; do
+        run_harness "osgi multi-bundle (${transport})" \
+            env SOFTWARE_RENDER=1 ACTIVATOR=1 TRANSPORT="${transport}" \
+                BUNDLE="${OSGI_BUNDLE}" "${IVI_SRC}/test/osgi_multi_bundle.sh"
+    done
+else
+    echo "== osgi multi-bundle: skipped (no activator bundle) =="
+fi
 
 echo "vkms harness integration: overall rc=${rc}"
 exit "${rc}"


### PR DESCRIPTION
`osgi_multi_bundle.sh` has been wired into `vkms_harness_integration.sh` since it
was written, with a comment saying it would go live *"by flipping ENABLE_OSGI in
the build step above it"*. **The flip never happened**, so every run took the
harness's honest-skip path — the binary carries no `[osgi]` strings, which it
reads as "not an OSGi build".

### Flipping it alone would have been worse than leaving it off

The OSGi leg inherited `BUNDLE` from the scroll_bench build, and scroll_bench is
an ordinary Flutter app that never reports ACTIVE. So **B3** — the critical-first
ordering guarantee, the one property unit tests can only assert against a fake —
would have skipped while B1/B2/B4/B5 went green: a run that looks like it covered
the subsystem and quietly proved nothing about ordering.

So three changes, not one:

1. `ENABLE_OSGI=ON` in the build.
2. A second `emb bundle` for `test/integration/osgi_activator_test`, which *does*
   report ACTIVE — used only for this leg, with `ACTIVATOR=1`.
3. The leg runs **once per transport**, `channel` and `ffi`.

### The ffi leg is the part worth having

Nothing had run the `ihs_osgi_*` path against a live Dart VM. The shell suites
fake the Dart DL calls, `ihs_osgi-test` fakes the host, `osgi_host-test` joins two
real halves and still fakes the VM, and `osgi_ffi` is tested against a fake of the
C surface. This is a real bundle, a real VM, a real registry, a real orchestrator.

No assertion changes: both transports end at the same `BridgeRegistry` and drive
the same lifecycle state machine, and B3 greps that state machine's transition
rather than a transport's log line.

A missing activator bundle warns and skips rather than failing — the census and
input harnesses don't need it and shouldn't lose their signal over it.
scroll_bench stays exported for those; `BUNDLE` is overridden only inside the
OSGi legs' `env`.

### Verification

- `bash -n` parses the script; the earlier harnesses still receive the
  scroll_bench bundle
- the legs themselves need a vkms card, which is why they run in CI rather than
  locally — and the job already degrades to a warning when the runner's kernel
  has vkms stripped

Item 3 of six coverage items (#546 item 1, #548 item 2, dart_osgi #15/#16).